### PR TITLE
Make timeouts work for SPDY.

### DIFF
--- a/src/main/java/com/squareup/okhttp/Connection.java
+++ b/src/main/java/com/squareup/okhttp/Connection.java
@@ -156,6 +156,7 @@ public final class Connection implements Closeable {
         if (modernTls
                 && (selectedProtocol = platform.getNpnSelectedProtocol(sslSocket)) != null) {
             if (Arrays.equals(selectedProtocol, SPDY2)) {
+                sslSocket.setSoTimeout(0); // SPDY timeouts are set per-stream.
                 spdyConnection = new SpdyConnection.Builder(true, in, out).build();
             } else if (!Arrays.equals(selectedProtocol, HTTP_11)) {
                 throw new IOException("Unexpected NPN transport "

--- a/src/main/java/com/squareup/okhttp/internal/net/http/SpdyTransport.java
+++ b/src/main/java/com/squareup/okhttp/internal/net/http/SpdyTransport.java
@@ -55,6 +55,7 @@ public final class SpdyTransport implements Transport {
         boolean hasResponseBody = true;
         stream = spdyConnection.newStream(requestHeaders.toNameValueBlock(),
                 hasRequestBody, hasResponseBody);
+        stream.setReadTimeout(httpEngine.policy.getReadTimeout());
     }
 
     @Override public void writeRequestBody(RetryableOutputStream requestBody) throws IOException {

--- a/src/test/java/com/squareup/okhttp/internal/net/spdy/MockSpdyPeer.java
+++ b/src/test/java/com/squareup/okhttp/internal/net/spdy/MockSpdyPeer.java
@@ -71,7 +71,7 @@ public final class MockSpdyPeer {
                 try {
                     readAndWriteFrames(serverSocket);
                 } catch (IOException e) {
-                    e.printStackTrace(); // TODO
+                    throw new RuntimeException(e);
                 }
             }
         });


### PR DESCRIPTION
We can't use the regular socket timeouts because the
socket is shared. Moving it to the application level
is more complicated, but it allows different streams
to set timeouts independently.
