### PR TITLE
Merge: TLS + SNI + proxy => bug

### DIFF
--- a/src/main/java/libcore/net/http/HttpConnection.java
+++ b/src/main/java/libcore/net/http/HttpConnection.java
@@ -201,7 +201,7 @@ final class HttpConnection {
         // Create the wrapper over connected socket.
         sslSocket = (SSLSocket) sslSocketFactory.createSocket(socket,
                 address.uriHost, address.uriPort, true /* autoClose */);
-        Libcore.makeTlsTolerant(sslSocket, address.socketHost, tlsTolerant);
+        Libcore.makeTlsTolerant(sslSocket, address.uriHost, tlsTolerant);
 
         if (tlsTolerant) {
             Libcore.setNpnProtocols(sslSocket, NPN_PROTOCOLS);

--- a/src/main/java/libcore/util/Libcore.java
+++ b/src/main/java/libcore/util/Libcore.java
@@ -72,7 +72,7 @@ public final class Libcore {
         }
     }
 
-    public static void makeTlsTolerant(SSLSocket socket, String socketHost, boolean tlsTolerant) {
+    public static void makeTlsTolerant(SSLSocket socket, String uriHost, boolean tlsTolerant) {
         if (!tlsTolerant) {
             socket.setEnabledProtocols(new String[] {"SSLv3"});
             return;
@@ -85,7 +85,7 @@ public final class Libcore {
                 setEnabledCompressionMethods.invoke(socket,
                         new Object[] {compressionMethods});
                 setUseSessionTickets.invoke(socket, true);
-                setHostname.invoke(socket, socketHost);
+                setHostname.invoke(socket, uriHost);
             } catch (InvocationTargetException e) {
                 throw new RuntimeException(e);
             } catch (IllegalAccessException e) {


### PR DESCRIPTION
Original AOSP/libcore commit from Brian Carlstrom;
The SNI at the TLS layer is the hostname of the proxy instead
of the hostname in the URL.
