### PR TITLE
GOAWAY when payload size is too long

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/ProtocolException.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/ProtocolException.java
@@ -1,0 +1,13 @@
+package com.squareup.okhttp.internal.spdy;
+
+import java.io.IOException;
+
+/** Indicates a compatibility or framing problem. */
+class ProtocolException extends IOException {
+  final ErrorCode errorCode;
+
+  ProtocolException(ErrorCode errorCode) {
+    super(errorCode.name());
+    this.errorCode = errorCode;
+  }
+}

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -435,6 +435,9 @@ public final class SpdyConnection implements Closeable {
         }
         connectionErrorCode = ErrorCode.NO_ERROR;
         streamErrorCode = ErrorCode.CANCEL;
+      } catch (ProtocolException e) {
+        connectionErrorCode = e.errorCode;
+        streamErrorCode = ErrorCode.PROTOCOL_ERROR;
       } catch (IOException e) {
         connectionErrorCode = ErrorCode.PROTOCOL_ERROR;
         streamErrorCode = ErrorCode.PROTOCOL_ERROR;


### PR DESCRIPTION
This change enforces the contract wrt payload size on http 2.0 messages.

Before we write a HEADER or DATA frame (the two variable length frames implemented so far), we check to see if it will end up with more than 2^14-1 (16383) octets.  According to the [spec](http://tools.ietf.org/html/draft-ietf-httpbis-http2-04#section-9.1), an attempt to go over this should end up in a `GOAWAY` `FRAME_TOO_LARGE` message.
