### PR TITLE
Use animal-sniffer to ensure only Java 1.5 is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,26 @@
           <excludePackageNames>com.squareup.okhttp.internal:com.squareup.okhttp.internal.*</excludePackageNames>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.9</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java15</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Using http://mojo.codehaus.org/animal-sniffer/index.html will ensure that okhttp will always run on Java 1.5 regardless of what version of Java is used to build it. This check prevents problems  such as those fixed in #186.
