### PR TITLE
Catch SecurityExceptions from socket connects.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -97,7 +97,7 @@ public final class Connection implements Closeable {
     }
     connected = true;
     socket = (route.proxy.type() != Proxy.Type.HTTP) ? new Socket(route.proxy) : new Socket();
-    socket.connect(route.inetSocketAddress, connectTimeout);
+    Platform.get().connectSocket(socket, route.inetSocketAddress, connectTimeout);
     socket.setSoTimeout(readTimeout);
     in = socket.getInputStream();
     out = socket.getOutputStream();

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.Socket;
 import java.net.SocketException;
@@ -97,6 +98,11 @@ public class Platform {
    * protocols are only sent if the socket implementation supports NPN.
    */
   public void setNpnProtocols(SSLSocket socket, byte[] npnProtocols) {
+  }
+
+  public void connectSocket(Socket socket, InetSocketAddress address,
+      int connectTimeout) throws IOException {
+    socket.connect(address, connectTimeout);
   }
 
   /**
@@ -237,6 +243,18 @@ public class Platform {
       this.setUseSessionTickets = setUseSessionTickets;
       this.setHostname = setHostname;
     }
+
+    @Override public void connectSocket(Socket socket, InetSocketAddress address,
+        int connectTimeout) throws IOException {
+      try {
+        socket.connect(address, connectTimeout);
+      } catch (SecurityException se) {
+        // Before android 4.3, socket.connect could throw a SecurityException
+        // if opening a socket resulted in an EACCES error.
+        throw new IOException("Exception in connect", se);
+      }
+    }
+
 
     @Override public void enableTlsExtensions(SSLSocket socket, String uriHost) {
       super.enableTlsExtensions(socket, uriHost);


### PR DESCRIPTION
Versions of android prior to 4.3 would throw RTEs
if the underlying socket threw an EACCES error.

See change 50144 on the Android Open Source Project.
