### PR TITLE
Support more than 64 referenced headers in HPACK

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/BitArray.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/BitArray.java
@@ -21,10 +21,6 @@ import java.util.List;
 
 /** A simple bitset which supports left shifting. */
 public final class BitArray {
-  /** Create a bit array from a bit-packed long. */
-  public static BitArray fromValue(long bitLong) {
-    return new BitArray(bitLong);
-  }
 
   long[] data;
 
@@ -32,12 +28,8 @@ public final class BitArray {
   // offset the outward facing index to support shifts without having to move the underlying bits.
   private int start; // Valid values are [0..63]
 
-  BitArray() {
+  public BitArray() {
     data = new long[1];
-  }
-
-  private BitArray(long bitLong) {
-    data = new long[] { bitLong, 0 };
   }
 
   private void growToSize(int size) {

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/BitArrayTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/BitArrayTest.java
@@ -20,36 +20,9 @@ import org.junit.Test;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class BitArrayTest {
-  @Test public void initializeFromLong() {
-    long bits = 1L | (1L << 3) | (1L << 7);
-    BitArray b = BitArray.fromValue(bits);
-    assertTrue(b.get(0));
-    assertTrue(b.get(3));
-    assertTrue(b.get(7));
-  }
-
-  @Test public void initializedFullFromLong() {
-    long bits = -1;
-    BitArray b = BitArray.fromValue(bits);
-    for (int i = 0; i < 64; i++) {
-      assertTrue(b.get(i));
-    }
-  }
-
-  @Test public void hpackUseCase() {
-    long bits = 1L | (1L << 63);
-    BitArray b = BitArray.fromValue(bits);
-    assertTrue(b.get(0));
-    assertFalse(b.get(1));
-    assertTrue(b.get(63));
-    assertFalse(b.get(64));
-    b.set(64);
-    assertTrue(b.get(64));
-  }
 
   @Test public void setExpandsData() {
     BitArray b = new BitArray();


### PR DESCRIPTION
I initially wanted to implement > 64 referenced headers with a BitSet, but the lack of a left shift op means we would have to write it.  Jake wrote it (BitArray), and I benchmarked it to show it is equally efficient to using longs directly.
