### PR TITLE
Tidy the public API for HttpResponseCache.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -19,7 +19,6 @@ package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.Address;
 import com.squareup.okhttp.Connection;
-import com.squareup.okhttp.HttpResponseCache;
 import com.squareup.okhttp.ResponseSource;
 import com.squareup.okhttp.TunnelRequest;
 import com.squareup.okhttp.internal.Dns;
@@ -176,8 +175,8 @@ public class HttpEngine {
 
     prepareRawRequestHeaders();
     initResponseSource();
-    if (policy.responseCache instanceof HttpResponseCache) {
-      ((HttpResponseCache) policy.responseCache).trackResponse(responseSource);
+    if (policy.responseCache != null) {
+      policy.responseCache.trackResponse(responseSource);
     }
 
     // The raw response source may require the network, but the request
@@ -635,11 +634,8 @@ public class HttpEngine {
         release(false);
         ResponseHeaders combinedHeaders = cachedResponseHeaders.combine(responseHeaders);
         setResponse(combinedHeaders, cachedResponseBody);
-        if (policy.responseCache instanceof HttpResponseCache) {
-          HttpResponseCache httpResponseCache = (HttpResponseCache) policy.responseCache;
-          httpResponseCache.trackConditionalCacheHit();
-          httpResponseCache.update(cacheResponse, policy.getHttpConnectionToCache());
-        }
+        policy.responseCache.trackConditionalCacheHit();
+        policy.responseCache.update(cacheResponse, policy.getHttpConnectionToCache());
         return;
       } else {
         Util.closeQuietly(cachedResponseBody);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -32,7 +32,6 @@ import java.net.InetSocketAddress;
 import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.ProxySelector;
-import java.net.ResponseCache;
 import java.net.SocketPermission;
 import java.net.URL;
 import java.security.Permission;
@@ -77,7 +76,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
 
   final ProxySelector proxySelector;
   final CookieHandler cookieHandler;
-  final ResponseCache responseCache;
+  final OkResponseCache responseCache;
   final ConnectionPool connectionPool;
   /* SSL configuration; necessary for HTTP requests that get redirected to HTTPS. */
   SSLSocketFactory sslSocketFactory;
@@ -90,16 +89,16 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   protected IOException httpEngineFailure;
   protected HttpEngine httpEngine;
 
-  public HttpURLConnectionImpl(URL url, OkHttpClient client) {
+  public HttpURLConnectionImpl(URL url, OkHttpClient client, OkResponseCache responseCache) {
     super(url);
     this.followProtocolRedirects = client.getFollowProtocolRedirects();
     this.requestedProxy = client.getProxy();
     this.proxySelector = client.getProxySelector();
     this.cookieHandler = client.getCookieHandler();
-    this.responseCache = client.getResponseCache();
     this.connectionPool = client.getConnectionPool();
     this.sslSocketFactory = client.getSslSocketFactory();
     this.hostnameVerifier = client.getHostnameVerifier();
+    this.responseCache = responseCache;
   }
 
   @Override public final void connect() throws IOException {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsURLConnectionImpl.java
@@ -45,9 +45,9 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
   /** HttpUrlConnectionDelegate allows reuse of HttpURLConnectionImpl. */
   private final HttpUrlConnectionDelegate delegate;
 
-  public HttpsURLConnectionImpl(URL url, OkHttpClient client) {
+  public HttpsURLConnectionImpl(URL url, OkHttpClient client, OkResponseCache responseCache) {
     super(url);
-    delegate = new HttpUrlConnectionDelegate(url, client);
+    delegate = new HttpUrlConnectionDelegate(url, client, responseCache);
   }
 
   @Override public String getCipherSuite() {
@@ -399,8 +399,8 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
   }
 
   private final class HttpUrlConnectionDelegate extends HttpURLConnectionImpl {
-    private HttpUrlConnectionDelegate(URL url, OkHttpClient client) {
-      super(url, client);
+    private HttpUrlConnectionDelegate(URL url, OkHttpClient client, OkResponseCache responseCache) {
+      super(url, client, responseCache);
     }
 
     @Override protected HttpURLConnection getHttpConnectionToCache() {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkResponseCache.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import com.squareup.okhttp.ResponseSource;
+import java.io.IOException;
+import java.net.CacheRequest;
+import java.net.CacheResponse;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An extended response cache API. Unlike {@link java.net.ResponseCache}, this
+ * interface supports conditional caching and statistics.
+ *
+ * <p>Along with the rest of the {@code internal} package, this is not a public
+ * API. Applications wishing to supply their own caches must use the more
+ * limited {@link java.net.ResponseCache} interface.
+ */
+public interface OkResponseCache {
+  CacheResponse get(URI uri, String requestMethod, Map<String, List<String>> requestHeaders)
+      throws IOException;
+
+  CacheRequest put(URI uri, URLConnection urlConnection) throws IOException;
+
+  /**
+   * Handles a conditional request hit by updating the stored cache response
+   * with the headers from {@code httpConnection}. The cached response body is
+   * not updated. If the stored response has changed since {@code
+   * conditionalCacheHit} was returned, this does nothing.
+   */
+  void update(CacheResponse conditionalCacheHit, HttpURLConnection connection) throws IOException;
+
+  /** Track an conditional GET that was satisfied by this cache. */
+  void trackConditionalCacheHit();
+
+  /** Track an HTTP response being satisfied by {@code source}. */
+  void trackResponse(ResponseSource source);
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkResponseCacheAdapter.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkResponseCacheAdapter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import com.squareup.okhttp.ResponseSource;
+import java.io.IOException;
+import java.net.CacheRequest;
+import java.net.CacheResponse;
+import java.net.HttpURLConnection;
+import java.net.ResponseCache;
+import java.net.URI;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.Map;
+
+public final class OkResponseCacheAdapter implements OkResponseCache {
+  private final ResponseCache responseCache;
+  public OkResponseCacheAdapter(ResponseCache responseCache) {
+    this.responseCache = responseCache;
+  }
+
+  @Override public CacheResponse get(URI uri, String requestMethod,
+      Map<String, List<String>> requestHeaders) throws IOException {
+    return responseCache.get(uri, requestMethod, requestHeaders);
+  }
+
+  @Override public CacheRequest put(URI uri, URLConnection urlConnection) throws IOException {
+    return responseCache.put(uri, urlConnection);
+  }
+
+  @Override public void update(CacheResponse conditionalCacheHit, HttpURLConnection connection)
+      throws IOException {
+  }
+
+  @Override public void trackConditionalCacheHit() {
+  }
+
+  @Override public void trackResponse(ResponseSource source) {
+  }
+}

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
@@ -114,7 +114,7 @@ public final class HttpResponseCacheTest {
   @After public void tearDown() throws Exception {
     server.shutdown();
     ResponseCache.setDefault(null);
-    cache.getCache().delete();
+    cache.delete();
     CookieHandler.setDefault(null);
   }
 

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -118,7 +118,7 @@ public final class URLConnectionTest {
     server.shutdown();
     server2.shutdown();
     if (cache != null) {
-      cache.getCache().delete();
+      cache.delete();
     }
   }
 


### PR DESCRIPTION
This moves the special internal-only methods into a new interface,
OkHttpResponseCache. I jump through some hoops to expose only the
java.net.ResponseCache interface in the API.
