### PR TITLE
Mark a racy test with @Ignore.

### DIFF
--- a/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -395,7 +395,11 @@ public final class URLConnectionTest {
         testServerClosesOutput(SHUTDOWN_INPUT_AT_END);
     }
 
-    @Test public void serverShutdownOutput() throws Exception {
+    /**
+     * Ignored because this test is racy.
+     * https://github.com/square/okhttp/issues/90
+     */
+    @Test @Ignore public void serverShutdownOutput() throws Exception {
         testServerClosesOutput(SHUTDOWN_OUTPUT_AT_END);
     }
 


### PR DESCRIPTION
We've seen this fail consistently on Travis, and very rarely
on my desktop. Ignore it until it can be investigated fully.

https://github.com/square/okhttp/issues/90
