### PR TITLE
Improve cache strategy.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Response.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Response.java
@@ -15,11 +15,11 @@
  */
 package com.squareup.okhttp;
 
-import com.squareup.okhttp.internal.Platform;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HeaderParser;
 import com.squareup.okhttp.internal.http.Headers;
 import com.squareup.okhttp.internal.http.HttpDate;
+import com.squareup.okhttp.internal.http.SyntheticHeaders;
 import com.squareup.okhttp.internal.http.StatusLine;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -47,21 +47,6 @@ import static com.squareup.okhttp.internal.Util.equal;
  * This class is in beta. APIs are subject to change!
  */
 public final class Response {
-  /** HTTP header name for the local time when the request was sent. */
-  private static final String SENT_MILLIS = Platform.get().getPrefix() + "-Sent-Millis";
-
-  /** HTTP header name for the local time when the response was received. */
-  private static final String RECEIVED_MILLIS = Platform.get().getPrefix() + "-Received-Millis";
-
-  /** HTTP synthetic header with the response source. */
-  // TODO: this shouldn't be public.
-  public static final String RESPONSE_SOURCE = Platform.get().getPrefix() + "-Response-Source";
-
-  /** HTTP synthetic header with the selected transport (spdy/3, http/1.1, etc). */
-  // TODO: this shouldn't be public.
-  public static final String SELECTED_TRANSPORT
-      = Platform.get().getPrefix() + "-Selected-Transport";
-
   private final Request request;
   private final StatusLine statusLine;
   private final Handshake handshake;
@@ -561,9 +546,9 @@ public final class Response {
           contentType = value;
         } else if ("Connection".equalsIgnoreCase(fieldName)) {
           connection = value;
-        } else if (SENT_MILLIS.equalsIgnoreCase(fieldName)) {
+        } else if (SyntheticHeaders.SENT_MILLIS.equalsIgnoreCase(fieldName)) {
           sentRequestMillis = Long.parseLong(value);
-        } else if (RECEIVED_MILLIS.equalsIgnoreCase(fieldName)) {
+        } else if (SyntheticHeaders.RECEIVED_MILLIS.equalsIgnoreCase(fieldName)) {
           receivedResponseMillis = Long.parseLong(value);
         }
       }
@@ -691,14 +676,14 @@ public final class Response {
 
     // TODO: this shouldn't be public.
     public Builder setLocalTimestamps(long sentRequestMillis, long receivedResponseMillis) {
-      headers.set(SENT_MILLIS, Long.toString(sentRequestMillis));
-      headers.set(RECEIVED_MILLIS, Long.toString(receivedResponseMillis));
+      headers.set(SyntheticHeaders.SENT_MILLIS, Long.toString(sentRequestMillis));
+      headers.set(SyntheticHeaders.RECEIVED_MILLIS, Long.toString(receivedResponseMillis));
       return this;
     }
 
     // TODO: this shouldn't be public.
     public Builder setResponseSource(ResponseSource responseSource) {
-      headers.set(RESPONSE_SOURCE, responseSource.toString() + " " + statusLine.code());
+      headers.set(SyntheticHeaders.RESPONSE_SOURCE, responseSource + " " + statusLine.code());
       return this;
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/ResponseSource.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ResponseSource.java
@@ -29,7 +29,14 @@ public enum ResponseSource {
   CONDITIONAL_CACHE,
 
   /** The response was returned from the network. */
-  NETWORK;
+  NETWORK,
+
+  /**
+   * The request demanded a cached response that the cache couldn't satisfy.
+   * This yields a 504 (Gateway Timeout) response as specified by
+   * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.4.
+   */
+  NONE;
 
   public boolean requiresConnection() {
     return this == CONDITIONAL_CACHE || this == NETWORK;

--- a/okhttp/src/main/java/com/squareup/okhttp/TunnelRequest.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/TunnelRequest.java
@@ -60,7 +60,8 @@ public final class TunnelRequest {
    * the proxy unencrypted.
    */
   Request getRequest() throws IOException {
-    Request.Builder result = new Request.Builder(new URL("https", host, port, "/"));
+    Request.Builder result = new Request.Builder()
+        .url(new URL("https", host, port, "/"));
 
     // Always set Host and User-Agent.
     result.header("Host", port == getDefaultPort("https") ? host : (host + ":" + port));

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -174,7 +174,7 @@ public final class HttpTransport implements Transport {
 
       Response.Builder responseBuilder = new Response.Builder(request);
       responseBuilder.statusLine(statusLine);
-      responseBuilder.header(Response.SELECTED_TRANSPORT, "http/1.1");
+      responseBuilder.header(SyntheticHeaders.SELECTED_TRANSPORT, "http/1.1");
 
       Headers.Builder headersBuilder = new Headers.Builder();
       headersBuilder.readHeaders(in);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -172,7 +172,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
     }
 
     // For the request line property assigned to the null key, just use no proxy and HTTP 1.1.
-    Request request = new Request.Builder(getURL()).method(method, null).build();
+    Request request = new Request.Builder().url(getURL()).method(method, null).build();
     String requestLine = RequestLine.get(request, null, 1);
     return requestHeaders.build().toMultimap(requestLine);
   }
@@ -271,10 +271,14 @@ public class HttpURLConnectionImpl extends HttpURLConnection implements Policy {
 
   private HttpEngine newHttpEngine(String method, Connection connection,
       RetryableOutputStream requestBody) throws IOException {
-    Request request = new Request.Builder(getURL())
-        .method(method, null) // No body: that's provided later!
-        .headers(requestHeaders.build())
-        .build();
+    Request.Builder builder = new Request.Builder()
+        .url(getURL())
+        .method(method, null /* No body; that's passed separately. */);
+    Headers headers = requestHeaders.build();
+    for (int i = 0; i < headers.length(); i++) {
+      builder.addHeader(headers.getFieldName(i), headers.getValue(i));
+    }
+    Request request = builder.build();
 
     // If we're currently not using caches, make sure the engine's client doesn't have one.
     OkHttpClient engineClient = client;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SyntheticHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SyntheticHeaders.java
@@ -1,0 +1,23 @@
+package com.squareup.okhttp.internal.http;
+
+import com.squareup.okhttp.internal.Platform;
+
+/** Headers added to the HTTP response for internal use by OkHttp. */
+public final class SyntheticHeaders {
+  static final String PREFIX = Platform.get().getPrefix();
+
+  /** The local time when the request was sent. */
+  public static final String SENT_MILLIS = PREFIX + "-Sent-Millis";
+
+  /** The local time when the response was received. */
+  public static final String RECEIVED_MILLIS = PREFIX + "-Received-Millis";
+
+  /** The response source. */
+  public static final String RESPONSE_SOURCE = PREFIX + "-Response-Source";
+
+  /** The selected transport (spdy/3, http/1.1, etc). */
+  public static final String SELECTED_TRANSPORT = PREFIX + "-Selected-Transport";
+
+  private SyntheticHeaders() {
+  }
+}

--- a/okhttp/src/test/java/com/squareup/okhttp/AsyncApiTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/AsyncApiTest.java
@@ -57,7 +57,8 @@ public final class AsyncApiTest {
         .addHeader("Content-Type: text/plain"));
     server.play();
 
-    Request request = new Request.Builder(server.getUrl("/"))
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
         .header("User-Agent", "AsyncApiTest")
         .build();
     client.enqueue(request, receiver);
@@ -80,7 +81,9 @@ public final class AsyncApiTest {
     client.setSslSocketFactory(sslContext.getSocketFactory());
     client.setHostnameVerifier(new RecordingHostnameVerifier());
 
-    Request request = new Request.Builder(server.getUrl("/")).build();
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .build();
     client.enqueue(request, receiver);
 
     receiver.await(request.url()).assertHandshake();
@@ -90,7 +93,8 @@ public final class AsyncApiTest {
     server.enqueue(new MockResponse().setBody("abc"));
     server.play();
 
-    Request request = new Request.Builder(server.getUrl("/"))
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
         .post(Request.Body.create(MediaType.parse("text/plain"), "def"))
         .build();
     client.enqueue(request, receiver);
@@ -112,12 +116,16 @@ public final class AsyncApiTest {
 
     client.setOkResponseCache(cache);
 
-    Request request1 = new Request.Builder(server.getUrl("/")).build();
+    Request request1 = new Request.Builder()
+        .url(server.getUrl("/"))
+        .build();
     client.enqueue(request1, receiver);
     receiver.await(request1.url()).assertCode(200).assertBody("A");
     assertNull(server.takeRequest().getHeader("If-None-Match"));
 
-    Request request2 = new Request.Builder(server.getUrl("/")).build();
+    Request request2 = new Request.Builder()
+        .url(server.getUrl("/"))
+        .build();
     client.enqueue(request2, receiver);
     receiver.await(request2.url()).assertCode(200).assertBody("A");
     assertEquals("v1", server.takeRequest().getHeader("If-None-Match"));

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
@@ -32,15 +32,15 @@ public final class HeadersTest {
         "set-cookie", "Cookie1\u0000Cookie2",
         ":status", "200 OK",
         ":version", "HTTP/1.1");
-    Request request = new Request.Builder("http://square.com/").build();
+    Request request = new Request.Builder().url("http://square.com/").build();
     Response response = SpdyTransport.readNameValueBlock(request, nameValueBlock).build();
     Headers headers = response.headers();
     assertEquals(4, headers.length());
     assertEquals("HTTP/1.1 200 OK", response.statusLine());
     assertEquals("no-cache, no-store", headers.get("cache-control"));
     assertEquals("Cookie2", headers.get("set-cookie"));
-    assertEquals("spdy/3", headers.get(Response.SELECTED_TRANSPORT));
-    assertEquals(Response.SELECTED_TRANSPORT, headers.getFieldName(0));
+    assertEquals("spdy/3", headers.get(SyntheticHeaders.SELECTED_TRANSPORT));
+    assertEquals(SyntheticHeaders.SELECTED_TRANSPORT, headers.getFieldName(0));
     assertEquals("spdy/3", headers.getValue(0));
     assertEquals("cache-control", headers.getFieldName(1));
     assertEquals("no-cache, no-store", headers.getValue(1));


### PR DESCRIPTION
This renames ResponseStrategy to CacheStrategy and cleans up
the code that calls into it.

This fixes a bug where we were incorrectly reporting stats
when the caller was requesting only-if-cached. In those cases
we were tracking stats before applying that constraint. Tests
for these cases have been added
