### PR TITLE
Fix some bugs from exercising HttpConnection + SPDY.

### DIFF
--- a/src/main/java/libcore/net/http/HttpConnection.java
+++ b/src/main/java/libcore/net/http/HttpConnection.java
@@ -153,8 +153,6 @@ final class HttpConnection {
             // extensions enabled, if it fails (and its not unheard of that it
             // will) fallback to a barebones connection.
             try {
-                result = new HttpConnection(
-                        address, socket, socket.getInputStream(), socket.getOutputStream());
                 result.upgradeToTls(true, tunnelConfig);
             } catch (IOException e) {
                 // If the problem was a CertificateException from the X509TrustManager,

--- a/src/main/java/libcore/net/http/HttpEngine.java
+++ b/src/main/java/libcore/net/http/HttpEngine.java
@@ -529,12 +529,22 @@ public class HttpEngine {
         if (includeAuthorityInRequestLine()) {
             return url.toString();
         } else {
-            String fileOnly = url.getFile();
-            if (fileOnly == null) {
-                fileOnly = "/";
-            } else if (!fileOnly.startsWith("/")) {
-                fileOnly = "/" + fileOnly;
-            }
+            return requestPath(url);
+        }
+    }
+
+    /**
+     * Returns the path to request, like the '/' in 'GET / HTTP/1.1'. Never
+     * empty, even if the request URL is. Includes the query component if it
+     * exists.
+     */
+    public static String requestPath(URL url) {
+        String fileOnly = url.getFile();
+        if (fileOnly == null) {
+            return "/";
+        } else if (!fileOnly.startsWith("/")) {
+            return "/" + fileOnly;
+        } else {
             return fileOnly;
         }
     }

--- a/src/main/java/libcore/net/http/SpdyTransport.java
+++ b/src/main/java/libcore/net/http/SpdyTransport.java
@@ -51,7 +51,7 @@ final class SpdyTransport implements Transport {
         RawHeaders requestHeaders = httpEngine.requestHeaders.getHeaders();
         String version = httpEngine.connection.httpMinorVersion == 1 ? "HTTP/1.1" : "HTTP/1.0";
         requestHeaders.addSpdyRequestHeaders(httpEngine.method, httpEngine.uri.getScheme(),
-                httpEngine.uri.getPath(), version);
+                HttpEngine.requestPath(httpEngine.policy.getURL()), version);
         boolean hasRequestBody = httpEngine.hasRequestBody();
         boolean hasResponseBody = true;
         stream = spdyConnection.newStream(requestHeaders.toNameValueBlock(),


### PR DESCRIPTION
I was trying to reproduce a connectivity problem and
I found other related problems along the way:
- We were unnecessarily creating new HttpConnection instances.
- We were using "" as the file instead of "/" for SPDY.
