### PR TITLE
Don't explode if NetworkInterface.getByInetAddress does.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -205,6 +205,9 @@ public class Platform {
           return super.getMtu(socket); // There's no longer an interface with this local address.
         }
         return (Integer) getMtu.invoke(networkInterface);
+      } catch (SocketException e) {
+        // Certain Motorola devices always throw on getByInetAddress. Return the default for those.
+        return super.getMtu(socket);
       } catch (IllegalAccessException e) {
         throw new AssertionError(e);
       } catch (InvocationTargetException e) {


### PR DESCRIPTION
Certain Motorola RAZRs always throw a SocketException when
you call that method. We don't _really_ need a perfect MTU,
so for those devices just return the default MTU.
