### PR TITLE
Removed trailing whitespace in website/index.html.

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -192,7 +192,7 @@ limitations under the License.</pre>
 
         // Spy on scroll position for real-time updating of current section.
         $('body').scrollspy();
-        
+
         // Use smooth-scroll for internal links.
         $('a').smoothScroll();
 


### PR DESCRIPTION
After the other whitespace style fix, might as well search for any others.  Made the empty line consistent with the others in the html file.
