### PR TITLE
Push state from HttpURLConnectionImpl to OkHttpClient

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -23,7 +23,6 @@ import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.HttpURLConnectionImpl;
 import com.squareup.okhttp.internal.http.HttpsURLConnectionImpl;
-import com.squareup.okhttp.internal.http.OkResponseCache;
 import com.squareup.okhttp.internal.http.RawHeaders;
 import com.squareup.okhttp.internal.http.ResponseHeaders;
 import java.io.BufferedWriter;

--- a/okhttp/src/main/java/com/squareup/okhttp/OkResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkResponseCache.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.okhttp.internal.http;
+package com.squareup.okhttp;
 
-import com.squareup.okhttp.ResponseSource;
 import java.io.IOException;
 import java.net.CacheRequest;
 import java.net.CacheResponse;
@@ -29,9 +28,8 @@ import java.util.Map;
  * An extended response cache API. Unlike {@link java.net.ResponseCache}, this
  * interface supports conditional caching and statistics.
  *
- * <p>Along with the rest of the {@code internal} package, this is not a public
- * API. Applications wishing to supply their own caches must use the more
- * limited {@link java.net.ResponseCache} interface.
+ * <h3>Warning: Experimental OkHttp 2.0 API</h3>
+ * This class is in beta. APIs are subject to change!
  */
 public interface OkResponseCache {
   CacheResponse get(URI uri, String requestMethod, Map<String, List<String>> requestHeaders)

--- a/okhttp/src/main/java/com/squareup/okhttp/Route.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Route.java
@@ -59,13 +59,13 @@ public class Route {
     return inetSocketAddress;
   }
 
-  /** Returns true if this route uses modern tls. */
+  /** Returns true if this route uses modern TLS. */
   public boolean isModernTls() {
     return modernTls;
   }
 
-  /** Returns a copy of this route with flipped tls mode. */
-  public Route flipTlsMode() {
+  /** Returns a copy of this route with flipped TLS mode. */
+  Route flipTlsMode() {
     return new Route(address, proxy, inetSocketAddress, !modernTls);
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/RouteDatabase.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/RouteDatabase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.net.ssl.SSLHandshakeException;
+
+/**
+ * A blacklist of failed routes to avoid when creating a new connection to a
+ * target address. This is used so that OkHttp can learn from its mistakes: if
+ * there was a failure attempting to connect to a specific IP address, proxy
+ * server or TLS mode, that failure is remembered and alternate routes are
+ * preferred.
+ */
+public final class RouteDatabase {
+  private final Set<Route> failedRoutes = new LinkedHashSet<Route>();
+
+  /** Records a failure connecting to {@code failedRoute}. */
+  public synchronized void failed(Route failedRoute, IOException failure) {
+    failedRoutes.add(failedRoute);
+
+    if (!(failure instanceof SSLHandshakeException)) {
+      // If the problem was not related to SSL then it will also fail with
+      // a different TLS mode therefore we can be proactive about it.
+      failedRoutes.add(failedRoute.flipTlsMode());
+    }
+  }
+
+  /** Records success connecting to {@code failedRoute}. */
+  public synchronized void connected(Route route) {
+    failedRoutes.remove(route);
+  }
+
+  /** Returns true if {@code route} has failed recently and should be avoided. */
+  public synchronized boolean shouldPostpone(Route route) {
+    return failedRoutes.contains(route);
+  }
+
+  public synchronized int failedRoutesCount() {
+    return failedRoutes.size();
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsURLConnectionImpl.java
@@ -18,7 +18,6 @@ package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.Connection;
 import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Route;
 import com.squareup.okhttp.TunnelRequest;
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,7 +32,6 @@ import java.security.Principal;
 import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -47,10 +45,9 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
   /** HttpUrlConnectionDelegate allows reuse of HttpURLConnectionImpl. */
   private final HttpUrlConnectionDelegate delegate;
 
-  public HttpsURLConnectionImpl(URL url, OkHttpClient client, OkResponseCache responseCache,
-      Set<Route> failedRoutes) {
+  public HttpsURLConnectionImpl(URL url, OkHttpClient client) {
     super(url);
-    delegate = new HttpUrlConnectionDelegate(url, client, responseCache, failedRoutes);
+    delegate = new HttpUrlConnectionDelegate(url, client);
   }
 
   @Override public String getCipherSuite() {
@@ -386,25 +383,24 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
   }
 
   @Override public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
-    delegate.hostnameVerifier = hostnameVerifier;
+    delegate.client.setHostnameVerifier(hostnameVerifier);
   }
 
   @Override public HostnameVerifier getHostnameVerifier() {
-    return delegate.hostnameVerifier;
+    return delegate.client.getHostnameVerifier();
   }
 
   @Override public void setSSLSocketFactory(SSLSocketFactory sslSocketFactory) {
-    delegate.sslSocketFactory = sslSocketFactory;
+    delegate.client.setSslSocketFactory(sslSocketFactory);
   }
 
   @Override public SSLSocketFactory getSSLSocketFactory() {
-    return delegate.sslSocketFactory;
+    return delegate.client.getSslSocketFactory();
   }
 
   private final class HttpUrlConnectionDelegate extends HttpURLConnectionImpl {
-    private HttpUrlConnectionDelegate(URL url, OkHttpClient client, OkResponseCache responseCache,
-        Set<Route> failedRoutes) {
-      super(url, client, responseCache, failedRoutes);
+    private HttpUrlConnectionDelegate(URL url, OkHttpClient client) {
+      super(url, client);
     }
 
     @Override protected HttpURLConnection getHttpConnectionToCache() {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Job.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Job.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import com.squareup.okhttp.Failure;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+public final class Job implements Runnable {
+  final HttpURLConnection connection;
+  final Request request;
+  final Response.Receiver responseReceiver;
+  final Dispatcher dispatcher;
+
+  public Job(Dispatcher dispatcher, HttpURLConnection connection, Request request,
+      Response.Receiver responseReceiver) {
+    this.dispatcher = dispatcher;
+    this.connection = connection;
+    this.request = request;
+    this.responseReceiver = responseReceiver;
+  }
+
+  @Override public void run() {
+    try {
+      sendRequest();
+      Response response = readResponse();
+      responseReceiver.onResponse(response);
+    } catch (IOException e) {
+      responseReceiver.onFailure(new Failure.Builder()
+          .request(request)
+          .exception(e)
+          .build());
+    } finally {
+      connection.disconnect();
+      dispatcher.finished(this);
+    }
+  }
+
+  private HttpURLConnection sendRequest() throws IOException {
+    for (int i = 0; i < request.headerCount(); i++) {
+      connection.addRequestProperty(request.headerName(i), request.headerValue(i));
+    }
+    Request.Body body = request.body();
+    if (body != null) {
+      connection.setDoOutput(true);
+      long contentLength = body.contentLength();
+      if (contentLength == -1 || contentLength > Integer.MAX_VALUE) {
+        connection.setChunkedStreamingMode(0);
+      } else {
+        // Don't call setFixedLengthStreamingMode(long); that's only available on Java 1.7+.
+        connection.setFixedLengthStreamingMode((int) contentLength);
+      }
+      body.writeTo(connection.getOutputStream());
+    }
+    return connection;
+  }
+
+  private Response readResponse() throws IOException {
+    int responseCode = connection.getResponseCode();
+    Response.Builder responseBuilder = new Response.Builder(request, responseCode);
+
+    for (int i = 0; true; i++) {
+      String name = connection.getHeaderFieldKey(i);
+      if (name == null) break;
+      String value = connection.getHeaderField(i);
+      responseBuilder.addHeader(name, value);
+    }
+
+    responseBuilder.body(new Dispatcher.RealResponseBody(connection, connection.getInputStream()));
+    // TODO: set redirectedBy
+    return responseBuilder.build();
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkResponseCacheAdapter.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkResponseCacheAdapter.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.okhttp.internal.http;
 
+import com.squareup.okhttp.OkResponseCache;
 import com.squareup.okhttp.ResponseSource;
 import java.io.IOException;
 import java.net.CacheRequest;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -55,7 +55,7 @@ public final class SpdyTransport implements Transport {
     boolean hasResponseBody = true;
     stream = spdyConnection.newStream(requestHeaders.toNameValueBlock(), hasRequestBody,
         hasResponseBody);
-    stream.setReadTimeout(httpEngine.policy.getReadTimeout());
+    stream.setReadTimeout(httpEngine.client.getReadTimeout());
   }
 
   @Override public void writeRequestBody(RetryableOutputStream requestBody) throws IOException {


### PR DESCRIPTION
We aren't going to use HttpURLConnectionImpl for
requests with the new API.

This is safe because we always do a shallow copy of
the OkHttpClient before using it to create a
HttpURLConnectionImpl.
