### PR TITLE
Introduce a Policy interface between engine and connection.

### DIFF
--- a/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
+++ b/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
@@ -179,15 +179,13 @@ public class OkApacheClient implements HttpClient {
     return execute(null, request, handler, context);
   }
 
-  @Override
-  public <T> T execute(HttpHost host, HttpRequest request, ResponseHandler<? extends T> handler)
-      throws IOException {
+  @Override public <T> T execute(HttpHost host, HttpRequest request,
+      ResponseHandler<? extends T> handler) throws IOException {
     return execute(host, request, handler, null);
   }
 
-  @Override
-  public <T> T execute(HttpHost host, HttpRequest request, ResponseHandler<? extends T> handler,
-      HttpContext context) throws IOException {
+  @Override public <T> T execute(HttpHost host, HttpRequest request,
+      ResponseHandler<? extends T> handler, HttpContext context) throws IOException {
     HttpResponse response = execute(host, request, context);
     try {
       return handler.handleResponse(response);

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -22,6 +22,7 @@ import com.squareup.okhttp.internal.StrictLineReader;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.HttpURLConnectionImpl;
+import com.squareup.okhttp.internal.http.HttpsEngine;
 import com.squareup.okhttp.internal.http.HttpsURLConnectionImpl;
 import com.squareup.okhttp.internal.http.RawHeaders;
 import com.squareup.okhttp.internal.http.ResponseHeaders;
@@ -421,8 +422,7 @@ public final class HttpResponseCache extends ResponseCache {
           editor.commit();
         }
 
-        @Override
-        public void write(byte[] buffer, int offset, int length) throws IOException {
+        @Override public void write(byte[] buffer, int offset, int length) throws IOException {
           // Since we don't override "write(int oneByte)", we can write directly to "out"
           // and avoid the inefficient implementation from the FilterOutputStream.
           out.write(buffer, offset, length);
@@ -579,8 +579,8 @@ public final class HttpResponseCache extends ResponseCache {
       HttpEngine engine = httpConnection instanceof HttpsURLConnectionImpl
           ? ((HttpsURLConnectionImpl) httpConnection).getHttpEngine()
           : ((HttpURLConnectionImpl) httpConnection).getHttpEngine();
-      return engine instanceof HttpsURLConnectionImpl.HttpsEngine
-          ? ((HttpsURLConnectionImpl.HttpsEngine) engine).getSslSocket()
+      return engine instanceof HttpsEngine
+          ? ((HttpsEngine) engine).getSslSocket()
           : null;
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/StrictLineReader.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/StrictLineReader.java
@@ -146,8 +146,7 @@ public class StrictLineReader implements Closeable {
 
       // Let's anticipate up to 80 characters on top of those already read.
       ByteArrayOutputStream out = new ByteArrayOutputStream(end - pos + 80) {
-        @Override
-        public String toString() {
+        @Override public String toString() {
           int length = (count > 0 && buf[count - 1] == CR) ? count - 1 : count;
           try {
             return new String(buf, 0, length, charset.name());

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -88,7 +88,7 @@ public class HttpEngine {
   };
   public static final int HTTP_CONTINUE = 100;
 
-  protected final HttpURLConnectionImpl policy;
+  protected final Policy policy;
   protected final OkHttpClient client;
 
   protected final String method;
@@ -141,16 +141,16 @@ public class HttpEngine {
 
   /**
    * @param requestHeaders the client's supplied request headers. This class
-   * creates a private copy that it can mutate.
+   *     creates a private copy that it can mutate.
    * @param connection the connection used for an intermediate response
-   * immediately prior to this request/response pair, such as a same-host
-   * redirect. This engine assumes ownership of the connection and must
-   * release it when it is unneeded.
+   *     immediately prior to this request/response pair, such as a same-host
+   *     redirect. This engine assumes ownership of the connection and must
+   *     release it when it is unneeded.
    */
-  public HttpEngine(HttpURLConnectionImpl policy, String method, RawHeaders requestHeaders,
+  public HttpEngine(OkHttpClient client, Policy policy, String method, RawHeaders requestHeaders,
       Connection connection, RetryableOutputStream requestBodyOut) throws IOException {
+    this.client = client;
     this.policy = policy;
-    this.client = policy.client;
     this.method = method;
     this.connection = connection;
     this.requestBodyOut = requestBodyOut;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -58,7 +58,7 @@ import static com.squareup.okhttp.internal.Util.getEffectivePort;
  * connection} field on this class for null/non-null to determine of an instance
  * is currently connected to a server.
  */
-public class HttpURLConnectionImpl extends HttpURLConnection {
+public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
 
   /** Numeric status code, 307: Temporary Redirect. */
   static final int HTTP_TEMP_REDIRECT = 307;
@@ -289,17 +289,16 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     }
   }
 
-  protected HttpURLConnection getHttpConnectionToCache() {
+  @Override public HttpURLConnection getHttpConnectionToCache() {
     return this;
   }
 
   private HttpEngine newHttpEngine(String method, RawHeaders requestHeaders,
       Connection connection, RetryableOutputStream requestBody) throws IOException {
     if (url.getProtocol().equals("http")) {
-      return new HttpEngine(this, method, requestHeaders, connection, requestBody);
+      return new HttpEngine(client, this, method, requestHeaders, connection, requestBody);
     } else if (url.getProtocol().equals("https")) {
-      return new HttpsURLConnectionImpl.HttpsEngine(
-          this, method, requestHeaders, connection, requestBody);
+      return new HttpsEngine(client, this, method, requestHeaders, connection, requestBody);
     } else {
       throw new AssertionError();
     }
@@ -501,12 +500,11 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   }
 
   /** @see java.net.HttpURLConnection#setFixedLengthStreamingMode(int) */
-  final long getFixedContentLength() {
+  @Override public final long getFixedContentLength() {
     return fixedContentLength;
   }
 
-  /** @see java.net.HttpURLConnection#setChunkedStreamingMode(int) */
-  final int getChunkLength() {
+  @Override public final int getChunkLength() {
     return chunkLength;
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsEngine.java
@@ -1,0 +1,71 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import com.squareup.okhttp.Connection;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.TunnelRequest;
+import java.io.IOException;
+import java.net.CacheResponse;
+import java.net.SecureCacheResponse;
+import java.net.URL;
+import javax.net.ssl.SSLSocket;
+
+import static com.squareup.okhttp.internal.Util.getEffectivePort;
+
+public final class HttpsEngine extends HttpEngine {
+  /**
+   * Stash of HttpsEngine.connection.socket to implement requests like {@code
+   * HttpsURLConnection#getCipherSuite} even after the connection has been
+   * recycled.
+   */
+  private SSLSocket sslSocket;
+
+  public HttpsEngine(OkHttpClient client, Policy policy, String method, RawHeaders requestHeaders,
+      Connection connection, RetryableOutputStream requestBody) throws IOException {
+    super(client, policy, method, requestHeaders, connection, requestBody);
+    this.sslSocket = connection != null ? (SSLSocket) connection.getSocket() : null;
+  }
+
+  @Override protected void connected(Connection connection) {
+    this.sslSocket = (SSLSocket) connection.getSocket();
+  }
+
+  @Override protected boolean acceptCacheResponseType(CacheResponse cacheResponse) {
+    return cacheResponse instanceof SecureCacheResponse;
+  }
+
+  @Override protected boolean includeAuthorityInRequestLine() {
+    // Even if there is a proxy, it isn't involved. Always request just the path.
+    return false;
+  }
+
+  public SSLSocket getSslSocket() {
+    return sslSocket;
+  }
+
+  @Override protected TunnelRequest getTunnelConfig() {
+    String userAgent = requestHeaders.getUserAgent();
+    if (userAgent == null) {
+      userAgent = getDefaultUserAgent();
+    }
+
+    URL url = policy.getURL();
+    return new TunnelRequest(url.getHost(), getEffectivePort(url), userAgent,
+        requestHeaders.getProxyAuthorization());
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsURLConnectionImpl.java
@@ -16,13 +16,10 @@
  */
 package com.squareup.okhttp.internal.http;
 
-import com.squareup.okhttp.Connection;
 import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.TunnelRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.CacheResponse;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.net.SecureCacheResponse;
@@ -37,8 +34,6 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
-
-import static com.squareup.okhttp.internal.Util.getEffectivePort;
 
 public final class HttpsURLConnectionImpl extends HttpsURLConnection {
 
@@ -121,264 +116,213 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
       throw new IllegalStateException("Connection has not yet been established");
     }
     return delegate.httpEngine instanceof HttpsEngine
-        ? ((HttpsEngine) delegate.httpEngine).sslSocket
+        ? ((HttpsEngine) delegate.httpEngine).getSslSocket()
         : null; // Not HTTPS! Probably an https:// to http:// redirect.
   }
 
-  @Override
-  public void disconnect() {
+  @Override public void disconnect() {
     delegate.disconnect();
   }
 
-  @Override
-  public InputStream getErrorStream() {
+  @Override public InputStream getErrorStream() {
     return delegate.getErrorStream();
   }
 
-  @Override
-  public String getRequestMethod() {
+  @Override public String getRequestMethod() {
     return delegate.getRequestMethod();
   }
 
-  @Override
-  public int getResponseCode() throws IOException {
+  @Override public int getResponseCode() throws IOException {
     return delegate.getResponseCode();
   }
 
-  @Override
-  public String getResponseMessage() throws IOException {
+  @Override public String getResponseMessage() throws IOException {
     return delegate.getResponseMessage();
   }
 
-  @Override
-  public void setRequestMethod(String method) throws ProtocolException {
+  @Override public void setRequestMethod(String method) throws ProtocolException {
     delegate.setRequestMethod(method);
   }
 
-  @Override
-  public boolean usingProxy() {
+  @Override public boolean usingProxy() {
     return delegate.usingProxy();
   }
 
-  @Override
-  public boolean getInstanceFollowRedirects() {
+  @Override public boolean getInstanceFollowRedirects() {
     return delegate.getInstanceFollowRedirects();
   }
 
-  @Override
-  public void setInstanceFollowRedirects(boolean followRedirects) {
+  @Override public void setInstanceFollowRedirects(boolean followRedirects) {
     delegate.setInstanceFollowRedirects(followRedirects);
   }
 
-  @Override
-  public void connect() throws IOException {
+  @Override public void connect() throws IOException {
     connected = true;
     delegate.connect();
   }
 
-  @Override
-  public boolean getAllowUserInteraction() {
+  @Override public boolean getAllowUserInteraction() {
     return delegate.getAllowUserInteraction();
   }
 
-  @Override
-  public Object getContent() throws IOException {
+  @Override public Object getContent() throws IOException {
     return delegate.getContent();
   }
 
   @SuppressWarnings("unchecked") // Spec does not generify
-  @Override
-  public Object getContent(Class[] types) throws IOException {
+  @Override public Object getContent(Class[] types) throws IOException {
     return delegate.getContent(types);
   }
 
-  @Override
-  public String getContentEncoding() {
+  @Override public String getContentEncoding() {
     return delegate.getContentEncoding();
   }
 
-  @Override
-  public int getContentLength() {
+  @Override public int getContentLength() {
     return delegate.getContentLength();
   }
 
-  @Override
-  public String getContentType() {
+  @Override public String getContentType() {
     return delegate.getContentType();
   }
 
-  @Override
-  public long getDate() {
+  @Override public long getDate() {
     return delegate.getDate();
   }
 
-  @Override
-  public boolean getDefaultUseCaches() {
+  @Override public boolean getDefaultUseCaches() {
     return delegate.getDefaultUseCaches();
   }
 
-  @Override
-  public boolean getDoInput() {
+  @Override public boolean getDoInput() {
     return delegate.getDoInput();
   }
 
-  @Override
-  public boolean getDoOutput() {
+  @Override public boolean getDoOutput() {
     return delegate.getDoOutput();
   }
 
-  @Override
-  public long getExpiration() {
+  @Override public long getExpiration() {
     return delegate.getExpiration();
   }
 
-  @Override
-  public String getHeaderField(int pos) {
+  @Override public String getHeaderField(int pos) {
     return delegate.getHeaderField(pos);
   }
 
-  @Override
-  public Map<String, List<String>> getHeaderFields() {
+  @Override public Map<String, List<String>> getHeaderFields() {
     return delegate.getHeaderFields();
   }
 
-  @Override
-  public Map<String, List<String>> getRequestProperties() {
+  @Override public Map<String, List<String>> getRequestProperties() {
     return delegate.getRequestProperties();
   }
 
-  @Override
-  public void addRequestProperty(String field, String newValue) {
+  @Override public void addRequestProperty(String field, String newValue) {
     delegate.addRequestProperty(field, newValue);
   }
 
-  @Override
-  public String getHeaderField(String key) {
+  @Override public String getHeaderField(String key) {
     return delegate.getHeaderField(key);
   }
 
-  @Override
-  public long getHeaderFieldDate(String field, long defaultValue) {
+  @Override public long getHeaderFieldDate(String field, long defaultValue) {
     return delegate.getHeaderFieldDate(field, defaultValue);
   }
 
-  @Override
-  public int getHeaderFieldInt(String field, int defaultValue) {
+  @Override public int getHeaderFieldInt(String field, int defaultValue) {
     return delegate.getHeaderFieldInt(field, defaultValue);
   }
 
-  @Override
-  public String getHeaderFieldKey(int position) {
+  @Override public String getHeaderFieldKey(int position) {
     return delegate.getHeaderFieldKey(position);
   }
 
-  @Override
-  public long getIfModifiedSince() {
+  @Override public long getIfModifiedSince() {
     return delegate.getIfModifiedSince();
   }
 
-  @Override
-  public InputStream getInputStream() throws IOException {
+  @Override public InputStream getInputStream() throws IOException {
     return delegate.getInputStream();
   }
 
-  @Override
-  public long getLastModified() {
+  @Override public long getLastModified() {
     return delegate.getLastModified();
   }
 
-  @Override
-  public OutputStream getOutputStream() throws IOException {
+  @Override public OutputStream getOutputStream() throws IOException {
     return delegate.getOutputStream();
   }
 
-  @Override
-  public Permission getPermission() throws IOException {
+  @Override public Permission getPermission() throws IOException {
     return delegate.getPermission();
   }
 
-  @Override
-  public String getRequestProperty(String field) {
+  @Override public String getRequestProperty(String field) {
     return delegate.getRequestProperty(field);
   }
 
-  @Override
-  public URL getURL() {
+  @Override public URL getURL() {
     return delegate.getURL();
   }
 
-  @Override
-  public boolean getUseCaches() {
+  @Override public boolean getUseCaches() {
     return delegate.getUseCaches();
   }
 
-  @Override
-  public void setAllowUserInteraction(boolean newValue) {
+  @Override public void setAllowUserInteraction(boolean newValue) {
     delegate.setAllowUserInteraction(newValue);
   }
 
-  @Override
-  public void setDefaultUseCaches(boolean newValue) {
+  @Override public void setDefaultUseCaches(boolean newValue) {
     delegate.setDefaultUseCaches(newValue);
   }
 
-  @Override
-  public void setDoInput(boolean newValue) {
+  @Override public void setDoInput(boolean newValue) {
     delegate.setDoInput(newValue);
   }
 
-  @Override
-  public void setDoOutput(boolean newValue) {
+  @Override public void setDoOutput(boolean newValue) {
     delegate.setDoOutput(newValue);
   }
 
-  @Override
-  public void setIfModifiedSince(long newValue) {
+  @Override public void setIfModifiedSince(long newValue) {
     delegate.setIfModifiedSince(newValue);
   }
 
-  @Override
-  public void setRequestProperty(String field, String newValue) {
+  @Override public void setRequestProperty(String field, String newValue) {
     delegate.setRequestProperty(field, newValue);
   }
 
-  @Override
-  public void setUseCaches(boolean newValue) {
+  @Override public void setUseCaches(boolean newValue) {
     delegate.setUseCaches(newValue);
   }
 
-  @Override
-  public void setConnectTimeout(int timeoutMillis) {
+  @Override public void setConnectTimeout(int timeoutMillis) {
     delegate.setConnectTimeout(timeoutMillis);
   }
 
-  @Override
-  public int getConnectTimeout() {
+  @Override public int getConnectTimeout() {
     return delegate.getConnectTimeout();
   }
 
-  @Override
-  public void setReadTimeout(int timeoutMillis) {
+  @Override public void setReadTimeout(int timeoutMillis) {
     delegate.setReadTimeout(timeoutMillis);
   }
 
-  @Override
-  public int getReadTimeout() {
+  @Override public int getReadTimeout() {
     return delegate.getReadTimeout();
   }
 
-  @Override
-  public String toString() {
+  @Override public String toString() {
     return delegate.toString();
   }
 
-  @Override
-  public void setFixedLengthStreamingMode(int contentLength) {
+  @Override public void setFixedLengthStreamingMode(int contentLength) {
     delegate.setFixedLengthStreamingMode(contentLength);
   }
 
-  @Override
-  public void setChunkedStreamingMode(int chunkLength) {
+  @Override public void setChunkedStreamingMode(int chunkLength) {
     delegate.setChunkedStreamingMode(chunkLength);
   }
 
@@ -403,7 +347,7 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
       super(url, client);
     }
 
-    @Override protected HttpURLConnection getHttpConnectionToCache() {
+    @Override public HttpURLConnection getHttpConnectionToCache() {
       return HttpsURLConnectionImpl.this;
     }
 
@@ -411,51 +355,6 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
       return httpEngine instanceof HttpsEngine
           ? (SecureCacheResponse) httpEngine.getCacheResponse()
           : null;
-    }
-  }
-
-  public static final class HttpsEngine extends HttpEngine {
-    /**
-     * Stash of HttpsEngine.connection.socket to implement requests like
-     * {@link #getCipherSuite} even after the connection has been recycled.
-     */
-    private SSLSocket sslSocket;
-
-    /**
-     * @param policy the HttpURLConnectionImpl with connection configuration
-     */
-    public HttpsEngine(HttpURLConnectionImpl policy, String method, RawHeaders requestHeaders,
-        Connection connection, RetryableOutputStream requestBody) throws IOException {
-      super(policy, method, requestHeaders, connection, requestBody);
-      this.sslSocket = connection != null ? (SSLSocket) connection.getSocket() : null;
-    }
-
-    @Override protected void connected(Connection connection) {
-      this.sslSocket = (SSLSocket) connection.getSocket();
-    }
-
-    @Override protected boolean acceptCacheResponseType(CacheResponse cacheResponse) {
-      return cacheResponse instanceof SecureCacheResponse;
-    }
-
-    @Override protected boolean includeAuthorityInRequestLine() {
-      // Even if there is a proxy, it isn't involved. Always request just the file.
-      return false;
-    }
-
-    public SSLSocket getSslSocket() {
-      return sslSocket;
-    }
-
-    @Override protected TunnelRequest getTunnelConfig() {
-      String userAgent = requestHeaders.getUserAgent();
-      if (userAgent == null) {
-        userAgent = getDefaultUserAgent();
-      }
-
-      URL url = policy.getURL();
-      return new TunnelRequest(url.getHost(), getEffectivePort(url), userAgent,
-          requestHeaders.getProxyAuthorization());
     }
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Policy.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Policy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public interface Policy {
+  /** Returns true if HTTP response caches should be used. */
+  boolean getUseCaches();
+
+  /** Returns the HttpURLConnection instance to store in the cache. */
+  HttpURLConnection getHttpConnectionToCache();
+
+  /** Returns the current destination URL, possibly a redirect. */
+  URL getURL();
+
+  /** Returns the If-Modified-Since timestamp, or 0 if none is set. */
+  long getIfModifiedSince();
+
+  /** Returns true if a non-direct proxy is specified. */
+  boolean usingProxy();
+
+  /** @see java.net.HttpURLConnection#setChunkedStreamingMode(int) */
+  int getChunkLength();
+
+  /** @see java.net.HttpURLConnection#setFixedLengthStreamingMode(int) */
+  long getFixedContentLength();
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -446,9 +446,8 @@ public final class SpdyConnection implements Closeable {
       }
     }
 
-    @Override
-    public void synStream(int flags, int streamId, int associatedStreamId, int priority, int slot,
-        List<String> nameValueBlock) {
+    @Override public void synStream(int flags, int streamId, int associatedStreamId, int priority,
+        int slot, List<String> nameValueBlock) {
       final SpdyStream synStream;
       final SpdyStream previous;
       synchronized (SpdyConnection.this) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyReader.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyReader.java
@@ -222,8 +222,8 @@ final class SpdyReader implements Closeable {
 
     // Subclass inflater to install a dictionary when it's needed.
     Inflater inflater = new Inflater() {
-      @Override
-      public int inflate(byte[] buffer, int offset, int count) throws DataFormatException {
+      @Override public int inflate(byte[] buffer, int offset, int count)
+          throws DataFormatException {
         int result = super.inflate(buffer, offset, count);
         if (result == 0 && needsDictionary()) {
           setDictionary(DICTIONARY);

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -2090,22 +2090,18 @@ public final class URLConnectionTest {
   @Test public void responseCacheReturnsNullOutputStream() throws Exception {
     final AtomicBoolean aborted = new AtomicBoolean();
     client.setResponseCache(new ResponseCache() {
-      @Override
-      public CacheResponse get(URI uri, String requestMethod,
+      @Override public CacheResponse get(URI uri, String requestMethod,
           Map<String, List<String>> requestHeaders) throws IOException {
         return null;
       }
 
-      @Override
-      public CacheRequest put(URI uri, URLConnection connection) throws IOException {
+      @Override public CacheRequest put(URI uri, URLConnection connection) throws IOException {
         return new CacheRequest() {
-          @Override
-          public void abort() {
+          @Override public void abort() {
             aborted.set(true);
           }
 
-          @Override
-          public OutputStream getBody() throws IOException {
+          @Override public OutputStream getBody() throws IOException {
             return null;
           }
         };

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -185,9 +185,8 @@ public final class MockSpdyPeer implements Closeable {
       this.settings = settings;
     }
 
-    @Override
-    public void synStream(int flags, int streamId, int associatedStreamId, int priority, int slot,
-        List<String> nameValueBlock) {
+    @Override public void synStream(int flags, int streamId, int associatedStreamId, int priority,
+        int slot, List<String> nameValueBlock) {
       if (this.type != -1) throw new IllegalStateException();
       this.type = SpdyConnection.TYPE_SYN_STREAM;
       this.flags = flags;


### PR DESCRIPTION
This breaks the direct dependency from HttpEngine to
HttpURLConnectionImpl. With this dependency broken, we
can start to use HttpEngine directly from Dispatcher and
Job.
