### PR TITLE
New route selector to support multiple routes.

### DIFF
--- a/src/main/java/libcore/net/Dns.java
+++ b/src/main/java/libcore/net/Dns.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package libcore.net;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Domain name service. Prefer this over {@link InetAddress#getAllByName} to
+ * make code more testable.
+ */
+public interface Dns {
+    Dns DEFAULT = new Dns() {
+        @Override public InetAddress[] getAllByName(String host) throws UnknownHostException {
+            return InetAddress.getAllByName(host);
+        }
+    };
+
+    InetAddress[] getAllByName(String host) throws UnknownHostException;
+}

--- a/src/main/java/libcore/net/http/HttpTransport.java
+++ b/src/main/java/libcore/net/http/HttpTransport.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.CacheRequest;
 import java.net.CookieHandler;
+import java.net.ProtocolException;
 import libcore.io.Streams;
 import libcore.util.Libcore;
 
@@ -217,7 +218,7 @@ final class HttpTransport implements Transport {
             checkNotClosed();
             Libcore.checkOffsetAndCount(buffer.length, offset, count);
             if (count > bytesRemaining) {
-                throw new IOException("expected " + bytesRemaining
+                throw new ProtocolException("expected " + bytesRemaining
                         + " bytes but received " + count);
             }
             socketOut.write(buffer, offset, count);
@@ -237,7 +238,7 @@ final class HttpTransport implements Transport {
             }
             closed = true;
             if (bytesRemaining > 0) {
-                throw new IOException("unexpected end of stream");
+                throw new ProtocolException("unexpected end of stream");
             }
         }
     }
@@ -376,7 +377,7 @@ final class HttpTransport implements Transport {
             int read = in.read(buffer, offset, Math.min(count, bytesRemaining));
             if (read == -1) {
                 unexpectedEndOfInput(); // the server didn't supply the promised content length
-                throw new IOException("unexpected end of stream");
+                throw new ProtocolException("unexpected end of stream");
             }
             bytesRemaining -= read;
             cacheWrite(buffer, offset, read);
@@ -466,7 +467,7 @@ final class HttpTransport implements Transport {
             try {
                 bytesRemainingInChunk = Integer.parseInt(chunkSizeString.trim(), 16);
             } catch (NumberFormatException e) {
-                throw new IOException("Expected a hex chunk size, but was " + chunkSizeString);
+                throw new ProtocolException("Expected a hex chunk size but was " + chunkSizeString);
             }
             if (bytesRemainingInChunk == 0) {
                 hasMoreChunks = false;

--- a/src/main/java/libcore/net/http/RawHeaders.java
+++ b/src/main/java/libcore/net/http/RawHeaders.java
@@ -20,6 +20,7 @@ package libcore.net.http;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.ProtocolException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -101,17 +102,17 @@ public final class RawHeaders {
         if (!statusLine.startsWith("HTTP/1.")
                 || statusLine.charAt(8) != ' '
                 || statusLine.charAt(12) != ' ') {
-            throw new IOException("Unexpected status line: " + statusLine);
+            throw new ProtocolException("Unexpected status line: " + statusLine);
         }
         int httpMinorVersion = statusLine.charAt(7) - '0';
         if (httpMinorVersion < 0 || httpMinorVersion > 9) {
-            throw new IOException("Unexpected status line: " + statusLine);
+            throw new ProtocolException("Unexpected status line: " + statusLine);
         }
         int responseCode;
         try {
             responseCode = Integer.parseInt(statusLine.substring(9, 12));
         } catch (NumberFormatException e) {
-            throw new IOException("Unexpected status line: " + statusLine);
+            throw new ProtocolException("Unexpected status line: " + statusLine);
         }
         this.responseMessage = statusLine.substring(13);
         this.responseCode = responseCode;
@@ -131,7 +132,7 @@ public final class RawHeaders {
             }
         }
         if (status == null || version == null) {
-            throw new IOException("Expected 'status' and 'version' headers not present");
+            throw new ProtocolException("Expected 'status' and 'version' headers not present");
         }
         setStatusLine(version + " " + status);
     }

--- a/src/main/java/libcore/net/http/RetryableOutputStream.java
+++ b/src/main/java/libcore/net/http/RetryableOutputStream.java
@@ -19,6 +19,7 @@ package libcore.net.http;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.ProtocolException;
 import libcore.util.Libcore;
 
 /**
@@ -40,13 +41,13 @@ final class RetryableOutputStream extends AbstractHttpOutputStream {
         this.content = new ByteArrayOutputStream();
     }
 
-    @Override public synchronized void close() {
+    @Override public synchronized void close() throws IOException {
         if (closed) {
             return;
         }
         closed = true;
         if (content.size() < limit) {
-            throw new IllegalStateException("content-length promised "
+            throw new ProtocolException("content-length promised "
                     + limit + " bytes, but received " + content.size());
         }
     }
@@ -56,12 +57,12 @@ final class RetryableOutputStream extends AbstractHttpOutputStream {
         checkNotClosed();
         Libcore.checkOffsetAndCount(buffer.length, offset, count);
         if (limit != -1 && content.size() > limit - count) {
-            throw new IOException("exceeded content-length limit of " + limit + " bytes");
+            throw new ProtocolException("exceeded content-length limit of " + limit + " bytes");
         }
         content.write(buffer, offset, count);
     }
 
-    public synchronized int contentLength() {
+    public synchronized int contentLength() throws IOException {
         close();
         return content.size();
     }

--- a/src/main/java/libcore/net/http/RouteSelector.java
+++ b/src/main/java/libcore/net/http/RouteSelector.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package libcore.net.http;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import libcore.net.Dns;
+import static libcore.net.http.HttpConnection.TLS_MODE_AGGRESSIVE;
+import static libcore.net.http.HttpConnection.TLS_MODE_COMPATIBLE;
+import static libcore.net.http.HttpConnection.TLS_MODE_NULL;
+import libcore.util.Libcore;
+
+/**
+ * Selects routes to connect to an origin server. Each connection requires a
+ * choice of proxy server, IP address, and TLS mode. Connections may also be
+ * recycled.
+ */
+public final class RouteSelector {
+    private final HttpConnection.Address address;
+    private final URI uri;
+    private final ProxySelector proxySelector;
+    private final Dns dns;
+
+    /* The most recently attempted route. */
+    private Proxy lastProxy;
+    private InetSocketAddress lastInetSocketAddress;
+
+    /* State for negotiating the next proxy to use. */
+    private boolean hasNextProxy;
+    private Proxy userSpecifiedProxy;
+    private Iterator<Proxy> proxySelectorProxies;
+
+    /* State for negotiating the next InetSocketAddress to use. */
+    private InetAddress[] socketAddresses;
+    private int nextSocketAddressIndex;
+    private String socketHost;
+    private int socketPort;
+
+    /* State for negotiating the next TLS configuration */
+    private int nextTlsMode = TLS_MODE_NULL;
+
+    public RouteSelector(HttpConnection.Address address, URI uri, ProxySelector proxySelector, Dns dns) {
+        this.address = address;
+        this.uri = uri;
+        this.proxySelector = proxySelector;
+        this.dns = dns;
+
+        resetNextProxy(uri, address.proxy);
+    }
+
+    /**
+     * Returns true if there's another route to attempt. Every address has at
+     * least one route.
+     */
+    public boolean hasNext() {
+        return hasNextTlsMode() || hasNextInetSocketAddress() || hasNextProxy();
+    }
+
+    /**
+     * Returns the next route address to attempt.
+     *
+     * @throws NoSuchElementException if there are no more routes to attempt.
+     */
+    public HttpConnection next() throws IOException {
+        // Always prefer pooled connections over new connections.
+        HttpConnection pooled = HttpConnectionPool.INSTANCE.get(address);
+        if (pooled != null) {
+            return pooled;
+        }
+
+        // Compute the next route to attempt.
+        if (!hasNextTlsMode()) {
+            if (!hasNextInetSocketAddress()) {
+                if (!hasNextProxy()) {
+                    throw new NoSuchElementException();
+                }
+                lastProxy = nextProxy();
+                resetNextInetSocketAddress(lastProxy);
+            }
+            lastInetSocketAddress = nextInetSocketAddress();
+            resetNextTlsMode();
+        }
+        int tlsMode = nextTlsMode();
+
+        return new HttpConnection(address, lastProxy, lastInetSocketAddress, tlsMode);
+    }
+
+    /**
+     * Clients should invoke this method when they encounter a connectivity
+     * failure on a connection returned by this route selector.
+     */
+    public void connectFailed(HttpConnection connection, IOException failure) {
+        if (connection.proxy.type() != Proxy.Type.DIRECT && proxySelector != null) {
+            // Tell the proxy selector when we fail to connect on a fresh connection.
+            proxySelector.connectFailed(uri, connection.proxy.address(), failure);
+        }
+    }
+
+    /** Resets {@link #nextProxy} to the first option. */
+    private void resetNextProxy(URI uri, Proxy proxy) {
+        this.hasNextProxy = true; // This includes NO_PROXY!
+        if (proxy != null) {
+            this.userSpecifiedProxy = proxy;
+        } else {
+            List<Proxy> proxyList = proxySelector.select(uri);
+            if (proxyList != null) {
+                this.proxySelectorProxies = proxyList.iterator();
+            }
+        }
+    }
+
+    /** Returns true if there's another proxy to try. */
+    private boolean hasNextProxy() {
+        return hasNextProxy;
+    }
+
+    /** Returns the next proxy to try. May be PROXY.NO_PROXY but never null. */
+    private Proxy nextProxy() {
+        // If the user specifies a proxy, try that and only that.
+        if (userSpecifiedProxy != null) {
+            hasNextProxy = false;
+            return userSpecifiedProxy;
+        }
+
+        // Try each of the ProxySelector choices until one connection succeeds. If none succeed
+        // then we'll try a direct connection below.
+        if (proxySelectorProxies != null) {
+            while (proxySelectorProxies.hasNext()) {
+                Proxy candidate = proxySelectorProxies.next();
+                if (candidate.type() != Proxy.Type.DIRECT) {
+                    return candidate;
+                }
+            }
+        }
+
+        // Finally try a direct connection.
+        hasNextProxy = false;
+        return Proxy.NO_PROXY;
+    }
+
+    /** Resets {@link #nextInetSocketAddress} to the first option. */
+    private void resetNextInetSocketAddress(Proxy proxy) throws UnknownHostException {
+        socketAddresses = null; // Clear the addresses. Necessary if getAllByName() below throws!
+
+        if (proxy.type() == Proxy.Type.DIRECT) {
+            socketHost = uri.getHost();
+            socketPort = Libcore.getEffectivePort(uri);
+        } else {
+            SocketAddress proxyAddress = proxy.address();
+            if (!(proxyAddress instanceof InetSocketAddress)) {
+                throw new IllegalArgumentException("Proxy.address() is not an "
+                        + "InetSocketAddress: " + proxyAddress.getClass());
+            }
+            InetSocketAddress proxySocketAddress = (InetSocketAddress) proxyAddress;
+            socketHost = proxySocketAddress.getHostName();
+            socketPort = proxySocketAddress.getPort();
+        }
+
+        // Try each address for best behavior in mixed IPv4/IPv6 environments.
+        socketAddresses = dns.getAllByName(socketHost);
+        nextSocketAddressIndex = 0;
+    }
+
+    /** Returns true if there's another socket address to try. */
+    private boolean hasNextInetSocketAddress() {
+        return socketAddresses != null;
+    }
+
+    /** Returns the next socket address to try. */
+    private InetSocketAddress nextInetSocketAddress() throws UnknownHostException {
+        InetSocketAddress result = new InetSocketAddress(
+                socketAddresses[nextSocketAddressIndex++], socketPort);
+        if (nextSocketAddressIndex == socketAddresses.length) {
+            socketAddresses = null; // So that hasNextInetSocketAddress() returns false.
+            nextSocketAddressIndex = 0;
+        }
+
+        return result;
+    }
+
+    /** Resets {@link #nextTlsMode} to the first option. */
+    private void resetNextTlsMode() {
+        nextTlsMode = (address.sslSocketFactory != null)
+                ? TLS_MODE_AGGRESSIVE
+                : TLS_MODE_COMPATIBLE;
+    }
+
+    /** Returns true if there's another TLS mode to try. */
+    private boolean hasNextTlsMode() {
+        return nextTlsMode != TLS_MODE_NULL;
+    }
+
+    /** Returns the next TLS mode to try. */
+    private int nextTlsMode() {
+        if (nextTlsMode == TLS_MODE_AGGRESSIVE) {
+            nextTlsMode = TLS_MODE_COMPATIBLE;
+            return TLS_MODE_AGGRESSIVE;
+        } else if (nextTlsMode == TLS_MODE_COMPATIBLE) {
+            nextTlsMode = TLS_MODE_NULL;  // So that hasNextTlsMode() returns false.
+            return TLS_MODE_COMPATIBLE;
+        } else {
+            throw new AssertionError();
+        }
+    }
+}

--- a/src/test/java/libcore/net/http/RouteSelectorTest.java
+++ b/src/test/java/libcore/net/http/RouteSelectorTest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package libcore.net.http;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import static java.net.Proxy.NO_PROXY;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import junit.framework.TestCase;
+import libcore.net.Dns;
+import static libcore.net.http.HttpConnection.TLS_MODE_AGGRESSIVE;
+import static libcore.net.http.HttpConnection.TLS_MODE_COMPATIBLE;
+import libcore.net.ssl.SslContextBuilder;
+
+public final class RouteSelectorTest extends TestCase {
+    private static final int proxyAPort = 1001;
+    private static final String proxyAHost = "proxyA";
+    private static final Proxy proxyA
+            = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyAHost, proxyAPort));
+    private static final int proxyBPort = 1002;
+    private static final String proxyBHost = "proxyB";
+    private static final Proxy proxyB
+            = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyBHost, proxyBPort));
+    private static final URI uri;
+    private static final String uriHost = "hostA";
+    private static final int uriPort = 80;
+
+    private static final SSLContext sslContext;
+    private static final SSLSocketFactory socketFactory;
+    private static final HostnameVerifier hostnameVerifier;
+    static {
+        try {
+            uri = new URI("http://" + uriHost + ":" + uriPort + "/path");
+            sslContext = new SslContextBuilder(InetAddress.getLocalHost().getHostName()).build();
+            socketFactory = sslContext.getSocketFactory();
+            hostnameVerifier = HttpsURLConnectionImpl.getDefaultHostnameVerifier();
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private final FakeDns dns = new FakeDns();
+    private final FakeProxySelector proxySelector = new FakeProxySelector();
+
+    public void testSingleRoute() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(uri, null, null, null);
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 1);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(uriHost);
+
+        assertFalse(routeSelector.hasNext());
+        try {
+            routeSelector.next();
+            fail();
+        } catch (NoSuchElementException expected) {
+        }
+    }
+
+    public void testExplicitProxyTriesThatProxiesAddressesOnly() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(uri, null, null, proxyA);
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 2);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[0], proxyAPort, TLS_MODE_COMPATIBLE);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[1], proxyAPort, TLS_MODE_COMPATIBLE);
+
+        assertFalse(routeSelector.hasNext());
+        dns.assertRequests(proxyAHost);
+        proxySelector.assertRequests(); // No proxy selector requests!
+    }
+
+    public void testExplicitDirectProxy() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(uri, null, null, NO_PROXY);
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 2);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_COMPATIBLE);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[1], uriPort, TLS_MODE_COMPATIBLE);
+
+        assertFalse(routeSelector.hasNext());
+        dns.assertRequests(uri.getHost());
+        proxySelector.assertRequests(); // No proxy selector requests!
+    }
+
+    public void testProxySelectorReturnsNull() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(uri, null, null, null);
+
+        proxySelector.proxies = null;
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+        proxySelector.assertRequests(uri);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 1);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(uriHost);
+
+        assertFalse(routeSelector.hasNext());
+    }
+
+    public void testProxySelectorReturnsNoProxies() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(uri, null, null, null);
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 2);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_COMPATIBLE);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[1], uriPort, TLS_MODE_COMPATIBLE);
+
+        assertFalse(routeSelector.hasNext());
+        dns.assertRequests(uri.getHost());
+        proxySelector.assertRequests(uri);
+    }
+
+    public void testProxySelectorReturnsMultipleProxies() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(uri, null, null, null);
+
+        proxySelector.proxies.add(proxyA);
+        proxySelector.proxies.add(proxyB);
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+        proxySelector.assertRequests(uri);
+
+        // First try the IP addresses of the first proxy, in sequence.
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 2);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[0], proxyAPort, TLS_MODE_COMPATIBLE);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[1], proxyAPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(proxyAHost);
+
+        // Next try the IP address of the second proxy.
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(254, 1);
+        assertConnection(routeSelector.next(),
+                address, proxyB, dns.inetAddresses[0], proxyBPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(proxyBHost);
+
+        // Finally try the only IP address of the origin server.
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(253, 1);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(uriHost);
+
+        assertFalse(routeSelector.hasNext());
+    }
+
+    public void testProxySelectorDirectConnectionsAreSkipped() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(uri, null, null, null);
+
+        proxySelector.proxies.add(NO_PROXY);
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+        proxySelector.assertRequests(uri);
+
+        // Only the origin server will be attempted.
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 1);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(uriHost);
+
+        assertFalse(routeSelector.hasNext());
+    }
+
+    public void testProxyDnsFailureContinuesToNextProxy() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(uri, null, null, null);
+
+        proxySelector.proxies.add(proxyA);
+        proxySelector.proxies.add(proxyB);
+        proxySelector.proxies.add(proxyA);
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+        proxySelector.assertRequests(uri);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 1);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[0], proxyAPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(proxyAHost);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = null;
+        try {
+            routeSelector.next();
+            fail();
+        } catch (UnknownHostException expected) {
+        }
+        dns.assertRequests(proxyBHost);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 1);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[0], proxyAPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(proxyAHost);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(254, 1);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(uriHost);
+
+        assertFalse(routeSelector.hasNext());
+    }
+
+    public void testMultipleTlsModes() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(
+                uri, socketFactory, hostnameVerifier, Proxy.NO_PROXY);
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+
+        assertTrue(routeSelector.hasNext());
+        dns.inetAddresses = makeFakeAddresses(255, 1);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_AGGRESSIVE);
+        dns.assertRequests(uriHost);
+
+        assertTrue(routeSelector.hasNext());
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_COMPATIBLE);
+        dns.assertRequests(); // No more DNS requests since the previous!
+
+        assertFalse(routeSelector.hasNext());
+    }
+
+    public void testMultipleProxiesMultipleInetAddressesMultipleTlsModes() throws Exception {
+        HttpConnection.Address address = new HttpConnection.Address(
+                uri, socketFactory, hostnameVerifier, null);
+        proxySelector.proxies.add(proxyA);
+        proxySelector.proxies.add(proxyB);
+        RouteSelector routeSelector = new RouteSelector(address, uri, proxySelector, dns);
+
+        // Proxy A
+        dns.inetAddresses = makeFakeAddresses(255, 2);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[0], proxyAPort, TLS_MODE_AGGRESSIVE);
+        dns.assertRequests(proxyAHost);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[0], proxyAPort, TLS_MODE_COMPATIBLE);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[1], proxyAPort, TLS_MODE_AGGRESSIVE);
+        assertConnection(routeSelector.next(),
+                address, proxyA, dns.inetAddresses[1], proxyAPort, TLS_MODE_COMPATIBLE);
+
+        // Proxy B
+        dns.inetAddresses = makeFakeAddresses(254, 2);
+        assertConnection(routeSelector.next(),
+                address, proxyB, dns.inetAddresses[0], proxyBPort, TLS_MODE_AGGRESSIVE);
+        dns.assertRequests(proxyBHost);
+        assertConnection(routeSelector.next(),
+                address, proxyB, dns.inetAddresses[0], proxyBPort, TLS_MODE_COMPATIBLE);
+        assertConnection(routeSelector.next(),
+                address, proxyB, dns.inetAddresses[1], proxyBPort, TLS_MODE_AGGRESSIVE);
+        assertConnection(routeSelector.next(),
+                address, proxyB, dns.inetAddresses[1], proxyBPort, TLS_MODE_COMPATIBLE);
+
+        // Origin
+        dns.inetAddresses = makeFakeAddresses(253, 2);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_AGGRESSIVE);
+        dns.assertRequests(uriHost);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[0], uriPort, TLS_MODE_COMPATIBLE);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[1], uriPort, TLS_MODE_AGGRESSIVE);
+        assertConnection(routeSelector.next(),
+                address, NO_PROXY, dns.inetAddresses[1], uriPort, TLS_MODE_COMPATIBLE);
+
+        assertFalse(routeSelector.hasNext());
+    }
+
+    private void assertConnection(HttpConnection connection, HttpConnection.Address address,
+            Proxy proxy, InetAddress socketAddress, int socketPort, int tlsMode) {
+        assertEquals(address, connection.address);
+        assertEquals(proxy, connection.proxy);
+        assertEquals(socketAddress, connection.inetSocketAddress.getAddress());
+        assertEquals(socketPort, connection.inetSocketAddress.getPort());
+        assertEquals(tlsMode, connection.tlsMode);
+    }
+
+    private static InetAddress[] makeFakeAddresses(int prefix, int count) {
+        try {
+            InetAddress[] result = new InetAddress[count];
+            for (int i = 0; i < count; i++) {
+                result[i] = InetAddress.getByAddress(
+                        new byte[] { (byte) prefix, (byte) 0, (byte) 0, (byte) i });
+            }
+            return result;
+        } catch (UnknownHostException e) {
+            throw new AssertionError();
+        }
+    }
+
+    private static class FakeDns implements Dns {
+        List<String> requestedHosts = new ArrayList<String>();
+        InetAddress[] inetAddresses;
+
+        @Override public InetAddress[] getAllByName(String host) throws UnknownHostException {
+            requestedHosts.add(host);
+            if (inetAddresses == null) throw new UnknownHostException();
+            return inetAddresses;
+        }
+
+        public void assertRequests(String... expectedHosts) {
+            assertEquals(Arrays.asList(expectedHosts), requestedHosts);
+            requestedHosts.clear();
+        }
+    }
+
+    private static class FakeProxySelector extends ProxySelector {
+        List<URI> requestedUris = new ArrayList<URI>();
+        List<Proxy> proxies = new ArrayList<Proxy>();
+        List<String> failures = new ArrayList<String>();
+
+        @Override public List<Proxy> select(URI uri) {
+            requestedUris.add(uri);
+            return proxies;
+        }
+
+        public void assertRequests(URI... expectedUris) {
+            assertEquals(Arrays.asList(expectedUris), requestedUris);
+            requestedUris.clear();
+        }
+
+        @Override public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+            InetSocketAddress socketAddress = (InetSocketAddress) sa;
+            failures.add(String.format("%s %s:%d %s", uri, socketAddress.getHostName(),
+                    socketAddress.getPort(), ioe.getMessage()));
+        }
+    }
+}


### PR DESCRIPTION
If the ProxySelector reports multiple proxies for a URL, we'll try them each in sequence.
If DNS reports multiple addresses for a single host, we'll try them each in sequence.
And we always try two modes for HTTPS, aggressive and compatible.

The net result is that we Try Very Hard to connect.
I need a follow up change so that the request body is retransmitted if necessary.
