### PR TITLE
Support PATCH requests in MockWebServer

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -504,7 +504,9 @@ public final class MockWebServer {
       if (hasBody) {
         throw new IllegalArgumentException("Request must not have a body: " + request);
       }
-    } else if (!request.startsWith("POST ") && !request.startsWith("PUT ")) {
+    } else if (!request.startsWith("POST ")
+        && !request.startsWith("PUT ")
+        && !request.startsWith("PATCH ")) {
       throw new UnsupportedOperationException("Unexpected method: " + request);
     }
 


### PR DESCRIPTION
The `HttpURLConnectionImpl` supports PATCH methods with a body. MockWebServer shouldn't reject those requests. 
