### PR TITLE
Update to http/2 draft 6 CONTINUATION after HEADERS frame

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -71,15 +71,15 @@ import static com.squareup.okhttp.mockwebserver.SocketPolicy.FAIL_HANDSHAKE;
 public final class MockWebServer {
   private static final byte[] NPN_PROTOCOLS = {
       // TODO: support HTTP/2.0.
-      // 17, 'H', 'T', 'T', 'P', '-', 'd', 'r', 'a', 'f', 't', '-', '0', '4', '/', '2', '.', '0',
+      // 17, 'H', 'T', 'T', 'P', '-', 'd', 'r', 'a', 'f', 't', '-', '0', '6', '/', '2', '.', '0',
       6, 's', 'p', 'd', 'y', '/', '3',
       8, 'h', 't', 't', 'p', '/', '1', '.', '1'
   };
   private static final byte[] SPDY3 = new byte[] {
       's', 'p', 'd', 'y', '/', '3'
   };
-  private static final byte[] HTTP_20_DRAFT_04 = new byte[] {
-      'H', 'T', 'T', 'P', '-', 'd', 'r', 'a', 'f', 't', '-', '0', '4', '/', '2', '.', '0'
+  private static final byte[] HTTP_20_DRAFT_06 = new byte[] {
+      'H', 'T', 'T', 'P', '-', 'd', 'r', 'a', 'f', 't', '-', '0', '6', '/', '2', '.', '0'
   };
   private static final byte[] HTTP_11 = new byte[] {
       'h', 't', 't', 'p', '/', '1', '.', '1'
@@ -327,8 +327,8 @@ public final class MockWebServer {
             byte[] selectedProtocol = Platform.get().getNpnSelectedProtocol(sslSocket);
             if (selectedProtocol == null || Arrays.equals(selectedProtocol, HTTP_11)) {
               transport = Transport.HTTP_11;
-            } else if (Arrays.equals(selectedProtocol, HTTP_20_DRAFT_04)) {
-              transport = Transport.HTTP_20_DRAFT_04;
+            } else if (Arrays.equals(selectedProtocol, HTTP_20_DRAFT_06)) {
+              transport = Transport.HTTP_20_DRAFT_06;
             } else if (Arrays.equals(selectedProtocol, SPDY3)) {
               transport = Transport.SPDY_3;
             } else {
@@ -341,14 +341,14 @@ public final class MockWebServer {
           socket = raw;
         }
 
-        if (transport == Transport.SPDY_3 || transport == Transport.HTTP_20_DRAFT_04) {
+        if (transport == Transport.SPDY_3 || transport == Transport.HTTP_20_DRAFT_06) {
           SpdySocketHandler spdySocketHandler = new SpdySocketHandler(socket, transport);
           SpdyConnection.Builder builder = new SpdyConnection.Builder(false, socket)
               .handler(spdySocketHandler);
           if (transport == Transport.SPDY_3) {
             builder.spdy3();
           } else {
-            builder.http20Draft04();
+            builder.http20Draft06();
           }
           SpdyConnection spdyConnection = builder.build();
           openSpdyConnections.put(spdyConnection, Boolean.TRUE);
@@ -717,6 +717,6 @@ public final class MockWebServer {
   }
 
   enum Transport {
-    HTTP_11, SPDY_3, HTTP_20_DRAFT_04
+    HTTP_11, SPDY_3, HTTP_20_DRAFT_06
   }
 }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Hpack.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Hpack.java
@@ -9,8 +9,8 @@ import java.util.BitSet;
 import java.util.List;
 
 /**
- * Read and write HPACK v01.
- * http://http2.github.io/compression-spec/compression-spec.html#rfc.status
+ * Read and write HPACK v03.
+ * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-03
  */
 final class Hpack {
   static final int PREFIX_5_BITS = 0x1f;

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -59,7 +59,7 @@ public final class SpdyConnection implements Closeable {
       Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
       Util.daemonThreadFactory("OkHttp SpdyConnection"));
 
-  /** The protocol variant, like SPDY/3 or HTTP-draft-04/2.0. */
+  /** The protocol variant, like SPDY/3 or HTTP-draft-06/2.0. */
   final Variant variant;
 
   /** True if this peer initiated the connection. */
@@ -416,8 +416,8 @@ public final class SpdyConnection implements Closeable {
       return this;
     }
 
-    public Builder http20Draft04() {
-      this.variant = Variant.HTTP_20_DRAFT_04;
+    public Builder http20Draft06() {
+      this.variant = Variant.HTTP_20_DRAFT_06;
       return this;
     }
 

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
@@ -21,7 +21,7 @@ import java.io.OutputStream;
 /** A version and dialect of the framed socket protocol. */
 interface Variant {
   Variant SPDY3 = new Spdy3();
-  Variant HTTP_20_DRAFT_04 = new Http20Draft04();
+  Variant HTTP_20_DRAFT_06 = new Http20Draft06();
 
   /**
    * @param client true if this is the HTTP client's reader, reading frames from


### PR DESCRIPTION
This adjusts currently implemented code to be in compliance with http/2 draft 6 headers continuations.
