### PR TITLE
spdy 3 support length 0 header value

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -261,7 +261,6 @@ final class Spdy3 implements Variant {
           String name = readString();
           String values = readString();
           if (name.length() == 0) throw ioException("name.length == 0");
-          if (values.length() == 0) throw ioException("values.length == 0");
           entries.add(name);
           entries.add(values);
         }


### PR DESCRIPTION
Spdy 3 support length 0 header value (http://dev.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3#TOC-2.6.10-Name-Value-Header-Block) while okhttp follows spdy2 convention throwing an exception when detecting 0 length header value. 
