### PR TITLE
Merge: Fix HttpURLConnection CloseGuard warning due to lack of close on ...

### DIFF
--- a/src/test/java/libcore/net/http/URLConnectionTest.java
+++ b/src/test/java/libcore/net/http/URLConnectionTest.java
@@ -773,6 +773,50 @@ public final class URLConnectionTest extends TestCase {
         assertEquals(200, connection.getResponseCode());
     }
 
+//    public void testDisconnectAfterOnlyResponseCodeCausesNoCloseGuardWarning() throws IOException {
+//        CloseGuardGuard guard = new CloseGuardGuard();
+//        try {
+//            server.enqueue(new MockResponse()
+//                    .setBody(gzip("ABCABCABC".getBytes("UTF-8")))
+//                    .addHeader("Content-Encoding: gzip"));
+//            server.play();
+//
+//            HttpURLConnection connection = (HttpURLConnection) server.getUrl("/").openConnection();
+//            assertEquals(200, connection.getResponseCode());
+//            connection.disconnect();
+//            connection = null;
+//            assertFalse(guard.wasCloseGuardCalled());
+//        } finally {
+//            guard.close();
+//        }
+//    }
+//
+//    public static class CloseGuardGuard implements Closeable, CloseGuard.Reporter  {
+//        private final CloseGuard.Reporter oldReporter = CloseGuard.getReporter();
+//
+//        private AtomicBoolean closeGuardCalled = new AtomicBoolean();
+//
+//        public CloseGuardGuard() {
+//            CloseGuard.setReporter(this);
+//        }
+//
+//        @Override public void report(String message, Throwable allocationSite) {
+//            oldReporter.report(message, allocationSite);
+//            closeGuardCalled.set(true);
+//        }
+//
+//        public boolean wasCloseGuardCalled() {
+//            // FinalizationTester.induceFinalization();
+//            close();
+//            return closeGuardCalled.get();
+//        }
+//
+//        @Override public void close() {
+//            CloseGuard.setReporter(oldReporter);
+//        }
+//
+//    }
+
     public void testDefaultRequestProperty() throws Exception {
         URLConnection.setDefaultRequestProperty("X-testSetDefaultRequestProperty", "A");
         assertNull(URLConnection.getDefaultRequestProperty("X-setDefaultRequestProperty"));


### PR DESCRIPTION
...GZIPInputStream

Original AOSP/libcore commit by Brian Carlstrom:
java.lang.Throwable: Explicit termination method 'end' not called
  at dalvik.system.CloseGuard.open(CloseGuard.java:184)
  at java.util.zip.Inflater.<init>(Inflater.java:82)
  at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:96)
  at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:81)
  at libcore.net.http.HttpEngine.initContentStream(HttpEngine.java:523)
  at libcore.net.http.HttpEngine.readResponse(HttpEngine.java:831)
  at libcore.net.http.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:274)
  at libcore.net.http.HttpURLConnectionImpl.getResponseCode(HttpURLConnectionImpl.java:486)
  at ...

Bug: 6602529
Change-Id: I9b49cbca561f8780d08844e566820087fdffc4d7
