### PR TITLE
Improve SPDY+HTTP integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mvn clean
 mvn package -DskipTests
 vogar \
     --classpath ~/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.47/bcprov-jdk15on-1.47.jar \
-    --classpath ~/.m2/repository/com/google/mockwebserver/mockwebserver/20120905/mockwebserver-20120905.jar \
+    --classpath ~/.m2/repository/com/google/mockwebserver/mockwebserver/20130122/mockwebserver-20130122.jar \
     --classpath target/okhttp-0.9-SNAPSHOT.jar \
     ./src/test/java
 ```

--- a/src/main/java/com/squareup/okhttp/Connection.java
+++ b/src/main/java/com/squareup/okhttp/Connection.java
@@ -84,6 +84,7 @@ public final class Connection implements Closeable {
     private InputStream in;
     private OutputStream out;
     private boolean recycled = false;
+    private boolean connected = false;
     private SpdyConnection spdyConnection;
     private int httpMinorVersion = 1; // Assume HTTP/1.1
 
@@ -100,6 +101,10 @@ public final class Connection implements Closeable {
 
     public void connect(int connectTimeout, int readTimeout, TunnelRequest tunnelRequest)
             throws IOException {
+        if (connected) {
+            throw new IllegalStateException("already connected");
+        }
+        connected = true;
         socket = (proxy.type() != Proxy.Type.HTTP)
                 ? new Socket(proxy)
                 : new Socket();
@@ -167,6 +172,13 @@ public final class Connection implements Closeable {
                         + new String(selectedProtocol, "ISO-8859-1"));
             }
         }
+    }
+
+    /**
+     * Returns true if {@link #connect} has been attempted on this connection.
+     */
+    public boolean isConnected() {
+        return connected;
     }
 
     @Override public void close() throws IOException {

--- a/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringWriter;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
 import java.nio.ByteOrder;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public final class Util {
     public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+    public static final String[] EMPTY_STRING_ARRAY = new String[0];
 
     /** A cheap and type-safe constant for the ISO-8859-1 Charset. */
     public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
@@ -102,12 +104,28 @@ public final class Util {
     }
 
     /**
-     * Closes 'closeable', ignoring any checked exceptions. Does nothing if 'closeable' is null.
+     * Closes {@code closeable}, ignoring any checked exceptions. Does nothing
+     * if {@code closeable} is null.
      */
     public static void closeQuietly(Closeable closeable) {
         if (closeable != null) {
             try {
                 closeable.close();
+            } catch (RuntimeException rethrown) {
+                throw rethrown;
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    /**
+     * Closes {@code socket}, ignoring any checked exceptions. Does nothing if
+     * {@code socket} is null.
+     */
+    public static void closeQuietly(Socket socket) {
+        if (socket != null) {
+            try {
+                socket.close();
             } catch (RuntimeException rethrown) {
                 throw rethrown;
             } catch (Exception ignored) {

--- a/src/main/java/com/squareup/okhttp/internal/http/AbstractHttpInputStream.java
+++ b/src/main/java/com/squareup/okhttp/internal/http/AbstractHttpInputStream.java
@@ -79,11 +79,11 @@ abstract class AbstractHttpInputStream extends InputStream {
      * Closes the cache entry and makes the socket available for reuse. This
      * should be invoked when the end of the body has been reached.
      */
-    protected final void endOfInput(boolean reuseSocket) throws IOException {
+    protected final void endOfInput(boolean streamCancelled) throws IOException {
         if (cacheRequest != null) {
             cacheBody.close();
         }
-        httpEngine.release(reuseSocket);
+        httpEngine.release(streamCancelled);
     }
 
     /**
@@ -102,6 +102,6 @@ abstract class AbstractHttpInputStream extends InputStream {
         if (cacheRequest != null) {
             cacheRequest.abort();
         }
-        httpEngine.release(false);
+        httpEngine.release(true);
     }
 }

--- a/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -108,7 +108,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
             if (httpEngine.hasResponse()) {
                 Util.closeQuietly(httpEngine.getResponseBody());
             }
-            httpEngine.release(false);
+            httpEngine.release(true);
         }
     }
 
@@ -328,7 +328,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
                 httpEngine.automaticallyReleaseConnectionToPool();
             }
 
-            httpEngine.release(true);
+            httpEngine.release(false);
 
             httpEngine = newHttpEngine(retryMethod, rawRequestHeaders,
                     httpEngine.getConnection(), (RetryableOutputStream) requestBody);
@@ -359,7 +359,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
             OutputStream requestBody = httpEngine.getRequestBody();
             if (routeSelector.hasNext() && isRecoverable(e)
                     && (requestBody == null || requestBody instanceof RetryableOutputStream)) {
-                httpEngine.release(false);
+                httpEngine.release(true);
                 httpEngine = newHttpEngine(method, rawRequestHeaders, null,
                         (RetryableOutputStream) requestBody);
                 httpEngine.routeSelector = routeSelector; // Keep the same routeSelector.

--- a/src/main/java/com/squareup/okhttp/internal/http/Transport.java
+++ b/src/main/java/com/squareup/okhttp/internal/http/Transport.java
@@ -67,5 +67,6 @@ interface Transport {
     /**
      * Returns true if the underlying connection can be recycled.
      */
-    boolean makeReusable(OutputStream requestBodyOut, InputStream responseBodyIn);
+    boolean makeReusable(boolean streamReusable,
+            OutputStream requestBodyOut, InputStream responseBodyIn);
 }

--- a/src/main/java/com/squareup/okhttp/internal/http/UnknownLengthHttpInputStream.java
+++ b/src/main/java/com/squareup/okhttp/internal/http/UnknownLengthHttpInputStream.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import static com.squareup.okhttp.internal.Util.checkOffsetAndCount;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.CacheRequest;
+
+/**
+ * An HTTP message body terminated by the end of the underlying stream.
+ */
+final class UnknownLengthHttpInputStream extends AbstractHttpInputStream {
+    private boolean inputExhausted;
+
+    UnknownLengthHttpInputStream(InputStream is, CacheRequest cacheRequest,
+            HttpEngine httpEngine) throws IOException {
+        super(is, httpEngine, cacheRequest);
+    }
+
+    @Override public int read(byte[] buffer, int offset, int count) throws IOException {
+        checkOffsetAndCount(buffer.length, offset, count);
+        checkNotClosed();
+        if (in == null || inputExhausted) {
+            return -1;
+        }
+        int read = in.read(buffer, offset, count);
+        if (read == -1) {
+            inputExhausted = true;
+            endOfInput(false);
+            return -1;
+        }
+        cacheWrite(buffer, offset, read);
+        return read;
+    }
+
+    @Override public int available() throws IOException {
+        checkNotClosed();
+        return in == null ? 0 : in.available();
+    }
+
+    @Override public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (!inputExhausted) {
+            unexpectedEndOfInput();
+        }
+    }
+}

--- a/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
+++ b/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
@@ -252,7 +252,8 @@ public final class SpdyStream {
     }
 
     /**
-     * Abnormally terminate this stream.
+     * Abnormally terminate this stream. This blocks until the {@code RST_STREAM}
+     * frame has been transmitted.
      */
     public void close(int rstStatusCode) throws IOException {
         if (!closeInternal(rstStatusCode)) {
@@ -261,7 +262,11 @@ public final class SpdyStream {
         connection.writeSynReset(id, rstStatusCode);
     }
 
-    void closeLater(int rstStatusCode) {
+    /**
+     * Abnormally terminate this stream. This enqueues a {@code RST_STREAM}
+     * frame and returns immediately.
+     */
+    public void closeLater(int rstStatusCode) {
         if (!closeInternal(rstStatusCode)) {
             return; // Already closed.
         }

--- a/src/test/java/com/squareup/okhttp/internal/RecordingAuthenticator.java
+++ b/src/test/java/com/squareup/okhttp/internal/RecordingAuthenticator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RecordingAuthenticator extends Authenticator {
+    /** base64("username:password") */
+    public static final String BASE_64_CREDENTIALS = "dXNlcm5hbWU6cGFzc3dvcmQ=";
+
+    public final List<String> calls = new ArrayList<String>();
+    public final PasswordAuthentication authentication;
+
+    public RecordingAuthenticator(PasswordAuthentication authentication) {
+        this.authentication = authentication;
+    }
+
+    public RecordingAuthenticator() {
+        this(new PasswordAuthentication("username", "password".toCharArray()));
+    }
+
+    @Override protected PasswordAuthentication getPasswordAuthentication() {
+        this.calls.add("host=" + getRequestingHost()
+                + " port=" + getRequestingPort()
+                + " site=" + getRequestingSite()
+                + " url=" + getRequestingURL()
+                + " type=" + getRequestorType()
+                + " prompt=" + getRequestingPrompt()
+                + " protocol=" + getRequestingProtocol()
+                + " scheme=" + getRequestingScheme());
+        return authentication;
+    }
+}

--- a/src/test/java/com/squareup/okhttp/internal/RecordingHostnameVerifier.java
+++ b/src/test/java/com/squareup/okhttp/internal/RecordingHostnameVerifier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+public final class RecordingHostnameVerifier implements HostnameVerifier {
+    public final List<String> calls = new ArrayList<String>();
+
+    public boolean verify(String hostname, SSLSession session) {
+        calls.add("verify " + hostname);
+        return true;
+    }
+}

--- a/src/test/java/com/squareup/okhttp/internal/spdy/HttpOverSpdyTest.java
+++ b/src/test/java/com/squareup/okhttp/internal/spdy/HttpOverSpdyTest.java
@@ -18,22 +18,33 @@ package com.squareup.okhttp.internal.spdy;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.RecordedRequest;
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.internal.RecordingAuthenticator;
 import com.squareup.okhttp.internal.SslContextBuilder;
+import com.squareup.okhttp.internal.Util;
+import com.squareup.okhttp.internal.http.HttpResponseCache;
 import com.squareup.okhttp.internal.mockspdyserver.MockSpdyServer;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Authenticator;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.zip.GZIPOutputStream;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,10 +71,14 @@ public final class HttpOverSpdyTest {
     private final MockSpdyServer server = new MockSpdyServer(sslContext.getSocketFactory());
     private final String hostName = server.getHostName();
     private final OkHttpClient client = new OkHttpClient();
+    private HttpResponseCache cache;
 
     @Before public void setUp() throws Exception {
         client.setSSLSocketFactory(sslContext.getSocketFactory());
         client.setHostnameVerifier(NULL_HOSTNAME_VERIFIER);
+        String systemTmpDir = System.getProperty("java.io.tmpdir");
+        File cacheDir = new File(systemTmpDir, "HttpCache-" + UUID.randomUUID());
+        cache = new HttpResponseCache(cacheDir, Integer.MAX_VALUE);
     }
 
     @After public void tearDown() throws Exception {
@@ -84,6 +99,96 @@ public final class HttpOverSpdyTest {
         assertContains(request.getHeaders(), ":host: " + hostName + ":" + server.getPort());
     }
 
+    @Test public void spdyConnectionReuse() throws Exception {
+        server.enqueue(new MockResponse().setBody("ABCDEF"));
+        server.enqueue(new MockResponse().setBody("GHIJKL"));
+        server.play();
+
+        HttpURLConnection connection1 = client.open(server.getUrl("/r1"));
+        HttpURLConnection connection2 = client.open(server.getUrl("/r2"));
+        assertEquals("ABC", readAscii(connection1.getInputStream(), 3));
+        assertEquals("GHI", readAscii(connection2.getInputStream(), 3));
+        assertEquals("DEF", readAscii(connection1.getInputStream(), 3));
+        assertEquals("JKL", readAscii(connection2.getInputStream(), 3));
+        assertEquals(0, server.takeRequest().getSequenceNumber());
+        assertEquals(0, server.takeRequest().getSequenceNumber());
+    }
+
+    @Test public void gzippedResponseBody() throws Exception {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Encoding: gzip")
+                .setBody(gzip("ABCABCABC".getBytes(Util.UTF_8))));
+        server.play();
+        assertContent("ABCABCABC", client.open(server.getUrl("/r1")), Integer.MAX_VALUE);
+    }
+
+    @Test public void authenticate() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(HttpURLConnection.HTTP_UNAUTHORIZED)
+                .addHeader("www-authenticate: Basic realm=\"protected area\"")
+                .setBody("Please authenticate."));
+        server.enqueue(new MockResponse().setBody("Successful auth!"));
+        server.play();
+
+        Authenticator.setDefault(new RecordingAuthenticator());
+        HttpURLConnection connection = client.open(server.getUrl("/"));
+        assertEquals("Successful auth!", readAscii(connection.getInputStream(), Integer.MAX_VALUE));
+
+        RecordedRequest denied = server.takeRequest();
+        assertContainsNoneMatching(denied.getHeaders(), "authorization: Basic .*");
+        RecordedRequest accepted = server.takeRequest();
+        assertEquals("GET / HTTP/1.1", accepted.getRequestLine());
+        assertContains(accepted.getHeaders(), "authorization: Basic "
+                + RecordingAuthenticator.BASE_64_CREDENTIALS);
+    }
+
+    @Test public void redirect() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
+                .addHeader("Location: /foo")
+                .setBody("This page has moved!"));
+        server.enqueue(new MockResponse().setBody("This is the new location!"));
+        server.play();
+
+        HttpURLConnection connection = client.open(server.getUrl("/"));
+        assertContent("This is the new location!", connection, Integer.MAX_VALUE);
+
+        RecordedRequest request1 = server.takeRequest();
+        assertEquals("/", request1.getPath());
+        RecordedRequest request2 = server.takeRequest();
+        assertEquals("/foo", request2.getPath());
+    }
+
+    @Test public void readAfterLastByte() throws Exception {
+        server.enqueue(new MockResponse().setBody("ABC"));
+        server.play();
+
+        HttpURLConnection connection = client.open(server.getUrl("/"));
+        InputStream in = connection.getInputStream();
+        assertEquals("ABC", readAscii(in, 3));
+        assertEquals(-1, in.read());
+        assertEquals(-1, in.read());
+    }
+
+    @Test public void responsesAreCached() throws IOException {
+        client.setResponseCache(cache);
+
+        server.enqueue(new MockResponse()
+                .addHeader("cache-control: max-age=60")
+                .setBody("A"));
+        server.play();
+
+        assertContent("A", client.open(server.getUrl("/")), Integer.MAX_VALUE);
+        assertEquals(1, cache.getRequestCount());
+        assertEquals(1, cache.getNetworkCount());
+        assertEquals(0, cache.getHitCount());
+        assertContent("A", client.open(server.getUrl("/")), Integer.MAX_VALUE);
+        assertContent("A", client.open(server.getUrl("/")), Integer.MAX_VALUE);
+        assertEquals(3, cache.getRequestCount());
+        assertEquals(1, cache.getNetworkCount());
+        assertEquals(2, cache.getHitCount());
+    }
+
     private <T> void assertContains(Collection<T> collection, T value) {
         assertTrue(collection.toString(), collection.contains(value));
     }
@@ -93,6 +198,14 @@ public final class HttpOverSpdyTest {
         connection.connect();
         assertEquals(expected, readAscii(connection.getInputStream(), limit));
         ((HttpURLConnection) connection).disconnect();
+    }
+
+    private void assertContainsNoneMatching(List<String> headers, String pattern) {
+        for (String header : headers) {
+            if (header.matches(pattern)) {
+                fail("Header " + header + " matches " + pattern);
+            }
+        }
     }
 
     private String readAscii(InputStream in, int count) throws IOException {
@@ -106,5 +219,13 @@ public final class HttpOverSpdyTest {
             result.append((char) value);
         }
         return result.toString();
+    }
+
+    public byte[] gzip(byte[] bytes) throws IOException {
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        OutputStream gzippedOut = new GZIPOutputStream(bytesOut);
+        gzippedOut.write(bytes);
+        gzippedOut.close();
+        return bytesOut.toByteArray();
     }
 }


### PR DESCRIPTION
Writing tests shook out a few bugs:
- Pooling wasn't working well. We were trying to connect
  after already having been connected.
- We weren't writing response bodies to the cache.
- We weren't capturing the request time for the cache.
- MockSpdyServer wasn't trimming headers.

New files in this change aren't new, they're just inner classes promoted
to top-level classes for better sharing.
