### PR TITLE
Rename RawHeaders to Headers.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -72,14 +72,10 @@ public final class Util {
     return specifiedPort != -1 ? specifiedPort : getDefaultPort(scheme);
   }
 
-  public static int getDefaultPort(String scheme) {
-    if ("http".equalsIgnoreCase(scheme)) {
-      return 80;
-    } else if ("https".equalsIgnoreCase(scheme)) {
-      return 443;
-    } else {
-      return -1;
-    }
+  public static int getDefaultPort(String protocol) {
+    if ("http".equals(protocol)) return 80;
+    if ("https".equals(protocol)) return 443;
+    return -1;
   }
 
   public static void checkOffsetAndCount(int arrayLength, int offset, int count) {

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -310,7 +310,7 @@ public final class Connection implements Closeable {
     Request request = tunnelRequest.getRequest();
     String requestLine = tunnelRequest.requestLine();
     while (true) {
-      out.write(request.rawHeaders().toBytes(requestLine));
+      HttpTransport.writeRequest(out, request.headers(), requestLine);
       Response response = HttpTransport.readResponse(request, in).build();
 
       switch (response.code()) {

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -20,7 +20,7 @@ import com.squareup.okhttp.internal.Base64;
 import com.squareup.okhttp.internal.DiskLruCache;
 import com.squareup.okhttp.internal.StrictLineReader;
 import com.squareup.okhttp.internal.Util;
-import com.squareup.okhttp.internal.http.RawHeaders;
+import com.squareup.okhttp.internal.http.Headers;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -356,10 +356,10 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
 
   private static final class Entry {
     private final String url;
-    private final RawHeaders varyHeaders;
+    private final Headers varyHeaders;
     private final String requestMethod;
     private final String statusLine;
-    private final RawHeaders responseHeaders;
+    private final Headers responseHeaders;
     private final Handshake handshake;
 
     /**
@@ -416,7 +416,7 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
         StrictLineReader reader = new StrictLineReader(in, US_ASCII);
         url = reader.readLine();
         requestMethod = reader.readLine();
-        RawHeaders.Builder varyHeadersBuilder = new RawHeaders.Builder();
+        Headers.Builder varyHeadersBuilder = new Headers.Builder();
         int varyRequestHeaderLineCount = reader.readInt();
         for (int i = 0; i < varyRequestHeaderLineCount; i++) {
           varyHeadersBuilder.addLine(reader.readLine());
@@ -424,7 +424,7 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
         varyHeaders = varyHeadersBuilder.build();
 
         statusLine = reader.readLine();
-        RawHeaders.Builder responseHeadersBuilder = new RawHeaders.Builder();
+        Headers.Builder responseHeadersBuilder = new Headers.Builder();
         int responseHeaderLineCount = reader.readInt();
         for (int i = 0; i < responseHeaderLineCount; i++) {
           responseHeadersBuilder.addLine(reader.readLine());
@@ -450,10 +450,10 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
 
     public Entry(Response response) {
       this.url = response.request().urlString();
-      this.varyHeaders = response.request().rawHeaders().getAll(response.getVaryFields());
+      this.varyHeaders = response.request().headers().getAll(response.getVaryFields());
       this.requestMethod = response.request().method();
       this.statusLine = response.statusLine();
-      this.responseHeaders = response.rawHeaders();
+      this.responseHeaders = response.headers();
       this.handshake = response.handshake();
     }
 
@@ -529,7 +529,7 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
       String contentLength = responseHeaders.get("Content-Length");
       return new Response.Builder(request)
           .statusLine(statusLine)
-          .rawHeaders(responseHeaders)
+          .headers(responseHeaders)
           .body(new CacheResponseBody(snapshot, contentType, contentLength))
           .handshake(handshake)
           .build();

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -18,8 +18,8 @@ package com.squareup.okhttp;
 import com.squareup.okhttp.internal.Platform;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HeaderParser;
+import com.squareup.okhttp.internal.http.Headers;
 import com.squareup.okhttp.internal.http.HttpDate;
-import com.squareup.okhttp.internal.http.RawHeaders;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -45,7 +45,7 @@ import java.util.Set;
 public final class Request {
   private final URL url;
   private final String method;
-  private final RawHeaders headers;
+  private final Headers headers;
   private final Body body;
   private final Object tag;
 
@@ -93,7 +93,7 @@ public final class Request {
     return headers.names();
   }
 
-  RawHeaders rawHeaders() {
+  Headers headers() {
     return headers;
   }
 
@@ -120,7 +120,7 @@ public final class Request {
   public Builder newBuilder() {
     return new Builder(url)
         .method(method, body)
-        .rawHeaders(headers)
+        .headers(headers)
         .tag(tag);
   }
 
@@ -132,7 +132,7 @@ public final class Request {
     return "close".equalsIgnoreCase(parsedHeaders().connection);
   }
 
-  public RawHeaders getHeaders() {
+  public Headers getHeaders() {
     return headers;
   }
 
@@ -255,7 +255,7 @@ public final class Request {
     private String ifNoneMatch;
     private String proxyAuthorization;
 
-    public ParsedHeaders(RawHeaders headers) {
+    public ParsedHeaders(Headers headers) {
       HeaderParser.CacheControlHandler handler = new HeaderParser.CacheControlHandler() {
         @Override public void handle(String directive, String parameter) {
           if ("no-cache".equalsIgnoreCase(directive)) {
@@ -398,7 +398,7 @@ public final class Request {
   public static class Builder {
     private URL url;
     private String method = "GET";
-    private RawHeaders.Builder headers = new RawHeaders.Builder();
+    private Headers.Builder headers = new Headers.Builder();
     private Body body;
     private Object tag;
 
@@ -444,8 +444,8 @@ public final class Request {
     }
 
     // TODO: this shouldn't be public.
-    public Builder rawHeaders(RawHeaders rawHeaders) {
-      headers = rawHeaders.newBuilder();
+    public Builder headers(Headers headers) {
+      this.headers = headers.newBuilder();
       return this;
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Response.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Response.java
@@ -18,8 +18,8 @@ package com.squareup.okhttp;
 import com.squareup.okhttp.internal.Platform;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HeaderParser;
+import com.squareup.okhttp.internal.http.Headers;
 import com.squareup.okhttp.internal.http.HttpDate;
-import com.squareup.okhttp.internal.http.RawHeaders;
 import com.squareup.okhttp.internal.http.StatusLine;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -65,7 +65,7 @@ public final class Response {
   private final Request request;
   private final StatusLine statusLine;
   private final Handshake handshake;
-  private final RawHeaders headers;
+  private final Headers headers;
   private final Body body;
   private final Response redirectedBy;
 
@@ -146,7 +146,7 @@ public final class Response {
   }
 
   // TODO: this shouldn't be public.
-  public RawHeaders rawHeaders() {
+  public Headers headers() {
     return headers;
   }
 
@@ -162,7 +162,7 @@ public final class Response {
     return new Builder(request)
         .statusLine(statusLine)
         .handshake(handshake)
-        .rawHeaders(headers)
+        .headers(headers)
         .body(body)
         .redirectedBy(redirectedBy);
   }
@@ -187,10 +187,6 @@ public final class Response {
 
   public boolean hasConnectionClose() {
     return "close".equalsIgnoreCase(parsedHeaders().connection);
-  }
-
-  public RawHeaders getHeaders() {
-    return headers;
   }
 
   public Date getServedDate() {
@@ -267,7 +263,7 @@ public final class Response {
    * Returns true if none of the Vary headers on this response have changed
    * between {@code cachedRequest} and {@code newRequest}.
    */
-  public boolean varyMatches(RawHeaders varyHeaders, Request newRequest) {
+  public boolean varyMatches(Headers varyHeaders, Request newRequest) {
     for (String field : parsedHeaders().varyFields) {
       if (!equal(varyHeaders.values(field), newRequest.headers(field))) return false;
     }
@@ -301,7 +297,7 @@ public final class Response {
    * 13.5.3.
    */
   public Response combine(Response network) throws IOException {
-    RawHeaders.Builder result = new RawHeaders.Builder();
+    Headers.Builder result = new Headers.Builder();
 
     for (int i = 0; i < headers.length(); i++) {
       String fieldName = headers.getFieldName(i);
@@ -321,7 +317,7 @@ public final class Response {
       }
     }
 
-    return newBuilder().rawHeaders(result.build()).build();
+    return newBuilder().headers(result.build()).build();
   }
 
   /**
@@ -506,7 +502,7 @@ public final class Response {
     private String connection;
     private String contentType;
 
-    private ParsedHeaders(RawHeaders headers) {
+    private ParsedHeaders(Headers headers) {
       HeaderParser.CacheControlHandler handler = new HeaderParser.CacheControlHandler() {
         @Override public void handle(String directive, String parameter) {
           if ("no-cache".equalsIgnoreCase(directive)) {
@@ -619,7 +615,7 @@ public final class Response {
     private final Request request;
     private StatusLine statusLine;
     private Handshake handshake;
-    private RawHeaders.Builder headers = new RawHeaders.Builder();
+    private Headers.Builder headers = new Headers.Builder();
     private Body body;
     private Response redirectedBy;
 
@@ -666,8 +662,8 @@ public final class Response {
     }
 
     // TODO: this shouldn't be public.
-    public Builder rawHeaders(RawHeaders rawHeaders) {
-      headers = rawHeaders.newBuilder();
+    public Builder headers(Headers headers) {
+      this.headers = headers.newBuilder();
       return this;
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpAuthenticator.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpAuthenticator.java
@@ -102,7 +102,7 @@ public final class HttpAuthenticator {
     } else {
       throw new IllegalArgumentException(); // TODO: ProtocolException?
     }
-    List<Challenge> challenges = parseChallenges(response.rawHeaders(), responseField);
+    List<Challenge> challenges = parseChallenges(response.headers(), responseField);
     if (challenges.isEmpty()) return null; // Could not find a challenge so end the request cycle.
 
     Request request = response.request();
@@ -119,7 +119,7 @@ public final class HttpAuthenticator {
    * Parse RFC 2617 challenges. This API is only interested in the scheme
    * name and realm.
    */
-  private static List<Challenge> parseChallenges(RawHeaders responseHeaders,
+  private static List<Challenge> parseChallenges(Headers responseHeaders,
       String challengeHeader) {
     // auth-scheme = token
     // auth-param  = token "=" ( token | quoted-string )

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -69,7 +69,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
 
   final OkHttpClient client;
 
-  private RawHeaders.Builder requestHeaders = new RawHeaders.Builder();
+  private Headers.Builder requestHeaders = new Headers.Builder();
 
   /** Like the superclass field of the same name, but a long and available on all platforms. */
   private long fixedContentLength = -1;
@@ -113,7 +113,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
   @Override public final InputStream getErrorStream() {
     try {
       HttpEngine response = getResponse();
-      if (response.hasResponseBody() && response.getResponseCode() >= HTTP_BAD_REQUEST) {
+      if (response.hasResponseBody() && response.getResponse().code() >= HTTP_BAD_REQUEST) {
         return response.getResponseBody();
       }
       return null;
@@ -128,7 +128,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
    */
   @Override public final String getHeaderField(int position) {
     try {
-      return getResponse().getResponse().getHeaders().getValue(position);
+      return getResponse().getResponse().headers().getValue(position);
     } catch (IOException e) {
       return null;
     }
@@ -142,7 +142,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
   @Override public final String getHeaderField(String fieldName) {
     try {
       Response response = getResponse().getResponse();
-      return fieldName == null ? response.statusLine() : response.getHeaders().get(fieldName);
+      return fieldName == null ? response.statusLine() : response.headers().get(fieldName);
     } catch (IOException e) {
       return null;
     }
@@ -150,7 +150,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
 
   @Override public final String getHeaderFieldKey(int position) {
     try {
-      return getResponse().getResponse().getHeaders().getFieldName(position);
+      return getResponse().getResponse().headers().getFieldName(position);
     } catch (IOException e) {
       return null;
     }
@@ -159,7 +159,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
   @Override public final Map<String, List<String>> getHeaderFields() {
     try {
       Response response = getResponse().getResponse();
-      return response.getHeaders().toMultimap(response.statusLine());
+      return response.headers().toMultimap(response.statusLine());
     } catch (IOException e) {
       return Collections.emptyMap();
     }
@@ -273,7 +273,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
       RetryableOutputStream requestBody) throws IOException {
     Request request = new Request.Builder(getURL())
         .method(method, null) // No body: that's provided later!
-        .rawHeaders(requestHeaders.build())
+        .headers(requestHeaders.build())
         .build();
 
     // If we're currently not using caches, make sure the engine's client doesn't have one.
@@ -315,7 +315,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
       // Although RFC 2616 10.3.2 specifies that a HTTP_MOVED_PERM
       // redirect should keep the same method, Chrome, Firefox and the
       // RI all issue GETs when following any redirect.
-      int responseCode = httpEngine.getResponseCode();
+      int responseCode = httpEngine.getResponse().code();
       if (responseCode == HTTP_MULT_CHOICE
           || responseCode == HTTP_MOVED_PERM
           || responseCode == HTTP_MOVED_TEMP
@@ -501,7 +501,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
   }
 
   @Override public final int getResponseCode() throws IOException {
-    return getResponse().getResponseCode();
+    return getResponse().getResponse().code();
   }
 
   @Override public final void setRequestProperty(String field, String newValue) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpsURLConnectionImpl.java
@@ -76,7 +76,7 @@ public final class HttpsURLConnectionImpl extends HttpsURLConnection {
     if (delegate.httpEngine == null) {
       throw new IllegalStateException("Connection has not yet been established");
     }
-    return delegate.httpEngine.getHandshake();
+    return delegate.httpEngine.getResponse().handshake();
   }
 
   @Override public void disconnect() {

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 
-public final class RawHeadersTest {
+public final class HeadersTest {
   @Test public void parseNameValueBlock() throws IOException {
     List<String> nameValueBlock = Arrays.asList(
         "cache-control", "no-cache, no-store",
@@ -34,31 +34,31 @@ public final class RawHeadersTest {
         ":version", "HTTP/1.1");
     Request request = new Request.Builder("http://square.com/").build();
     Response response = SpdyTransport.readNameValueBlock(request, nameValueBlock).build();
-    RawHeaders rawHeaders = response.rawHeaders();
-    assertEquals(4, rawHeaders.length());
+    Headers headers = response.headers();
+    assertEquals(4, headers.length());
     assertEquals("HTTP/1.1 200 OK", response.statusLine());
-    assertEquals("no-cache, no-store", rawHeaders.get("cache-control"));
-    assertEquals("Cookie2", rawHeaders.get("set-cookie"));
-    assertEquals("spdy/3", rawHeaders.get(Response.SELECTED_TRANSPORT));
-    assertEquals(Response.SELECTED_TRANSPORT, rawHeaders.getFieldName(0));
-    assertEquals("spdy/3", rawHeaders.getValue(0));
-    assertEquals("cache-control", rawHeaders.getFieldName(1));
-    assertEquals("no-cache, no-store", rawHeaders.getValue(1));
-    assertEquals("set-cookie", rawHeaders.getFieldName(2));
-    assertEquals("Cookie1", rawHeaders.getValue(2));
-    assertEquals("set-cookie", rawHeaders.getFieldName(3));
-    assertEquals("Cookie2", rawHeaders.getValue(3));
-    assertNull(rawHeaders.get(":status"));
-    assertNull(rawHeaders.get(":version"));
+    assertEquals("no-cache, no-store", headers.get("cache-control"));
+    assertEquals("Cookie2", headers.get("set-cookie"));
+    assertEquals("spdy/3", headers.get(Response.SELECTED_TRANSPORT));
+    assertEquals(Response.SELECTED_TRANSPORT, headers.getFieldName(0));
+    assertEquals("spdy/3", headers.getValue(0));
+    assertEquals("cache-control", headers.getFieldName(1));
+    assertEquals("no-cache, no-store", headers.getValue(1));
+    assertEquals("set-cookie", headers.getFieldName(2));
+    assertEquals("Cookie1", headers.getValue(2));
+    assertEquals("set-cookie", headers.getFieldName(3));
+    assertEquals("Cookie2", headers.getValue(3));
+    assertNull(headers.get(":status"));
+    assertNull(headers.get(":version"));
   }
 
   @Test public void toNameValueBlock() {
-    RawHeaders.Builder builder = new RawHeaders.Builder();
+    Headers.Builder builder = new Headers.Builder();
     builder.add("cache-control", "no-cache, no-store");
     builder.add("set-cookie", "Cookie1");
     builder.add("set-cookie", "Cookie2");
     builder.add(":status", "200 OK");
-    List<String> nameValueBlock = builder.build().toNameValueBlock();
+    List<String> nameValueBlock = SpdyTransport.writeNameValueBlock(builder.build());
     List<String> expected = Arrays.asList(
         "cache-control", "no-cache, no-store",
         "set-cookie", "Cookie1\u0000Cookie2",
@@ -67,9 +67,9 @@ public final class RawHeadersTest {
   }
 
   @Test public void toNameValueBlockDropsForbiddenHeaders() {
-    RawHeaders.Builder builder = new RawHeaders.Builder();
+    Headers.Builder builder = new Headers.Builder();
     builder.add("Connection", "close");
     builder.add("Transfer-Encoding", "chunked");
-    assertEquals(Arrays.<String>asList(), builder.build().toNameValueBlock());
+    assertEquals(Arrays.<String>asList(), SpdyTransport.writeNameValueBlock(builder.build()));
   }
 }


### PR DESCRIPTION
Now that Request and Response self-describe, I think the
word Headers is sufficient. And it's a lot less ugly than
RawHeaders.
