### PR TITLE
Implement flow control for the outgoing stream.

### DIFF
--- a/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
+++ b/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
@@ -16,7 +16,10 @@
 package com.squareup.okhttp.internal.spdy;
 
 final class Settings {
-    /** From the spdy/3 spec, the default initial window size for all streams is 64 KiB. */
+    /**
+     * From the spdy/3 spec, the default initial window size for all streams is
+     * 64 KiB. (Chrome 25 uses 10 MiB).
+     */
     static final int DEFAULT_INITIAL_WINDOW_SIZE = 64 * 1024;
 
     /** Peer request to clear durable settings. */

--- a/src/main/java/com/squareup/okhttp/internal/spdy/SpdyReader.java
+++ b/src/main/java/com/squareup/okhttp/internal/spdy/SpdyReader.java
@@ -284,11 +284,8 @@ final class SpdyReader implements Closeable {
         for (int i = 0; i < numberOfEntries; i++) {
             int w1 = in.readInt();
             int value = in.readInt();
-            // The ID is a 24 bit little-endian value, so 0xabcdefxx becomes 0x00efcdab.
-            int id = ((w1 & 0xff000000) >>> 24)
-                    | ((w1 & 0xff0000) >>> 8)
-                    | ((w1 & 0xff00) << 8);
-            int idFlags = (w1 & 0xff);
+            int idFlags = (w1 & 0xff000000) >>> 24;
+            int id = w1 & 0xffffff;
             settings.set(id, idFlags, value);
         }
         handler.settings(flags, settings);

--- a/src/main/java/com/squareup/okhttp/internal/spdy/SpdyWriter.java
+++ b/src/main/java/com/squareup/okhttp/internal/spdy/SpdyWriter.java
@@ -126,11 +126,7 @@ final class SpdyWriter implements Closeable {
         for (int i = 0; i <= Settings.COUNT; i++) {
             if (!settings.isSet(i)) continue;
             int settingsFlags = settings.flags(i);
-            // settingId 0x00efcdab and settingFlags 0x12 combine to 0xabcdef12.
-            out.writeInt(((i & 0xff0000) >>> 8)
-                    | ((i & 0xff00) << 8)
-                    | ((i & 0xff) << 24)
-                    | (settingsFlags & 0xff));
+            out.writeInt((settingsFlags & 0xff) << 24 | (i & 0xffffff));
             out.writeInt(settings.get(i));
         }
         out.flush();


### PR DESCRIPTION
We had a bug where we were using spdy/2's layout for
setting frames rather than spdy/3's layout. I discovered
this when testing flow control against Chrome.

This fixes uploads greater than 64 KiB.
