### PR TITLE
Fail gracefully on a 401 response code with no WWW-Authenticate header.

### DIFF
--- a/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
+++ b/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
@@ -423,13 +423,15 @@ public class HttpURLConnectionImpl extends OkHttpConnection {
     }
 
     /**
-     * Returns the authorization credentials on the base of provided challenge.
+     * Returns the authorization credentials that may satisfy the challenge.
+     * Returns null if a challenge header was not provided or if credentials
+     * were not available.
      */
     private String getAuthorizationCredentials(RawHeaders responseHeaders, String challengeHeader)
             throws IOException {
         List<Challenge> challenges = HeaderParser.parseChallenges(responseHeaders, challengeHeader);
         if (challenges.isEmpty()) {
-            throw new IOException("No authentication challenges found");
+            return null;
         }
 
         for (Challenge challenge : challenges) {


### PR DESCRIPTION
This is more lenient than necessary; the HTTP spec says this:
  10.4.2 401 Unauthorized
     The request requires user authentication. The response MUST include a
     WWW-Authenticate header field (section 14.47) containing a challenge
     applicable to the requested resource.

Not throwing will still cause the request to fail, since the 401
response code triggers an IOException. But this type of failure is
more recoverable and allows the caller to inspect the headers and
response body.
