### PR TITLE
Settings: Wiring, Variant-specific defaults, and HTTP/2 acks

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
@@ -25,6 +25,7 @@ import java.util.List;
 public interface FrameWriter extends Closeable {
   /** HTTP/2.0 only. */
   void connectionHeader() throws IOException;
+  void ackSettings() throws IOException;
 
   /** SPDY/3 only. */
   void flush() throws IOException;
@@ -37,7 +38,8 @@ public interface FrameWriter extends Closeable {
   void data(boolean outFinished, int streamId, byte[] data) throws IOException;
   void data(boolean outFinished, int streamId, byte[] data, int offset, int byteCount)
       throws IOException;
-  void settings(Settings settings) throws IOException;
+  /** Write okhttp's settings to the peer. */
+  void settings(Settings okHttpSettings) throws IOException;
   void noop() throws IOException;
   void ping(boolean reply, int payload1, int payload2) throws IOException;
   void goAway(int lastGoodStreamId, ErrorCode errorCode) throws IOException;

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -36,6 +36,16 @@ final class Spdy3 implements Variant {
     return Protocol.SPDY_3;
   }
 
+  @Override public Settings defaultOkHttpSettings(boolean client) {
+    return initialPeerSettings(client); // no difference in defaults.
+  }
+
+  @Override public Settings initialPeerSettings(boolean client) {
+    Settings settings = new Settings();
+    settings.set(Settings.INITIAL_WINDOW_SIZE, 0, 65535);
+    return settings;
+  }
+
   static final int TYPE_DATA = 0x0;
   static final int TYPE_SYN_STREAM = 0x1;
   static final int TYPE_SYN_REPLY = 0x2;
@@ -94,11 +104,11 @@ final class Spdy3 implements Variant {
     }
   }
 
-  @Override public FrameReader newReader(InputStream in, boolean client) {
+  @Override public FrameReader newReader(InputStream in, Settings ignored, boolean client) {
     return new Reader(in, client);
   }
 
-  @Override public FrameWriter newWriter(OutputStream out, boolean client) {
+  @Override public FrameWriter newWriter(OutputStream out, Settings ignored, boolean client) {
     return new Writer(out, client);
   }
 
@@ -306,6 +316,10 @@ final class Spdy3 implements Variant {
       nameValueBlockBuffer = new ByteArrayOutputStream();
       nameValueBlockOut = new DataOutputStream(
           Platform.get().newDeflaterOutputStream(nameValueBlockBuffer, deflater, true));
+    }
+
+    @Override public void ackSettings() {
+      // Do nothing: no ACK for SPDY/3 settings.
     }
 
     @Override public synchronized void connectionHeader() {

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
@@ -28,14 +28,28 @@ interface Variant {
   Protocol getProtocol();
 
   /**
-   * @param client true if this is the HTTP client's reader, reading frames from
-   *     a peer SPDY or HTTP/2 server.
+   * Default settings used for sending frames to the peer.
+   * @param client true if these settings apply to writing requests, false if responses.
    */
-  FrameReader newReader(InputStream in, boolean client);
+  Settings defaultOkHttpSettings(boolean client);
 
   /**
-   * @param client true if this is the HTTP client's writer, writing frames to a
-   *     peer SPDY or HTTP/2 server.
+   * Initial settings used for reading frames from the peer until we are sent
+   * a Settings frame.
+   * @param client true if these settings apply to reading responses, false if requests.
    */
-  FrameWriter newWriter(OutputStream out, boolean client);
+  Settings initialPeerSettings(boolean client);
+
+  /**
+   * @param peerSettings potentially stale settings that reflect the remote peer.
+   * @param client true if this is the HTTP client's reader, reading frames from a server.
+   */
+  FrameReader newReader(InputStream in, Settings peerSettings, boolean client);
+
+  /**
+   * @param okHttpSettings settings configured locally.
+   * @param client true if this is the HTTP client's writer, writing frames to a server.
+   */
+  FrameWriter newWriter(OutputStream out, Settings okHttpSettings, boolean client);
+
 }

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -37,6 +37,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 public final class MockSpdyPeer implements Closeable {
   private int frameCount = 0;
   private final boolean client;
+  private final Variant variant;
   private final ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
   private final FrameWriter frameWriter;
   private final List<OutFrame> outFrames = new ArrayList<OutFrame>();
@@ -47,9 +48,10 @@ public final class MockSpdyPeer implements Closeable {
   private ServerSocket serverSocket;
   private Socket socket;
 
-  public MockSpdyPeer(boolean client) {
+  public MockSpdyPeer(Variant variant, boolean client) {
     this.client = client;
-    this.frameWriter = Variant.SPDY3.newWriter(bytesOut, client);
+    this.variant = variant;
+    this.frameWriter = variant.newWriter(bytesOut, variant.defaultOkHttpSettings(client), client);
   }
 
   public void acceptFrame() {
@@ -109,7 +111,7 @@ public final class MockSpdyPeer implements Closeable {
     socket = serverSocket.accept();
     OutputStream out = socket.getOutputStream();
     InputStream in = socket.getInputStream();
-    FrameReader reader = Variant.SPDY3.newReader(in, client);
+    FrameReader reader = variant.newReader(in, variant.initialPeerSettings(client), client);
 
     Iterator<OutFrame> outFramesIterator = outFrames.iterator();
     byte[] outBytes = bytesOut.toByteArray();

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SettingsTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SettingsTest.java
@@ -38,7 +38,7 @@ public final class SettingsTest {
 
     // WARNING: clash on flags between spdy/3 and http/2!
     assertEquals(-3, settings.getUploadBandwidth(-3));
-    assertEquals(4096, settings.getHeaderTableSize());
+    assertEquals(-1, settings.getHeaderTableSize());
     settings.set(Settings.UPLOAD_BANDWIDTH, 0, 42);
     assertEquals(42, settings.getUploadBandwidth(-3));
     settings.set(Settings.HEADER_TABLE_SIZE, 0, 8096);
@@ -46,11 +46,11 @@ public final class SettingsTest {
 
     // WARNING: clash on flags between spdy/3 and http/2!
     assertEquals(-3, settings.getDownloadBandwidth(-3));
-    assertTrue(settings.getEnablePush());
+    assertEquals(true, settings.getEnablePush(true));
     settings.set(Settings.DOWNLOAD_BANDWIDTH, 0, 53);
     assertEquals(53, settings.getDownloadBandwidth(-3));
     settings.set(Settings.ENABLE_PUSH, 0, 0);
-    assertFalse(settings.getEnablePush());
+    assertEquals(false, settings.getEnablePush(true));
 
     assertEquals(-3, settings.getRoundTripTime(-3));
     settings.set(Settings.ROUND_TRIP_TIME, 0, 64);
@@ -68,9 +68,9 @@ public final class SettingsTest {
     settings.set(Settings.DOWNLOAD_RETRANS_RATE, 0, 97);
     assertEquals(97, settings.getDownloadRetransRate(-3));
 
-    assertEquals(-3, settings.getInitialWindowSize(-3));
+    assertEquals(-1, settings.getInitialWindowSize());
     settings.set(Settings.INITIAL_WINDOW_SIZE, 0, 108);
-    assertEquals(108, settings.getInitialWindowSize(-3));
+    assertEquals(108, settings.getInitialWindowSize());
 
     assertEquals(-3, settings.getClientCertificateVectorSize(-3));
     settings.set(Settings.CLIENT_CERTIFICATE_VECTOR_SIZE, 0, 117);


### PR DESCRIPTION
This change extracts default settings to variants, and reacts to changes in http/2 headerTableSize.  It also refactors window size in spdy to use settings as opposed to constants.  Finally, this implements the ACK contract of settings frames in http/2.
