### PR TITLE
Remove duplicate plugin definitions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,27 +127,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals><goal>jar-no-fork</goal></goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals><goal>jar</goal></goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <!--
                   OkHttp requires with javac >= 1.7 for syncFlush on DeflaterOutputStream.
                   Its language version must be <= 1.6 for dx.


### PR DESCRIPTION
Sources and javadoc artifacts are configured by the parent pom.
