### PR TITLE
backfill base test of simple http/2 headers frame

### DIFF
--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.spdy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.Assert.fail;
+
+class BaseTestHandler implements FrameReader.Handler {
+  @Override public void data(boolean inFinished, int streamId, InputStream in, int length)
+      throws IOException {
+    fail();
+  }
+
+  @Override
+  public void headers(boolean outFinished, boolean inFinished, int streamId, int associatedStreamId,
+      int priority, List<String> nameValueBlock, HeadersMode headersMode) {
+    fail();
+  }
+
+  @Override public void rstStream(int streamId, ErrorCode errorCode) {
+    fail();
+  }
+
+  @Override public void settings(boolean clearPrevious, Settings settings) {
+    fail();
+  }
+
+  @Override public void noop() {
+    fail();
+  }
+
+  @Override public void ping(boolean reply, int payload1, int payload2) {
+    fail();
+  }
+
+  @Override public void goAway(int lastGoodStreamId, ErrorCode errorCode) {
+    fail();
+  }
+
+  @Override
+  public void windowUpdate(int streamId, int deltaWindowSize, boolean endFlowControl) {
+    fail();
+  }
+
+  @Override public void priority(int streamId, int priority) {
+    fail();
+  }
+}

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Http20Draft04Test.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Http20Draft04Test.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.spdy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Http20Draft04Test {
+
+  @Test public void onlyOneLiteralHeadersFrame() throws IOException {
+    final int expectedStreamId = 15;
+    final List<String> sentHeaders = Arrays.asList("name", "value");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputStream dataOut = new DataOutputStream(out);
+
+    // Write the headers frame, specifying no more frames are expected.
+    {
+      byte[] headerBytes = literalHeaders(sentHeaders);
+      dataOut.writeShort(headerBytes.length);
+      dataOut.write(Http20Draft04.TYPE_HEADERS);
+      dataOut.write(Http20Draft04.FLAG_END_HEADERS | Http20Draft04.FLAG_END_STREAM);
+      dataOut.writeInt(expectedStreamId & 0x7fffffff); // stream with reserved bit set
+      dataOut.write(headerBytes);
+    }
+
+    FrameReader fr = new Http20Draft04.Reader(new ByteArrayInputStream(out.toByteArray()), false);
+
+    // Consume the headers frame.
+    fr.nextFrame(new BaseTestHandler() {
+
+      @Override
+      public void headers(boolean outFinished, boolean inFinished, int streamId,
+          int associatedStreamId, int priority, List<String> nameValueBlock,
+          HeadersMode headersMode) {
+        assertFalse(outFinished);
+        assertTrue(inFinished);
+        assertEquals(expectedStreamId, streamId);
+        assertEquals(-1, associatedStreamId);
+        assertEquals(-1, priority);
+        assertEquals(sentHeaders, nameValueBlock);
+        assertEquals(HeadersMode.HTTP_20_HEADERS, headersMode);
+      }
+    });
+  }
+
+  @Test public void twoLiteralHeadersFrames() throws IOException {
+    final int expectedStreamId = 15;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputStream dataOut = new DataOutputStream(out);
+
+    // Write the first headers frame.
+    {
+      byte[] headerBytes = literalHeaders(Arrays.asList("foo", "bar"));
+      dataOut.writeShort(headerBytes.length);
+      dataOut.write(Http20Draft04.TYPE_HEADERS);
+      dataOut.write(0); // no flags
+      dataOut.writeInt(expectedStreamId & 0x7fffffff); // stream with reserved bit set
+      dataOut.write(headerBytes);
+    }
+
+    // Write the second headers frame, specifying no more frames are expected.
+    {
+      byte[] headerBytes = literalHeaders(Arrays.asList("baz", "qux"));
+      dataOut.writeShort(headerBytes.length);
+      dataOut.write(Http20Draft04.TYPE_HEADERS);
+      dataOut.write(Http20Draft04.FLAG_END_HEADERS | Http20Draft04.FLAG_END_STREAM);
+      dataOut.writeInt(expectedStreamId & 0x7fffffff); // stream with reserved bit set
+      dataOut.write(headerBytes);
+    }
+
+    FrameReader fr = new Http20Draft04.Reader(new ByteArrayInputStream(out.toByteArray()), false);
+
+    // Reading the above frames should result in a concatenated nameValueBlock.
+    fr.nextFrame(new BaseTestHandler() {
+
+      @Override
+      public void headers(boolean outFinished, boolean inFinished, int streamId,
+          int associatedStreamId, int priority, List<String> nameValueBlock,
+          HeadersMode headersMode) {
+        assertFalse(outFinished);
+        assertTrue(inFinished);
+        assertEquals(expectedStreamId, streamId);
+        assertEquals(-1, associatedStreamId);
+        assertEquals(-1, priority);
+        assertEquals(Arrays.asList("foo", "bar", "baz", "qux"), nameValueBlock);
+        assertEquals(HeadersMode.HTTP_20_HEADERS, headersMode);
+      }
+    });
+  }
+
+  static byte[] literalHeaders(List<String> sentHeaders) throws IOException {
+    ByteArrayOutputStream headerBytes = new ByteArrayOutputStream();
+    new Hpack.Writer(new DataOutputStream(headerBytes)).writeHeaders(sentHeaders);
+    return headerBytes.toByteArray();
+  }
+}


### PR DESCRIPTION
setting stage to test behavior of our http/2 impl as drafts are in flux.
