### PR TITLE
Be strict and careful when parsing the response status line.

### DIFF
--- a/src/main/java/libcore/net/http/HttpEngine.java
+++ b/src/main/java/libcore/net/http/HttpEngine.java
@@ -197,7 +197,8 @@ public class HttpEngine {
             }
             this.responseSource = ResponseSource.CACHE;
             this.cacheResponse = GATEWAY_TIMEOUT_RESPONSE;
-            RawHeaders rawResponseHeaders = RawHeaders.fromMultimap(cacheResponse.getHeaders());
+            RawHeaders rawResponseHeaders
+                    = RawHeaders.fromMultimap(cacheResponse.getHeaders(), true);
             setResponse(new ResponseHeaders(uri, rawResponseHeaders), cacheResponse.getBody());
         }
 
@@ -220,7 +221,7 @@ public class HttpEngine {
         }
 
         CacheResponse candidate = responseCache.get(uri, method,
-                requestHeaders.getHeaders().toMultimap());
+                requestHeaders.getHeaders().toMultimap(false));
         if (candidate == null) {
             return;
         }
@@ -234,7 +235,7 @@ public class HttpEngine {
             return;
         }
 
-        RawHeaders rawResponseHeaders = RawHeaders.fromMultimap(responseHeadersMap);
+        RawHeaders rawResponseHeaders = RawHeaders.fromMultimap(responseHeadersMap, true);
         cachedResponseHeaders = new ResponseHeaders(uri, rawResponseHeaders);
         long now = System.currentTimeMillis();
         this.responseSource = cachedResponseHeaders.chooseResponseSource(now, requestHeaders);
@@ -284,7 +285,7 @@ public class HttpEngine {
         if (proxy != null) {
             policy.setProxy(proxy);
             // Add the authority to the request line when we're using a proxy.
-            requestHeaders.getHeaders().setStatusLine(getRequestLine());
+            requestHeaders.getHeaders().setRequestLine(getRequestLine());
         }
         result.setSoTimeout(policy.getReadTimeout());
         return result;
@@ -481,7 +482,7 @@ public class HttpEngine {
      * doesn't know what content types the application is interested in.
      */
     private void prepareRawRequestHeaders() throws IOException {
-        requestHeaders.getHeaders().setStatusLine(getRequestLine());
+        requestHeaders.getHeaders().setRequestLine(getRequestLine());
 
         if (requestHeaders.getUserAgent() == null) {
             requestHeaders.setUserAgent(getDefaultUserAgent());
@@ -515,7 +516,7 @@ public class HttpEngine {
         CookieHandler cookieHandler = CookieHandler.getDefault();
         if (cookieHandler != null) {
             requestHeaders.addCookies(
-                    cookieHandler.get(uri, requestHeaders.getHeaders().toMultimap()));
+                    cookieHandler.get(uri, requestHeaders.getHeaders().toMultimap(false)));
         }
     }
 

--- a/src/main/java/libcore/net/http/HttpResponseCache.java
+++ b/src/main/java/libcore/net/http/HttpResponseCache.java
@@ -181,8 +181,8 @@ public final class HttpResponseCache extends ResponseCache implements ExtendedRe
      * not updated. If the stored response has changed since {@code
      * conditionalCacheHit} was returned, this does nothing.
      */
-    @Override
-    public void update(CacheResponse conditionalCacheHit, OkHttpConnection httpConnection) {
+    @Override public void update(CacheResponse conditionalCacheHit, OkHttpConnection httpConnection)
+            throws IOException {
         HttpEngine httpEngine = getHttpEngine(httpConnection);
         URI uri = httpEngine.getUri();
         ResponseHeaders response = httpEngine.getResponseHeaders();
@@ -408,11 +408,12 @@ public final class HttpResponseCache extends ResponseCache implements ExtendedRe
             }
         }
 
-        public Entry(URI uri, RawHeaders varyHeaders, OkHttpConnection httpConnection) {
+        public Entry(URI uri, RawHeaders varyHeaders, OkHttpConnection httpConnection)
+                throws IOException {
             this.uri = uri.toString();
             this.varyHeaders = varyHeaders;
             this.requestMethod = httpConnection.getRequestMethod();
-            this.responseHeaders = RawHeaders.fromMultimap(httpConnection.getHeaderFields());
+            this.responseHeaders = RawHeaders.fromMultimap(httpConnection.getHeaderFields(), true);
 
             if (isHttps()) {
                 OkHttpsConnection httpsConnection
@@ -506,7 +507,7 @@ public final class HttpResponseCache extends ResponseCache implements ExtendedRe
             return this.uri.equals(uri.toString())
                     && this.requestMethod.equals(requestMethod)
                     && new ResponseHeaders(uri, responseHeaders)
-                            .varyMatches(varyHeaders.toMultimap(), requestHeaders);
+                            .varyMatches(varyHeaders.toMultimap(false), requestHeaders);
         }
     }
 
@@ -535,7 +536,7 @@ public final class HttpResponseCache extends ResponseCache implements ExtendedRe
         }
 
         @Override public Map<String, List<String>> getHeaders() {
-            return entry.responseHeaders.toMultimap();
+            return entry.responseHeaders.toMultimap(true);
         }
 
         @Override public InputStream getBody() {
@@ -555,7 +556,7 @@ public final class HttpResponseCache extends ResponseCache implements ExtendedRe
         }
 
         @Override public Map<String, List<String>> getHeaders() {
-            return entry.responseHeaders.toMultimap();
+            return entry.responseHeaders.toMultimap(true);
         }
 
         @Override public InputStream getBody() {

--- a/src/main/java/libcore/net/http/HttpTransport.java
+++ b/src/main/java/libcore/net/http/HttpTransport.java
@@ -125,7 +125,7 @@ final class HttpTransport implements Transport {
 
         int contentLength = httpEngine.requestHeaders.getContentLength();
         RawHeaders headersToSend = getNetworkRequestHeaders();
-        byte[] bytes = headersToSend.toHeaderString().getBytes("ISO-8859-1");
+        byte[] bytes = headersToSend.toRequestHeader().getBytes("ISO-8859-1");
 
         if (contentLength != -1 && bytes.length + contentLength <= MAX_REQUEST_BUFFER_LENGTH) {
             requestOut = new BufferedOutputStream(socketOut, bytes.length + contentLength);
@@ -150,7 +150,7 @@ final class HttpTransport implements Transport {
         URL url = httpEngine.policy.getURL();
 
         RawHeaders result = new RawHeaders();
-        result.setStatusLine("CONNECT " + url.getHost() + ":" + Libcore.getEffectivePort(url)
+        result.setRequestLine("CONNECT " + url.getHost() + ":" + Libcore.getEffectivePort(url)
                 + " HTTP/1.1");
 
         // Always set Host and User-Agent.
@@ -201,7 +201,7 @@ final class HttpTransport implements Transport {
 
         CookieHandler cookieHandler = CookieHandler.getDefault();
         if (cookieHandler != null) {
-            cookieHandler.put(httpEngine.uri, headers.toMultimap());
+            cookieHandler.put(httpEngine.uri, headers.toMultimap(true));
         }
     }
 

--- a/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
+++ b/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
@@ -160,7 +160,7 @@ public class HttpURLConnectionImpl extends OkHttpConnection {
 
     @Override public final Map<String, List<String>> getHeaderFields() {
         try {
-            return getResponse().getResponseHeaders().getHeaders().toMultimap();
+            return getResponse().getResponseHeaders().getHeaders().toMultimap(true);
         } catch (IOException e) {
             return null;
         }
@@ -171,7 +171,7 @@ public class HttpURLConnectionImpl extends OkHttpConnection {
             throw new IllegalStateException(
                     "Cannot access request header fields after connection is set");
         }
-        return rawRequestHeaders.toMultimap();
+        return rawRequestHeaders.toMultimap(false);
     }
 
     @Override public final InputStream getInputStream() throws IOException {

--- a/src/main/java/libcore/net/http/ResponseHeaders.java
+++ b/src/main/java/libcore/net/http/ResponseHeaders.java
@@ -16,6 +16,7 @@
 
 package libcore.net.http;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Collections;
@@ -461,7 +462,7 @@ public final class ResponseHeaders {
      * Combines this cached header with a network header as defined by RFC 2616,
      * 13.5.3.
      */
-    public ResponseHeaders combine(ResponseHeaders network) {
+    public ResponseHeaders combine(ResponseHeaders network) throws IOException {
         RawHeaders result = new RawHeaders();
         result.setStatusLine(headers.getStatusLine());
 

--- a/src/main/java/libcore/util/ExtendedResponseCache.java
+++ b/src/main/java/libcore/util/ExtendedResponseCache.java
@@ -17,6 +17,7 @@
 package libcore.util;
 
 import com.squareup.okhttp.OkHttpConnection;
+import java.io.IOException;
 import java.net.CacheResponse;
 
 /**
@@ -50,5 +51,5 @@ public interface ExtendedResponseCache {
      * Updates stored HTTP headers using a hit on a conditional GET.
      * @hide
      */
-    void update(CacheResponse conditionalCacheHit, OkHttpConnection httpConnection);
+    void update(CacheResponse conditionalCacheHit, OkHttpConnection httpConnection) throws IOException;
 }

--- a/src/test/java/libcore/net/http/URLConnectionTest.java
+++ b/src/test/java/libcore/net/http/URLConnectionTest.java
@@ -233,6 +233,54 @@ public final class URLConnectionTest extends TestCase {
         assertEquals("e", urlConnection.getHeaderField(2));
     }
 
+    public void testServerSendsInvalidResponseHeaders() throws Exception {
+        server.enqueue(new MockResponse().setStatus("HTP/1.1 200 OK"));
+        server.play();
+
+        OkHttpConnection urlConnection = openConnection(server.getUrl("/"));
+        try {
+            urlConnection.getResponseCode();
+            fail();
+        } catch (IOException expected) {
+        }
+    }
+
+    public void testServerSendsInvalidCodeTooLarge() throws Exception {
+        server.enqueue(new MockResponse().setStatus("HTTP/1.1 2147483648 OK"));
+        server.play();
+
+        OkHttpConnection urlConnection = openConnection(server.getUrl("/"));
+        try {
+            urlConnection.getResponseCode();
+            fail();
+        } catch (IOException expected) {
+        }
+    }
+
+    public void testServerSendsInvalidCodeNotANumber() throws Exception {
+        server.enqueue(new MockResponse().setStatus("HTTP/1.1 00a OK"));
+        server.play();
+
+        OkHttpConnection urlConnection = openConnection(server.getUrl("/"));
+        try {
+            urlConnection.getResponseCode();
+            fail();
+        } catch (IOException expected) {
+        }
+    }
+
+    public void testServerSendsUnnecessaryWhitespace() throws Exception {
+        server.enqueue(new MockResponse().setStatus(" HTTP/1.1 2147483648 OK"));
+        server.play();
+
+        OkHttpConnection urlConnection = openConnection(server.getUrl("/"));
+        try {
+            urlConnection.getResponseCode();
+            fail();
+        } catch (IOException expected) {
+        }
+    }
+
     public void testGetErrorStreamOnSuccessfulRequest() throws Exception {
         server.enqueue(new MockResponse().setBody("A"));
         server.play();


### PR DESCRIPTION
The current status line parsing is lenient and sloppy; a
holdover from an ancient version of this library. The new
code is strict and provides a helpful message if a bogus
status line is encountered.

To make this possible the RawHeaders class needs a hint
about whether it's looking for a request line (from an
HTTP request) or a status line (from an HTTP response).
The old sloppy code used the same APIs for both.
