### PR TITLE
Clean up commented out URLConnection tests.

### DIFF
--- a/src/test/java/com/squareup/okhttp/internal/net/ssl/SslContextBuilder.java
+++ b/src/test/java/com/squareup/okhttp/internal/net/ssl/SslContextBuilder.java
@@ -103,7 +103,7 @@ public final class SslContextBuilder {
         X509V3CertificateGenerator generator = new X509V3CertificateGenerator();
         X500Principal issuer = new X500Principal("CN=" + hostName);
         X500Principal subject = new X500Principal("CN=" + hostName);
-        generator.setSerialNumber(BigInteger.valueOf(System.currentTimeMillis()));
+        generator.setSerialNumber(BigInteger.ONE);
         generator.setIssuerDN(issuer);
         generator.setNotBefore(new Date(notBefore));
         generator.setNotAfter(new Date(notAfter));


### PR DESCRIPTION
There were some tests that only work on Dalvik/Linux: the CloseGuard
test and the timeout test rely on Linux-specific behavior that's too
flaky for a general test.

The TrustManager test just needed some attention and simplification to
work on both the JDK and Dalvik TLS stacks.
