### PR TITLE
Increase the stream drain timeout from 30ms to 100ms.

### DIFF
--- a/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -43,7 +43,7 @@ public final class HttpTransport implements Transport {
    * used for connection reuse, this timeout should be significantly less than
    * the time it takes to establish a new connection.
    */
-  private static final int DISCARD_STREAM_TIMEOUT_MILLIS = 30;
+  private static final int DISCARD_STREAM_TIMEOUT_MILLIS = 100;
 
   public static final int DEFAULT_CHUNK_LENGTH = 1024;
 

--- a/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -393,11 +393,7 @@ public final class URLConnectionTest {
     testServerClosesOutput(SHUTDOWN_INPUT_AT_END);
   }
 
-  /**
-   * Ignored because this test is racy.
-   * https://github.com/square/okhttp/issues/90
-   */
-  @Test @Ignore public void serverShutdownOutput() throws Exception {
+  @Test public void serverShutdownOutput() throws Exception {
     testServerClosesOutput(SHUTDOWN_OUTPUT_AT_END);
   }
 


### PR DESCRIPTION
We were missing out on opportunities to reuse HTTPS connections
with the previous timeout. This even occured on unit tests where
the latency should be very low.

https://github.com/square/okhttp/issues/90
