### PR TITLE
Don't use jarjar to strip unused classes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,9 +112,6 @@
                                     <pattern>libcore.**</pattern>
                                     <result>com.squareup.okhttp.libcore.@1</result>
                                 </rule>
-                                <keep>
-                                    <pattern>com.squareup.okhttp.**</pattern>
-                                </keep>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
It was stripping required classes that were only needed
moved classes. We don't have any unused classes so this is
a wasted step anyway.
