### PR TITLE
Use AOSP ByteArrayPool to try and avoid buffer GC.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/ByteArrayPool.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/ByteArrayPool.java
@@ -1,0 +1,133 @@
+  /*
+   * Copyright (C) 2012 The Android Open Source Project
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *      http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  package com.squareup.okhttp.internal.spdy;
+
+  import java.util.ArrayList;
+  import java.util.Collections;
+  import java.util.Comparator;
+  import java.util.List;
+
+  /**
+   * ByteArrayPool is a source and repository of <code>byte[]</code> objects. Its purpose is to
+   * supply those buffers to consumers who need to use them for a short period of time and then
+   * dispose of them. Simply creating and disposing such buffers in the conventional manner can
+   * considerable heap churn and garbage collection delays on Android, which lacks good management
+   * of short-lived heap objects. It may be advantageous to trade off some memory in the form of a
+   * permanently allocated pool of buffers in order to gain heap performance improvements; that is
+   * what this class does.
+   * <p>
+   * A good candidate user for this class is something like an I/O system that uses large temporary
+   * <code>byte[]</code> buffers to copy data around. In these use cases, often the consumer wants
+   * the buffer to be a certain minimum size to ensure good performance (e.g. when copying data
+   * chunks off of a stream), but doesn't mind if the buffer is larger than the minimum. Taking this
+   * into account and also to maximize the odds of being able to reuse a recycled buffer, this
+   * class is free to return buffers larger than the requested size. The caller needs to be able
+   * to gracefully deal with getting buffers any size over the minimum.
+   * <p>
+   * If there is not a suitably-sized buffer in its recycling pool when a buffer is requested, this
+   * class will allocate a new buffer and return it.
+   * <p>
+   * This class has no special ownership of buffers it creates; the caller is free to take a buffer
+   * it receives from this pool, use it permanently, and never return it to the pool; additionally,
+   * it is not harmful to return to this pool a buffer that was allocated elsewhere, provided there
+   * are no other lingering references to it.
+   * <p>
+   * This class ensures that the total size of the buffers in its recycling pool never exceeds a
+   * certain byte limit. When a buffer is returned that would cause the pool to exceed the limit,
+   * least-recently-used buffers are disposed.
+   */
+  public class ByteArrayPool {
+    /** The buffer pool, arranged both by last use and by buffer size. */
+    private List<byte[]> mBuffersByLastUse = new ArrayList<byte[]>();
+    private List<byte[]> mBuffersBySize = new ArrayList<byte[]>(64);
+
+    /** The total size of the buffers in the pool. */
+    private int mCurrentSize = 0;
+
+    /**
+     * The maximum aggregate size of the buffers in the pool. Old buffers are discarded to stay
+     * under this limit.
+     */
+    private final int mSizeLimit;
+
+    /** Compares buffers by size. */
+    protected static final Comparator<byte[]> BUF_COMPARATOR = new Comparator<byte[]>() {
+      @Override
+      public int compare(byte[] lhs, byte[] rhs) {
+        return lhs.length - rhs.length;
+      }
+    };
+
+    /**
+     * @param sizeLimit the maximum size of the pool, in bytes
+     */
+    public ByteArrayPool(int sizeLimit) {
+      mSizeLimit = sizeLimit;
+    }
+
+    /**
+     * Returns a buffer from the pool if one is available in the requested size, or
+     * allocates a new one if a pooled one is not available.
+     *
+     * @param len the minimum size, in bytes, of the requested buffer. The returned buffer may be
+     * larger.
+     * @return a byte[] buffer is always returned.
+     */
+    public synchronized byte[] getBuf(int len) {
+      for (int i = 0; i < mBuffersBySize.size(); i++) {
+        byte[] buf = mBuffersBySize.get(i);
+        if (buf.length >= len) {
+          mCurrentSize -= buf.length;
+          mBuffersBySize.remove(i);
+          mBuffersByLastUse.remove(buf);
+          return buf;
+        }
+      }
+      return new byte[len];
+    }
+
+    /**
+     * Returns a buffer to the pool, throwing away old buffers if the pool would exceed its
+     * allotted size.
+     *
+     * @param buf the buffer to return to the pool.
+     */
+    public synchronized void returnBuf(byte[] buf) {
+      if (buf == null || buf.length > mSizeLimit) {
+        return;
+      }
+      mBuffersByLastUse.add(buf);
+      int pos = Collections.binarySearch(mBuffersBySize, buf, BUF_COMPARATOR);
+      if (pos < 0) {
+        pos = -pos - 1;
+      }
+      mBuffersBySize.add(pos, buf);
+      mCurrentSize += buf.length;
+      trim();
+    }
+
+    /**
+     * Removes buffers from the pool until it is under its size limit.
+     */
+    private synchronized void trim() {
+      while (mCurrentSize > mSizeLimit) {
+        byte[] buf = mBuffersByLastUse.remove(0);
+        mBuffersBySize.remove(buf);
+        mCurrentSize -= buf.length;
+      }
+    }
+  }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -87,6 +87,8 @@ public final class SpdyConnection implements Closeable {
   /** Lazily-created settings for the peer. */
   Settings settings;
 
+  ByteArrayPool bufferPool = new ByteArrayPool(8 * Settings.DEFAULT_INITIAL_WINDOW_SIZE);
+
   private SpdyConnection(Builder builder) {
     variant = builder.variant;
     client = builder.client;

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/ByteArrayPoolTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/ByteArrayPoolTest.java
@@ -1,0 +1,75 @@
+  /*
+   * Copyright (C) 2012 The Android Open Source Project
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *      http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+
+  package com.squareup.okhttp.internal.spdy;
+
+  import org.junit.Test;
+
+  import static org.junit.Assert.assertTrue;
+  import static org.junit.Assert.assertNotSame;
+  import static org.junit.Assert.assertSame;
+
+  public class ByteArrayPoolTest {
+    @Test public void testReusesBuffer() {
+      ByteArrayPool pool = new ByteArrayPool(32);
+
+      byte[] buf1 = pool.getBuf(16);
+      byte[] buf2 = pool.getBuf(16);
+
+      pool.returnBuf(buf1);
+      pool.returnBuf(buf2);
+
+      byte[] buf3 = pool.getBuf(16);
+      byte[] buf4 = pool.getBuf(16);
+      assertTrue(buf3 == buf1 || buf3 == buf2);
+      assertTrue(buf4 == buf1 || buf4 == buf2);
+      assertTrue(buf3 != buf4);
+    }
+
+    @Test public void testObeysSizeLimit() {
+      ByteArrayPool pool = new ByteArrayPool(32);
+
+      byte[] buf1 = pool.getBuf(16);
+      byte[] buf2 = pool.getBuf(16);
+      byte[] buf3 = pool.getBuf(16);
+
+      pool.returnBuf(buf1);
+      pool.returnBuf(buf2);
+      pool.returnBuf(buf3);
+
+      byte[] buf4 = pool.getBuf(16);
+      byte[] buf5 = pool.getBuf(16);
+      byte[] buf6 = pool.getBuf(16);
+
+      assertTrue(buf4 == buf2 || buf4 == buf3);
+      assertTrue(buf5 == buf2 || buf5 == buf3);
+      assertTrue(buf4 != buf5);
+      assertTrue(buf6 != buf1 && buf6 != buf2 && buf6 != buf3);
+    }
+
+    @Test public void testReturnsBufferWithRightSize() {
+      ByteArrayPool pool = new ByteArrayPool(32);
+
+      byte[] buf1 = pool.getBuf(16);
+      pool.returnBuf(buf1);
+
+      byte[] buf2 = pool.getBuf(17);
+      assertNotSame(buf2, buf1);
+
+      byte[] buf3 = pool.getBuf(15);
+      assertSame(buf3, buf1);
+    }
+  }


### PR DESCRIPTION
Re-using buffers can help avoid GC and make things run more smoothly when streaming data.

I don't have caliper properly set up, so if someone would like to test this using that I would appreciate it. The ByteArrayPool is from the Volley toolbox.
