### PR TITLE
Implement GOAWAY, for clean shutdowns of SPDY connections.

### DIFF
--- a/src/main/java/com/squareup/okhttp/ConnectionPool.java
+++ b/src/main/java/com/squareup/okhttp/ConnectionPool.java
@@ -113,7 +113,7 @@ public final class ConnectionPool {
      */
     public void recycle(Connection connection) {
         if (connection.isSpdy()) {
-            throw new IllegalArgumentException(); // TODO: just 'return' here?
+            return;
         }
 
         try {

--- a/src/main/java/com/squareup/okhttp/internal/net/http/HttpEngine.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/http/HttpEngine.java
@@ -503,7 +503,6 @@ public class HttpEngine {
             requestHeaders.setHost(getOriginAddress(policy.getURL()));
         }
 
-        // TODO: this shouldn't be set for SPDY (it's ignored)
         if ((connection == null || connection.getHttpMinorVersion() != 0)
                 && requestHeaders.getConnection() == null) {
             requestHeaders.setConnection("Keep-Alive");
@@ -511,7 +510,6 @@ public class HttpEngine {
 
         if (requestHeaders.getAcceptEncoding() == null) {
             transparentGzip = true;
-            // TODO: this shouldn't be set for SPDY (it isn't necessary)
             requestHeaders.setAcceptEncoding("gzip");
         }
 

--- a/src/main/java/com/squareup/okhttp/internal/net/http/RawHeaders.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/http/RawHeaders.java
@@ -393,6 +393,11 @@ public final class RawHeaders {
                 throw new IllegalArgumentException("Unexpected header: " + name + ": " + value);
             }
 
+            // Drop headers that are ignored when layering HTTP over SPDY.
+            if (name.equals("connection") || name.equals("accept-encoding")) {
+                continue;
+            }
+
             // If we haven't seen this name before, add the pair to the end of the list...
             if (names.add(name)) {
                 result.add(name);

--- a/src/main/java/com/squareup/okhttp/internal/net/spdy/SpdyReader.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/spdy/SpdyReader.java
@@ -113,6 +113,9 @@ final class SpdyReader {
                 return true;
 
             case SpdyConnection.TYPE_GOAWAY:
+                readGoAway(handler, flags, length);
+                return true;
+
             case SpdyConnection.TYPE_HEADERS:
                 Streams.skipByReading(in, length);
                 throw new UnsupportedOperationException("TODO");
@@ -227,6 +230,12 @@ final class SpdyReader {
         handler.ping(flags, id);
     }
 
+    private void readGoAway(Handler handler, int flags, int length) throws IOException {
+        if (length != 4) throw ioException("TYPE_GOAWAY length: %d != 4", length);
+        int lastGoodStreamId = in.readInt() & 0x7fffffff;
+        handler.goAway(flags, lastGoodStreamId);
+    }
+
     private void readSettings(Handler handler, int flags, int length) throws IOException {
         int numberOfEntries = in.readInt();
         if (length != 4 + 8 * numberOfEntries) {
@@ -259,7 +268,7 @@ final class SpdyReader {
         void settings(int flags, Settings settings);
         void noop();
         void ping(int flags, int streamId);
-        // TODO: goaway
+        void goAway(int flags, int lastGoodStreamId);
         // TODO: headers
     }
 }

--- a/src/main/java/com/squareup/okhttp/internal/net/spdy/SpdyWriter.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/spdy/SpdyWriter.java
@@ -140,4 +140,13 @@ final class SpdyWriter {
         out.writeInt(id);
         out.flush();
     }
+
+    public synchronized void goAway(int flags, int lastGoodStreamId) throws IOException {
+        int type = SpdyConnection.TYPE_GOAWAY;
+        int length = 4;
+        out.writeInt(0x80000000 | (SpdyConnection.VERSION & 0x7fff) << 16 | type & 0xffff);
+        out.writeInt((flags & 0xff) << 24 | length & 0xffffff);
+        out.writeInt(lastGoodStreamId);
+        out.flush();
+    }
 }

--- a/src/test/java/com/squareup/okhttp/internal/net/spdy/MockSpdyPeer.java
+++ b/src/test/java/com/squareup/okhttp/internal/net/spdy/MockSpdyPeer.java
@@ -81,6 +81,7 @@ public final class MockSpdyPeer {
         Socket socket = serverSocket.accept();
         OutputStream out = socket.getOutputStream();
         InputStream in = socket.getInputStream();
+        SpdyReader reader = new SpdyReader(in);
 
         Iterator<OutFrame> outFramesIterator = outFrames.iterator();
         byte[] outBytes = bytesOut.toByteArray();
@@ -106,7 +107,6 @@ public final class MockSpdyPeer {
 
             } else {
                 // read a frame
-                SpdyReader reader = new SpdyReader(in);
                 InFrame inFrame = new InFrame(i, reader);
                 reader.nextFrame(inFrame);
                 inFrames.add(inFrame);
@@ -200,6 +200,13 @@ public final class MockSpdyPeer {
         @Override public void noop() {
             if (this.type != -1) throw new IllegalStateException();
             this.type = SpdyConnection.TYPE_NOOP;
+        }
+
+        @Override public void goAway(int flags, int lastGoodStreamId) {
+            if (this.type != -1) throw new IllegalStateException();
+            this.type = SpdyConnection.TYPE_GOAWAY;
+            this.flags = flags;
+            this.streamId = lastGoodStreamId;
         }
     }
 }


### PR DESCRIPTION
Also clean up some SPDY headers and improve error messages.
