### PR TITLE
recover should not occur if entire buffer has been written successfully

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/FaultRecoveringOutputStream.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/FaultRecoveringOutputStream.java
@@ -60,8 +60,9 @@ public abstract class FaultRecoveringOutputStream extends AbstractOutputStream {
         out.write(buffer, offset, count);
 
         if (replayBuffer != null) {
-          if (count + replayBuffer.size() > maxReplayBufferLength) {
-            // Failure recovery is no longer possible once we overflow the replay buffer.
+          final int dataWritten = count + replayBuffer.size();
+          if (dataWritten > maxReplayBufferLength || dataWritten == buffer.length) {
+            // Failure recovery is no longer possible once we overflow the replay buffer OR written the entire buffer successfully.
             replayBuffer = null;
           } else {
             // Remember the written bytes to the replay buffer.


### PR DESCRIPTION
If the underline socket has successfully written the entire buffer, it usually means that the server got everything.
Any (?) exception after that means an internal server error:
Timeout - server took too long to process my request, but it still got it!
Broken Pipe - server instance/process/thread crashed, but it still got the request.

This patch will prevent duplicate calls.
