### PR TITLE
Restore tests for response caching + TLS.

### DIFF
--- a/src/main/java/com/squareup/okhttp/internal/net/http/HttpConnectionPool.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/http/HttpConnectionPool.java
@@ -18,7 +18,6 @@
 package com.squareup.okhttp.internal.net.http;
 
 import com.squareup.okhttp.internal.util.Libcore;
-import java.net.Socket;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -73,8 +72,7 @@ final class HttpConnectionPool {
                 }
                 if (connection.isEligibleForRecycling()) {
                     // Since Socket is recycled, re-tag before using
-                    Socket socket = connection.getSocket();
-                    Libcore.tagSocket(socket);
+                    Libcore.tagSocket(connection.getSocket());
                     return connection;
                 }
             }
@@ -91,9 +89,8 @@ final class HttpConnectionPool {
             throw new IllegalArgumentException(); // TODO: just 'return' here?
         }
 
-        Socket socket = connection.getSocket();
         try {
-            Libcore.untagSocket(socket);
+            Libcore.untagSocket(connection.getSocket());
         } catch (SocketException e) {
             // When unable to remove tagging, skip recycling and close
             Libcore.logW("Unable to untagSocket(): " + e);

--- a/src/main/java/com/squareup/okhttp/internal/net/http/HttpEngine.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/http/HttpEngine.java
@@ -287,12 +287,20 @@ public class HttpEngine {
             connection.connect(policy.getConnectTimeout(), policy.getReadTimeout(),
                     getTunnelConfig());
         }
+        connected(connection);
         Proxy proxy = connection.getProxy();
         if (proxy != null) {
             policy.setProxy(proxy);
             // Add the authority to the request line when we're using a proxy.
             requestHeaders.getHeaders().setRequestLine(getRequestLine());
         }
+    }
+
+    /**
+     * Called after a socket connection has been created or retrieved from the
+     * pool. Subclasses use this hook to get a reference to the TLS data.
+     */
+    protected void connected(HttpConnection connection) {
     }
 
     /**

--- a/src/main/java/com/squareup/okhttp/internal/net/http/HttpsURLConnectionImpl.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/http/HttpsURLConnectionImpl.java
@@ -395,14 +395,9 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
     }
 
     private static final class HttpsEngine extends HttpEngine {
-
         /**
-         * Local stash of HttpsEngine.connection.sslSocket for answering
-         * queries such as getCipherSuite even after
-         * httpsEngine.Connection has been recycled. It's presence is also
-         * used to tell if the HttpsURLConnection is considered connected,
-         * as opposed to the connected field of URLConnection or the a
-         * non-null connect in HttpURLConnectionImpl
+         * Stash of HttpsEngine.connection.socket to implement requests like
+         * {@link #getCipherSuite} even after the connection has been recycled.
          */
         private SSLSocket sslSocket;
 
@@ -418,6 +413,10 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
             super(policy, method, requestHeaders, connection, requestBody);
             this.sslSocket = connection != null ? (SSLSocket) connection.getSocket() : null;
             this.enclosing = enclosing;
+        }
+
+        @Override protected void connected(HttpConnection connection) {
+            this.sslSocket = (SSLSocket) connection.getSocket();
         }
 
         @Override protected boolean acceptCacheResponseType(CacheResponse cacheResponse) {


### PR DESCRIPTION
One of the test cases bitrotted to failure as a consequence
of the HTTP route selector change. I stopped assigning the
socket, which it needed to cache the TLS metadata. This is
fixed.
