### PR TITLE
Drop explicit and now duplicate Java 6 enforcement.

### DIFF
--- a/mockwebserver/pom.xml
+++ b/mockwebserver/pom.xml
@@ -35,20 +35,7 @@
   </dependencies>
 
   <build>
-    <!-- Don't restrict test code to Java 1.5 APIs. -->
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
The root pom now enforces Java 6 across the entire project so there is no need to explicitly enable it for MockWebServer.
