### PR TITLE
Support streaming request bodies longer than 2 GiB.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RequestHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RequestHeaders.java
@@ -48,7 +48,7 @@ public final class RequestHeaders {
    */
   private boolean hasAuthorization;
 
-  private int contentLength = -1;
+  private long contentLength = -1;
   private String transferEncoding;
   private String userAgent;
   private String host;
@@ -157,7 +157,7 @@ public final class RequestHeaders {
     return hasAuthorization;
   }
 
-  public int getContentLength() {
+  public long getContentLength() {
     return contentLength;
   }
 
@@ -205,11 +205,11 @@ public final class RequestHeaders {
     this.transferEncoding = "chunked";
   }
 
-  public void setContentLength(int contentLength) {
+  public void setContentLength(long contentLength) {
     if (this.contentLength != -1) {
       headers.removeAll("Content-Length");
     }
-    headers.add("Content-Length", Integer.toString(contentLength));
+    headers.add("Content-Length", Long.toString(contentLength));
     this.contentLength = contentLength;
   }
 

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -2491,6 +2491,28 @@ public final class URLConnectionTest {
     }
   }
 
+  @Test public void veryLargeFixedLengthRequest() throws Exception {
+    server.setBodyLimit(0);
+    server.enqueue(new MockResponse());
+    server.play();
+
+    HttpURLConnection connection = client.open(server.getUrl("/"));
+    connection.setDoOutput(true);
+    long contentLength = Integer.MAX_VALUE + 1L;
+    connection.setFixedLengthStreamingMode(contentLength);
+    OutputStream out = connection.getOutputStream();
+    byte[] buffer = new byte[1024 * 1024];
+    for (long bytesWritten = 0; bytesWritten < contentLength; ) {
+      int byteCount = (int) Math.min(buffer.length, contentLength - bytesWritten);
+      out.write(buffer, 0, byteCount);
+      bytesWritten += byteCount;
+    }
+    assertContent("", connection);
+
+    RecordedRequest request = server.takeRequest();
+    assertEquals(Long.toString(contentLength), request.getHeader("Content-Length"));
+  }
+
   /** Returns a gzipped copy of {@code bytes}. */
   public byte[] gzip(byte[] bytes) throws IOException {
     ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <!-- Compilation -->
     <java.version>1.6</java.version>
     <npn.version>8.1.2.v20120308</npn.version>
-    <mockwebserver.version>20130505</mockwebserver.version>
+    <mockwebserver.version>20130706</mockwebserver.version>
     <bouncycastle.version>1.48</bouncycastle.version>
     <gson.version>2.2.3</gson.version>
     <apache.http.version>4.2.2</apache.http.version>


### PR DESCRIPTION
This uses a new API only available in Java 1.7 and
better.
