### PR TITLE
Don't drop out of connect if the first request fails.

### DIFF
--- a/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
+++ b/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
@@ -80,7 +80,10 @@ public class HttpURLConnectionImpl extends OkHttpConnection {
 
     @Override public final void connect() throws IOException {
         initHttpEngine();
-        execute(false);
+        boolean success;
+        do {
+            success = execute(false);
+        } while (!success);
     }
 
     @Override public final void disconnect() {


### PR DESCRIPTION
This fixes a break caused by the recent try-harder-on-IP-addresses
change, where if the first connect failed we returned rather than
trying until we reached a connection or an error.
