### PR TITLE
portably handle prohibited headers across SPDY variants.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -29,6 +29,11 @@ import java.util.List;
 import java.util.zip.Deflater;
 
 final class Spdy3 implements Variant {
+
+  @Override public String getProtocol() {
+    return "spdy/3";
+  }
+
   static final int TYPE_DATA = 0x0;
   static final int TYPE_SYN_STREAM = 0x1;
   static final int TYPE_SYN_REPLY = 0x2;

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -104,6 +104,15 @@ public final class SpdyConnection implements Closeable {
   }
 
   /**
+   * The protocol name, like {@code spdy/3} or {@code HTTP-draft-09/2.0}.
+   *
+   * @see com.squareup.okhttp.internal.spdy.Variant#getProtocol()
+   */
+  public String getProtocol() {
+     return variant.getProtocol();
+  }
+
+  /**
    * Returns the number of {@link SpdyStream#isOpen() open streams} on this
    * connection.
    */

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
@@ -23,6 +23,9 @@ interface Variant {
   Variant SPDY3 = new Spdy3();
   Variant HTTP_20_DRAFT_09 = new Http20Draft09();
 
+  /** The protocol name, like {@code spdy/3} or {@code HTTP-draft-09/2.0}. */
+  String getProtocol();
+
   /**
    * @param client true if this is the HTTP client's reader, reading frames from
    *     a peer SPDY or HTTP/2 server.


### PR DESCRIPTION
moves logic so that we can avoid ArrayList manipulation.

@JakeWharton
