### PR TITLE
Support Froyo.

### DIFF
--- a/src/main/java/libcore/io/Base64.java
+++ b/src/main/java/libcore/io/Base64.java
@@ -21,7 +21,7 @@
 
 package libcore.io;
 
-import libcore.util.Charsets;
+import java.io.UnsupportedEncodingException;
 import libcore.util.EmptyArray;
 
 /**
@@ -156,6 +156,10 @@ public final class Base64 {
                 out[index++] = '=';
                 break;
         }
-        return new String(out, 0, index, Charsets.US_ASCII);
+        try {
+            return new String(out, 0, index, "US-ASCII");
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError(e);
+        }
     }
 }

--- a/src/main/java/libcore/net/MimeUtils.java
+++ b/src/main/java/libcore/net/MimeUtils.java
@@ -434,7 +434,7 @@ public final class MimeUtils {
      * @return True iff there is a mimeType entry in the map.
      */
     public static boolean hasMimeType(String mimeType) {
-        if (mimeType == null || mimeType.isEmpty()) {
+        if (mimeType == null || mimeType.length() == 0) {
             return false;
         }
         return MIME_TYPE_TO_EXTENSION_MAP.containsKey(mimeType);
@@ -446,7 +446,7 @@ public final class MimeUtils {
      * @return The MIME type for the given extension or null iff there is none.
      */
     public static String guessMimeTypeFromExtension(String extension) {
-        if (extension == null || extension.isEmpty()) {
+        if (extension == null || extension.length() == 0) {
             return null;
         }
         return EXTENSION_TO_MIME_TYPE_MAP.get(extension);
@@ -458,7 +458,7 @@ public final class MimeUtils {
      * @return True iff there is an extension entry in the map.
      */
     public static boolean hasExtension(String extension) {
-        if (extension == null || extension.isEmpty()) {
+        if (extension == null || extension.length() == 0) {
             return false;
         }
         return EXTENSION_TO_MIME_TYPE_MAP.containsKey(extension);
@@ -472,7 +472,7 @@ public final class MimeUtils {
      * @return The extension for the given MIME type or null iff there is none.
      */
     public static String guessExtensionFromMimeType(String mimeType) {
-        if (mimeType == null || mimeType.isEmpty()) {
+        if (mimeType == null || mimeType.length() == 0) {
             return null;
         }
         return MIME_TYPE_TO_EXTENSION_MAP.get(mimeType);

--- a/src/main/java/libcore/net/http/HttpConnection.java
+++ b/src/main/java/libcore/net/http/HttpConnection.java
@@ -37,7 +37,6 @@ import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import libcore.io.IoUtils;
 import libcore.net.spdy.SpdyConnection;
-import libcore.util.Charsets;
 import libcore.util.Libcore;
 import libcore.util.Objects;
 
@@ -229,7 +228,7 @@ final class HttpConnection {
                 HttpConnectionPool.INSTANCE.share(this);
             } else if (!Arrays.equals(selectedProtocol, HTTP_11)) {
                 throw new IOException("Unexpected NPN transport "
-                        + new String(selectedProtocol, Charsets.ISO_8859_1));
+                        + new String(selectedProtocol, "ISO-8859-1"));
             }
         }
 

--- a/src/main/java/libcore/net/http/HttpResponseCache.java
+++ b/src/main/java/libcore/net/http/HttpResponseCache.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.CacheRequest;
 import java.net.CacheResponse;
@@ -84,9 +85,11 @@ public final class HttpResponseCache extends ResponseCache implements ExtendedRe
     private String uriToKey(URI uri) {
         try {
             MessageDigest messageDigest = MessageDigest.getInstance("MD5");
-            byte[] md5bytes = messageDigest.digest(uri.toString().getBytes(Charsets.UTF_8));
+            byte[] md5bytes = messageDigest.digest(uri.toString().getBytes("UTF-8"));
             return IntegralToString.bytesToHexString(md5bytes, false);
         } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError(e);
+        } catch (UnsupportedEncodingException e) {
             throw new AssertionError(e);
         }
     }
@@ -381,7 +384,7 @@ public final class HttpResponseCache extends ResponseCache implements ExtendedRe
 
                 if (isHttps()) {
                     String blank = Streams.readAsciiLine(in);
-                    if (!blank.isEmpty()) {
+                    if (blank.length() != 0) {
                         throw new IOException("expected \"\" but was \"" + blank + "\"");
                     }
                     cipherSuite = Streams.readAsciiLine(in);
@@ -472,7 +475,7 @@ public final class HttpResponseCache extends ResponseCache implements ExtendedRe
                 Certificate[] result = new Certificate[length];
                 for (int i = 0; i < result.length; i++) {
                     String line = Streams.readAsciiLine(in);
-                    byte[] bytes = Base64.decode(line.getBytes(Charsets.US_ASCII));
+                    byte[] bytes = Base64.decode(line.getBytes("US-ASCII"));
                     result[i] = certificateFactory.generateCertificate(
                             new ByteArrayInputStream(bytes));
                 }

--- a/src/main/java/libcore/net/http/HttpTransport.java
+++ b/src/main/java/libcore/net/http/HttpTransport.java
@@ -25,7 +25,6 @@ import java.net.CacheRequest;
 import java.net.CookieHandler;
 import java.net.URL;
 import libcore.io.Streams;
-import libcore.util.Charsets;
 import libcore.util.Libcore;
 
 final class HttpTransport implements Transport {
@@ -126,7 +125,7 @@ final class HttpTransport implements Transport {
 
         int contentLength = httpEngine.requestHeaders.getContentLength();
         RawHeaders headersToSend = getNetworkRequestHeaders();
-        byte[] bytes = headersToSend.toHeaderString().getBytes(Charsets.ISO_8859_1);
+        byte[] bytes = headersToSend.toHeaderString().getBytes("ISO-8859-1");
 
         if (contentLength != -1 && bytes.length + contentLength <= MAX_REQUEST_BUFFER_LENGTH) {
             requestOut = new BufferedOutputStream(socketOut, bytes.length + contentLength);
@@ -196,7 +195,7 @@ final class HttpTransport implements Transport {
     private void readHeaders(RawHeaders headers) throws IOException {
         // parse the result headers until the first blank line
         String line;
-        while (!(line = Streams.readAsciiLine(socketIn)).isEmpty()) {
+        while ((line = Streams.readAsciiLine(socketIn)).length() != 0) {
             headers.addLine(line);
         }
 

--- a/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
+++ b/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
@@ -31,7 +31,6 @@ import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.SocketPermission;
 import java.net.URL;
-import libcore.util.Charsets;
 import java.security.Permission;
 import java.util.List;
 import java.util.Map;
@@ -444,7 +443,7 @@ public class HttpURLConnectionImpl extends OkHttpConnection {
 
             // base64 encode the username and password
             String usernameAndPassword = auth.getUserName() + ":" + new String(auth.getPassword());
-            byte[] bytes = usernameAndPassword.getBytes(Charsets.ISO_8859_1);
+            byte[] bytes = usernameAndPassword.getBytes("ISO-8859-1");
             String encoded = Base64.encode(bytes);
             return challenge.scheme + " " + encoded;
         }

--- a/src/main/java/libcore/net/http/RawHeaders.java
+++ b/src/main/java/libcore/net/http/RawHeaders.java
@@ -344,7 +344,7 @@ public final class RawHeaders {
             String value = namesAndValues.get(i + 1);
 
             // TODO: promote this check to where names and values are created
-            if (name.isEmpty() || value.isEmpty()
+            if (name.length() == 0 || value.length() == 0
                     || name.indexOf('\0') != -1 || value.indexOf('\0') != -1) {
                 throw new IllegalArgumentException("Unexpected header: " + name + ": " + value);
             }

--- a/src/main/java/libcore/net/http/ResponseHeaders.java
+++ b/src/main/java/libcore/net/http/ResponseHeaders.java
@@ -17,7 +17,6 @@
 package libcore.net.http;
 
 import java.net.HttpURLConnection;
-import libcore.util.ResponseSource;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Date;
@@ -27,6 +26,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import libcore.util.Objects;
+import libcore.util.ResponseSource;
 
 /**
  * Parsed HTTP response headers.

--- a/src/main/java/libcore/net/http/SpdyTransport.java
+++ b/src/main/java/libcore/net/http/SpdyTransport.java
@@ -16,14 +16,14 @@
 
 package libcore.net.http;
 
-import libcore.net.spdy.SpdyConnection;
-import libcore.net.spdy.SpdyStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.CacheRequest;
 import java.util.List;
+import libcore.net.spdy.SpdyConnection;
+import libcore.net.spdy.SpdyStream;
 
 final class SpdyTransport implements Transport {
     private final HttpEngine httpEngine;

--- a/src/main/java/libcore/net/spdy/SpdyReader.java
+++ b/src/main/java/libcore/net/spdy/SpdyReader.java
@@ -20,6 +20,7 @@ import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +35,7 @@ import libcore.io.Streams;
  */
 final class SpdyReader {
     public static final Charset UTF_8 = Charset.forName("UTF-8");
-    public static final byte[] DICTIONARY = (""
+    private static final String DICTIONARY_STRING = ""
             + "optionsgetheadpostputdeletetraceacceptaccept-charsetaccept-encodingaccept-"
             + "languageauthorizationexpectfromhostif-modified-sinceif-matchif-none-matchi"
             + "f-rangeif-unmodifiedsincemax-forwardsproxy-authorizationrangerefererteuser"
@@ -47,7 +48,15 @@ final class SpdyReader {
             + "ndayTuesdayWednesdayThursdayFridaySaturdaySundayJanFebMarAprMayJunJulAugSe"
             + "pOctNovDecchunkedtext/htmlimage/pngimage/jpgimage/gifapplication/xmlapplic"
             + "ation/xhtmltext/plainpublicmax-agecharset=iso-8859-1utf-8gzipdeflateHTTP/1"
-            + ".1statusversionurl\0").getBytes(UTF_8);
+            + ".1statusversionurl\0";
+    public static final byte[] DICTIONARY;
+    static {
+        try {
+            DICTIONARY = DICTIONARY_STRING.getBytes("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError(e);
+        }
+    }
 
     public final DataInputStream in;
     public int flags;
@@ -184,7 +193,7 @@ final class SpdyReader {
             for (int i = 0; i < numberOfPairs; i++) {
                 String name = readString();
                 String values = readString();
-                if (name.isEmpty() || values.isEmpty()) {
+                if (name.length() == 0 || values.length() == 0) {
                     throw new IOException(); // TODO: PROTOCOL ERROR
                 }
                 entries.add(name);
@@ -206,6 +215,6 @@ final class SpdyReader {
         int length = nameValueBlockIn.readShort();
         byte[] bytes = new byte[length];
         Streams.readFully(nameValueBlockIn, bytes);
-        return new String(bytes, 0, length, UTF_8);
+        return new String(bytes, 0, length, "UTF-8");
     }
 }

--- a/src/main/java/libcore/net/spdy/SpdyServer.java
+++ b/src/main/java/libcore/net/spdy/SpdyServer.java
@@ -80,7 +80,7 @@ public final class SpdyServer implements IncomingStreamHandler {
         );
         OutputStream out = stream.reply(responseHeaders);
         String text = "Not found: " + path;
-        out.write(text.getBytes());
+        out.write(text.getBytes("UTF-8"));
         out.close();
     }
 

--- a/src/main/java/libcore/net/spdy/SpdyStream.java
+++ b/src/main/java/libcore/net/spdy/SpdyStream.java
@@ -20,10 +20,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
-import static java.nio.ByteOrder.BIG_ENDIAN;
 import java.util.List;
 import libcore.io.Streams;
 import libcore.util.Libcore;
+
+import static java.nio.ByteOrder.BIG_ENDIAN;
 
 /**
  * A logical bidirectional stream.

--- a/src/main/java/libcore/net/spdy/SpdyWriter.java
+++ b/src/main/java/libcore/net/spdy/SpdyWriter.java
@@ -101,7 +101,7 @@ final class SpdyWriter {
         nameValueBlockOut.writeShort(numberOfPairs);
         for (String s : nameValueBlock) {
             nameValueBlockOut.writeShort(s.length());
-            nameValueBlockOut.write(s.getBytes(SpdyReader.UTF_8));
+            nameValueBlockOut.write(s.getBytes("UTF-8"));
         }
         nameValueBlockOut.flush();
     }

--- a/src/test/java/libcore/net/http/URLConnectionTest.java
+++ b/src/test/java/libcore/net/http/URLConnectionTest.java
@@ -548,7 +548,7 @@ public final class URLConnectionTest extends TestCase {
         mockResponse.setChunkedBody("abc", 3);
         ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
         bytesOut.write(mockResponse.getBody());
-        bytesOut.write("\r\nYOU SHOULD NOT SEE THIS".getBytes());
+        bytesOut.write("\r\nYOU SHOULD NOT SEE THIS".getBytes("UTF-8"));
         mockResponse.setBody(bytesOut.toByteArray());
         mockResponse.clearHeaders();
         mockResponse.addHeader("Transfer-encoding: chunked");

--- a/src/test/java/libcore/net/spdy/SpdyConnectionTest.java
+++ b/src/test/java/libcore/net/spdy/SpdyConnectionTest.java
@@ -37,7 +37,7 @@ public final class SpdyConnectionTest extends TestCase {
         SpdyWriter replyData = peer.sendFrame();
         replyData.flags = SpdyConnection.FLAG_FIN;
         replyData.streamId = 1;
-        replyData.data("robot".getBytes());
+        replyData.data("robot".getBytes("UTF-8"));
         peer.acceptFrame();
         peer.play();
 
@@ -50,7 +50,7 @@ public final class SpdyConnectionTest extends TestCase {
         assertEquals("robot", reader.readLine());
         assertEquals(null, reader.readLine());
         OutputStream out = stream.getOutputStream();
-        out.write("c3po".getBytes());
+        out.write("c3po".getBytes("UTF-8"));
         out.close();
 
         // verify the peer received what was expected
@@ -60,7 +60,7 @@ public final class SpdyConnectionTest extends TestCase {
         assertEquals(0, synStream.reader.associatedStreamId);
         assertEquals(Arrays.asList("b", "banana"), synStream.reader.nameValueBlock);
         MockSpdyPeer.InFrame requestData = peer.takeFrame();
-        assertTrue(Arrays.equals("c3po".getBytes(), requestData.data));
+        assertTrue(Arrays.equals("c3po".getBytes("UTF-8"), requestData.data));
     }
 
     public void testServerCreatesStreamAndClientReplies() throws Exception {

--- a/src/test/java/libcore/net/ssl/SslContextBuilder.java
+++ b/src/test/java/libcore/net/ssl/SslContextBuilder.java
@@ -28,7 +28,6 @@ import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Date;
-import java.util.concurrent.TimeUnit;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
@@ -48,9 +47,10 @@ public final class SslContextBuilder {
         Security.addProvider(new BouncyCastleProvider());
     }
 
+    private static final long ONE_DAY_MILLIS = 1000L * 60 * 60 * 24;
     private final String hostName;
     private long notBefore = System.currentTimeMillis();
-    private long notAfter = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);
+    private long notAfter = System.currentTimeMillis() + ONE_DAY_MILLIS;
 
     /**
      * @param hostName the subject of the host. For TLS this should be the
@@ -120,7 +120,7 @@ public final class SslContextBuilder {
             keyStore.load(in, password);
             return keyStore;
         } catch (IOException e) {
-            throw new AssertionError();
+            throw new AssertionError(e);
         }
     }
 }


### PR DESCRIPTION
This makes a bunch of sad changes for compatibility:
- Using String.length() rather than String.isEmpty()
- Using String.getBytes(String) rather than String.getBytes(Charset)
- Using new String(..., String) rather than new String(..., Charset)
- Avoiding TimeUnit.DAYS

I've tested this and the HTTP tests run perfectly fine on Froyo.
The HTTPS tests time out due to a bug in Froyo that prevents
its TLS library from working as a server. I manually verified
that TLS works as a client without problem.

I also tested this on Gingerbread. It passes all tests except
for testConnectViaHttpProxyToHttpsUsingProxySystemProperty, which
fails because of a bug in Gingerbread's java.net.ProxySelector.

This change introduces caching reflective objects for NPN access.
That'll make clients that make multiple SSL connections slightly
more efficient.
