### PR TITLE
Improve connection reuse.

### DIFF
--- a/src/test/java/libcore/net/http/HttpResponseCacheTest.java
+++ b/src/test/java/libcore/net/http/HttpResponseCacheTest.java
@@ -506,7 +506,8 @@ public final class HttpResponseCacheTest extends TestCase {
     }
 
     private void testClientPrematureDisconnect(TransferKind transferKind) throws IOException {
-        MockResponse response = new MockResponse();
+        // Setting a low transfer speed ensures that stream discarding will time out.
+        MockResponse response = new MockResponse().setBytesPerSecond(6);
         transferKind.setBody(response, "ABCDE\nFGHIJKLMNOPQRSTUVWXYZ", 1024);
         server.enqueue(response);
         server.enqueue(new MockResponse().setBody("Request #2"));


### PR DESCRIPTION
Instead of trying to read the last bytes of a content body
when the input stream is read, do it when the connection is
closed. This approach is less elegant, since it requires
a connection to do work on behalf of a potentially nonexistent
follow up connection. But it should result in more reuse in
practice.

http://code.google.com/p/android/issues/detail?id=38817
