### PR TITLE
Change custom headers to 'OkHttp-Foo-Bar' format.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -57,6 +57,11 @@ public class Platform {
     return PLATFORM;
   }
 
+  /** Prefix used on custom headers. */
+  public String getPrefix() {
+    return "OkHttp";
+  }
+
   public void logW(String warning) {
     System.out.println(warning);
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/ResponseHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/ResponseHeaders.java
@@ -17,6 +17,7 @@
 package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.ResponseSource;
+import com.squareup.okhttp.internal.Platform;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -34,16 +35,16 @@ import static com.squareup.okhttp.internal.Util.equal;
 public final class ResponseHeaders {
 
   /** HTTP header name for the local time when the request was sent. */
-  private static final String SENT_MILLIS = "X-Android-Sent-Millis";
+  private static final String SENT_MILLIS = Platform.get().getPrefix() + "-Sent-Millis";
 
   /** HTTP header name for the local time when the response was received. */
-  private static final String RECEIVED_MILLIS = "X-Android-Received-Millis";
+  private static final String RECEIVED_MILLIS = Platform.get().getPrefix() + "-Received-Millis";
 
   /** HTTP synthetic header with the response source. */
-  static final String RESPONSE_SOURCE = "X-Android-Response-Source";
+  static final String RESPONSE_SOURCE = Platform.get().getPrefix() + "-Response-Source";
 
   /** HTTP synthetic header with the selected transport (spdy/3, http/1.1, etc). */
-  static final String SELECTED_TRANSPORT = "X-Android-Selected-Transport";
+  static final String SELECTED_TRANSPORT = Platform.get().getPrefix() + "-Selected-Transport";
 
   private final URI uri;
   private final RawHeaders headers;


### PR DESCRIPTION
Provide a public but internal API for setting this to different values. For example, the Android OS will need to call this method with 'X-Android' as a value.

Closes #207.
