### PR TITLE
Support querying & setting transport lists on connections.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ release.properties
 
 .idea
 *.iml
+*.ipr
+*.iws
 classes
 
 obj

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -278,7 +278,7 @@ public class HttpEngine {
         hostnameVerifier = policy.hostnameVerifier;
       }
       Address address = new Address(uriHost, getEffectivePort(uri), sslSocketFactory,
-          hostnameVerifier, policy.authenticator, policy.requestedProxy, policy.transports);
+          hostnameVerifier, policy.authenticator, policy.requestedProxy, policy.getTransports());
       routeSelector = new RouteSelector(address, uri, policy.proxySelector, policy.connectionPool,
           Dns.DEFAULT, policy.getFailedRoutes());
     }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -127,10 +127,13 @@ public final class HttpTransport implements Transport {
   }
 
   @Override public ResponseHeaders readResponseHeaders() throws IOException {
-    RawHeaders headers = RawHeaders.fromBytes(socketIn);
-    httpEngine.connection.setHttpMinorVersion(headers.getHttpMinorVersion());
-    httpEngine.receiveHeaders(headers);
-    return new ResponseHeaders(httpEngine.uri, headers);
+    RawHeaders rawHeaders = RawHeaders.fromBytes(socketIn);
+    httpEngine.connection.setHttpMinorVersion(rawHeaders.getHttpMinorVersion());
+    httpEngine.receiveHeaders(rawHeaders);
+
+    ResponseHeaders headers = new ResponseHeaders(httpEngine.uri, rawHeaders);
+    headers.setTransport("http/1.1");
+    return headers;
   }
 
   public boolean makeReusable(boolean streamCancelled, OutputStream requestBodyOut,

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/ResponseHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/ResponseHeaders.java
@@ -42,6 +42,9 @@ public final class ResponseHeaders {
   /** HTTP synthetic header with the response source. */
   static final String RESPONSE_SOURCE = "X-Android-Response-Source";
 
+  /** HTTP synthetic header with the selected transport (spdy/3, http/1.1, etc.) */
+  static final String SELECTED_TRANSPORT = "X-Android-Selected-Transport";
+
   private final URI uri;
   private final RawHeaders headers;
 
@@ -276,6 +279,10 @@ public final class ResponseHeaders {
 
   public void setResponseSource(ResponseSource responseSource) {
     headers.set(RESPONSE_SOURCE, responseSource.toString() + " " + headers.getResponseCode());
+  }
+
+  public void setTransport(String transport) {
+    headers.set(SELECTED_TRANSPORT, transport);
   }
 
   /**

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -71,7 +71,10 @@ public final class SpdyTransport implements Transport {
     RawHeaders rawHeaders = RawHeaders.fromNameValueBlock(nameValueBlock);
     rawHeaders.computeResponseStatusLineFromSpdyHeaders();
     httpEngine.receiveHeaders(rawHeaders);
-    return new ResponseHeaders(httpEngine.uri, rawHeaders);
+
+    ResponseHeaders headers = new ResponseHeaders(httpEngine.uri, rawHeaders);
+    headers.setTransport("spdy/3");
+    return headers;
   }
 
   @Override public InputStream getTransferStream(CacheRequest cacheRequest) throws IOException {


### PR DESCRIPTION
The list is specified via a magic request property
"X-Android-Transports" and can be queried via the request
property "X-Android-Selected-Transport".

System wide defaults / switches don't need any changes
to okhttp. They can be set as options on the OkHttpClient
used by the platform UrlStreamHandlers.
