### PR TITLE
Be more careful about synchronization.

### DIFF
--- a/src/main/java/libcore/net/http/HttpConnectionPool.java
+++ b/src/main/java/libcore/net/http/HttpConnectionPool.java
@@ -95,7 +95,7 @@ final class HttpConnectionPool {
      */
     public void recycle(HttpConnection connection) {
         if (connection.isSpdy()) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(); // TODO: just 'return' here?
         }
 
         Socket socket = connection.getSocket();


### PR DESCRIPTION
SpdyConnection needs to guard its own state separately from
the SpdyWriter, which permits slow blocking calls. Split these
into multiple independent locks.

Also use independent right-sized thread pools for reading (exactly
one thread all the time) delayed writing (0 or 1 threads) and
callbacks (any number of threads).
