### PR TITLE
Fix TLS requiresTunnel which was being computed incorrectly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <!-- Compilation -->
         <java.version>1.6</java.version>
         <npn.version>8.1.2.v20120308</npn.version>
-        <mockwebserver.version>20120731</mockwebserver.version>
+        <mockwebserver.version>20120905</mockwebserver.version>
         <bouncycastle.version>1.47</bouncycastle.version>
 
         <!-- Test Dependencies -->

--- a/src/main/java/com/squareup/okhttp/OkHttpsConnection.java
+++ b/src/main/java/com/squareup/okhttp/OkHttpsConnection.java
@@ -266,8 +266,6 @@ public abstract class OkHttpsConnection extends OkHttpConnection {
 
     /**
      * Returns the hostname verifier used by this instance.
-     *
-     * @return the hostname verifier used by this instance.
      */
     public HostnameVerifier getHostnameVerifier() {
         return hostnameVerifier;
@@ -290,8 +288,6 @@ public abstract class OkHttpsConnection extends OkHttpConnection {
 
     /**
      * Returns the SSL socket factory used by this instance.
-     *
-     * @return the SSL socket factory used by this instance.
      */
     public SSLSocketFactory getSSLSocketFactory() {
         return sslSocketFactory;

--- a/src/main/java/libcore/net/http/HttpEngine.java
+++ b/src/main/java/libcore/net/http/HttpEngine.java
@@ -279,7 +279,7 @@ public class HttpEngine {
 
     protected final HttpConnection openSocketConnection() throws IOException {
         HttpConnection result = HttpConnection.connect(uri, getSslSocketFactory(),
-                policy.getProxy(), requiresTunnel(), policy.getConnectTimeout());
+                policy.getProxy(), policy.getConnectTimeout());
         Proxy proxy = result.getAddress().getProxy();
         if (proxy != null) {
             policy.setProxy(proxy);
@@ -578,10 +578,6 @@ public class HttpEngine {
             result = result + ":" + port;
         }
         return result;
-    }
-
-    protected boolean requiresTunnel() {
-        return false;
     }
 
     /**

--- a/src/main/java/libcore/net/http/HttpsURLConnectionImpl.java
+++ b/src/main/java/libcore/net/http/HttpsURLConnectionImpl.java
@@ -452,7 +452,7 @@ public final class HttpsURLConnectionImpl extends OkHttpsConnection {
             // make an SSL Tunnel on the first message pair of each SSL + proxy connection
             if (connection == null) {
                 connection = openSocketConnection();
-                if (connection.getAddress().getProxy() != null) {
+                if (connection.getAddress().requiresTunnel()) {
                     makeTunnel(policy, connection, getRequestHeaders());
                 }
             }
@@ -526,10 +526,6 @@ public final class HttpsURLConnectionImpl extends OkHttpsConnection {
         public ProxyConnectEngine(HttpURLConnectionImpl policy, RawHeaders requestHeaders,
                 HttpConnection connection) throws IOException {
             super(policy, HttpEngine.CONNECT, requestHeaders, connection, null);
-        }
-
-        @Override protected boolean requiresTunnel() {
-            return true;
         }
     }
 }


### PR DESCRIPTION
We were only returning 'true' once we were already in a tunnel.
This was bogus. In theory a TLS tunnel sending extra data could
be corrupted due to this bug.

Also migrate one of the TLS tunnel tests to use SslContextBuilder
instead of TestSSLContext.
