### PR TITLE
Introduce Handshake as a value object.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/internal/spdy/SpdyServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/internal/spdy/SpdyServer.java
@@ -24,12 +24,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Arrays;
 import java.util.List;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import org.eclipse.jetty.npn.NextProtoNego;
@@ -154,8 +152,7 @@ public final class SpdyServer implements IncomingStreamHandler {
     }
 
     SpdyServer server = new SpdyServer(new File(args[0]));
-    SSLContext sslContext = new SslContextBuilder(InetAddress.getLocalHost().getHostName()).build();
-    server.useHttps(sslContext.getSocketFactory());
+    server.useHttps(SslContextBuilder.localhost().getSocketFactory());
     server.run();
   }
 }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -25,8 +25,8 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
-import java.net.Socket;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
 import java.nio.ByteOrder;
@@ -34,6 +34,7 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
@@ -380,6 +381,11 @@ public final class Util {
   /** Returns an immutable copy of {@code list}. */
   public static <T> List<T> immutableList(List<T> list) {
     return Collections.unmodifiableList(new ArrayList<T>(list));
+  }
+
+  /** Returns an immutable list containing {@code elements}. */
+  public static <T> List<T> immutableList(T[] elements) {
+    return Collections.unmodifiableList(Arrays.asList(elements.clone()));
   }
 
   public static ThreadFactory daemonThreadFactory(final String name) {

--- a/okhttp/src/main/java/com/squareup/okhttp/Handshake.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Handshake.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.okhttp;
+
+import com.squareup.okhttp.internal.Util;
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
+/**
+ * A record of a TLS handshake. For HTTPS clients, the client is <i>local</i>
+ * and the remote server is its <i>peer</i>.
+ *
+ * <p>This value object describes a completed handshake. Use {@link
+ * javax.net.ssl.SSLSocketFactory} to set policy for new handshakes.
+ */
+public final class Handshake {
+  private final String cipherSuite;
+  private final List<Certificate> peerCertificates;
+  private final List<Certificate> localCertificates;
+
+  private Handshake(
+      String cipherSuite, List<Certificate> peerCertificates, List<Certificate> localCertificates) {
+    this.cipherSuite = cipherSuite;
+    this.peerCertificates = peerCertificates;
+    this.localCertificates = localCertificates;
+  }
+
+  public static Handshake get(SSLSession session) {
+    String cipherSuite = session.getCipherSuite();
+    if (cipherSuite == null) throw new IllegalStateException("cipherSuite == null");
+
+    Certificate[] peerCertificates;
+    try {
+      peerCertificates = session.getPeerCertificates();
+    } catch (SSLPeerUnverifiedException ignored) {
+      peerCertificates = null;
+    }
+    List<Certificate> peerCertificatesList = peerCertificates != null
+        ? Util.immutableList(peerCertificates)
+        : Collections.<Certificate>emptyList();
+
+    Certificate[] localCertificates = session.getLocalCertificates();
+    List<Certificate> localCertificatesList = localCertificates != null
+        ? Util.immutableList(localCertificates)
+        : Collections.<Certificate>emptyList();
+
+    return new Handshake(cipherSuite, peerCertificatesList, localCertificatesList);
+  }
+
+  public static Handshake get(
+      String cipherSuite, List<Certificate> peerCertificates, List<Certificate> localCertificates) {
+    if (cipherSuite == null) throw new IllegalArgumentException("cipherSuite == null");
+    return new Handshake(cipherSuite, Util.immutableList(peerCertificates),
+        Util.immutableList(localCertificates));
+  }
+
+  /** Returns a cipher suite name like "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA". */
+  public String cipherSuite() {
+    return cipherSuite;
+  }
+
+  /** Returns a possibly-empty list of certificates that identify the remote peer. */
+  public List<Certificate> peerCertificates() {
+    return peerCertificates;
+  }
+
+  /** Returns the remote peer's principle, or null if that peer is anonymous. */
+  public Principal peerPrincipal() {
+    return !peerCertificates.isEmpty()
+        ? ((X509Certificate) peerCertificates.get(0)).getSubjectX500Principal()
+        : null;
+  }
+
+  /** Returns a possibly-empty list of certificates that identify this peer. */
+  public List<Certificate> localCertificates() {
+    return localCertificates;
+  }
+
+  /** Returns the local principle, or null if this peer is anonymous. */
+  public Principal localPrincipal() {
+    return !localCertificates.isEmpty()
+        ? ((X509Certificate) localCertificates.get(0)).getSubjectX500Principal()
+        : null;
+  }
+
+  @Override public boolean equals(Object other) {
+    if (!(other instanceof Handshake)) return false;
+    Handshake that = (Handshake) other;
+    return cipherSuite.equals(that.cipherSuite)
+        && peerCertificates.equals(that.peerCertificates)
+        && localCertificates.equals(that.localCertificates);
+  }
+
+  @Override public int hashCode() {
+    int result = 17;
+    result = 31 * result + cipherSuite.hashCode();
+    result = 31 * result + peerCertificates.hashCode();
+    result = 31 * result + localCertificates.hashCode();
+    return result;
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/Job.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Job.java
@@ -133,6 +133,7 @@ final class Job implements Runnable, Policy {
           engine.getResponseHeaders(), engine.getResponseBody());
 
       Response response = new Response.Builder(request, responseCode)
+          .handshake(engine.getHandshake())
           .rawHeaders(engine.getResponseHeaders().getHeaders())
           .body(responseBody)
           .redirectedBy(redirectedBy)
@@ -224,7 +225,7 @@ final class Job implements Runnable, Policy {
     }
   }
 
-  private boolean sameConnection(Request a, Request b) {
+  static boolean sameConnection(Request a, Request b) {
     return a.url().getHost().equals(b.url().getHost())
         && getEffectivePort(a.url()) == getEffectivePort(b.url())
         && a.url().getProtocol().equals(b.url().getProtocol());

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -214,7 +214,7 @@ import java.util.Set;
     }
 
     public Builder url(URL url) {
-      if (url == null) throw new IllegalStateException("url == null");
+      if (url == null) throw new IllegalArgumentException("url == null");
       this.url = url;
       return this;
     }

--- a/okhttp/src/main/java/com/squareup/okhttp/Response.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Response.java
@@ -39,6 +39,7 @@ import static com.squareup.okhttp.internal.Util.UTF_8;
 /* OkHttp 2.0: public */ final class Response {
   private final Request request;
   private final int code;
+  private final Handshake handshake;
   private final RawHeaders headers;
   private final Body body;
   private final Response redirectedBy;
@@ -46,6 +47,7 @@ import static com.squareup.okhttp.internal.Util.UTF_8;
   private Response(Builder builder) {
     this.request = builder.request;
     this.code = builder.code;
+    this.handshake = builder.handshake;
     this.headers = new RawHeaders(builder.headers);
     this.body = builder.body;
     this.redirectedBy = builder.redirectedBy;
@@ -69,6 +71,14 @@ import static com.squareup.okhttp.internal.Util.UTF_8;
 
   public int code() {
     return code;
+  }
+
+  /**
+   * Returns the TLS handshake of the connection that carried this response, or
+   * null if the response was received without TLS.
+   */
+  public Handshake handshake() {
+    return handshake;
   }
 
   public String header(String name) {
@@ -237,6 +247,7 @@ import static com.squareup.okhttp.internal.Util.UTF_8;
   public static class Builder {
     private final Request request;
     private final int code;
+    private Handshake handshake;
     private RawHeaders headers = new RawHeaders();
     private Body body;
     private Response redirectedBy;
@@ -246,6 +257,11 @@ import static com.squareup.okhttp.internal.Util.UTF_8;
       if (code <= 0) throw new IllegalArgumentException("code <= 0");
       this.request = request;
       this.code = code;
+    }
+
+    public Builder handshake(Handshake handshake) {
+      this.handshake = handshake;
+      return this;
     }
 
     /**

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsEngine.java
@@ -23,26 +23,16 @@ import java.io.IOException;
 import java.net.CacheResponse;
 import java.net.SecureCacheResponse;
 import java.net.URL;
-import javax.net.ssl.SSLSocket;
 
 import static com.squareup.okhttp.internal.Util.getEffectivePort;
 
 public final class HttpsEngine extends HttpEngine {
-  /**
-   * Stash of HttpsEngine.connection.socket to implement requests like {@code
-   * HttpsURLConnection#getCipherSuite} even after the connection has been
-   * recycled.
-   */
-  private SSLSocket sslSocket;
-
   public HttpsEngine(OkHttpClient client, Policy policy, String method, RawHeaders requestHeaders,
       Connection connection, RetryableOutputStream requestBody) throws IOException {
     super(client, policy, method, requestHeaders, connection, requestBody);
-    this.sslSocket = connection != null ? (SSLSocket) connection.getSocket() : null;
   }
 
   @Override protected void connected(Connection connection) {
-    this.sslSocket = (SSLSocket) connection.getSocket();
     super.connected(connection);
   }
 
@@ -53,10 +43,6 @@ public final class HttpsEngine extends HttpEngine {
   @Override protected boolean includeAuthorityInRequestLine() {
     // Even if there is a proxy, it isn't involved. Always request just the path.
     return false;
-  }
-
-  public SSLSocket getSslSocket() {
-    return sslSocket;
   }
 
   @Override protected TunnelRequest getTunnelConfig() {

--- a/okhttp/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.net.UnknownHostException;
-import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import javax.net.ssl.SSLContext;
 import org.junit.After;
@@ -40,17 +38,7 @@ import static org.junit.Assert.assertTrue;
 
 public final class ConnectionPoolTest {
   private static final int KEEP_ALIVE_DURATION_MS = 5000;
-  private static final SSLContext sslContext;
-
-  static {
-    try {
-      sslContext = new SslContextBuilder(InetAddress.getLocalHost().getHostName()).build();
-    } catch (GeneralSecurityException e) {
-      throw new RuntimeException(e);
-    } catch (UnknownHostException e) {
-      throw new RuntimeException(e);
-    }
-  }
+  private static final SSLContext sslContext = SslContextBuilder.localhost();
 
   private final MockWebServer spdyServer = new MockWebServer();
   private InetSocketAddress spdySocketAddress;

--- a/okhttp/src/test/java/com/squareup/okhttp/RecordedResponse.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/RecordedResponse.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -56,6 +58,16 @@ public class RecordedResponse {
 
   public RecordedResponse assertBody(String expectedBody) {
     assertEquals(expectedBody, body);
+    return this;
+  }
+
+  public RecordedResponse assertHandshake() {
+    Handshake handshake = response.handshake();
+    assertNotNull(handshake.cipherSuite());
+    assertNotNull(handshake.peerPrincipal());
+    assertEquals(1, handshake.peerCertificates().size());
+    assertNull(handshake.localPrincipal());
+    assertEquals(0, handshake.localCertificates().size());
     return this;
   }
 }

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HttpOverSpdyTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HttpOverSpdyTest.java
@@ -31,11 +31,8 @@ import java.io.OutputStream;
 import java.net.Authenticator;
 import java.net.CookieManager;
 import java.net.HttpURLConnection;
-import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLConnection;
-import java.net.UnknownHostException;
-import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -64,16 +61,7 @@ public final class HttpOverSpdyTest {
     }
   };
 
-  private static final SSLContext sslContext;
-  static {
-    try {
-      sslContext = new SslContextBuilder(InetAddress.getLocalHost().getHostName()).build();
-    } catch (GeneralSecurityException e) {
-      throw new RuntimeException(e);
-    } catch (UnknownHostException e) {
-      throw new RuntimeException(e);
-    }
-  }
+  private static final SSLContext sslContext = SslContextBuilder.localhost();
   private final MockWebServer server = new MockWebServer();
   private final String hostName = server.getHostName();
   private final OkHttpClient client = new OkHttpClient();

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
@@ -59,16 +59,14 @@ public final class RouteSelectorTest {
   private static final String uriHost = "hostA";
   private static final int uriPort = 80;
 
-  private static final SSLContext sslContext;
-  private static final SSLSocketFactory socketFactory;
+  private static final SSLContext sslContext = SslContextBuilder.localhost();
+  private static final SSLSocketFactory socketFactory = sslContext.getSocketFactory();
   private static final HostnameVerifier hostnameVerifier;
   private static final ConnectionPool pool;
 
   static {
     try {
       uri = new URI("http://" + uriHost + ":" + uriPort + "/path");
-      sslContext = new SslContextBuilder(InetAddress.getLocalHost().getHostName()).build();
-      socketFactory = sslContext.getSocketFactory();
       pool = ConnectionPool.getDefault();
       hostnameVerifier = HttpsURLConnectionImpl.getDefaultHostnameVerifier();
     } catch (Exception e) {

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -48,7 +48,6 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
-import java.security.GeneralSecurityException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -89,23 +88,14 @@ import static org.junit.Assert.fail;
 
 /** Android's URLConnectionTest. */
 public final class URLConnectionTest {
+  private static final SSLContext sslContext = SslContextBuilder.localhost();
+
   private MockWebServer server = new MockWebServer();
   private MockWebServer server2 = new MockWebServer();
 
   private final OkHttpClient client = new OkHttpClient();
   private HttpResponseCache cache;
   private String hostName;
-
-  private static final SSLContext sslContext;
-  static {
-    try {
-      sslContext = new SslContextBuilder(InetAddress.getLocalHost().getHostName()).build();
-    } catch (GeneralSecurityException e) {
-      throw new RuntimeException(e);
-    } catch (UnknownHostException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   @Before public void setUp() throws Exception {
     hostName = server.getHostName();


### PR DESCRIPTION
I needed a non-terrible way to provide the HTTPS handshake
information to the async API. Previously we were passing the
live socket around, which was leaky and gross.

This creates a new value object that captures the relevant
bits of the handshake. We can use it in the response, the
connection, and also in the cache. It's plausible that in
the future we can use it to allow the application to block
requests if the handshake is insufficient.
