### PR TITLE
Add new classname for AOSP's SSLSocket change

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -151,7 +151,14 @@ public class Platform {
     Method setUseSessionTickets;
     Method setHostname;
     try {
-      openSslSocketClass = Class.forName("org.apache.harmony.xnet.provider.jsse.OpenSSLSocketImpl");
+      try {
+        openSslSocketClass = Class.forName("com.android.org.conscrypt.OpenSSLSocketImpl");
+      } catch (ClassNotFoundException ignored) {
+        // Older platform before being unbundled.
+        openSslSocketClass = Class.forName(
+            "org.apache.harmony.xnet.provider.jsse.OpenSSLSocketImpl");
+      }
+
       setUseSessionTickets = openSslSocketClass.getMethod("setUseSessionTickets", boolean.class);
       setHostname = openSslSocketClass.getMethod("setHostname", String.class);
 


### PR DESCRIPTION
AOSP moved OpenSSLSocketImpl to com.android.org.conscrypt.\* so add that
as the first choice for unbundled apps.

Change-Id: I7bad6533dcb86ee1cac3b15f42dd386bd651eaed
