### PR TITLE
added OkHttpClient.setSpdyAddress to bypass npn negotiation

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -38,6 +38,7 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
+
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -235,7 +236,8 @@ public class HttpEngine {
     connection = routeSelector.next(request.method());
 
     if (!connection.isConnected()) {
-      connection.connect(client.getConnectTimeout(), client.getReadTimeout(), getTunnelConfig());
+      connection.connect(client.getConnectTimeout(), client.getReadTimeout(), getTunnelConfig(),
+              client.forceSpdyAddresses);
       client.getConnectionPool().maybeShare(connection);
       client.getRoutesDatabase().connected(connection.getRoute());
     } else {

--- a/okhttp/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
@@ -25,7 +25,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Arrays;
+
 import javax.net.ssl.SSLContext;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,19 +77,19 @@ public final class ConnectionPoolTest {
     Route httpRoute = new Route(httpAddress, Proxy.NO_PROXY, httpSocketAddress, true);
     Route spdyRoute = new Route(spdyAddress, Proxy.NO_PROXY, spdySocketAddress, true);
     httpA = new Connection(httpRoute);
-    httpA.connect(100, 100, null);
+    httpA.connect(100, 100, null, null);
     httpB = new Connection(httpRoute);
-    httpB.connect(100, 100, null);
+    httpB.connect(100, 100, null, null);
     httpC = new Connection(httpRoute);
-    httpC.connect(100, 100, null);
+    httpC.connect(100, 100, null, null);
     httpD = new Connection(httpRoute);
-    httpD.connect(100, 100, null);
+    httpD.connect(100, 100, null, null);
     httpE = new Connection(httpRoute);
-    httpE.connect(100, 100, null);
+    httpE.connect(100, 100, null, null);
     spdyA = new Connection(spdyRoute);
-    spdyA.connect(100, 100, null);
+    spdyA.connect(100, 100, null, null);
     spdyB = new Connection(spdyRoute);
-    spdyB.connect(100, 100, null);
+    spdyB.connect(100, 100, null, null);
   }
 
   @After public void tearDown() throws Exception {
@@ -109,7 +111,7 @@ public final class ConnectionPoolTest {
     assertNull(connection);
 
     connection = new Connection(new Route(httpAddress, Proxy.NO_PROXY, httpSocketAddress, true));
-    connection.connect(100, 100, null);
+    connection.connect(100, 100, null, null);
     assertEquals(0, pool.getConnectionCount());
     pool.recycle(connection);
     assertEquals(1, pool.getConnectionCount());


### PR DESCRIPTION
skip npn negotiation to specify some addresses of the server which supports spdy protocol obviously.

it's possible to use spdy for some architectures not supports npn like android 2.2 to 4.0.

thanks.
