### PR TITLE
Allow access to the underlying DiskLruCache.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -331,6 +331,30 @@ public final class HttpResponseCache extends ResponseCache {
     return writeSuccessCount;
   }
 
+  public long getSize() {
+    return cache.size();
+  }
+
+  public long getMaxSize() {
+    return cache.getMaxSize();
+  }
+
+  public void flush() throws IOException {
+    cache.flush();
+  }
+
+  public void close() throws IOException {
+    cache.close();
+  }
+
+  public File getDirectory() {
+    return cache.getDirectory();
+  }
+
+  public boolean isClosed() {
+    return cache.isClosed();
+  }
+
   private synchronized void trackResponse(ResponseSource source) {
     requestCount++;
 


### PR DESCRIPTION
This is needed to implement public android APIs
android.net.HttpResponseCache.{flush,size,maxSize,close}
as well android.net.HttpResponseCache.install.

install needs to inspect the underlying DiskLruCache because
it promises not to install a new cache if the file directory and
size are the same as the old cache.
