### PR TITLE
Fix unresolved function call on JVM < 1.7

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -26,6 +26,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.Socket;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URL;
 import java.nio.ByteOrder;
@@ -129,6 +130,21 @@ public final class Util {
     if (socket != null) {
       try {
         socket.close();
+      } catch (RuntimeException rethrown) {
+        throw rethrown;
+      } catch (Exception ignored) {
+      }
+    }
+  }
+
+  /**
+   * Closes {@code serverSocket}, ignoring any checked exceptions. Does nothing if
+   * {@code serverSocket} is null.
+   */
+  public static void closeQuietly(ServerSocket serverSocket) {
+    if (serverSocket != null) {
+      try {
+        serverSocket.close();
       } catch (RuntimeException rethrown) {
         throw rethrown;
       } catch (Exception ignored) {


### PR DESCRIPTION
This is a fix for using Mockwebserver on Android.

I think the project is supposed to support Java 1.5 and 1.6 and that this is the proper way to fix it (looking at the other closeQuietly(Socket) method) hence the pull request,
otherwise just let me know.

See commit message for details.
