### PR TITLE
Fix Authenticator callbacks to include full information.

### DIFF
--- a/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
+++ b/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
@@ -445,9 +445,18 @@ public class HttpURLConnectionImpl extends OkHttpConnection {
 
         for (Challenge challenge : challenges) {
             // use the global authenticator to get the password
-            PasswordAuthentication auth = Authenticator.requestPasswordAuthentication(
-                    getConnectToInetAddress(), getConnectToPort(), url.getProtocol(),
-                    challenge.realm, challenge.scheme);
+            PasswordAuthentication auth;
+            if (responseHeaders.getResponseCode() == HTTP_PROXY_AUTH) {
+                InetSocketAddress proxyAddress = (InetSocketAddress) proxy.address();
+                auth = Authenticator.requestPasswordAuthentication(
+                        proxyAddress.getHostName(), getConnectToInetAddress(),
+                        proxyAddress.getPort(), url.getProtocol(), challenge.realm,
+                        challenge.scheme, url, Authenticator.RequestorType.PROXY);
+            } else {
+                auth = Authenticator.requestPasswordAuthentication(
+                        url.getHost(), getConnectToInetAddress(), url.getPort(), url.getProtocol(),
+                        challenge.realm, challenge.scheme, url, Authenticator.RequestorType.SERVER);
+            }
             if (auth == null) {
                 continue;
             }


### PR DESCRIPTION
These were passing the wrong parameters for proxies, and not
including enough information for origin servers.

Related to: http://code.google.com/p/android/issues/detail?id=18856
