### PR TITLE
Remove more stuff from Policy.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Job.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Job.java
@@ -30,7 +30,7 @@ import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_MOVED
 import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_MULT_CHOICE;
 import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_PROXY_AUTH;
 import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_SEE_OTHER;
-import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_TEMP_REDIRECT;
+import static com.squareup.okhttp.internal.http.StatusLine.HTTP_TEMP_REDIRECT;
 import static com.squareup.okhttp.internal.http.HttpURLConnectionImpl.HTTP_UNAUTHORIZED;
 
 final class Job implements Runnable, Policy {
@@ -55,18 +55,6 @@ final class Job implements Runnable, Policy {
 
   @Override public long getFixedContentLength() {
     return request.body().contentLength();
-  }
-
-  @Override public boolean getUseCaches() {
-    return true;
-  }
-
-  @Override public long getIfModifiedSince() {
-    return 0; // For HttpURLConnection only. We let the cache drive this.
-  }
-
-  @Override public boolean usingProxy() {
-    return false; // We let the connection decide this.
   }
 
   @Override public void setSelectedProxy(Proxy proxy) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -30,6 +30,7 @@ import java.net.ProtocolException;
 import java.net.Socket;
 
 import static com.squareup.okhttp.internal.Util.checkOffsetAndCount;
+import static com.squareup.okhttp.internal.http.StatusLine.HTTP_CONTINUE;
 
 public final class HttpTransport implements Transport {
   /**
@@ -165,7 +166,7 @@ public final class HttpTransport implements Transport {
       headersBuilder.readHeaders(in);
       responseBuilder.rawHeaders(headersBuilder.build());
 
-      if (statusLine.code() != HttpEngine.HTTP_CONTINUE) return responseBuilder;
+      if (statusLine.code() != HTTP_CONTINUE) return responseBuilder;
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Policy.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Policy.java
@@ -18,15 +18,6 @@ package com.squareup.okhttp.internal.http;
 import java.net.Proxy;
 
 public interface Policy {
-  /** Returns true if HTTP response caches should be used. */
-  boolean getUseCaches();
-
-  /** Returns the If-Modified-Since timestamp, or 0 if none is set. */
-  long getIfModifiedSince();
-
-  /** Returns true if a non-direct proxy is specified. */
-  boolean usingProxy();
-
   /** @see java.net.HttpURLConnection#setChunkedStreamingMode(int) */
   int getChunkLength();
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/StatusLine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/StatusLine.java
@@ -4,6 +4,10 @@ import java.io.IOException;
 import java.net.ProtocolException;
 
 public final class StatusLine {
+  /** Numeric status code, 307: Temporary Redirect. */
+  public static final int HTTP_TEMP_REDIRECT = 307;
+  public static final int HTTP_CONTINUE = 100;
+
   private final String statusLine;
   private final int httpMinorVersion;
   private final int responseCode;

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -75,6 +75,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.squareup.okhttp.OkAuthenticator.Credential;
+import static com.squareup.okhttp.internal.http.StatusLine.HTTP_TEMP_REDIRECT;
 import static com.squareup.okhttp.mockwebserver.SocketPolicy.DISCONNECT_AT_END;
 import static com.squareup.okhttp.mockwebserver.SocketPolicy.DISCONNECT_AT_START;
 import static com.squareup.okhttp.mockwebserver.SocketPolicy.SHUTDOWN_INPUT_AT_END;
@@ -1778,7 +1779,7 @@ public final class URLConnectionTest {
 
   private void test307Redirect(String method) throws Exception {
     MockResponse response1 = new MockResponse()
-        .setResponseCode(HttpURLConnectionImpl.HTTP_TEMP_REDIRECT)
+        .setResponseCode(HTTP_TEMP_REDIRECT)
         .addHeader("Location: /page2");
     if (!method.equals("HEAD")) {
       response1.setBody("This page has moved!");


### PR DESCRIPTION
Policy is a bridge to get us from a place where HttpEngine
depends 100% on HttpURLConnection to a place where it
doesn't.

We've refactored the code in HttpEngine enough now that
some Policy methods are no longer necessary. Delete 'em.
