### PR TITLE
Cache SPDY responses even if the body isn't fully consumed.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Headers.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Headers.java
@@ -119,6 +119,14 @@ public final class Headers {
     return result;
   }
 
+  @Override public String toString() {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < size(); i++) {
+      result.append(name(i)).append(": ").append(value(i)).append("\n");
+    }
+    return result.toString();
+  }
+
   private static String get(String[] namesAndValues, String fieldName) {
     for (int i = namesAndValues.length - 2; i >= 0; i -= 2) {
       if (fieldName.equalsIgnoreCase(namesAndValues[i])) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/AbstractHttpInputStream.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/AbstractHttpInputStream.java
@@ -36,7 +36,7 @@ abstract class AbstractHttpInputStream extends InputStream {
   protected final InputStream in;
   protected final HttpEngine httpEngine;
   private final CacheRequest cacheRequest;
-  private final OutputStream cacheBody;
+  protected final OutputStream cacheBody;
   protected boolean closed;
 
   AbstractHttpInputStream(InputStream in, HttpEngine httpEngine, CacheRequest cacheRequest)

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -35,13 +35,6 @@ import static com.squareup.okhttp.internal.Util.checkOffsetAndCount;
 import static com.squareup.okhttp.internal.http.StatusLine.HTTP_CONTINUE;
 
 public final class HttpTransport implements Transport {
-  /**
-   * The timeout to use while discarding a stream of input data. Since this is
-   * used for connection reuse, this timeout should be significantly less than
-   * the time it takes to establish a new connection.
-   */
-  private static final int DISCARD_STREAM_TIMEOUT_MILLIS = 100;
-
   public static final int DEFAULT_CHUNK_LENGTH = 1024;
 
   private final HttpEngine httpEngine;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
@@ -25,6 +25,13 @@ import java.net.CacheRequest;
 
 interface Transport {
   /**
+   * The timeout to use while discarding a stream of input data. Since this is
+   * used for connection reuse, this timeout should be significantly less than
+   * the time it takes to establish a new connection.
+   */
+  int DISCARD_STREAM_TIMEOUT_MILLIS = 100;
+
+  /**
    * Returns an output stream where the request body can be written. The
    * returned stream will of one of two types:
    * <ul>


### PR DESCRIPTION
https://github.com/square/okhttp/issues/450
