### PR TITLE
Merge: HttpEngine should not attempt to cache proxy CONNECT responses

### DIFF
--- a/src/main/java/libcore/net/http/HttpEngine.java
+++ b/src/main/java/libcore/net/http/HttpEngine.java
@@ -368,6 +368,11 @@ public class HttpEngine {
     }
 
     private void maybeCache() throws IOException {
+        // Never cache responses to proxy CONNECT requests.
+        if (method == CONNECT) {
+            return;
+        }
+
         // Are we caching at all?
         if (!policy.getUseCaches() || responseCache == null) {
             return;


### PR DESCRIPTION
Original AOSP/libcore commit from Brian Carlstrom:
This fixes an issue where a bad proxy repsonse that included a body
would turn into an IllegalStateException instead of an IOException.

Bug: 6754912

Change-Id: I204ad975820693d6add2780d7b77360463e33710
