### PR TITLE
Switch NPN from optional to provided.

### DIFF
--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.mortbay.jetty.npn</groupId>
       <artifactId>npn-boot</artifactId>
-      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Optional dependencies get included in the fat jar but are not transitive. Provided dependencies do NOT get included in the fat jar and are also not transitive.

I believe the former is a bug in the Maven assembly plugin so the latter case is used as a workaround.
