### PR TITLE
Make ConnectionPoolTest less flaky

### DIFF
--- a/okhttp/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public final class ConnectionPoolTest {
-  private static final int KEEP_ALIVE_DURATION_MS = 500;
+  private static final int KEEP_ALIVE_DURATION_MS = 5000;
   private static final SSLContext sslContext;
 
   static {


### PR DESCRIPTION
I was seeing flaky results in the debugger because pooled
connections were being evicted as the test ran.
