### PR TITLE
Fix a bug where discardStream took way too long.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
@@ -24,6 +24,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /** A scripted response to be replayed by the mock web server. */
 public final class MockResponse implements Cloneable {
@@ -37,10 +38,14 @@ public final class MockResponse implements Cloneable {
   /** The response body content, or null if {@code body} is set. */
   private InputStream bodyStream;
 
-  private int bytesPerSecond = Integer.MAX_VALUE;
+  private int throttleBytesPerPeriod = Integer.MAX_VALUE;
+  private long throttlePeriod = 1;
+  private TimeUnit throttleUnit = TimeUnit.SECONDS;
+
   private SocketPolicy socketPolicy = SocketPolicy.KEEP_OPEN;
 
   private int bodyDelayTimeMs = 0;
+
   /** Creates a new mock response with an empty body. */
   public MockResponse() {
     setBody(new byte[0]);
@@ -205,18 +210,30 @@ public final class MockResponse implements Cloneable {
     return this;
   }
 
-  public int getBytesPerSecond() {
-    return bytesPerSecond;
-  }
-
   /**
-   * Set simulated network speed, in bytes per second. This applies to the
-   * response body only; response headers are not throttled.
+   * Throttles the response body writer to sleep for the given period after each
+   * series of {@code bytesPerPeriod} bytes are written. Use this to simulate
+   * network behavior.
    */
-  public MockResponse setBytesPerSecond(int bytesPerSecond) {
-    this.bytesPerSecond = bytesPerSecond;
+  public MockResponse throttleBody(int bytesPerPeriod, long period, TimeUnit unit) {
+    this.throttleBytesPerPeriod = bytesPerPeriod;
+    this.throttlePeriod = period;
+    this.throttleUnit = unit;
     return this;
   }
+
+  public int getThrottleBytesPerPeriod() {
+    return throttleBytesPerPeriod;
+  }
+
+  public long getThrottlePeriod() {
+    return throttlePeriod;
+  }
+
+  public TimeUnit getThrottleUnit() {
+    return throttleUnit;
+  }
+
   /**
    * Set the delayed time of the response body to {@code delay}. This applies to the
    * response body only; response headers are not affected.

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -216,7 +216,7 @@ public final class HttpTransport implements Transport {
       int socketTimeout = socket.getSoTimeout();
       socket.setSoTimeout(DISCARD_STREAM_TIMEOUT_MILLIS);
       try {
-        Util.skipAll(responseBodyIn);
+        Util.skipByReading(responseBodyIn, Long.MAX_VALUE, DISCARD_STREAM_TIMEOUT_MILLIS);
         return true;
       } finally {
         socket.setSoTimeout(socketTimeout);

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
@@ -564,7 +564,7 @@ public final class HttpResponseCacheTest {
 
   private void testClientPrematureDisconnect(TransferKind transferKind) throws IOException {
     // Setting a low transfer speed ensures that stream discarding will time out.
-    MockResponse response = new MockResponse().setBytesPerSecond(6);
+    MockResponse response = new MockResponse().throttleBody(6, 1, TimeUnit.SECONDS);
     transferKind.setBody(response, "ABCDE\nFGHIJKLMNOPQRSTUVWXYZ", 1024);
     server.enqueue(response);
     server.enqueue(new MockResponse().setBody("Request #2"));


### PR DESCRIPTION
We were relying on the socket timeout of a single read,
but performing multiple reads each with independent
timeouts.
