### PR TITLE
Clean up around HttpEngine.sendRequest().

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -311,7 +311,7 @@ public final class Connection implements Closeable {
     String requestLine = tunnelRequest.requestLine();
     while (true) {
       HttpTransport.writeRequest(out, request.headers(), requestLine);
-      Response response = HttpTransport.readResponse(request, in).build();
+      Response response = HttpTransport.readResponse(in).request(request).build();
 
       switch (response.code()) {
         case HTTP_OK:

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -527,7 +527,8 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
     public Response response(Request request, DiskLruCache.Snapshot snapshot) {
       String contentType = responseHeaders.get("Content-Type");
       String contentLength = responseHeaders.get("Content-Length");
-      return new Response.Builder(request)
+      return new Response.Builder()
+          .request(request)
           .statusLine(statusLine)
           .headers(responseHeaders)
           .body(new CacheResponseBody(snapshot, contentType, contentLength))

--- a/okhttp/src/main/java/com/squareup/okhttp/Response.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Response.java
@@ -19,8 +19,8 @@ import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HeaderParser;
 import com.squareup.okhttp.internal.http.Headers;
 import com.squareup.okhttp.internal.http.HttpDate;
-import com.squareup.okhttp.internal.http.SyntheticHeaders;
 import com.squareup.okhttp.internal.http.StatusLine;
+import com.squareup.okhttp.internal.http.SyntheticHeaders;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -144,12 +144,7 @@ public final class Response {
   }
 
   public Builder newBuilder() {
-    return new Builder(request)
-        .statusLine(statusLine)
-        .handshake(handshake)
-        .headers(headers)
-        .body(body)
-        .redirectedBy(redirectedBy);
+    return new Builder(this);
   }
 
   /**
@@ -597,16 +592,29 @@ public final class Response {
   }
 
   public static class Builder {
-    private final Request request;
+    private Request request;
     private StatusLine statusLine;
     private Handshake handshake;
-    private Headers.Builder headers = new Headers.Builder();
+    private Headers.Builder headers;
     private Body body;
     private Response redirectedBy;
 
-    public Builder(Request request) {
-      if (request == null) throw new IllegalArgumentException("request == null");
+    public Builder() {
+      headers = new Headers.Builder();
+    }
+
+    private Builder(Response response) {
+      this.request = response.request;
+      this.statusLine = response.statusLine;
+      this.handshake = response.handshake;
+      this.headers = response.headers.newBuilder();
+      this.body = response.body;
+      this.redirectedBy = response.redirectedBy;
+    }
+
+    public Builder request(Request request) {
       this.request = request;
+      return this;
     }
 
     public Builder statusLine(StatusLine statusLine) {

--- a/okhttp/src/main/java/com/squareup/okhttp/ResponseSource.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ResponseSource.java
@@ -41,4 +41,8 @@ public enum ResponseSource {
   public boolean requiresConnection() {
     return this == CONDITIONAL_CACHE || this == NETWORK;
   }
+
+  public boolean usesCache() {
+    return this == CACHE || this == CONDITIONAL_CACHE;
+  }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
@@ -47,10 +47,10 @@ interface Transport {
    */
   // TODO: don't bother retransmitting the request body? It's quite a corner
   // case and there's uncertainty whether Firefox or Chrome do this
-  OutputStream createRequestBody() throws IOException;
+  OutputStream createRequestBody(Request request) throws IOException;
 
   /** This should update the HTTP engine's sentRequestMillis field. */
-  void writeRequestHeaders() throws IOException;
+  void writeRequestHeaders(Request request) throws IOException;
 
   /**
    * Sends the request body returned by {@link #createRequestBody} to the
@@ -62,7 +62,7 @@ interface Transport {
   void flushRequest() throws IOException;
 
   /** Read response headers and update the cookie manager. */
-  Response readResponseHeaders() throws IOException;
+  Response.Builder readResponseHeaders() throws IOException;
 
   // TODO: make this the content stream?
   InputStream getTransferStream(CacheRequest cacheRequest) throws IOException;

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
@@ -33,7 +33,7 @@ public final class HeadersTest {
         ":status", "200 OK",
         ":version", "HTTP/1.1");
     Request request = new Request.Builder().url("http://square.com/").build();
-    Response response = SpdyTransport.readNameValueBlock(request, nameValueBlock).build();
+    Response response = SpdyTransport.readNameValueBlock(nameValueBlock).request(request).build();
     Headers headers = response.headers();
     assertEquals(4, headers.length());
     assertEquals("HTTP/1.1 200 OK", response.statusLine());


### PR DESCRIPTION
Move gateway timeout failures to CacheStrategy, and inline
methods nearby for a strict top-to-bottom flow in this method.

It becomes more obvious that the end of sendRequest has two
cases: we need a connection (opening if necessary) or we don't
need a connection (closing if necessary). Previously this was
true but not as explicit.
