### PR TITLE
Merge: Improve HttpResponseCache performance.

### DIFF
--- a/src/main/java/libcore/net/http/HttpResponseCache.java
+++ b/src/main/java/libcore/net/http/HttpResponseCache.java
@@ -287,6 +287,13 @@ public final class HttpResponseCache extends ResponseCache implements ExtendedRe
                     super.close();
                     editor.commit();
                 }
+
+                @Override
+                public void write(byte[] buffer, int offset, int length) throws IOException {
+                    // Since we don't override "write(int oneByte)", we can write directly to "out"
+                    // and avoid the inefficient implementation from the FilterOutputStream.
+                    out.write(buffer, offset, length);
+                }
             };
         }
 


### PR DESCRIPTION
Original AOSP/libcore commit from Vladimir Marko:
Avoid writing to HttpResponseCache.CacheRequestImpl.cacheOut
one byte at a time via inefficient FilterOutputStream write.

(cherry-picked from 91cc423115fdfa682d9c4cd025dee06aaa145b3c.)

Bug: 6738383
Change-Id: Ia657d7417cc292746968809f6896a5e790f1394d
