### PR TITLE
Connected after everything is initialized

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -109,7 +109,6 @@ public final class Connection implements Closeable {
       throws IOException {
     if (connected) throw new IllegalStateException("already connected");
 
-    connected = true;
     socket = (route.proxy.type() != Proxy.Type.HTTP) ? new Socket(route.proxy) : new Socket();
     Platform.get().connectSocket(socket, route.inetSocketAddress, connectTimeout);
     socket.setSoTimeout(readTimeout);
@@ -121,6 +120,7 @@ public final class Connection implements Closeable {
     } else {
       streamWrapper();
     }
+    connected = true;
   }
 
   /**


### PR DESCRIPTION
Assuming there are two concurrent threads A, B.

If A sets 

<pre><code>connected = true;</code></pre> 

B gets into 

<pre><code>
else if (!connection.isSpdy()) {
connection.updateReadTimeout(client.getReadTimeout());
</code> </pre>

before A initializes Socket/SpdyConnection, there will be something bad happen.
