### PR TITLE
Fix connection recycling for TLS+gzip+chunked.

### DIFF
--- a/src/main/java/libcore/net/http/HttpConnection.java
+++ b/src/main/java/libcore/net/http/HttpConnection.java
@@ -214,9 +214,14 @@ final class HttpConnection {
             throw new IOException("Hostname '" + address.uriHost + "' was not verified");
         }
 
-        // SSL success. Prepare to hand out Transport instances.
+        /*
+         * Buffer the input to mask SSL InputStream's degenerate available()
+         * implementation. That way we can read the end of a chunked response
+         * without blocking and will recycle the connection more reliably.
+         * http://code.google.com/p/android/issues/detail?id=38817
+         */
         sslOutputStream = sslSocket.getOutputStream();
-        sslInputStream = sslSocket.getInputStream();
+        sslInputStream = new BufferedInputStream(sslSocket.getInputStream(), 128);
 
         byte[] selectedProtocol;
         if (tlsTolerant

--- a/src/main/java/libcore/net/http/HttpEngine.java
+++ b/src/main/java/libcore/net/http/HttpEngine.java
@@ -101,6 +101,7 @@ public class HttpEngine {
 
     private Transport transport;
 
+    private InputStream responseTransferIn;
     private InputStream responseBodyIn;
 
     private final ResponseCache responseCache = ResponseCache.getDefault();
@@ -421,7 +422,7 @@ public class HttpEngine {
         if (!connectionReleased && connection != null) {
             connectionReleased = true;
 
-            if (!reusable || !transport.makeReusable(requestBodyOut, responseBodyIn)) {
+            if (!reusable || !transport.makeReusable(requestBodyOut, responseTransferIn)) {
                 connection.closeSocketAndStreams();
                 connection = null;
             } else if (automaticallyReleaseConnectionToPool) {
@@ -432,6 +433,7 @@ public class HttpEngine {
     }
 
     private void initContentStream(InputStream transferStream) throws IOException {
+        responseTransferIn = transferStream;
         if (transparentGzip && responseHeaders.isContentEncodingGzip()) {
             /*
              * If the response was transparently gzipped, remove the gzip header field

--- a/src/main/java/libcore/net/http/HttpTransport.java
+++ b/src/main/java/libcore/net/http/HttpTransport.java
@@ -501,12 +501,12 @@ final class HttpTransport implements Transport {
             cacheWrite(buffer, offset, read);
 
             /*
-            * If we're at the end of a chunk and the next chunk size is readable,
-            * read it! Reading the last chunk causes the underlying connection to
-            * be recycled and we want to do that as early as possible. Otherwise
-            * self-delimiting streams like gzip will never be recycled.
-            * http://code.google.com/p/android/issues/detail?id=7059
-            */
+             * If we're at the end of a chunk and the next chunk size is readable,
+             * read it! Reading the last chunk causes the underlying connection to
+             * be recycled and we want to do that as early as possible. Otherwise
+             * self-delimiting streams like gzip will never be recycled.
+             * http://code.google.com/p/android/issues/detail?id=7059
+             */
             if (bytesRemainingInChunk == 0 && in.available() >= MIN_LAST_CHUNK_LENGTH) {
                 readChunkSize();
             }


### PR DESCRIPTION
We had a bug where the underlying SSLInputStream always returned
0 for InputStream.available(). This prevented us from ever reading
the "end of stream" chunk, which prevented connection recycling.
http://code.google.com/p/android/issues/detail?id=38817

Also fix a nearby bug where we were fast-forwarding the gzipped
stream when we should have been fast-forwarding the transfer
stream when we were preparing to recycle a connection.
