### PR TITLE
MockWebServer can now read headers sent by http2 clients

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -70,8 +70,7 @@ import static com.squareup.okhttp.mockwebserver.SocketPolicy.FAIL_HANDSHAKE;
  */
 public final class MockWebServer {
   private static final byte[] NPN_PROTOCOLS = {
-      // TODO: support HTTP/2.0.
-      // 17, 'H', 'T', 'T', 'P', '-', 'd', 'r', 'a', 'f', 't', '-', '0', '6', '/', '2', '.', '0',
+      17, 'H', 'T', 'T', 'P', '-', 'd', 'r', 'a', 'f', 't', '-', '0', '6', '/', '2', '.', '0',
       6, 's', 'p', 'd', 'y', '/', '3',
       8, 'h', 't', 't', 'p', '/', '1', '.', '1'
   };


### PR DESCRIPTION
This knocks out some dents in HPACK (http2 header compression).

Along with unit tests, I ran the SampleServer example (with  `-Xbootclasspath/p:/path/to/npn-boot.jar`) and was able to run the [http2 ruby client](https://github.com/igrigorik/http-2) against it.

This doesn't perfect the HPACK impl or fully support it.  However, it seems far enough progress to start enabling http2 on MockWebServer.
