### PR TITLE
Implement flow control for the incoming stream.

### DIFF
--- a/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
+++ b/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
@@ -16,6 +16,9 @@
 package com.squareup.okhttp.internal.spdy;
 
 final class Settings {
+    /** From the spdy/3 spec, the default initial window size for all streams is 64 KiB. */
+    static final int DEFAULT_INITIAL_WINDOW_SIZE = 64 * 1024;
+
     /** Peer request to clear durable settings. */
     static final int FLAG_CLEAR_PREVIOUSLY_PERSISTED_SETTINGS = 0x1;
 

--- a/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -205,6 +205,21 @@ public final class SpdyConnection implements Closeable {
         spdyWriter.rstStream(streamId, statusCode);
     }
 
+    void writeWindowUpdateLater(final int streamId, final int deltaWindowSize) {
+        writeExecutor.execute(new Runnable() {
+            @Override public void run() {
+                try {
+                    writeWindowUpdate(streamId, deltaWindowSize);
+                } catch (IOException ignored) {
+                }
+            }
+        });
+    }
+
+    void writeWindowUpdate(int streamId, int deltaWindowSize) throws IOException {
+        spdyWriter.windowUpdate(streamId, deltaWindowSize);
+    }
+
     /**
      * Sends a ping frame to the peer. Use the returned object to await the
      * ping's response and observe its round trip time.

--- a/src/main/java/com/squareup/okhttp/internal/spdy/SpdyReader.java
+++ b/src/main/java/com/squareup/okhttp/internal/spdy/SpdyReader.java
@@ -187,6 +187,7 @@ final class SpdyReader implements Closeable {
     }
 
     private void readWindowUpdate(Handler handler, int flags, int length) throws IOException {
+        if (length != 8) throw ioException("TYPE_WINDOW_UPDATE length: %d != 8", length);
         int w1 = in.readInt();
         int w2 = in.readInt();
         int streamId = w1 & 0x7fffffff;

--- a/src/main/java/com/squareup/okhttp/internal/spdy/SpdyWriter.java
+++ b/src/main/java/com/squareup/okhttp/internal/spdy/SpdyWriter.java
@@ -165,9 +165,15 @@ final class SpdyWriter implements Closeable {
         out.flush();
     }
 
-    public synchronized void windowUpdate(int flags, int streamId, int deltaWindowSize)
-            throws IOException {
-        throw new UnsupportedOperationException("TODO"); // TODO
+    public synchronized void windowUpdate(int streamId, int deltaWindowSize) throws IOException {
+        int type = SpdyConnection.TYPE_WINDOW_UPDATE;
+        int flags = 0;
+        int length = 8;
+        out.writeInt(0x80000000 | (SpdyConnection.VERSION & 0x7fff) << 16 | type & 0xffff);
+        out.writeInt((flags & 0xff) << 24 | length & 0xffffff);
+        out.writeInt(streamId);
+        out.writeInt(deltaWindowSize);
+        out.flush();
     }
 
     @Override public void close() throws IOException {


### PR DESCRIPTION
This sends a WINDOW_UPDATE frame whenever the total number of
unacknowledged bytes exceeds 32 KiB. This is a simple policy;
we could tune it to be more sophisticated as necessary.

This fixes downloads of streams greater than 64 KiB.
