### PR TITLE
Use thread names everywhere.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -390,11 +390,11 @@ public final class Util {
     return Collections.unmodifiableList(Arrays.asList(elements.clone()));
   }
 
-  public static ThreadFactory daemonThreadFactory(final String name) {
+  public static ThreadFactory threadFactory(final String name, final boolean daemon) {
     return new ThreadFactory() {
       @Override public Thread newThread(Runnable runnable) {
         Thread result = new Thread(runnable, name);
-        result.setDaemon(true);
+        result.setDaemon(daemon);
         return result;
       }
     };

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -33,8 +33,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static java.util.concurrent.Executors.defaultThreadFactory;
-
 /** Replays prerecorded outgoing frames and records incoming frames. */
 public final class MockSpdyPeer implements Closeable {
   private int frameCount = 0;
@@ -44,7 +42,8 @@ public final class MockSpdyPeer implements Closeable {
   private final List<OutFrame> outFrames = new ArrayList<OutFrame>();
   private final BlockingQueue<InFrame> inFrames = new LinkedBlockingQueue<InFrame>();
   private int port;
-  private final Executor executor = Executors.newCachedThreadPool(defaultThreadFactory());
+  private final Executor executor = Executors.newCachedThreadPool(
+      Util.threadFactory("MockSpdyPeer", false));
   private ServerSocket serverSocket;
   private Socket socket;
 

--- a/okhttp/src/main/java/com/squareup/okhttp/ConnectionPool.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ConnectionPool.java
@@ -82,7 +82,7 @@ public class ConnectionPool {
   /** We use a single background thread to cleanup expired connections. */
   private final ExecutorService executorService = new ThreadPoolExecutor(0, 1,
       60L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),
-      Util.daemonThreadFactory("OkHttp ConnectionPool"));
+      Util.threadFactory("OkHttp ConnectionPool", true));
   private final Callable<Void> connectionsCleanupCallable = new Callable<Void>() {
     @Override public Void call() throws Exception {
       List<Connection> expiredConnections = new ArrayList<Connection>(MAX_CONNECTIONS_TO_CLEANUP);

--- a/okhttp/src/main/java/com/squareup/okhttp/Dispatcher.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Dispatcher.java
@@ -54,7 +54,7 @@ public final class Dispatcher {
   public synchronized Executor getExecutor() {
     if (executor == null) {
       executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
-          new LinkedBlockingQueue<Runnable>());
+          new LinkedBlockingQueue<Runnable>(), Util.threadFactory("OkHttp Dispatcher", false));
     }
     return executor;
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/DiskLruCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/DiskLruCache.java
@@ -158,8 +158,8 @@ public final class DiskLruCache implements Closeable {
   private long nextSequenceNumber = 0;
 
   /** This cache uses a single background thread to evict entries. */
-  final ThreadPoolExecutor executorService =
-      new ThreadPoolExecutor(0, 1, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
+  final ThreadPoolExecutor executorService = new ThreadPoolExecutor(0, 1, 60L, TimeUnit.SECONDS,
+      new LinkedBlockingQueue<Runnable>(), Util.threadFactory("OkHttp DiskLruCache", true));
   private final Callable<Void> cleanupCallable = new Callable<Void>() {
     public Void call() throws Exception {
       synchronized (DiskLruCache.this) {


### PR DESCRIPTION
Sometimes we name a thread both via its ExecutorService
and via a NamedRunnable. The ExecutorService thread needs
to be named because threads are cached and will be visible
in a thread dump even when no runnables are running.

NamedRunnables are also used because they provide additional
context: the host or URL being serviced by a thread.
