### PR TITLE
Fix a bug in SPDY plus HTTP caching.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -69,7 +69,6 @@ public final class SpdyTransport implements Transport {
   @Override public ResponseHeaders readResponseHeaders() throws IOException {
     List<String> nameValueBlock = stream.getResponseHeaders();
     RawHeaders rawHeaders = RawHeaders.fromNameValueBlock(nameValueBlock);
-    rawHeaders.computeResponseStatusLineFromSpdyHeaders();
     httpEngine.receiveHeaders(rawHeaders);
 
     ResponseHeaders headers = new ResponseHeaders(httpEngine.uri, rawHeaders);

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/RawHeadersTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/RawHeadersTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public final class RawHeadersTest {
-  @Test public void parseNameValueBlock() {
+  @Test public void parseNameValueBlock() throws IOException {
     List<String> nameValueBlock =
         Arrays.asList("cache-control", "no-cache, no-store", "set-cookie", "Cookie1\u0000Cookie2",
             ":status", "200 OK");


### PR DESCRIPTION
With spdy/3 the built-in headers were renamed from 'status'
to ':status' and 'version' to ':version'. This caused the
response cache to break, since it was parsing lines like
':status: 200 OK' by splitting on the first colon.

The fix drops these synthetic headers as soon as they're
received; converting them to the HTTP form immediately.
