### PR TITLE
 Fix bad locking in SpdyConnection

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -524,7 +524,7 @@ public final class SpdyConnection implements Closeable {
           // reads to 'settings'. We synchronize on 'stream' to guard the state change.
           // And we need to acquire the 'stream' lock first, since that may block.
           synchronized (stream) {
-            synchronized (this) {
+            synchronized (SpdyConnection.this) {
               stream.receiveSettings(settings);
             }
           }


### PR DESCRIPTION
This caused an assertion error in SpdyStream#setSettings
where we assert that the lock on the associated
SpdyConnection is held.
