### PR TITLE
Allow empty header values

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RawHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RawHeaders.java
@@ -373,7 +373,6 @@ public final class RawHeaders {
 
       // TODO: promote this check to where names and values are created
       if (name.length() == 0
-          || value.length() == 0
           || name.indexOf('\0') != -1
           || value.indexOf('\0') != -1) {
         throw new IllegalArgumentException("Unexpected header: " + name + ": " + value);


### PR DESCRIPTION
This tracks an AOSP change by Brian Carlstrom.
Change-Id: I78bb07a93d527eda6aaee6e986be39a68e0a02f4
