### PR TITLE
Buffered Stream wrapper should be taken place before SpdyConnection buil...

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -105,8 +105,7 @@ public final class Connection implements Closeable {
 
     if (route.address.sslSocketFactory != null) {
       upgradeToTls(tunnelRequest);
-    }
-    else{
+    } else {
       streamWrapper();
     }
   }
@@ -329,8 +328,8 @@ public final class Connection implements Closeable {
       }
     }
   }
-  
-  private void streamWrapper(){
+
+  private void streamWrapper() throws IOException {
     //Use MTU-sized buffers to send fewer packets.
     int mtu = Platform.get().getMtu(socket);
     if (mtu < 1024) mtu = 1024;


### PR DESCRIPTION
Hey I'm back with the small packet issue as I found that the Buffered Stream wrapper was implemented after SpdyConnection set up which cause it did not work.

This case is independent with the getMtu issue.
