### PR TITLE
Fix synchronization todos in SpdyStream.

### DIFF
--- a/src/main/java/com/squareup/okhttp/internal/net/spdy/IncomingStreamHandler.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/spdy/IncomingStreamHandler.java
@@ -30,9 +30,9 @@ public interface IncomingStreamHandler {
 
     /**
      * Handle a new stream from this connection's peer. Implementations should
-     * respond by either {@link SpdyStream#reply(java.util.List) replying to the
-     * stream} or {@link SpdyStream#close(int) closing it}. This response does
-     * not need to be synchronous.
+     * respond by either {@link SpdyStream#reply replying to the stream} or
+     * {@link SpdyStream#close closing it}. This response does not need to be
+     * synchronous.
      */
     void receive(SpdyStream stream) throws IOException;
 }

--- a/src/main/java/com/squareup/okhttp/internal/net/spdy/SpdyConnection.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/spdy/SpdyConnection.java
@@ -156,9 +156,7 @@ public final class SpdyConnection implements Closeable {
     }
 
     void writeSynReply(int streamId, int flags, List<String> alternating) throws IOException {
-        synchronized (spdyWriter) {
-            spdyWriter.synReply(flags, streamId, alternating);
-        }
+        spdyWriter.synReply(flags, streamId, alternating);
     }
 
     /** Writes a complete data frame. */
@@ -180,9 +178,7 @@ public final class SpdyConnection implements Closeable {
     }
 
     void writeSynReset(int streamId, int statusCode) throws IOException {
-        synchronized (spdyWriter) {
-            spdyWriter.synReset(streamId, statusCode);
-        }
+        spdyWriter.synReset(streamId, statusCode);
     }
 
     /**
@@ -229,9 +225,7 @@ public final class SpdyConnection implements Closeable {
      * Sends a noop frame to the peer.
      */
     public void noop() throws IOException {
-        synchronized (spdyWriter) {
-            spdyWriter.noop();
-        }
+        spdyWriter.noop();
     }
 
     public void flush() throws IOException {

--- a/src/main/java/com/squareup/okhttp/internal/net/spdy/SpdyWriter.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/spdy/SpdyWriter.java
@@ -42,8 +42,8 @@ final class SpdyWriter {
                 Platform.get().newDeflaterOutputStream(nameValueBlockBuffer, deflater, true));
     }
 
-    public void synStream(int flags, int streamId, int associatedStreamId, int priority,
-            List<String> nameValueBlock) throws IOException {
+    public synchronized void synStream(int flags, int streamId, int associatedStreamId,
+            int priority, List<String> nameValueBlock) throws IOException {
         writeNameValueBlockToBuffer(nameValueBlock);
         int length = 10 + nameValueBlockBuffer.size();
         int type = SpdyConnection.TYPE_SYN_STREAM;
@@ -58,7 +58,8 @@ final class SpdyWriter {
         out.flush();
     }
 
-    public void synReply(int flags, int streamId, List<String> nameValueBlock) throws IOException {
+    public synchronized void synReply(
+            int flags, int streamId, List<String> nameValueBlock) throws IOException {
         writeNameValueBlockToBuffer(nameValueBlock);
         int type = SpdyConnection.TYPE_SYN_REPLY;
         int length = nameValueBlockBuffer.size() + 6;
@@ -72,7 +73,7 @@ final class SpdyWriter {
         out.flush();
     }
 
-    public void synReset(int streamId, int statusCode) throws IOException {
+    public synchronized void synReset(int streamId, int statusCode) throws IOException {
         int flags = 0;
         int type = SpdyConnection.TYPE_RST_STREAM;
         int length = 8;
@@ -83,7 +84,7 @@ final class SpdyWriter {
         out.flush();
     }
 
-    public void data(int flags, int streamId, byte[] data) throws IOException {
+    public synchronized void data(int flags, int streamId, byte[] data) throws IOException {
         int length = data.length;
         out.writeInt(streamId & 0x7fffffff);
         out.writeInt((flags & 0xff) << 24 | length & 0xffffff);
@@ -102,7 +103,7 @@ final class SpdyWriter {
         nameValueBlockOut.flush();
     }
 
-    public void settings(int flags, Settings settings) throws IOException {
+    public synchronized void settings(int flags, Settings settings) throws IOException {
         int type = SpdyConnection.TYPE_SETTINGS;
         int size = settings.size();
         int length = 4 + size * 8;
@@ -122,7 +123,7 @@ final class SpdyWriter {
         out.flush();
     }
 
-    public void noop() throws IOException {
+    public synchronized void noop() throws IOException {
         int type = SpdyConnection.TYPE_NOOP;
         int length = 0;
         int flags = 0;
@@ -131,7 +132,7 @@ final class SpdyWriter {
         out.flush();
     }
 
-    public void ping(int flags, int id) throws IOException {
+    public synchronized void ping(int flags, int id) throws IOException {
         int type = SpdyConnection.TYPE_PING;
         int length = 4;
         out.writeInt(0x80000000 | (SpdyConnection.VERSION & 0x7fff) << 16 | type & 0xffff);


### PR DESCRIPTION
This code had bugs where ongoing reads could prevent
writes from occurring. This update adds some asserts
to prevent synchronization errors.
