### PR TITLE
Make OkHostnameVerifier a constant. This fixes connection reuse.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -284,7 +284,7 @@ public final class OkHttpClient {
         : HttpsURLConnection.getDefaultSSLSocketFactory();
     result.hostnameVerifier = hostnameVerifier != null
         ? hostnameVerifier
-        : new OkHostnameVerifier();
+        : OkHostnameVerifier.INSTANCE;
     result.authenticator = authenticator != null
         ? authenticator
         : HttpAuthenticator.SYSTEM_DEFAULT;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/tls/OkHostnameVerifier.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/tls/OkHostnameVerifier.java
@@ -36,6 +36,8 @@ import javax.security.auth.x500.X500Principal;
  * href="http://www.ietf.org/rfc/rfc2818.txt">RFC 2818</a>.
  */
 public final class OkHostnameVerifier implements HostnameVerifier {
+  public static final OkHostnameVerifier INSTANCE = new OkHostnameVerifier();
+
   /**
    * Quick and dirty pattern to differentiate IP addresses from hostnames. This
    * is an approximation of Android's private InetAddress#isNumeric API.
@@ -52,6 +54,9 @@ public final class OkHostnameVerifier implements HostnameVerifier {
 
   private static final int ALT_DNS_NAME = 2;
   private static final int ALT_IPA_NAME = 7;
+
+  private OkHostnameVerifier() {
+  }
 
   public boolean verify(String host, SSLSession session) {
     try {

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/tls/HostnameVerifierTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/tls/HostnameVerifierTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
  * itself includes tests from the Apache HTTP Client test suite.
  */
 public final class HostnameVerifierTest {
-  private HostnameVerifier verifier = new OkHostnameVerifier();
+  private HostnameVerifier verifier = OkHostnameVerifier.INSTANCE;
 
   @Test public void verify() throws Exception {
     FakeSSLSession session = new FakeSSLSession();


### PR DESCRIPTION
Previously HTTPS connection reuse was broken because the
hostname verifier is included as a route identifier, and
with a different hostname verifier on every request we weren't
reusing connections.
