### PR TITLE
Don't explode if DNS fails or if the address is malformed.

### DIFF
--- a/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
+++ b/src/main/java/libcore/net/http/HttpURLConnectionImpl.java
@@ -338,7 +338,11 @@ public class HttpURLConnectionImpl extends OkHttpConnection {
             return true;
         } catch (IOException e) {
             RouteSelector routeSelector = httpEngine.routeSelector;
-            routeSelector.connectFailed(httpEngine.connection, e);
+            if (routeSelector == null) {
+                throw e; // Without a route selector, we can't retry.
+            } else if (httpEngine.connection != null) {
+                routeSelector.connectFailed(httpEngine.connection, e);
+            }
 
             // The connection failure isn't fatal if there's another route to attempt.
             OutputStream requestBody = httpEngine.getRequestBody();

--- a/src/test/java/libcore/net/http/URLConnectionTest.java
+++ b/src/test/java/libcore/net/http/URLConnectionTest.java
@@ -133,8 +133,6 @@ public final class URLConnectionTest extends TestCase {
 
     // TODO: test that request bodies are retransmitted on IP address failures
     // TODO: pooled proxy failures are not reported to the proxy selector
-    // TODO: a URI with no host should fail in Address creation.
-    // TODO: make HttpURLConnection.connect() include a loop around execute
 
     public void testRequestHeaders() throws IOException, InterruptedException {
         server.enqueue(new MockResponse());
@@ -1933,6 +1931,24 @@ public final class URLConnectionTest extends TestCase {
             connection.getInputStream();
             fail();
         } catch (IOException expected) {
+        }
+    }
+
+    public void testDnsFailureThrowsIOException() throws IOException {
+        OkHttpConnection connection = openConnection(new URL("http://host.unlikelytld"));
+        try {
+            connection.connect();
+            fail();
+        } catch (IOException expected) {
+        }
+    }
+
+    public void testMalformedUrlThrowsUnknownHostException() throws IOException {
+        OkHttpConnection connection = openConnection(new URL("http:///foo.html"));
+        try {
+            connection.connect();
+            fail();
+        } catch (UnknownHostException expected) {
         }
     }
 


### PR DESCRIPTION
We had a bug where we were trying to report a proxy problem
before the connection was even created.
