### PR TITLE
Make RawHeaders, RequestHeaders and ResponseHeaders immutable.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -306,22 +306,17 @@ public final class Connection implements Closeable {
     RawHeaders requestHeaders = tunnelRequest.getRequestHeaders();
     while (true) {
       out.write(requestHeaders.toBytes());
-      RawHeaders responseHeaders = RawHeaders.fromBytes(in);
+      RawHeaders responseHeaders = RawHeaders.readHttpHeaders(in);
 
       switch (responseHeaders.getResponseCode()) {
         case HTTP_OK:
           return;
         case HTTP_PROXY_AUTH:
-          requestHeaders = new RawHeaders(requestHeaders);
           URL url = new URL("https", tunnelRequest.host, tunnelRequest.port, "/");
-          boolean credentialsFound = HttpAuthenticator.processAuthHeader(
-              route.address.authenticator, HTTP_PROXY_AUTH, responseHeaders, requestHeaders,
-              route.proxy, url);
-          if (credentialsFound) {
-            continue;
-          } else {
-            throw new IOException("Failed to authenticate with proxy");
-          }
+          requestHeaders = HttpAuthenticator.processAuthHeader(route.address.authenticator,
+              HTTP_PROXY_AUTH, responseHeaders, requestHeaders, route.proxy, url);
+          if (requestHeaders != null) continue;
+          throw new IOException("Failed to authenticate with proxy");
         default:
           throw new IOException(
               "Unexpected response code for CONNECT: " + responseHeaders.getResponseCode());

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -415,18 +415,20 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
         StrictLineReader reader = new StrictLineReader(in, US_ASCII);
         url = reader.readLine();
         requestMethod = reader.readLine();
-        varyHeaders = new RawHeaders();
+        RawHeaders.Builder varyHeadersBuilder = new RawHeaders.Builder();
         int varyRequestHeaderLineCount = reader.readInt();
         for (int i = 0; i < varyRequestHeaderLineCount; i++) {
-          varyHeaders.addLine(reader.readLine());
+          varyHeadersBuilder.addLine(reader.readLine());
         }
+        varyHeaders = varyHeadersBuilder.build();
 
-        responseHeaders = new RawHeaders();
-        responseHeaders.setStatusLine(reader.readLine());
+        RawHeaders.Builder responseHeadersBuilder = new RawHeaders.Builder();
+        responseHeadersBuilder.setStatusLine(reader.readLine());
         int responseHeaderLineCount = reader.readInt();
         for (int i = 0; i < responseHeaderLineCount; i++) {
-          responseHeaders.addLine(reader.readLine());
+          responseHeadersBuilder.addLine(reader.readLine());
         }
+        responseHeaders = responseHeadersBuilder.build();
 
         if (isHttps()) {
           String blank = reader.readLine();

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -45,7 +45,7 @@ public final class Request {
   private Request(Builder builder) {
     this.url = builder.url;
     this.method = builder.method;
-    this.headers = new RawHeaders(builder.headers);
+    this.headers = builder.headers.build();
     this.body = builder.body;
     this.tag = builder.tag != null ? builder.tag : this;
   }
@@ -75,7 +75,7 @@ public final class Request {
   }
 
   RawHeaders rawHeaders() {
-    return new RawHeaders(headers);
+    return headers;
   }
 
   public int headerCount() {
@@ -192,7 +192,7 @@ public final class Request {
   public static class Builder {
     private URL url;
     private String method = "GET";
-    private RawHeaders headers = new RawHeaders();
+    private RawHeaders.Builder headers = new RawHeaders.Builder();
     private Body body;
     private Object tag;
 
@@ -239,7 +239,7 @@ public final class Request {
 
     // TODO: this shouldn't be public.
     public Builder rawHeaders(RawHeaders rawHeaders) {
-      headers = new RawHeaders(rawHeaders);
+      headers = rawHeaders.newBuilder();
       return this;
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Response.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Response.java
@@ -49,7 +49,7 @@ public final class Response {
     this.request = builder.request;
     this.code = builder.code;
     this.handshake = builder.handshake;
-    this.headers = new RawHeaders(builder.headers);
+    this.headers = builder.headers.build();
     this.body = builder.body;
     this.redirectedBy = builder.redirectedBy;
   }
@@ -109,7 +109,7 @@ public final class Response {
 
   // TODO: this shouldn't be public.
   public RawHeaders rawHeaders() {
-    return new RawHeaders(headers);
+    return headers;
   }
 
   public String headerValue(int index) {
@@ -254,7 +254,7 @@ public final class Response {
     private final Request request;
     private final int code;
     private Handshake handshake;
-    private RawHeaders headers = new RawHeaders();
+    private RawHeaders.Builder headers = new RawHeaders.Builder();
     private Body body;
     private Response redirectedBy;
 
@@ -290,7 +290,7 @@ public final class Response {
 
     // TODO: this shouldn't be public.
     public Builder rawHeaders(RawHeaders rawHeaders) {
-      headers = new RawHeaders(rawHeaders);
+      headers = rawHeaders.newBuilder();
       return this;
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/TunnelRequest.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/TunnelRequest.java
@@ -55,8 +55,8 @@ public final class TunnelRequest {
    * the proxy unencrypted.
    */
   RawHeaders getRequestHeaders() {
-    RawHeaders result = new RawHeaders();
-    result.setRequestLine("CONNECT " + host + ":" + port + " HTTP/1.1");
+    RawHeaders.Builder result = new RawHeaders.Builder()
+        .setRequestLine("CONNECT " + host + ":" + port + " HTTP/1.1");
 
     // Always set Host and User-Agent.
     result.set("Host", port == getDefaultPort("https") ? host : (host + ":" + port));
@@ -70,6 +70,6 @@ public final class TunnelRequest {
     // Always set the Proxy-Connection to Keep-Alive for the benefit of
     // HTTP/1.0 proxies like Squid.
     result.set("Proxy-Connection", "Keep-Alive");
-    return result;
+    return result.build();
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/ResponseStrategy.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/ResponseStrategy.java
@@ -1,0 +1,172 @@
+package com.squareup.okhttp.internal.http;
+
+import com.squareup.okhttp.ResponseSource;
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Given a request and cached response, this figures out the next action. It
+ * may also update the request to add conditions, or the response to add
+ * warnings.
+ */
+public final class ResponseStrategy {
+  public final RequestHeaders request;
+  public final ResponseHeaders response;
+  public final ResponseSource source;
+
+  private ResponseStrategy(
+      RequestHeaders request, ResponseHeaders response, ResponseSource source) {
+    this.request = request;
+    this.response = response;
+    this.source = source;
+  }
+
+  /**
+   * Returns the current age of the response, in milliseconds. The calculation
+   * is specified by RFC 2616, 13.2.3 Age Calculations.
+   */
+  private static long computeAge(ResponseHeaders response, long nowMillis) {
+    long apparentReceivedAge = response.servedDate != null
+        ? Math.max(0, response.receivedResponseMillis - response.servedDate.getTime())
+        : 0;
+    long receivedAge = response.ageSeconds != -1
+        ? Math.max(apparentReceivedAge, TimeUnit.SECONDS.toMillis(response.ageSeconds))
+        : apparentReceivedAge;
+    long responseDuration = response.receivedResponseMillis - response.sentRequestMillis;
+    long residentDuration = nowMillis - response.receivedResponseMillis;
+    return receivedAge + responseDuration + residentDuration;
+  }
+
+  /**
+   * Returns the number of milliseconds that the response was fresh for,
+   * starting from the served date.
+   */
+  private static long computeFreshnessLifetime(ResponseHeaders response) {
+    if (response.maxAgeSeconds != -1) {
+      return TimeUnit.SECONDS.toMillis(response.maxAgeSeconds);
+    } else if (response.expires != null) {
+      long servedMillis = response.servedDate != null
+          ? response.servedDate.getTime()
+          : response.receivedResponseMillis;
+      long delta = response.expires.getTime() - servedMillis;
+      return delta > 0 ? delta : 0;
+    } else if (response.lastModified != null && response.uri.getRawQuery() == null) {
+      // As recommended by the HTTP RFC and implemented in Firefox, the
+      // max age of a document should be defaulted to 10% of the
+      // document's age at the time it was served. Default expiration
+      // dates aren't used for URIs containing a query.
+      long servedMillis = response.servedDate != null
+          ? response.servedDate.getTime()
+          : response.sentRequestMillis;
+      long delta = servedMillis - response.lastModified.getTime();
+      return delta > 0 ? (delta / 10) : 0;
+    }
+    return 0;
+  }
+
+  /**
+   * Returns true if computeFreshnessLifetime used a heuristic. If we used a
+   * heuristic to serve a cached response older than 24 hours, we are required
+   * to attach a warning.
+   */
+  private static boolean isFreshnessLifetimeHeuristic(ResponseHeaders response) {
+    return response.maxAgeSeconds == -1 && response.expires == null;
+  }
+
+  /**
+   * Returns true if this response can be stored to later serve another
+   * request.
+   */
+  public static boolean isCacheable(ResponseHeaders response, RequestHeaders request) {
+    // Always go to network for uncacheable response codes (RFC 2616, 13.4),
+    // This implementation doesn't support caching partial content.
+    int responseCode = response.headers.getResponseCode();
+    if (responseCode != HttpURLConnection.HTTP_OK
+        && responseCode != HttpURLConnection.HTTP_NOT_AUTHORITATIVE
+        && responseCode != HttpURLConnection.HTTP_MULT_CHOICE
+        && responseCode != HttpURLConnection.HTTP_MOVED_PERM
+        && responseCode != HttpURLConnection.HTTP_GONE) {
+      return false;
+    }
+
+    // Responses to authorized requests aren't cacheable unless they include
+    // a 'public', 'must-revalidate' or 's-maxage' directive.
+    if (request.hasAuthorization()
+        && !response.isPublic
+        && !response.mustRevalidate
+        && response.sMaxAgeSeconds == -1) {
+      return false;
+    }
+
+    if (response.noStore) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Returns a strategy to satisfy {@code request} using the a cached response
+   * {@code response}.
+   */
+  public static ResponseStrategy get(
+      long nowMillis, ResponseHeaders response, RequestHeaders request) {
+    // If this response shouldn't have been stored, it should never be used
+    // as a response source. This check should be redundant as long as the
+    // persistence store is well-behaved and the rules are constant.
+    if (!isCacheable(response, request)) {
+      return new ResponseStrategy(request, response, ResponseSource.NETWORK);
+    }
+
+    if (request.isNoCache() || request.hasConditions()) {
+      return new ResponseStrategy(request, response, ResponseSource.NETWORK);
+    }
+
+    long ageMillis = computeAge(response, nowMillis);
+    long freshMillis = computeFreshnessLifetime(response);
+
+    if (request.getMaxAgeSeconds() != -1) {
+      freshMillis = Math.min(freshMillis, TimeUnit.SECONDS.toMillis(request.getMaxAgeSeconds()));
+    }
+
+    long minFreshMillis = 0;
+    if (request.getMinFreshSeconds() != -1) {
+      minFreshMillis = TimeUnit.SECONDS.toMillis(request.getMinFreshSeconds());
+    }
+
+    long maxStaleMillis = 0;
+    if (!response.mustRevalidate && request.getMaxStaleSeconds() != -1) {
+      maxStaleMillis = TimeUnit.SECONDS.toMillis(request.getMaxStaleSeconds());
+    }
+
+    if (!response.noCache && ageMillis + minFreshMillis < freshMillis + maxStaleMillis) {
+      ResponseHeaders.Builder builder = response.newBuilder();
+      if (ageMillis + minFreshMillis >= freshMillis) {
+        builder.addWarning("110 HttpURLConnection \"Response is stale\"");
+      }
+      long oneDayMillis = 24 * 60 * 60 * 1000L;
+      if (ageMillis > oneDayMillis && isFreshnessLifetimeHeuristic(response)) {
+        builder.addWarning("113 HttpURLConnection \"Heuristic expiration\"");
+      }
+      return new ResponseStrategy(request, builder.build(), ResponseSource.CACHE);
+    }
+
+    RequestHeaders.Builder conditionalRequestBuilder = request.newBuilder();
+
+    if (response.lastModified != null) {
+      conditionalRequestBuilder.setIfModifiedSince(response.lastModified);
+    } else if (response.servedDate != null) {
+      conditionalRequestBuilder.setIfModifiedSince(response.servedDate);
+    }
+
+    if (response.etag != null) {
+      conditionalRequestBuilder.setIfNoneMatch(response.etag);
+    }
+
+    RequestHeaders conditionalRequest = conditionalRequestBuilder.build();
+    ResponseSource responseSource = conditionalRequest.hasConditions()
+        ? ResponseSource.CONDITIONAL_CACHE
+        : ResponseSource.NETWORK;
+    return new ResponseStrategy(conditionalRequest, response, responseSource);
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
@@ -23,6 +23,13 @@ import java.net.CacheRequest;
 
 interface Transport {
   /**
+   * Returns headers equivalent to {@code requestHeaders} but with
+   * transport-specific changes. For example, this may set a Transfer-Encoding
+   * header if it is required but not present for the current transport.
+   */
+  RequestHeaders prepareRequestHeaders(RequestHeaders requestHeaders);
+
+  /**
    * Returns an output stream where the request body can be written. The
    * returned stream will of one of two types:
    * <ul>

--- a/okhttp/src/test/java/com/squareup/okhttp/AsyncApiTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/AsyncApiTest.java
@@ -62,7 +62,7 @@ public final class AsyncApiTest {
         .build();
     client.enqueue(request, receiver);
 
-    receiver.await(request)
+    receiver.await(request.url())
         .assertCode(200)
         .assertContainsHeaders("Content-Type: text/plain")
         .assertBody("abc");
@@ -83,7 +83,7 @@ public final class AsyncApiTest {
     Request request = new Request.Builder(server.getUrl("/")).build();
     client.enqueue(request, receiver);
 
-    receiver.await(request).assertHandshake();
+    receiver.await(request.url()).assertHandshake();
   }
 
   @Test public void post() throws Exception {
@@ -95,7 +95,7 @@ public final class AsyncApiTest {
         .build();
     client.enqueue(request, receiver);
 
-    receiver.await(request)
+    receiver.await(request.url())
         .assertCode(200)
         .assertBody("abc");
 
@@ -114,12 +114,12 @@ public final class AsyncApiTest {
 
     Request request1 = new Request.Builder(server.getUrl("/")).build();
     client.enqueue(request1, receiver);
-    receiver.await(request1).assertCode(200).assertBody("A");
+    receiver.await(request1.url()).assertCode(200).assertBody("A");
     assertNull(server.takeRequest().getHeader("If-None-Match"));
 
     Request request2 = new Request.Builder(server.getUrl("/")).build();
     client.enqueue(request2, receiver);
-    receiver.await(request2).assertCode(200).assertBody("A");
+    receiver.await(request2.url()).assertCode(200).assertBody("A");
     assertEquals("v1", server.takeRequest().getHeader("If-None-Match"));
   }
 }

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
@@ -774,7 +774,7 @@ public final class HttpResponseCacheTest {
 
     URLConnection request2 = openConnection(url);
     if (expectCached) {
-      assertEquals("1", request1.getHeaderField("X-Response-ID"));
+      assertEquals("1", request2.getHeaderField("X-Response-ID"));
     } else {
       assertEquals("2", request2.getHeaderField("X-Response-ID"));
     }

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -213,12 +213,14 @@ public final class URLConnectionTest {
       fail("Modified an unmodifiable view.");
     } catch (UnsupportedOperationException expected) {
     }
-    assertEquals("A", urlConnection.getHeaderFieldKey(0));
-    assertEquals("c", urlConnection.getHeaderField(0));
-    assertEquals("B", urlConnection.getHeaderFieldKey(1));
-    assertEquals("d", urlConnection.getHeaderField(1));
-    assertEquals("A", urlConnection.getHeaderFieldKey(2));
-    assertEquals("e", urlConnection.getHeaderField(2));
+    assertEquals(ResponseHeaders.SELECTED_TRANSPORT, urlConnection.getHeaderFieldKey(0));
+    assertEquals("http/1.1", urlConnection.getHeaderField(0));
+    assertEquals("A", urlConnection.getHeaderFieldKey(1));
+    assertEquals("c", urlConnection.getHeaderField(1));
+    assertEquals("B", urlConnection.getHeaderFieldKey(2));
+    assertEquals("d", urlConnection.getHeaderField(2));
+    assertEquals("A", urlConnection.getHeaderFieldKey(3));
+    assertEquals("e", urlConnection.getHeaderField(3));
   }
 
   @Test public void serverSendsInvalidResponseHeaders() throws Exception {


### PR DESCRIPTION
This introduces a new, poorly-named class ResponseStrategy
that pulls some code out of ResponseHeaders. That was necessary
because the old method mutated itself and its parameters in
place.

Obvious follow-up for this is to combine ResponseHeaders with
Response, and RequestHeaders with Response.
