### PR TITLE
Don't explode if we can't find an interface for a local address.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -201,6 +201,9 @@ public class Platform {
       try {
         NetworkInterface networkInterface = NetworkInterface.getByInetAddress(
             socket.getLocalAddress());
+        if (networkInterface == null) {
+          return super.getMtu(socket); // There's no longer an interface with this local address.
+        }
         return (Integer) getMtu.invoke(networkInterface);
       } catch (IllegalAccessException e) {
         throw new AssertionError(e);


### PR DESCRIPTION
We'll likely explode later when attempting to use the socket.
But that will fail with an IOException, unlike this which was
failing with a NullPointerException.
