### PR TITLE
Tests and code for various SPDY close scenarios.

### DIFF
--- a/src/main/java/libcore/net/spdy/SpdyServer.java
+++ b/src/main/java/libcore/net/spdy/SpdyServer.java
@@ -82,7 +82,8 @@ public final class SpdyServer implements IncomingStreamHandler {
                 "version", "HTTP/1.1",
                 "content-type", "text/plain"
         );
-        OutputStream out = stream.reply(responseHeaders);
+        stream.reply(responseHeaders, true);
+        OutputStream out = stream.getOutputStream();
         String text = "Not found: " + path;
         out.write(text.getBytes("UTF-8"));
         out.close();
@@ -91,11 +92,12 @@ public final class SpdyServer implements IncomingStreamHandler {
     private void serveFile(SpdyStream stream, File file) throws IOException {
         InputStream in = new FileInputStream(file);
         byte[] buffer = new byte[8192];
-        OutputStream out = stream.reply(Arrays.asList(
+        stream.reply(Arrays.asList(
                 "status", "200",
                 "version", "HTTP/1.1",
                 "content-type", contentType(file)
-        ));
+        ), true);
+        OutputStream out = stream.getOutputStream();
         int count;
         while ((count = in.read(buffer)) != -1) {
             out.write(buffer, 0, count);


### PR DESCRIPTION
Writing this change has led me to believe that the
concurrency here is just plain awful, and I need to
find a better solution than what I have. In particular,
there are too many threads:
- the internal reader thread
- application reader threads
- application writer threads
  And too many locks:
- the SpdyWriter I/O write lock
- the SpdyConnection internal state lock
- each SpdyStream's internal state lock

What's currently very wrong is the internal reader thread
is updating state in the SpdyStream, and reading bytes from
the network into a particular stream. It is an error to hold
the SpdyStream's lock while reading, but we're doing it because
we need to hold the state on the buffer, position and limit.
We need to rethink this!

Chrome doesn't run into this problem because it can 'fire and
forget' events. We can't do that because SPDY writes need to
throw IOExceptions if the writes fail.
