### PR TITLE
Stopped sending final empty frame on stream initiated in sender half-closed state.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
@@ -670,7 +670,9 @@ public final class SpdyStream {
         }
         closed = true;
       }
-      writeFrame(true);
+      if (!out.finished) {
+        writeFrame(true);
+      }
       connection.flush();
       cancelStreamIfNecessary();
     }


### PR DESCRIPTION
The SPDY protocol states the sender of FLAG_FIN must not send further frames on that stream.  This change skips the sending of a final (empty) frame with FLAG_FIN set when the stream is already half-closed because SYN_STREAM was sent with FLAG_FIN set.

Without this change OkHttp will not be able to connect to strictly conforming sites such as https://twitter.com that will reply to the extra frame with RST_STREAM with error code 9 - STREAM_ALREADY_CLOSED.  The library then would continue to reconnect in a loop until memory is exhausted and the process crashes.
