### PR TITLE
Define async APIs and switch Job to use HttpEngine directly.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Job.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Job.java
@@ -15,27 +15,82 @@
  */
 package com.squareup.okhttp;
 
+import com.squareup.okhttp.internal.http.HttpAuthenticator;
+import com.squareup.okhttp.internal.http.HttpEngine;
+import com.squareup.okhttp.internal.http.HttpTransport;
+import com.squareup.okhttp.internal.http.HttpsEngine;
+import com.squareup.okhttp.internal.http.Policy;
+import com.squareup.okhttp.internal.http.RawHeaders;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.Proxy;
+import java.net.URL;
 
-final class Job implements Runnable {
-  final HttpURLConnection connection;
-  final Request request;
-  final Response.Receiver responseReceiver;
-  final Dispatcher dispatcher;
+import static com.squareup.okhttp.internal.Util.getEffectivePort;
+import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_MOVED_PERM;
+import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_MOVED_TEMP;
+import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_MULT_CHOICE;
+import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_PROXY_AUTH;
+import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_SEE_OTHER;
+import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_TEMP_REDIRECT;
+import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_UNAUTHORIZED;
 
-  public Job(Dispatcher dispatcher, HttpURLConnection connection, Request request,
+final class Job implements Runnable, Policy {
+  private final Dispatcher dispatcher;
+  private final OkHttpClient client;
+  private final Response.Receiver responseReceiver;
+
+  /** The request; possibly a consequence of redirects or auth headers. */
+  private Request request;
+
+  public Job(Dispatcher dispatcher, OkHttpClient client, Request request,
       Response.Receiver responseReceiver) {
     this.dispatcher = dispatcher;
-    this.connection = connection;
+    this.client = client;
     this.request = request;
     this.responseReceiver = responseReceiver;
   }
 
+  @Override public int getChunkLength() {
+    return request.body().contentLength() == -1 ? HttpTransport.DEFAULT_CHUNK_LENGTH : -1;
+  }
+
+  @Override public long getFixedContentLength() {
+    return request.body().contentLength();
+  }
+
+  @Override public boolean getUseCaches() {
+    return false; // TODO.
+  }
+
+  @Override public HttpURLConnection getHttpConnectionToCache() {
+    return null;
+  }
+
+  @Override public URL getURL() {
+    return request.url();
+  }
+
+  @Override public long getIfModifiedSince() {
+    return 0; // For HttpURLConnection only. We let the cache drive this.
+  }
+
+  @Override public boolean usingProxy() {
+    return false; // We let the connection decide this.
+  }
+
+  @Override public void setSelectedProxy(Proxy proxy) {
+    // Do nothing.
+  }
+
+  Object tag() {
+    return request.tag();
+  }
+
   @Override public void run() {
     try {
-      sendRequest();
-      Response response = readResponse();
+      Response response = execute();
       responseReceiver.onResponse(response);
     } catch (IOException e) {
       responseReceiver.onFailure(new Failure.Builder()
@@ -43,43 +98,135 @@ final class Job implements Runnable {
           .exception(e)
           .build());
     } finally {
-      connection.disconnect();
+      // TODO: close the response body
+      // TODO: release the HTTP engine (potentially multiple!)
       dispatcher.finished(this);
     }
   }
 
-  private HttpURLConnection sendRequest() throws IOException {
-    for (int i = 0; i < request.headerCount(); i++) {
-      connection.addRequestProperty(request.headerName(i), request.headerValue(i));
-    }
-    Request.Body body = request.body();
-    if (body != null) {
-      connection.setDoOutput(true);
-      long contentLength = body.contentLength();
-      if (contentLength == -1 || contentLength > Integer.MAX_VALUE) {
-        connection.setChunkedStreamingMode(0);
-      } else {
-        // Don't call setFixedLengthStreamingMode(long); that's only available on Java 1.7+.
-        connection.setFixedLengthStreamingMode((int) contentLength);
+  private Response execute() throws IOException {
+    Connection connection = null;
+    Response redirectedBy = null;
+
+    while (true) {
+      HttpEngine engine = newEngine(connection);
+
+      Request.Body body = request.body();
+      if (body != null) {
+        MediaType contentType = body.contentType();
+        if (contentType == null) throw new IllegalStateException("contentType == null");
+        if (engine.getRequestHeaders().getContentType() == null) {
+          engine.getRequestHeaders().setContentType(contentType.toString());
+        }
       }
-      body.writeTo(connection.getOutputStream());
+
+      engine.sendRequest();
+
+      if (body != null) {
+        body.writeTo(engine.getRequestBody());
+      }
+
+      engine.readResponse();
+
+      int responseCode = engine.getResponseCode();
+      Dispatcher.RealResponseBody responseBody = new Dispatcher.RealResponseBody(
+          engine.getResponseHeaders(), engine.getResponseBody());
+
+      Response response = new Response.Builder(request, responseCode)
+          .rawHeaders(engine.getResponseHeaders().getHeaders())
+          .body(responseBody)
+          .redirectedBy(redirectedBy)
+          .build();
+
+      Request redirect = processResponse(engine, response);
+
+      if (redirect == null) {
+        engine.automaticallyReleaseConnectionToPool();
+        return response;
+      }
+
+      // TODO: fail if too many redirects
+      // TODO: fail if not following redirects
+      // TODO: release engine
+
+      connection = sameConnection(request, redirect) ? engine.getConnection() : null;
+      redirectedBy = response;
+      request = redirect;
     }
-    return connection;
   }
 
-  private Response readResponse() throws IOException {
-    int responseCode = connection.getResponseCode();
-    Response.Builder responseBuilder = new Response.Builder(request, responseCode);
-
-    for (int i = 0; true; i++) {
-      String name = connection.getHeaderFieldKey(i);
-      if (name == null) break;
-      String value = connection.getHeaderField(i);
-      responseBuilder.addHeader(name, value);
+  HttpEngine newEngine(Connection connection) throws IOException {
+    String protocol = request.url().getProtocol();
+    RawHeaders requestHeaders = request.rawHeaders();
+    if (protocol.equals("http")) {
+      return new HttpEngine(client, this, request.method(), requestHeaders, connection, null);
+    } else if (protocol.equals("https")) {
+      return new HttpsEngine(client, this, request.method(), requestHeaders, connection, null);
+    } else {
+      throw new AssertionError();
     }
+  }
 
-    responseBuilder.body(new Dispatcher.RealResponseBody(connection, connection.getInputStream()));
-    // TODO: set redirectedBy
-    return responseBuilder.build();
+  /**
+   * Figures out the HTTP request to make in response to receiving {@code
+   * response}. This will either add authentication headers or follow
+   * redirects. If a follow-up is either unnecessary or not applicable, this
+   * returns null.
+   */
+  private Request processResponse(HttpEngine engine, Response response) throws IOException {
+    Request request = response.request();
+    Proxy selectedProxy = engine.getConnection() != null
+        ? engine.getConnection().getRoute().getProxy()
+        : client.getProxy();
+    int responseCode = response.code();
+
+    switch (responseCode) {
+      case HTTP_PROXY_AUTH:
+        if (selectedProxy.type() != Proxy.Type.HTTP) {
+          throw new ProtocolException("Received HTTP_PROXY_AUTH (407) code while not using proxy");
+        }
+        // fall-through
+      case HTTP_UNAUTHORIZED:
+        RawHeaders successorRequestHeaders = request.rawHeaders();
+        boolean credentialsFound = HttpAuthenticator.processAuthHeader(client.getAuthenticator(),
+            response.code(), response.rawHeaders(), successorRequestHeaders, selectedProxy,
+            this.request.url());
+        return credentialsFound
+            ? request.newBuilder().rawHeaders(successorRequestHeaders).build()
+            : null;
+
+      case HTTP_MULT_CHOICE:
+      case HTTP_MOVED_PERM:
+      case HTTP_MOVED_TEMP:
+      case HTTP_SEE_OTHER:
+      case HTTP_TEMP_REDIRECT:
+        String method = request.method();
+        if (responseCode == HTTP_TEMP_REDIRECT && !method.equals("GET") && !method.equals("HEAD")) {
+          // "If the 307 status code is received in response to a request other than GET or HEAD,
+          // the user agent MUST NOT automatically redirect the request"
+          return null;
+        }
+
+        String location = response.header("Location");
+        if (location == null) {
+          return null;
+        }
+
+        URL url = new URL(request.url(), location);
+        if (!url.getProtocol().equals("https") && !url.getProtocol().equals("http")) {
+          return null; // Don't follow redirects to unsupported protocols.
+        }
+
+        return this.request.newBuilder().url(url).build();
+
+      default:
+        return null;
+    }
+  }
+
+  private boolean sameConnection(Request a, Request b) {
+    return a.url().getHost().equals(b.url().getHost())
+        && getEffectivePort(a.url()) == getEffectivePort(b.url())
+        && a.url().getProtocol().equals(b.url().getProtocol());
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -324,7 +324,7 @@ public final class OkHttpClient implements URLStreamHandlerFactory {
     // Create the HttpURLConnection immediately so the enqueued job gets the current settings of
     // this client. Otherwise changes to this client (socket factory, redirect policy, etc.) may
     // incorrectly be reflected in the request when it is dispatched later.
-    dispatcher.enqueue(open(request.url()), request, responseReceiver);
+    dispatcher.enqueue(copyWithDefaults(), request, responseReceiver);
   }
 
   /**

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -74,6 +74,10 @@ import java.util.Set;
     return headers.names();
   }
 
+  RawHeaders rawHeaders() {
+    return new RawHeaders(headers);
+  }
+
   public int headerCount() {
     return headers.length();
   }
@@ -94,16 +98,21 @@ import java.util.Set;
     return tag;
   }
 
-  public abstract static class Body {
-    /**
-     * Returns the Content-Type header for this body, or null if the content
-     * type is unknown.
-     */
-    public MediaType contentType() {
-      return null;
-    }
+  Builder newBuilder() {
+    return new Builder(url)
+        .method(method, body)
+        .rawHeaders(headers)
+        .tag(tag);
+  }
 
-    /** Returns the number of bytes in this body, or -1 if that count is unknown. */
+  public abstract static class Body {
+    /** Returns the Content-Type header for this body. */
+    public abstract MediaType contentType();
+
+    /**
+     * Returns the number of bytes that will be written to {@code out} in a call
+     * to {@link #writeTo}, or -1 if that count is unknown.
+     */
     public long contentLength() {
       return -1;
     }
@@ -183,7 +192,7 @@ import java.util.Set;
   public static class Builder {
     private URL url;
     private String method = "GET";
-    private final RawHeaders headers = new RawHeaders();
+    private RawHeaders headers = new RawHeaders();
     private Body body;
     private Object tag;
 
@@ -225,6 +234,11 @@ import java.util.Set;
      */
     public Builder addHeader(String name, String value) {
       headers.add(name, value);
+      return this;
+    }
+
+    Builder rawHeaders(RawHeaders rawHeaders) {
+      headers = new RawHeaders(rawHeaders);
       return this;
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -370,10 +370,10 @@ public final class HttpTransport implements Transport {
 
   /** An HTTP body with a fixed length specified in advance. */
   private static class FixedLengthInputStream extends AbstractHttpInputStream {
-    private int bytesRemaining;
+    private long bytesRemaining;
 
     public FixedLengthInputStream(InputStream is, CacheRequest cacheRequest, HttpEngine httpEngine,
-        int length) throws IOException {
+        long length) throws IOException {
       super(is, httpEngine, cacheRequest);
       bytesRemaining = length;
       if (bytesRemaining == 0) {
@@ -387,7 +387,7 @@ public final class HttpTransport implements Transport {
       if (bytesRemaining == 0) {
         return -1;
       }
-      int read = in.read(buffer, offset, Math.min(count, bytesRemaining));
+      int read = in.read(buffer, offset, (int) Math.min(count, bytesRemaining));
       if (read == -1) {
         unexpectedEndOfInput(); // the server didn't supply the promised content length
         throw new ProtocolException("unexpected end of stream");
@@ -402,7 +402,7 @@ public final class HttpTransport implements Transport {
 
     @Override public int available() throws IOException {
       checkNotClosed();
-      return bytesRemaining == 0 ? 0 : Math.min(in.available(), bytesRemaining);
+      return bytesRemaining == 0 ? 0 : (int) Math.min(in.available(), bytesRemaining);
     }
 
     @Override public void close() throws IOException {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -60,7 +60,7 @@ import static com.squareup.okhttp.internal.Util.getEffectivePort;
 public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
 
   /** Numeric status code, 307: Temporary Redirect. */
-  static final int HTTP_TEMP_REDIRECT = 307;
+  public static final int HTTP_TEMP_REDIRECT = 307;
 
   /**
    * How many redirects should we follow? Chrome follows 21; Firefox, curl,
@@ -311,7 +311,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
       // Although RFC 2616 10.3.2 specifies that a HTTP_MOVED_PERM
       // redirect should keep the same method, Chrome, Firefox and the
       // RI all issue GETs when following any redirect.
-      int responseCode = getResponseCode();
+      int responseCode = httpEngine.getResponseCode();
       if (responseCode == HTTP_MULT_CHOICE
           || responseCode == HTTP_MOVED_PERM
           || responseCode == HTTP_MOVED_TEMP
@@ -321,8 +321,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
       }
 
       if (requestBody != null && !(requestBody instanceof RetryableOutputStream)) {
-        throw new HttpRetryException("Cannot retry streamed HTTP body",
-            httpEngine.getResponseCode());
+        throw new HttpRetryException("Cannot retry streamed HTTP body", responseCode);
       }
 
       if (retry == Retry.DIFFERENT_CONNECTION) {
@@ -413,7 +412,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
 
   /**
    * Returns the retry action to take for the current response headers. The
-   * headers, proxy and target URL or this connection may be adjusted to
+   * headers, proxy and target URL for this connection may be adjusted to
    * prepare for a follow up request.
    */
   private Retry processResponseHeaders() throws IOException {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/ResponseHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/ResponseHeaders.java
@@ -114,8 +114,9 @@ public final class ResponseHeaders {
 
   private String contentEncoding;
   private String transferEncoding;
-  private int contentLength = -1;
+  private long contentLength = -1;
   private String connection;
+  private String contentType;
 
   public ResponseHeaders(URI uri, RawHeaders headers) {
     this.uri = uri;
@@ -172,9 +173,11 @@ public final class ResponseHeaders {
         transferEncoding = value;
       } else if ("Content-Length".equalsIgnoreCase(fieldName)) {
         try {
-          contentLength = Integer.parseInt(value);
+          contentLength = Long.parseLong(value);
         } catch (NumberFormatException ignored) {
         }
+      } else if ("Content-Type".equalsIgnoreCase(fieldName)) {
+        contentType = value;
       } else if ("Connection".equalsIgnoreCase(fieldName)) {
         connection = value;
       } else if (SENT_MILLIS.equalsIgnoreCase(fieldName)) {
@@ -263,8 +266,12 @@ public final class ResponseHeaders {
     return contentEncoding;
   }
 
-  public int getContentLength() {
+  public long getContentLength() {
     return contentLength;
+  }
+
+  public String getContentType() {
+    return contentType;
   }
 
   public String getConnection() {

--- a/okhttp/src/test/java/com/squareup/okhttp/AsyncApiTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/AsyncApiTest.java
@@ -68,5 +68,6 @@ public final class AsyncApiTest {
     RecordedRequest recordedRequest = server.takeRequest();
     assertEquals("def", recordedRequest.getUtf8Body());
     assertEquals("3", recordedRequest.getHeader("Content-Length"));
+    assertEquals("text/plain; charset=utf-8", recordedRequest.getHeader("Content-Type"));
   }
 }


### PR DESCRIPTION
Using HttpEngine directly introduces some duplicated code with
HttpURLConnection. It also breaks the response cache. I think
this is the best route going forward; and eventually we could
invert this relationship to have HttpURLConnection depending on
Job directly rather than vice versa.
