### PR TITLE
Recover from connectivity problems in the async API.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -123,8 +123,8 @@ public final class HttpTransport implements Transport {
   public void writeRequestHeaders(Request request) throws IOException {
     httpEngine.writingRequestHeaders();
     String requestLine = RequestLine.get(request,
-        httpEngine.connection.getRoute().getProxy().type(),
-        httpEngine.connection.getHttpMinorVersion());
+        httpEngine.getConnection().getRoute().getProxy().type(),
+        httpEngine.getConnection().getHttpMinorVersion());
     writeRequest(requestOut, request.getHeaders(), requestLine);
   }
 
@@ -208,7 +208,7 @@ public final class HttpTransport implements Transport {
    * reuse.
    */
   private static boolean discardStream(HttpEngine httpEngine, InputStream responseBodyIn) {
-    Connection connection = httpEngine.connection;
+    Connection connection = httpEngine.getConnection();
     if (connection == null) return false;
     Socket socket = connection.getSocket();
     if (socket == null) return false;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -64,7 +64,7 @@ public final class SpdyTransport implements Transport {
     httpEngine.writingRequestHeaders();
     boolean hasRequestBody = httpEngine.hasRequestBody();
     boolean hasResponseBody = true;
-    String version = RequestLine.version(httpEngine.connection.getHttpMinorVersion());
+    String version = RequestLine.version(httpEngine.getConnection().getHttpMinorVersion());
     stream = spdyConnection.newStream(
         writeNameValueBlock(request, spdyConnection.getProtocol(), version), hasRequestBody,
         hasResponseBody);


### PR DESCRIPTION
This promotes HTTP engine failure recovery from HttpURLConnectionImpl
to HttpEngine. That has the nice side-effect of getting to hide some
more implementation details in HTTP engine.
