### PR TITLE
Remove some 'implementation detail' headers from the public API.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -463,15 +463,15 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
 
       writer.write(url + '\n');
       writer.write(requestMethod + '\n');
-      writer.write(Integer.toString(varyHeaders.length()) + '\n');
-      for (int i = 0; i < varyHeaders.length(); i++) {
-        writer.write(varyHeaders.getFieldName(i) + ": " + varyHeaders.getValue(i) + '\n');
+      writer.write(Integer.toString(varyHeaders.size()) + '\n');
+      for (int i = 0; i < varyHeaders.size(); i++) {
+        writer.write(varyHeaders.name(i) + ": " + varyHeaders.value(i) + '\n');
       }
 
       writer.write(statusLine + '\n');
-      writer.write(Integer.toString(responseHeaders.length()) + '\n');
-      for (int i = 0; i < responseHeaders.length(); i++) {
-        writer.write(responseHeaders.getFieldName(i) + ": " + responseHeaders.getValue(i) + '\n');
+      writer.write(Integer.toString(responseHeaders.size()) + '\n');
+      for (int i = 0; i < responseHeaders.size(); i++) {
+        writer.write(responseHeaders.name(i) + ": " + responseHeaders.value(i) + '\n');
       }
 
       if (isHttps()) {

--- a/okhttp/src/main/java/com/squareup/okhttp/Job.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Job.java
@@ -85,7 +85,7 @@ final class Job implements Runnable {
           requestBuilder.setContentLength(contentLength);
           requestBuilder.removeHeader("Transfer-Encoding");
         } else {
-          requestBuilder.setChunked();
+          requestBuilder.header("Transfer-Encoding", "chunked");
           requestBuilder.removeHeader("Content-Length");
         }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -98,15 +98,15 @@ public final class Request {
   }
 
   public int headerCount() {
-    return headers.length();
+    return headers.size();
   }
 
   public String headerName(int index) {
-    return headers.getFieldName(index);
+    return headers.name(index);
   }
 
   public String headerValue(int index) {
-    return headers.getValue(index);
+    return headers.value(index);
   }
 
   public Body body() {
@@ -121,19 +121,11 @@ public final class Request {
     return new Builder(this);
   }
 
-  public boolean isChunked() {
-    return "chunked".equalsIgnoreCase(parsedHeaders().transferEncoding);
-  }
-
-  public boolean hasConnectionClose() {
-    return "close".equalsIgnoreCase(parsedHeaders().connection);
-  }
-
   public Headers getHeaders() {
     return headers;
   }
 
-  public boolean isNoCache() {
+  public boolean getNoCache() {
     return parsedHeaders().noCache;
   }
 
@@ -149,12 +141,8 @@ public final class Request {
     return parsedHeaders().minFreshSeconds;
   }
 
-  public boolean isOnlyIfCached() {
+  public boolean getOnlyIfCached() {
     return parsedHeaders().onlyIfCached;
-  }
-
-  public boolean hasAuthorization() {
-    return parsedHeaders().hasAuthorization;
   }
 
   // TODO: Make non-public. This conflicts with the Body's content length!
@@ -162,24 +150,8 @@ public final class Request {
     return parsedHeaders().contentLength;
   }
 
-  public String getTransferEncoding() {
-    return parsedHeaders().transferEncoding;
-  }
-
   public String getUserAgent() {
     return parsedHeaders().userAgent;
-  }
-
-  public String getHost() {
-    return parsedHeaders().host;
-  }
-
-  public String getConnection() {
-    return parsedHeaders().connection;
-  }
-
-  public String getAcceptEncoding() {
-    return parsedHeaders().acceptEncoding;
   }
 
   // TODO: Make non-public. This conflicts with the Body's content type!
@@ -187,25 +159,8 @@ public final class Request {
     return parsedHeaders().contentType;
   }
 
-  public String getIfModifiedSince() {
-    return parsedHeaders().ifModifiedSince;
-  }
-
-  public String getIfNoneMatch() {
-    return parsedHeaders().ifNoneMatch;
-  }
-
   public String getProxyAuthorization() {
     return parsedHeaders().proxyAuthorization;
-  }
-
-  /**
-   * Returns true if the request contains conditions that save the server from
-   * sending a response that the client has locally. When a request is enqueued
-   * with conditions, built-in response caches won't be used for that request.
-   */
-  public boolean hasConditions() {
-    return parsedHeaders().ifModifiedSince != null || parsedHeaders().ifNoneMatch != null;
   }
 
   private ParsedHeaders parsedHeaders() {
@@ -234,22 +189,9 @@ public final class Request {
      */
     private boolean onlyIfCached;
 
-    /**
-     * True if the request contains an authorization field. Although this isn't
-     * necessarily a shared cache, it follows the spec's strict requirements for
-     * shared caches.
-     */
-    private boolean hasAuthorization;
-
     private long contentLength = -1;
-    private String transferEncoding;
     private String userAgent;
-    private String host;
-    private String connection;
-    private String acceptEncoding;
     private String contentType;
-    private String ifModifiedSince;
-    private String ifNoneMatch;
     private String proxyAuthorization;
 
     public ParsedHeaders(Headers headers) {
@@ -269,36 +211,22 @@ public final class Request {
         }
       };
 
-      for (int i = 0; i < headers.length(); i++) {
-        String fieldName = headers.getFieldName(i);
-        String value = headers.getValue(i);
+      for (int i = 0; i < headers.size(); i++) {
+        String fieldName = headers.name(i);
+        String value = headers.value(i);
         if ("Cache-Control".equalsIgnoreCase(fieldName)) {
           HeaderParser.parseCacheControl(value, handler);
         } else if ("Pragma".equalsIgnoreCase(fieldName)) {
           if ("no-cache".equalsIgnoreCase(value)) {
             noCache = true;
           }
-        } else if ("If-None-Match".equalsIgnoreCase(fieldName)) {
-          ifNoneMatch = value;
-        } else if ("If-Modified-Since".equalsIgnoreCase(fieldName)) {
-          ifModifiedSince = value;
-        } else if ("Authorization".equalsIgnoreCase(fieldName)) {
-          hasAuthorization = true;
         } else if ("Content-Length".equalsIgnoreCase(fieldName)) {
           try {
             contentLength = Long.parseLong(value);
           } catch (NumberFormatException ignored) {
           }
-        } else if ("Transfer-Encoding".equalsIgnoreCase(fieldName)) {
-          transferEncoding = value;
         } else if ("User-Agent".equalsIgnoreCase(fieldName)) {
           userAgent = value;
-        } else if ("Host".equalsIgnoreCase(fieldName)) {
-          host = value;
-        } else if ("Connection".equalsIgnoreCase(fieldName)) {
-          connection = value;
-        } else if ("Accept-Encoding".equalsIgnoreCase(fieldName)) {
-          acceptEncoding = value;
         } else if ("Content-Type".equalsIgnoreCase(fieldName)) {
           contentType = value;
         } else if ("Proxy-Authorization".equalsIgnoreCase(fieldName)) {
@@ -449,11 +377,6 @@ public final class Request {
       return this;
     }
 
-    public Builder setChunked() {
-      headers.set("Transfer-Encoding", "chunked");
-      return this;
-    }
-
     // TODO: conflict's with the body's content type.
     public Builder setContentLength(long contentLength) {
       headers.set("Content-Length", Long.toString(contentLength));
@@ -462,19 +385,6 @@ public final class Request {
 
     public void setUserAgent(String userAgent) {
       headers.set("User-Agent", userAgent);
-    }
-
-    // TODO: this shouldn't be public.
-    public void setHost(String host) {
-      headers.set("Host", host);
-    }
-
-    public void setConnection(String connection) {
-      headers.set("Connection", connection);
-    }
-
-    public void setAcceptEncoding(String acceptEncoding) {
-      headers.set("Accept-Encoding", acceptEncoding);
     }
 
     // TODO: conflict's with the body's content type.

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Headers.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Headers.java
@@ -68,12 +68,12 @@ public final class Headers {
   }
 
   /** Returns the number of field values. */
-  public int length() {
+  public int size() {
     return namesAndValues.size() / 2;
   }
 
   /** Returns the field at {@code position} or null if that is out of range. */
-  public String getFieldName(int index) {
+  public String name(int index) {
     int fieldNameIndex = index * 2;
     if (fieldNameIndex < 0 || fieldNameIndex >= namesAndValues.size()) {
       return null;
@@ -84,14 +84,14 @@ public final class Headers {
   /** Returns an immutable case-insensitive set of header names. */
   public Set<String> names() {
     TreeSet<String> result = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
-    for (int i = 0; i < length(); i++) {
-      result.add(getFieldName(i));
+    for (int i = 0; i < size(); i++) {
+      result.add(name(i));
     }
     return Collections.unmodifiableSet(result);
   }
 
   /** Returns the value at {@code index} or null if that is out of range. */
-  public String getValue(int index) {
+  public String value(int index) {
     int valueIndex = index * 2 + 1;
     if (valueIndex < 0 || valueIndex >= namesAndValues.size()) {
       return null;
@@ -107,10 +107,10 @@ public final class Headers {
   /** Returns an immutable list of the header values for {@code name}. */
   public List<String> values(String name) {
     List<String> result = null;
-    for (int i = 0; i < length(); i++) {
-      if (name.equalsIgnoreCase(getFieldName(i))) {
+    for (int i = 0; i < size(); i++) {
+      if (name.equalsIgnoreCase(name(i))) {
         if (result == null) result = new ArrayList<String>(2);
-        result.add(getValue(i));
+        result.add(value(i));
       }
     }
     return result != null

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpAuthenticator.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpAuthenticator.java
@@ -127,11 +127,11 @@ public final class HttpAuthenticator {
     // realm       = "realm" "=" realm-value
     // realm-value = quoted-string
     List<Challenge> result = new ArrayList<Challenge>();
-    for (int h = 0; h < responseHeaders.length(); h++) {
-      if (!challengeHeader.equalsIgnoreCase(responseHeaders.getFieldName(h))) {
+    for (int h = 0; h < responseHeaders.size(); h++) {
+      if (!challengeHeader.equalsIgnoreCase(responseHeaders.name(h))) {
         continue;
       }
-      String value = responseHeaders.getValue(h);
+      String value = responseHeaders.value(h);
       int pos = 0;
       while (pos < value.length()) {
         int tokenStart = pos;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -82,7 +82,7 @@ public final class HttpTransport implements Transport {
       }
     }
 
-    if (request.isChunked()) {
+    if ("chunked".equalsIgnoreCase(request.header("Transfer-Encoding"))) {
       // Stream a request body of unknown length.
       writeRequestHeaders(request);
       return new ChunkedOutputStream(requestOut, DEFAULT_CHUNK_LENGTH);
@@ -136,10 +136,10 @@ public final class HttpTransport implements Transport {
       throws IOException {
     StringBuilder result = new StringBuilder(256);
     result.append(requestLine).append("\r\n");
-    for (int i = 0; i < headers.length(); i ++) {
-      result.append(headers.getFieldName(i))
+    for (int i = 0; i < headers.size(); i ++) {
+      result.append(headers.name(i))
           .append(": ")
-          .append(headers.getValue(i))
+          .append(headers.value(i))
           .append("\r\n");
     }
     result.append("\r\n");
@@ -176,12 +176,13 @@ public final class HttpTransport implements Transport {
     }
 
     // If the request specified that the connection shouldn't be reused, don't reuse it.
-    if (httpEngine.getRequest().hasConnectionClose()) {
+    if ("close".equalsIgnoreCase(httpEngine.getRequest().header("Connection"))) {
       return false;
     }
 
     // If the response specified that the connection shouldn't be reused, don't reuse it.
-    if (httpEngine.getResponse() != null && httpEngine.getResponse().hasConnectionClose()) {
+    if (httpEngine.getResponse() != null
+        && "close".equalsIgnoreCase(httpEngine.getResponse().header("Connection"))) {
       return false;
     }
 
@@ -229,7 +230,7 @@ public final class HttpTransport implements Transport {
       return new FixedLengthInputStream(socketIn, cacheRequest, httpEngine, 0);
     }
 
-    if (httpEngine.getResponse().isChunked()) {
+    if ("chunked".equalsIgnoreCase(httpEngine.getResponse().header("Transfer-Encoding"))) {
       return new ChunkedInputStream(socketIn, cacheRequest, this);
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -134,7 +134,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
    */
   @Override public final String getHeaderField(int position) {
     try {
-      return getResponse().getResponse().headers().getValue(position);
+      return getResponse().getResponse().headers().value(position);
     } catch (IOException e) {
       return null;
     }
@@ -156,7 +156,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
 
   @Override public final String getHeaderFieldKey(int position) {
     try {
-      return getResponse().getResponse().headers().getFieldName(position);
+      return getResponse().getResponse().headers().name(position);
     } catch (IOException e) {
       return null;
     }
@@ -281,8 +281,8 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
         .url(getURL())
         .method(method, null /* No body; that's passed separately. */);
     Headers headers = requestHeaders.build();
-    for (int i = 0; i < headers.length(); i++) {
-      builder.addHeader(headers.getFieldName(i), headers.getValue(i));
+    for (int i = 0; i < headers.size(); i++) {
+      builder.addHeader(headers.name(i), headers.value(i));
     }
 
     boolean bufferRequestBody;

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
@@ -35,19 +35,19 @@ public final class HeadersTest {
     Request request = new Request.Builder().url("http://square.com/").build();
     Response response = SpdyTransport.readNameValueBlock(nameValueBlock).request(request).build();
     Headers headers = response.headers();
-    assertEquals(4, headers.length());
+    assertEquals(4, headers.size());
     assertEquals("HTTP/1.1 200 OK", response.statusLine());
     assertEquals("no-cache, no-store", headers.get("cache-control"));
     assertEquals("Cookie2", headers.get("set-cookie"));
     assertEquals("spdy/3", headers.get(SyntheticHeaders.SELECTED_TRANSPORT));
-    assertEquals(SyntheticHeaders.SELECTED_TRANSPORT, headers.getFieldName(0));
-    assertEquals("spdy/3", headers.getValue(0));
-    assertEquals("cache-control", headers.getFieldName(1));
-    assertEquals("no-cache, no-store", headers.getValue(1));
-    assertEquals("set-cookie", headers.getFieldName(2));
-    assertEquals("Cookie1", headers.getValue(2));
-    assertEquals("set-cookie", headers.getFieldName(3));
-    assertEquals("Cookie2", headers.getValue(3));
+    assertEquals(SyntheticHeaders.SELECTED_TRANSPORT, headers.name(0));
+    assertEquals("spdy/3", headers.value(0));
+    assertEquals("cache-control", headers.name(1));
+    assertEquals("no-cache, no-store", headers.value(1));
+    assertEquals("set-cookie", headers.name(2));
+    assertEquals("Cookie1", headers.value(2));
+    assertEquals("set-cookie", headers.name(3));
+    assertEquals("Cookie2", headers.value(3));
     assertNull(headers.get(":status"));
     assertNull(headers.get(":version"));
   }


### PR DESCRIPTION
Application code doesn't need to worry about headers like
'Connection' or 'Transfer-Encoding', so don't include them
in the API.
