### PR TITLE
Support use ';' as separator of "Cache-Control"

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HeaderParser.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HeaderParser.java
@@ -27,11 +27,11 @@ final class HeaderParser {
     int pos = 0;
     while (pos < value.length()) {
       int tokenStart = pos;
-      pos = skipUntil(value, pos, "=,");
+      pos = skipUntil(value, pos, "=,;");
       String directive = value.substring(tokenStart, pos).trim();
 
-      if (pos == value.length() || value.charAt(pos) == ',') {
-        pos++; // consume ',' (if necessary)
+      if (pos == value.length() || value.charAt(pos) == ',' || value.charAt(pos) == ';') {
+        pos++; // consume ',' or ';' (if necessary)
         handler.handle(directive, null);
         continue;
       }
@@ -52,7 +52,7 @@ final class HeaderParser {
         // unquoted string
       } else {
         int parameterStart = pos;
-        pos = skipUntil(value, pos, ",");
+        pos = skipUntil(value, pos, ",;");
         parameter = value.substring(parameterStart, pos).trim();
       }
 


### PR DESCRIPTION
Picasso set "Cache-Control" with this line of code

```
connection.setRequestProperty("Cache-Control", "only-if-cached;max-age=" + Integer.MAX_VALUE);
```

But okhttp only recognize ',' as separator of directives. I have test the behavior of HttpUrlConnection, it don't support ';' either.
 I'm not sure should okhttp add this compatibility.
