### PR TITLE
Reduce duplication around ascii header names.  Do not emit :version in http/2.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/ByteString.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/ByteString.java
@@ -61,17 +61,14 @@ public final class ByteString {
     return new ByteString(bytes);
   }
 
-  /**
-   * Returns a new byte string containing the {@code UTF-8} bytes of {@code s},
-   * or {@link #EMPTY} if {@code s} is zero length.
-   */
+  /** Returns a new byte string containing the {@code UTF-8} bytes of {@code s}. */
   public static ByteString encodeUtf8(String s) {
     ByteString byteString = new ByteString(s.getBytes(Util.UTF_8));
     byteString.utf8 = s;
     return byteString;
   }
 
-  /** Constructs a new {@code String} by decoding the bytes as UTF-8. */
+  /** Constructs a new {@code String} by decoding the bytes as {@code UTF-8}. */
   public String utf8() {
     String result = utf8;
     // We don't care if we double-allocate in racy code.

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -16,6 +16,7 @@
 
 package com.squareup.okhttp.internal;
 
+import com.squareup.okhttp.internal.spdy.Header;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.EOFException;
@@ -400,18 +401,10 @@ public final class Util {
     };
   }
 
-  public static List<ByteString> byteStringList(String... elements) {
-    List<ByteString> result = new ArrayList<ByteString>(elements.length);
-    for (String string : elements) {
-      result.add(ByteString.encodeUtf8(string));
-    }
-    return result;
-  }
-
-  public static List<ByteString> byteStringList(List<String> elements) {
-    List<ByteString> result = new ArrayList<ByteString>(elements.size());
-    for (int i = 0, size = elements.size(); i < size; i++) {
-      result.add(ByteString.encodeUtf8(elements.get(i)));
+  public static List<Header> headerEntries(String... elements) {
+    List<Header> result = new ArrayList<Header>(elements.length / 2);
+    for (int i = 0; i < elements.length; i += 2) {
+      result.add(new Header(elements[i], elements[i + 1]));
     }
     return result;
   }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
@@ -16,7 +16,6 @@
 
 package com.squareup.okhttp.internal.spdy;
 
-import com.squareup.okhttp.internal.ByteString;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,7 +43,7 @@ public interface FrameReader extends Closeable {
      * (highest) thru 7 (lowest). For HTTP/2.0, priorities range from 0
      */
     void headers(boolean outFinished, boolean inFinished, int streamId, int associatedStreamId,
-        int priority, List<ByteString> nameValueBlock, HeadersMode headersMode);
+        int priority, List<Header> nameValueBlock, HeadersMode headersMode);
     void rstStream(int streamId, ErrorCode errorCode);
     void settings(boolean clearPrevious, Settings settings);
     void noop();

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
@@ -16,7 +16,6 @@
 
 package com.squareup.okhttp.internal.spdy;
 
-import com.squareup.okhttp.internal.ByteString;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
@@ -30,10 +29,10 @@ public interface FrameWriter extends Closeable {
   /** SPDY/3 only. */
   void flush() throws IOException;
   void synStream(boolean outFinished, boolean inFinished, int streamId, int associatedStreamId,
-      int priority, int slot, List<ByteString> nameValueBlock) throws IOException;
-  void synReply(boolean outFinished, int streamId, List<ByteString> nameValueBlock)
+      int priority, int slot, List<Header> nameValueBlock) throws IOException;
+  void synReply(boolean outFinished, int streamId, List<Header> nameValueBlock)
       throws IOException;
-  void headers(int streamId, List<ByteString> nameValueBlock) throws IOException;
+  void headers(int streamId, List<Header> nameValueBlock) throws IOException;
   void rstStream(int streamId, ErrorCode errorCode) throws IOException;
   void data(boolean outFinished, int streamId, byte[] data) throws IOException;
   void data(boolean outFinished, int streamId, byte[] data, int offset, int byteCount)

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Header.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Header.java
@@ -1,0 +1,56 @@
+package com.squareup.okhttp.internal.spdy;
+
+import com.squareup.okhttp.internal.ByteString;
+
+/** HTTP header: the name is an ASCII string, but the value can be UTF-8. */
+public final class Header {
+  // Special header names defined in the SPDY and HTTP/2 specs.
+  public static final ByteString RESPONSE_STATUS = ByteString.encodeUtf8(":status");
+  public static final ByteString TARGET_METHOD = ByteString.encodeUtf8(":method");
+  public static final ByteString TARGET_PATH = ByteString.encodeUtf8(":path");
+  public static final ByteString TARGET_SCHEME = ByteString.encodeUtf8(":scheme");
+  public static final ByteString TARGET_AUTHORITY = ByteString.encodeUtf8(":authority"); // http/2
+  public static final ByteString TARGET_HOST = ByteString.encodeUtf8(":host"); // spdy/3
+  public static final ByteString VERSION = ByteString.encodeUtf8(":version"); // spdy/3
+
+  /** Name in case-insensitive ASCII encoding. */
+  public final ByteString name;
+  /** Value in UTF-8 encoding. */
+  public final ByteString value;
+  final int hpackSize;
+
+  // TODO: search for toLowerCase and consider moving logic here.
+  public Header(String name, String value) {
+    this(ByteString.encodeUtf8(name), ByteString.encodeUtf8(value));
+  }
+
+  public Header(ByteString name, String value) {
+    this(name, ByteString.encodeUtf8(value));
+  }
+
+  public Header(ByteString name, ByteString value) {
+    this.name = name;
+    this.value = value;
+    this.hpackSize = 32 + name.size() + value.size();
+  }
+
+  @Override public boolean equals(Object other) {
+    if (other instanceof Header) {
+      Header that = (Header) other;
+      return this.name.equals(that.name)
+          && this.value.equals(that.value);
+    }
+    return false;
+  }
+
+  @Override public int hashCode() {
+    int result = 17;
+    result = 31 * result + name.hashCode();
+    result = 31 * result + value.hashCode();
+    return result;
+  }
+
+  @Override public String toString() {
+    return String.format("%s: %s", name.utf8(), value.utf8());
+  }
+}

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/HpackDraft05.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/HpackDraft05.java
@@ -20,93 +20,71 @@ import java.util.List;
  * position moving forward.  When the array fills, it is doubled.
  */
 final class HpackDraft05 {
-
-  // Visible for testing.
-  static class HeaderEntry {
-    final ByteString name;
-    final ByteString value;
-    final int size;
-
-    HeaderEntry(String name, String value) {
-      this(ByteString.encodeUtf8(name), ByteString.encodeUtf8(value));
-    }
-
-    HeaderEntry(ByteString name, ByteString value) {
-      this(name, value, 32 + name.size() + value.size());
-    }
-
-    private HeaderEntry(ByteString name, ByteString value, int size) {
-      this.name = name;
-      this.value = value;
-      this.size = size;
-    }
-  }
-
   private static final int PREFIX_6_BITS = 0x3f;
   private static final int PREFIX_7_BITS = 0x7f;
   private static final int PREFIX_8_BITS = 0xff;
 
-  private static final HeaderEntry[] STATIC_HEADER_TABLE = new HeaderEntry[] {
-      new HeaderEntry(":authority", ""),
-      new HeaderEntry(":method", "GET"),
-      new HeaderEntry(":method", "POST"),
-      new HeaderEntry(":path", "/"),
-      new HeaderEntry(":path", "/index.html"),
-      new HeaderEntry(":scheme", "http"),
-      new HeaderEntry(":scheme", "https"),
-      new HeaderEntry(":status", "200"),
-      new HeaderEntry(":status", "500"),
-      new HeaderEntry(":status", "404"),
-      new HeaderEntry(":status", "403"),
-      new HeaderEntry(":status", "400"),
-      new HeaderEntry(":status", "401"),
-      new HeaderEntry("accept-charset", ""),
-      new HeaderEntry("accept-encoding", ""),
-      new HeaderEntry("accept-language", ""),
-      new HeaderEntry("accept-ranges", ""),
-      new HeaderEntry("accept", ""),
-      new HeaderEntry("access-control-allow-origin", ""),
-      new HeaderEntry("age", ""),
-      new HeaderEntry("allow", ""),
-      new HeaderEntry("authorization", ""),
-      new HeaderEntry("cache-control", ""),
-      new HeaderEntry("content-disposition", ""),
-      new HeaderEntry("content-encoding", ""),
-      new HeaderEntry("content-language", ""),
-      new HeaderEntry("content-length", ""),
-      new HeaderEntry("content-location", ""),
-      new HeaderEntry("content-range", ""),
-      new HeaderEntry("content-type", ""),
-      new HeaderEntry("cookie", ""),
-      new HeaderEntry("date", ""),
-      new HeaderEntry("etag", ""),
-      new HeaderEntry("expect", ""),
-      new HeaderEntry("expires", ""),
-      new HeaderEntry("from", ""),
-      new HeaderEntry("host", ""),
-      new HeaderEntry("if-match", ""),
-      new HeaderEntry("if-modified-since", ""),
-      new HeaderEntry("if-none-match", ""),
-      new HeaderEntry("if-range", ""),
-      new HeaderEntry("if-unmodified-since", ""),
-      new HeaderEntry("last-modified", ""),
-      new HeaderEntry("link", ""),
-      new HeaderEntry("location", ""),
-      new HeaderEntry("max-forwards", ""),
-      new HeaderEntry("proxy-authenticate", ""),
-      new HeaderEntry("proxy-authorization", ""),
-      new HeaderEntry("range", ""),
-      new HeaderEntry("referer", ""),
-      new HeaderEntry("refresh", ""),
-      new HeaderEntry("retry-after", ""),
-      new HeaderEntry("server", ""),
-      new HeaderEntry("set-cookie", ""),
-      new HeaderEntry("strict-transport-security", ""),
-      new HeaderEntry("transfer-encoding", ""),
-      new HeaderEntry("user-agent", ""),
-      new HeaderEntry("vary", ""),
-      new HeaderEntry("via", ""),
-      new HeaderEntry("www-authenticate", "")
+  private static final Header[] STATIC_HEADER_TABLE = new Header[] {
+      new Header(Header.TARGET_AUTHORITY, ""),
+      new Header(Header.TARGET_METHOD, "GET"),
+      new Header(Header.TARGET_METHOD, "POST"),
+      new Header(Header.TARGET_PATH, "/"),
+      new Header(Header.TARGET_PATH, "/index.html"),
+      new Header(Header.TARGET_SCHEME, "http"),
+      new Header(Header.TARGET_SCHEME, "https"),
+      new Header(Header.RESPONSE_STATUS, "200"),
+      new Header(Header.RESPONSE_STATUS, "500"),
+      new Header(Header.RESPONSE_STATUS, "404"),
+      new Header(Header.RESPONSE_STATUS, "403"),
+      new Header(Header.RESPONSE_STATUS, "400"),
+      new Header(Header.RESPONSE_STATUS, "401"),
+      new Header("accept-charset", ""),
+      new Header("accept-encoding", ""),
+      new Header("accept-language", ""),
+      new Header("accept-ranges", ""),
+      new Header("accept", ""),
+      new Header("access-control-allow-origin", ""),
+      new Header("age", ""),
+      new Header("allow", ""),
+      new Header("authorization", ""),
+      new Header("cache-control", ""),
+      new Header("content-disposition", ""),
+      new Header("content-encoding", ""),
+      new Header("content-language", ""),
+      new Header("content-length", ""),
+      new Header("content-location", ""),
+      new Header("content-range", ""),
+      new Header("content-type", ""),
+      new Header("cookie", ""),
+      new Header("date", ""),
+      new Header("etag", ""),
+      new Header("expect", ""),
+      new Header("expires", ""),
+      new Header("from", ""),
+      new Header("host", ""),
+      new Header("if-match", ""),
+      new Header("if-modified-since", ""),
+      new Header("if-none-match", ""),
+      new Header("if-range", ""),
+      new Header("if-unmodified-since", ""),
+      new Header("last-modified", ""),
+      new Header("link", ""),
+      new Header("location", ""),
+      new Header("max-forwards", ""),
+      new Header("proxy-authenticate", ""),
+      new Header("proxy-authorization", ""),
+      new Header("range", ""),
+      new Header("referer", ""),
+      new Header("refresh", ""),
+      new Header("retry-after", ""),
+      new Header("server", ""),
+      new Header("set-cookie", ""),
+      new Header("strict-transport-security", ""),
+      new Header("transfer-encoding", ""),
+      new Header("user-agent", ""),
+      new Header("vary", ""),
+      new Header("via", ""),
+      new Header("www-authenticate", "")
   };
 
   private HpackDraft05() {
@@ -118,12 +96,12 @@ final class HpackDraft05 {
     private final Huffman.Codec huffmanCodec;
 
     private final DataInputStream in;
-    private final List<ByteString> emittedHeaders = new ArrayList<ByteString>();
+    private final List<Header> emittedHeaders = new ArrayList<Header>();
     private int maxHeaderTableByteCount;
     private long bytesLeft = 0;
 
     // Visible for testing.
-    HeaderEntry[] headerTable = new HeaderEntry[8];
+    Header[] headerTable = new Header[8];
     // Array is populated back to front, so new entries always have lowest index.
     int nextHeaderIndex = headerTable.length - 1;
     int headerCount = 0;
@@ -139,7 +117,7 @@ final class HpackDraft05 {
      * emitted.
      */
     // Using a long since the static table < 64 entries.
-    long referencedStaticHeaders = 0L;;
+    long referencedStaticHeaders = 0L;
     int headerTableByteCount = 0;
 
     Reader(boolean client, int maxHeaderTableByteCount, DataInputStream in) {
@@ -166,8 +144,8 @@ final class HpackDraft05 {
       if (bytesToRecover > 0) {
         // determine how many headers need to be evicted.
         for (int j = headerTable.length - 1; j >= nextHeaderIndex && bytesToRecover > 0; j--) {
-          bytesToRecover -= headerTable[j].size;
-          headerTableByteCount -= headerTable[j].size;
+          bytesToRecover -= headerTable[j].hpackSize;
+          headerTableByteCount -= headerTable[j].hpackSize;
           headerCount--;
           entriesToEvict++;
         }
@@ -222,14 +200,12 @@ final class HpackDraft05 {
     public void emitReferenceSet() {
       for (int i = 0; i < STATIC_HEADER_TABLE.length; ++i) {
         if (((referencedStaticHeaders >> i) & 1L) == 1) {
-          emittedHeaders.add(STATIC_HEADER_TABLE[i].name);
-          emittedHeaders.add(STATIC_HEADER_TABLE[i].value);
+          emittedHeaders.add(STATIC_HEADER_TABLE[i]);
         }
       }
       for (int i = headerTable.length - 1; i != nextHeaderIndex; --i) {
         if (referencedHeaders.get(i)) {
-          emittedHeaders.add(headerTable[i].name);
-          emittedHeaders.add(headerTable[i].value);
+          emittedHeaders.add(headerTable[i]);
         }
       }
     }
@@ -238,8 +214,8 @@ final class HpackDraft05 {
      * Returns all headers emitted since they were last cleared, then clears the
      * emitted headers.
      */
-    public List<ByteString> getAndReset() {
-      List<ByteString> result = new ArrayList<ByteString>(emittedHeaders);
+    public List<Header> getAndReset() {
+      List<Header> result = new ArrayList<Header>(emittedHeaders);
       emittedHeaders.clear();
       return result;
     }
@@ -249,7 +225,7 @@ final class HpackDraft05 {
         if (maxHeaderTableByteCount == 0) {
           referencedStaticHeaders |= (1L << (index - headerCount));
         } else {
-          HeaderEntry staticEntry = STATIC_HEADER_TABLE[index - headerCount];
+          Header staticEntry = STATIC_HEADER_TABLE[index - headerCount];
           insertIntoHeaderTable(-1, staticEntry);
         }
       } else {
@@ -265,28 +241,26 @@ final class HpackDraft05 {
     private void readLiteralHeaderWithoutIndexingIndexedName(int index) throws IOException {
       ByteString name = getName(index);
       ByteString value = readString();
-      emittedHeaders.add(name);
-      emittedHeaders.add(value);
+      emittedHeaders.add(new Header(name, value));
     }
 
     private void readLiteralHeaderWithoutIndexingNewName() throws IOException {
       ByteString name = readString();
       ByteString value = readString();
-      emittedHeaders.add(name);
-      emittedHeaders.add(value);
+      emittedHeaders.add(new Header(name, value));
     }
 
     private void readLiteralHeaderWithIncrementalIndexingIndexedName(int nameIndex)
         throws IOException {
       ByteString name = getName(nameIndex);
       ByteString value = readString();
-      insertIntoHeaderTable(-1, new HeaderEntry(name, value));
+      insertIntoHeaderTable(-1, new Header(name, value));
     }
 
     private void readLiteralHeaderWithIncrementalIndexingNewName() throws IOException {
       ByteString name = readString();
       ByteString value = readString();
-      insertIntoHeaderTable(-1, new HeaderEntry(name, value));
+      insertIntoHeaderTable(-1, new Header(name, value));
     }
 
     private ByteString getName(int index) {
@@ -302,10 +276,10 @@ final class HpackDraft05 {
     }
 
     /** index == -1 when new. */
-    private void insertIntoHeaderTable(int index, HeaderEntry entry) {
-      int delta = entry.size;
+    private void insertIntoHeaderTable(int index, Header entry) {
+      int delta = entry.hpackSize;
       if (index != -1) { // Index -1 == new header.
-        delta -= headerTable[headerTableIndex(index)].size;
+        delta -= headerTable[headerTableIndex(index)].hpackSize;
       }
 
       // if the new or replacement header is too big, drop all entries.
@@ -316,8 +290,7 @@ final class HpackDraft05 {
         headerCount = 0;
         headerTableByteCount = 0;
         // emit the large header to the callback.
-        emittedHeaders.add(entry.name);
-        emittedHeaders.add(entry.value);
+        emittedHeaders.add(entry);
         return;
       }
 
@@ -327,7 +300,7 @@ final class HpackDraft05 {
 
       if (index == -1) {
         if (headerCount + 1 > headerTable.length) {
-          HeaderEntry[] doubled = new HeaderEntry[headerTable.length * 2];
+          Header[] doubled = new Header[headerTable.length * 2];
           System.arraycopy(headerTable, 0, doubled, headerTable.length, headerTable.length);
           if (doubled.length == 64) {
             referencedHeaders = ((BitArray.FixedCapacity) referencedHeaders).toVariableCapacity();
@@ -390,7 +363,7 @@ final class HpackDraft05 {
         return ByteString.of(huffmanCodec.decode(buff));
       }
       bytesLeft -= length;
-      return ByteString.read(in, length);
+      return length == 0 ? ByteString.EMPTY : ByteString.read(in, length);
     }
   }
 
@@ -401,12 +374,12 @@ final class HpackDraft05 {
       this.out = out;
     }
 
-    public void writeHeaders(List<ByteString> nameValueBlock) throws IOException {
+    public void writeHeaders(List<Header> nameValueBlock) throws IOException {
       // TODO: implement a compression strategy.
-      for (int i = 0, size = nameValueBlock.size(); i < size; i += 2) {
+      for (int i = 0, size = nameValueBlock.size(); i < size; i++) {
         out.write(0x40); // Literal Header without Indexing - New Name.
-        writeByteString(nameValueBlock.get(i));
-        writeByteString(nameValueBlock.get(i + 1));
+        writeByteString(nameValueBlock.get(i).name);
+        writeByteString(nameValueBlock.get(i).value);
       }
     }
 

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.okhttp.internal.spdy;
 
-import com.squareup.okhttp.internal.ByteString;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.internal.Util;
 import java.io.ByteArrayOutputStream;
@@ -186,7 +185,7 @@ public final class Http20Draft09 implements Variant {
 
         if ((flags & FLAG_END_HEADERS) != 0) {
           hpackReader.emitReferenceSet();
-          List<ByteString> nameValueBlock = hpackReader.getAndReset();
+          List<Header> nameValueBlock = hpackReader.getAndReset();
           // TODO: Concat multi-value headers with 0x0, except COOKIE, which uses 0x3B, 0x20.
           // http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-8.1.3
           int priority = -1; // TODO: priority
@@ -337,24 +336,24 @@ public final class Http20Draft09 implements Variant {
 
     @Override
     public synchronized void synStream(boolean outFinished, boolean inFinished, int streamId,
-        int associatedStreamId, int priority, int slot, List<ByteString> nameValueBlock)
+        int associatedStreamId, int priority, int slot, List<Header> nameValueBlock)
         throws IOException {
       if (inFinished) throw new UnsupportedOperationException();
       headers(outFinished, streamId, priority, nameValueBlock);
     }
 
     @Override public synchronized void synReply(boolean outFinished, int streamId,
-        List<ByteString> nameValueBlock) throws IOException {
+        List<Header> nameValueBlock) throws IOException {
       headers(outFinished, streamId, -1, nameValueBlock);
     }
 
-    @Override public synchronized void headers(int streamId, List<ByteString> nameValueBlock)
+    @Override public synchronized void headers(int streamId, List<Header> nameValueBlock)
         throws IOException {
       headers(false, streamId, -1, nameValueBlock);
     }
 
     private void headers(boolean outFinished, int streamId, int priority,
-        List<ByteString> nameValueBlock) throws IOException {
+        List<Header> nameValueBlock) throws IOException {
       hpackBuffer.reset();
       hpackWriter.writeHeaders(nameValueBlock);
       int type = TYPE_HEADERS;

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/NameValueBlockReader.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/NameValueBlockReader.java
@@ -72,7 +72,7 @@ class NameValueBlockReader implements Closeable {
     }
   }
 
-  public List<ByteString> readNameValueBlock(int length) throws IOException {
+  public List<Header> readNameValueBlock(int length) throws IOException {
     this.compressedLimit += length;
     try {
       int numberOfPairs = nameValueBlockIn.readInt();
@@ -82,13 +82,12 @@ class NameValueBlockReader implements Closeable {
       if (numberOfPairs > 1024) {
         throw new IOException("numberOfPairs > 1024: " + numberOfPairs);
       }
-      List<ByteString> entries = new ArrayList<ByteString>(numberOfPairs * 2);
+      List<Header> entries = new ArrayList<Header>(numberOfPairs);
       for (int i = 0; i < numberOfPairs; i++) {
         ByteString name = readString();
         ByteString values = readString();
         if (name.size() == 0) throw new IOException("name.size == 0");
-        entries.add(name);
-        entries.add(values);
+        entries.add(new Header(name, values));
       }
 
       doneReading();

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -213,7 +213,7 @@ final class Spdy3 implements Variant {
       int associatedStreamId = w2 & 0x7fffffff;
       int priority = (s3 & 0xe000) >>> 13;
       int slot = s3 & 0xff;
-      List<ByteString> nameValueBlock = nameValueBlockReader.readNameValueBlock(length - 10);
+      List<Header> nameValueBlock = nameValueBlockReader.readNameValueBlock(length - 10);
 
       boolean inFinished = (flags & FLAG_FIN) != 0;
       boolean outFinished = (flags & FLAG_UNIDIRECTIONAL) != 0;
@@ -224,7 +224,7 @@ final class Spdy3 implements Variant {
     private void readSynReply(Handler handler, int flags, int length) throws IOException {
       int w1 = in.readInt();
       int streamId = w1 & 0x7fffffff;
-      List<ByteString> nameValueBlock = nameValueBlockReader.readNameValueBlock(length - 4);
+      List<Header> nameValueBlock = nameValueBlockReader.readNameValueBlock(length - 4);
       boolean inFinished = (flags & FLAG_FIN) != 0;
       handler.headers(false, inFinished, streamId, -1, -1, nameValueBlock, HeadersMode.SPDY_REPLY);
     }
@@ -243,7 +243,7 @@ final class Spdy3 implements Variant {
     private void readHeaders(Handler handler, int flags, int length) throws IOException {
       int w1 = in.readInt();
       int streamId = w1 & 0x7fffffff;
-      List<ByteString> nameValueBlock = nameValueBlockReader.readNameValueBlock(length - 4);
+      List<Header> nameValueBlock = nameValueBlockReader.readNameValueBlock(length - 4);
       handler.headers(false, false, streamId, -1, -1, nameValueBlock, HeadersMode.SPDY_HEADERS);
     }
 
@@ -332,7 +332,7 @@ final class Spdy3 implements Variant {
 
     @Override
     public synchronized void synStream(boolean outFinished, boolean inFinished, int streamId,
-        int associatedStreamId, int priority, int slot, List<ByteString> nameValueBlock)
+        int associatedStreamId, int priority, int slot, List<Header> nameValueBlock)
         throws IOException {
       writeNameValueBlockToBuffer(nameValueBlock);
       int length = 10 + nameValueBlockBuffer.size();
@@ -350,7 +350,7 @@ final class Spdy3 implements Variant {
     }
 
     @Override public synchronized void synReply(boolean outFinished, int streamId,
-        List<ByteString> nameValueBlock) throws IOException {
+        List<Header> nameValueBlock) throws IOException {
       writeNameValueBlockToBuffer(nameValueBlock);
       int type = TYPE_SYN_REPLY;
       int flags = (outFinished ? FLAG_FIN : 0);
@@ -363,7 +363,7 @@ final class Spdy3 implements Variant {
       out.flush();
     }
 
-    @Override public synchronized void headers(int streamId, List<ByteString> nameValueBlock)
+    @Override public synchronized void headers(int streamId, List<Header> nameValueBlock)
         throws IOException {
       writeNameValueBlockToBuffer(nameValueBlock);
       int flags = 0;
@@ -403,14 +403,16 @@ final class Spdy3 implements Variant {
       out.write(data, offset, byteCount);
     }
 
-    private void writeNameValueBlockToBuffer(List<ByteString> nameValueBlock) throws IOException {
+    private void writeNameValueBlockToBuffer(List<Header> nameValueBlock) throws IOException {
       nameValueBlockBuffer.reset();
-      int numberOfPairs = nameValueBlock.size() / 2;
-      nameValueBlockOut.writeInt(numberOfPairs);
+      nameValueBlockOut.writeInt(nameValueBlock.size());
       for (int i = 0, size = nameValueBlock.size(); i < size; i++) {
-        ByteString s = nameValueBlock.get(i);
-        nameValueBlockOut.writeInt(s.size());
-        s.write(nameValueBlockOut);
+        ByteString name = nameValueBlock.get(i).name;
+        nameValueBlockOut.writeInt(name.size());
+        name.write(nameValueBlockOut);
+        ByteString value = nameValueBlock.get(i).value;
+        nameValueBlockOut.writeInt(value.size());
+        value.write(nameValueBlockOut);
       }
       nameValueBlockOut.flush();
     }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -16,7 +16,6 @@
 
 package com.squareup.okhttp.internal.spdy;
 
-import com.squareup.okhttp.internal.ByteString;
 import com.squareup.okhttp.internal.NamedRunnable;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.internal.Util;
@@ -159,7 +158,7 @@ public final class SpdyConnection implements Closeable {
    * @param in true to create an input stream that the remote peer can use to
    *     send data to us. Corresponds to {@code FLAG_UNIDIRECTIONAL}.
    */
-  public SpdyStream newStream(List<ByteString> requestHeaders, boolean out, boolean in)
+  public SpdyStream newStream(List<Header> requestHeaders, boolean out, boolean in)
       throws IOException {
     boolean outFinished = !out;
     boolean inFinished = !in;
@@ -191,7 +190,7 @@ public final class SpdyConnection implements Closeable {
     return stream;
   }
 
-  void writeSynReply(int streamId, boolean outFinished, List<ByteString> alternating)
+  void writeSynReply(int streamId, boolean outFinished, List<Header> alternating)
       throws IOException {
     frameWriter.synReply(outFinished, streamId, alternating);
   }
@@ -480,7 +479,7 @@ public final class SpdyConnection implements Closeable {
     }
 
     @Override public void headers(boolean outFinished, boolean inFinished, int streamId,
-        int associatedStreamId, int priority, List<ByteString> nameValueBlock,
+        int associatedStreamId, int priority, List<Header> nameValueBlock,
         HeadersMode headersMode) {
       SpdyStream stream;
       synchronized (SpdyConnection.this) {

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
@@ -16,7 +16,6 @@
 
 package com.squareup.okhttp.internal.spdy;
 
-import com.squareup.okhttp.internal.ByteString;
 import com.squareup.okhttp.internal.Util;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,10 +48,10 @@ public final class SpdyStream {
   private long readTimeoutMillis = 0;
 
   /** Headers sent by the stream initiator. Immutable and non null. */
-  private final List<ByteString> requestHeaders;
+  private final List<Header> requestHeaders;
 
   /** Headers sent in the stream reply. Null if reply is either not sent or not sent yet. */
-  private List<ByteString> responseHeaders;
+  private List<Header> responseHeaders;
 
   private final SpdyDataInputStream in;
   private final SpdyDataOutputStream out;
@@ -65,7 +64,7 @@ public final class SpdyStream {
   private ErrorCode errorCode = null;
 
   SpdyStream(int id, SpdyConnection connection, boolean outFinished, boolean inFinished,
-      int priority, List<ByteString> requestHeaders, Settings peerSettings) {
+      int priority, List<Header> requestHeaders, Settings peerSettings) {
     if (connection == null) throw new NullPointerException("connection == null");
     if (requestHeaders == null) throw new NullPointerException("requestHeaders == null");
     this.id = id;
@@ -109,7 +108,7 @@ public final class SpdyStream {
     return connection;
   }
 
-  public List<ByteString> getRequestHeaders() {
+  public List<Header> getRequestHeaders() {
     return requestHeaders;
   }
 
@@ -117,7 +116,7 @@ public final class SpdyStream {
    * Returns the stream's response headers, blocking if necessary if they
    * have not been received yet.
    */
-  public synchronized List<ByteString> getResponseHeaders() throws IOException {
+  public synchronized List<Header> getResponseHeaders() throws IOException {
     long remaining = 0;
     long start = 0;
     if (readTimeoutMillis != 0) {
@@ -161,7 +160,7 @@ public final class SpdyStream {
    * @param out true to create an output stream that we can use to send data
    * to the remote peer. Corresponds to {@code FLAG_FIN}.
    */
-  public void reply(List<ByteString> responseHeaders, boolean out) throws IOException {
+  public void reply(List<Header> responseHeaders, boolean out) throws IOException {
     assert (!Thread.holdsLock(SpdyStream.this));
     boolean outFinished = false;
     synchronized (this) {
@@ -254,7 +253,7 @@ public final class SpdyStream {
     return true;
   }
 
-  void receiveHeaders(List<ByteString> headers, HeadersMode headersMode) {
+  void receiveHeaders(List<Header> headers, HeadersMode headersMode) {
     assert (!Thread.holdsLock(SpdyStream.this));
     ErrorCode errorCode = null;
     boolean open = true;
@@ -271,7 +270,7 @@ public final class SpdyStream {
         if (headersMode.failIfHeadersPresent()) {
           errorCode = ErrorCode.STREAM_IN_USE;
         } else {
-          List<ByteString> newHeaders = new ArrayList<ByteString>();
+          List<Header> newHeaders = new ArrayList<Header>();
           newHeaders.addAll(responseHeaders);
           newHeaders.addAll(headers);
           this.responseHeaders = newHeaders;

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.okhttp.internal.spdy;
 
-import com.squareup.okhttp.internal.ByteString;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -30,7 +29,7 @@ class BaseTestHandler implements FrameReader.Handler {
 
   @Override
   public void headers(boolean outFinished, boolean inFinished, int streamId, int associatedStreamId,
-      int priority, List<ByteString> nameValueBlock, HeadersMode headersMode) {
+      int priority, List<Header> nameValueBlock, HeadersMode headersMode) {
     fail();
   }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/HpackDraft05Test.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/HpackDraft05Test.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.squareup.okhttp.internal.Util.byteStringList;
+import static com.squareup.okhttp.internal.Util.headerEntries;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -61,7 +61,7 @@ public class HpackDraft05Test {
 
     assertEquals(0, hpackReader.headerCount);
 
-    assertEquals(byteStringList("custom-key", "custom-header"), hpackReader.getAndReset());
+    assertEquals(headerEntries("custom-key", "custom-header"), hpackReader.getAndReset());
   }
 
   /** Oldest entries are evicted to support newer ones. */
@@ -97,7 +97,7 @@ public class HpackDraft05Test {
 
     assertEquals(2, hpackReader.headerCount);
 
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 1];
+    Header entry = hpackReader.headerTable[headerTableLength() - 1];
     checkEntry(entry, "custom-bar", "custom-header", 55);
     assertHeaderReferenced(headerTableLength() - 1);
 
@@ -107,7 +107,7 @@ public class HpackDraft05Test {
 
     // foo isn't here as it is no longer in the table.
     // TODO: emit before eviction?
-    assertEquals(byteStringList("custom-bar", "custom-header", "custom-baz", "custom-header"),
+    assertEquals(headerEntries("custom-bar", "custom-header", "custom-baz", "custom-header"),
         hpackReader.getAndReset());
 
     // Simulate receiving a small settings frame, that implies eviction.
@@ -158,7 +158,7 @@ public class HpackDraft05Test {
     assertEquals(1, hpackReader.headerCount);
     assertEquals(52, hpackReader.headerTableByteCount);
 
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 1];
+    Header entry = hpackReader.headerTable[headerTableLength() - 1];
     checkEntry(entry, ":path", "www.example.com", 52);
     assertHeaderReferenced(headerTableLength() - 1);
   }
@@ -183,11 +183,11 @@ public class HpackDraft05Test {
     assertEquals(1, hpackReader.headerCount);
     assertEquals(55, hpackReader.headerTableByteCount);
 
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 1];
+    Header entry = hpackReader.headerTable[headerTableLength() - 1];
     checkEntry(entry, "custom-key", "custom-header", 55);
     assertHeaderReferenced(headerTableLength() - 1);
 
-    assertEquals(byteStringList("custom-key", "custom-header"), hpackReader.getAndReset());
+    assertEquals(headerEntries("custom-key", "custom-header"), hpackReader.getAndReset());
   }
 
   /**
@@ -207,7 +207,7 @@ public class HpackDraft05Test {
 
     assertEquals(0, hpackReader.headerCount);
 
-    assertEquals(byteStringList(":path", "/sample/path"), hpackReader.getAndReset());
+    assertEquals(headerEntries(":path", "/sample/path"), hpackReader.getAndReset());
   }
 
   /**
@@ -226,11 +226,11 @@ public class HpackDraft05Test {
     assertEquals(1, hpackReader.headerCount);
     assertEquals(42, hpackReader.headerTableByteCount);
 
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 1];
+    Header entry = hpackReader.headerTable[headerTableLength() - 1];
     checkEntry(entry, ":method", "GET", 42);
     assertHeaderReferenced(headerTableLength() - 1);
 
-    assertEquals(byteStringList(":method", "GET"), hpackReader.getAndReset());
+    assertEquals(headerEntries(":method", "GET"), hpackReader.getAndReset());
   }
 
   /**
@@ -253,7 +253,7 @@ public class HpackDraft05Test {
     assertEquals(1, hpackReader.headerCount);
     assertEquals(42, hpackReader.headerTableByteCount);
 
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 1];
+    Header entry = hpackReader.headerTable[headerTableLength() - 1];
     checkEntry(entry, ":method", "GET", 42);
     assertHeaderNotReferenced(headerTableLength() - 1);
 
@@ -277,7 +277,7 @@ public class HpackDraft05Test {
     // Not buffered in header table.
     assertEquals(0, hpackReader.headerCount);
 
-    assertEquals(byteStringList(":method", "GET"), hpackReader.getAndReset());
+    assertEquals(headerEntries(":method", "GET"), hpackReader.getAndReset());
   }
 
   /**
@@ -324,7 +324,7 @@ public class HpackDraft05Test {
     assertEquals(4, hpackReader.headerCount);
 
     // [  1] (s =  57) :authority: www.example.com
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 4];
+    Header entry = hpackReader.headerTable[headerTableLength() - 4];
     checkEntry(entry, ":authority", "www.example.com", 57);
     assertHeaderReferenced(headerTableLength() - 4);
 
@@ -347,7 +347,7 @@ public class HpackDraft05Test {
     assertEquals(180, hpackReader.headerTableByteCount);
 
     // Decoded header set:
-    assertEquals(byteStringList(
+    assertEquals(headerEntries(
         ":method", "GET",
         ":scheme", "http",
         ":path", "/",
@@ -369,7 +369,7 @@ public class HpackDraft05Test {
     assertEquals(5, hpackReader.headerCount);
 
     // [  1] (s =  53) cache-control: no-cache
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 5];
+    Header entry = hpackReader.headerTable[headerTableLength() - 5];
     checkEntry(entry, "cache-control", "no-cache", 53);
     assertHeaderReferenced(headerTableLength() - 5);
 
@@ -397,7 +397,7 @@ public class HpackDraft05Test {
     assertEquals(233, hpackReader.headerTableByteCount);
 
     // Decoded header set:
-    assertEquals(byteStringList(
+    assertEquals(headerEntries(
         ":method", "GET",
         ":scheme", "http",
         ":path", "/",
@@ -430,7 +430,7 @@ public class HpackDraft05Test {
     assertEquals(8, hpackReader.headerCount);
 
     // [  1] (s =  54) custom-key: custom-value
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 8];
+    Header entry = hpackReader.headerTable[headerTableLength() - 8];
     checkEntry(entry, "custom-key", "custom-value", 54);
     assertHeaderReferenced(headerTableLength() - 8);
 
@@ -474,7 +474,7 @@ public class HpackDraft05Test {
 
     // Decoded header set:
     // TODO: order is not correct per docs, but then again, the spec doesn't require ordering.
-    assertEquals(byteStringList(
+    assertEquals(headerEntries(
         ":method", "GET",
         ":authority", "www.example.com",
         ":scheme", "https",
@@ -531,7 +531,7 @@ public class HpackDraft05Test {
     assertEquals(4, hpackReader.headerCount);
 
     // [  1] (s =  57) :authority: www.example.com
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 4];
+    Header entry = hpackReader.headerTable[headerTableLength() - 4];
     checkEntry(entry, ":authority", "www.example.com", 57);
     assertHeaderReferenced(headerTableLength() - 4);
 
@@ -554,7 +554,7 @@ public class HpackDraft05Test {
     assertEquals(180, hpackReader.headerTableByteCount);
 
     // Decoded header set:
-    assertEquals(byteStringList(
+    assertEquals(headerEntries(
         ":method", "GET",
         ":scheme", "http",
         ":path", "/",
@@ -580,7 +580,7 @@ public class HpackDraft05Test {
     assertEquals(5, hpackReader.headerCount);
 
     // [  1] (s =  53) cache-control: no-cache
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 5];
+    Header entry = hpackReader.headerTable[headerTableLength() - 5];
     checkEntry(entry, "cache-control", "no-cache", 53);
     assertHeaderReferenced(headerTableLength() - 5);
 
@@ -608,7 +608,7 @@ public class HpackDraft05Test {
     assertEquals(233, hpackReader.headerTableByteCount);
 
     // Decoded header set:
-    assertEquals(byteStringList(
+    assertEquals(headerEntries(
         ":method", "GET",
         ":scheme", "http",
         ":path", "/",
@@ -650,7 +650,7 @@ public class HpackDraft05Test {
     assertEquals(8, hpackReader.headerCount);
 
     // [  1] (s =  54) custom-key: custom-value
-    HpackDraft05.HeaderEntry entry = hpackReader.headerTable[headerTableLength() - 8];
+    Header entry = hpackReader.headerTable[headerTableLength() - 8];
     checkEntry(entry, "custom-key", "custom-value", 54);
     assertHeaderReferenced(headerTableLength() - 8);
 
@@ -694,7 +694,7 @@ public class HpackDraft05Test {
 
     // Decoded header set:
     // TODO: order is not correct per docs, but then again, the spec doesn't require ordering.
-    assertEquals(byteStringList(
+    assertEquals(headerEntries(
         ":method", "GET",
         ":authority", "www.example.com",
         ":scheme", "https",
@@ -767,13 +767,13 @@ public class HpackDraft05Test {
   }
 
   @Test public void headersRoundTrip() throws IOException {
-    List<ByteString> sentHeaders = byteStringList("name", "value");
+    List<Header> sentHeaders = headerEntries("name", "value");
     hpackWriter.writeHeaders(sentHeaders);
     ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesOut.toByteArray());
     HpackDraft05.Reader reader = newReader(new DataInputStream(bytesIn));
     reader.readHeaders(bytesOut.size());
     reader.emitReferenceSet();
-    List<ByteString> receivedHeaders = reader.getAndReset();
+    List<Header> receivedHeaders = reader.getAndReset();
     assertEquals(sentHeaders, receivedHeaders);
   }
 
@@ -786,10 +786,10 @@ public class HpackDraft05Test {
     return new DataInputStream(new ByteArrayInputStream(data));
   }
 
-  private void checkEntry(HpackDraft05.HeaderEntry entry, String name, String value, int size) {
+  private void checkEntry(Header entry, String name, String value, int size) {
     assertEquals(name, entry.name.utf8());
     assertEquals(value, entry.value.utf8());
-    assertEquals(size, entry.size);
+    assertEquals(size, entry.hpackSize);
   }
 
   private void assertBytes(int... bytes) {

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -16,7 +16,6 @@
 
 package com.squareup.okhttp.internal.spdy;
 
-import com.squareup.okhttp.internal.ByteString;
 import com.squareup.okhttp.internal.Util;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -187,7 +186,7 @@ public final class MockSpdyPeer implements Closeable {
     public int priority;
     public ErrorCode errorCode;
     public int deltaWindowSize;
-    public List<ByteString> nameValueBlock;
+    public List<Header> nameValueBlock;
     public byte[] data;
     public Settings settings;
     public HeadersMode headersMode;
@@ -205,7 +204,7 @@ public final class MockSpdyPeer implements Closeable {
     }
 
     @Override public void headers(boolean outFinished, boolean inFinished, int streamId,
-        int associatedStreamId, int priority, List<ByteString> nameValueBlock,
+        int associatedStreamId, int priority, List<Header> nameValueBlock,
         HeadersMode headersMode) {
       if (this.type != -1) throw new IllegalStateException();
       this.type = Spdy3.TYPE_HEADERS;

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
@@ -31,7 +31,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import static com.squareup.okhttp.internal.Util.UTF_8;
-import static com.squareup.okhttp.internal.Util.byteStringList;
+import static com.squareup.okhttp.internal.Util.headerEntries;
 import static com.squareup.okhttp.internal.spdy.ErrorCode.CANCEL;
 import static com.squareup.okhttp.internal.spdy.ErrorCode.FLOW_CONTROL_ERROR;
 import static com.squareup.okhttp.internal.spdy.ErrorCode.INTERNAL_ERROR;
@@ -69,15 +69,15 @@ public final class SpdyConnectionTest {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame()
-        .synReply(false, 1, byteStringList("a", "android"));
+        .synReply(false, 1, headerEntries("a", "android"));
     peer.sendFrame().data(true, 1, "robot".getBytes("UTF-8"));
     peer.acceptFrame(); // DATA
     peer.play();
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("b", "banana"), true, true);
-    assertEquals(byteStringList("a", "android"), stream.getResponseHeaders());
+    SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
+    assertEquals(headerEntries("a", "android"), stream.getResponseHeaders());
     assertStreamData("robot", stream.getInputStream());
     writeAndClose(stream, "c3po");
     assertEquals(0, connection.openStreamCount());
@@ -90,20 +90,20 @@ public final class SpdyConnectionTest {
     assertFalse(synStream.outFinished);
     assertEquals(1, synStream.streamId);
     assertEquals(0, synStream.associatedStreamId);
-    assertEquals(byteStringList("b", "banana"), synStream.nameValueBlock);
+    assertEquals(headerEntries("b", "banana"), synStream.nameValueBlock);
     MockSpdyPeer.InFrame requestData = peer.takeFrame();
     assertTrue(Arrays.equals("c3po".getBytes("UTF-8"), requestData.data));
   }
 
   @Test public void headersOnlyStreamIsClosedAfterReplyHeaders() throws Exception {
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame().synReply(false, 1, byteStringList("b", "banana"));
+    peer.sendFrame().synReply(false, 1, headerEntries("b", "banana"));
     peer.play();
 
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("a", "android"), false, false);
+    SpdyStream stream = connection.newStream(headerEntries("a", "android"), false, false);
     assertEquals(1, connection.openStreamCount());
-    assertEquals(byteStringList("b", "banana"), stream.getResponseHeaders());
+    assertEquals(headerEntries("b", "banana"), stream.getResponseHeaders());
     assertEquals(0, connection.openStreamCount());
   }
 
@@ -111,13 +111,13 @@ public final class SpdyConnectionTest {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
     peer.acceptFrame(); // PING
-    peer.sendFrame().synReply(true, 1, byteStringList("a", "android"));
+    peer.sendFrame().synReply(true, 1, headerEntries("a", "android"));
     peer.sendFrame().ping(true, 1, 0);
     peer.play();
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    connection.newStream(byteStringList("b", "banana"), false, true);
+    connection.newStream(headerEntries("b", "banana"), false, true);
     assertEquals(1, connection.openStreamCount());
     connection.ping().roundTripTime(); // Ensure that the SYN_REPLY has been received.
     assertEquals(0, connection.openStreamCount());
@@ -132,7 +132,7 @@ public final class SpdyConnectionTest {
 
   @Test public void serverCreatesStreamAndClientReplies() throws Exception {
     // write the mocking script
-    peer.sendFrame().synStream(false, false, 2, 0, 5, 129, byteStringList("a", "android"));
+    peer.sendFrame().synStream(false, false, 2, 0, 5, 129, headerEntries("a", "android"));
     peer.acceptFrame(); // SYN_REPLY
     peer.play();
 
@@ -141,10 +141,10 @@ public final class SpdyConnectionTest {
     IncomingStreamHandler handler = new IncomingStreamHandler() {
       @Override public void receive(SpdyStream stream) throws IOException {
         receiveCount.incrementAndGet();
-        assertEquals(byteStringList("a", "android"), stream.getRequestHeaders());
+        assertEquals(headerEntries("a", "android"), stream.getRequestHeaders());
         assertEquals(null, stream.getErrorCode());
         assertEquals(5, stream.getPriority());
-        stream.reply(byteStringList("b", "banana"), true);
+        stream.reply(headerEntries("b", "banana"), true);
       }
     };
     new SpdyConnection.Builder(true, peer.openSocket()).handler(handler).build();
@@ -155,13 +155,13 @@ public final class SpdyConnectionTest {
     assertEquals(HeadersMode.SPDY_REPLY, reply.headersMode);
     assertFalse(reply.inFinished);
     assertEquals(2, reply.streamId);
-    assertEquals(byteStringList("b", "banana"), reply.nameValueBlock);
+    assertEquals(headerEntries("b", "banana"), reply.nameValueBlock);
     assertEquals(1, receiveCount.get());
   }
 
   @Test public void replyWithNoData() throws Exception {
     // write the mocking script
-    peer.sendFrame().synStream(false, false, 2, 0, 0, 0, byteStringList("a", "android"));
+    peer.sendFrame().synStream(false, false, 2, 0, 0, 0, headerEntries("a", "android"));
     peer.acceptFrame(); // SYN_REPLY
     peer.play();
 
@@ -169,7 +169,7 @@ public final class SpdyConnectionTest {
     final AtomicInteger receiveCount = new AtomicInteger();
     IncomingStreamHandler handler = new IncomingStreamHandler() {
       @Override public void receive(SpdyStream stream) throws IOException {
-        stream.reply(byteStringList("b", "banana"), false);
+        stream.reply(headerEntries("b", "banana"), false);
         receiveCount.incrementAndGet();
       }
     };
@@ -180,7 +180,7 @@ public final class SpdyConnectionTest {
     assertEquals(TYPE_HEADERS, reply.type);
     assertEquals(HeadersMode.SPDY_REPLY, reply.headersMode);
     assertTrue(reply.inFinished);
-    assertEquals(byteStringList("b", "banana"), reply.nameValueBlock);
+    assertEquals(headerEntries("b", "banana"), reply.nameValueBlock);
     assertEquals(1, receiveCount.get());
   }
 
@@ -361,7 +361,7 @@ public final class SpdyConnectionTest {
 
   @Test public void bogusReplyFrameDoesNotDisruptConnection() throws Exception {
     // write the mocking script
-    peer.sendFrame().synReply(false, 42, byteStringList("a", "android"));
+    peer.sendFrame().synReply(false, 42, headerEntries("a", "android"));
     peer.acceptFrame(); // RST_STREAM
     peer.sendFrame().ping(false, 2, 0);
     peer.acceptFrame(); // PING
@@ -382,7 +382,7 @@ public final class SpdyConnectionTest {
   @Test public void clientClosesClientOutputStream() throws Exception {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame().synReply(false, 1, byteStringList("b", "banana"));
+    peer.sendFrame().synReply(false, 1, headerEntries("b", "banana"));
     peer.acceptFrame(); // TYPE_DATA
     peer.acceptFrame(); // TYPE_DATA with FLAG_FIN
     peer.acceptFrame(); // PING
@@ -393,7 +393,7 @@ public final class SpdyConnectionTest {
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
         .handler(REJECT_INCOMING_STREAMS)
         .build();
-    SpdyStream stream = connection.newStream(byteStringList("a", "android"), true, false);
+    SpdyStream stream = connection.newStream(headerEntries("a", "android"), true, false);
     OutputStream out = stream.getOutputStream();
     out.write("square".getBytes(UTF_8));
     out.flush();
@@ -439,7 +439,7 @@ public final class SpdyConnectionTest {
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
         .handler(REJECT_INCOMING_STREAMS)
         .build();
-    SpdyStream stream = connection.newStream(byteStringList("a", "android"), true, true);
+    SpdyStream stream = connection.newStream(headerEntries("a", "android"), true, true);
     OutputStream out = stream.getOutputStream();
     connection.ping().roundTripTime(); // Ensure that the RST_CANCEL has been received.
     try {
@@ -481,7 +481,7 @@ public final class SpdyConnectionTest {
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
         .handler(REJECT_INCOMING_STREAMS)
         .build();
-    SpdyStream stream = connection.newStream(byteStringList("a", "android"), false, true);
+    SpdyStream stream = connection.newStream(headerEntries("a", "android"), false, true);
     InputStream in = stream.getInputStream();
     OutputStream out = stream.getOutputStream();
     in.close();
@@ -526,7 +526,7 @@ public final class SpdyConnectionTest {
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
         .handler(REJECT_INCOMING_STREAMS)
         .build();
-    SpdyStream stream = connection.newStream(byteStringList("a", "android"), true, true);
+    SpdyStream stream = connection.newStream(headerEntries("a", "android"), true, true);
     InputStream in = stream.getInputStream();
     OutputStream out = stream.getOutputStream();
     in.close();
@@ -562,7 +562,7 @@ public final class SpdyConnectionTest {
   @Test public void serverClosesClientInputStream() throws Exception {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame().synReply(false, 1, byteStringList("b", "banana"));
+    peer.sendFrame().synReply(false, 1, headerEntries("b", "banana"));
     peer.sendFrame().data(true, 1, "square".getBytes(UTF_8));
     peer.play();
 
@@ -570,7 +570,7 @@ public final class SpdyConnectionTest {
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
         .handler(REJECT_INCOMING_STREAMS)
         .build();
-    SpdyStream stream = connection.newStream(byteStringList("a", "android"), false, true);
+    SpdyStream stream = connection.newStream(headerEntries("a", "android"), false, true);
     InputStream in = stream.getInputStream();
     assertStreamData("square", in);
     assertEquals(0, connection.openStreamCount());
@@ -586,17 +586,17 @@ public final class SpdyConnectionTest {
   @Test public void remoteDoubleSynReply() throws Exception {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame().synReply(false, 1, byteStringList("a", "android"));
+    peer.sendFrame().synReply(false, 1, headerEntries("a", "android"));
     peer.acceptFrame(); // PING
-    peer.sendFrame().synReply(false, 1, byteStringList("b", "banana"));
+    peer.sendFrame().synReply(false, 1, headerEntries("b", "banana"));
     peer.sendFrame().ping(true, 1, 0);
     peer.acceptFrame(); // RST_STREAM
     peer.play();
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("c", "cola"), true, true);
-    assertEquals(byteStringList("a", "android"), stream.getResponseHeaders());
+    SpdyStream stream = connection.newStream(headerEntries("c", "cola"), true, true);
+    assertEquals(headerEntries("a", "android"), stream.getResponseHeaders());
     connection.ping().roundTripTime(); // Ensure that the 2nd SYN REPLY has been received.
     try {
       stream.getInputStream().read();
@@ -619,9 +619,9 @@ public final class SpdyConnectionTest {
 
   @Test public void remoteDoubleSynStream() throws Exception {
     // write the mocking script
-    peer.sendFrame().synStream(false, false, 2, 0, 0, 0, byteStringList("a", "android"));
+    peer.sendFrame().synStream(false, false, 2, 0, 0, 0, headerEntries("a", "android"));
     peer.acceptFrame(); // SYN_REPLY
-    peer.sendFrame().synStream(false, false, 2, 0, 0, 0, byteStringList("b", "banana"));
+    peer.sendFrame().synStream(false, false, 2, 0, 0, 0, headerEntries("b", "banana"));
     peer.acceptFrame(); // RST_STREAM
     peer.play();
 
@@ -630,9 +630,9 @@ public final class SpdyConnectionTest {
     IncomingStreamHandler handler = new IncomingStreamHandler() {
       @Override public void receive(SpdyStream stream) throws IOException {
         receiveCount.incrementAndGet();
-        assertEquals(byteStringList("a", "android"), stream.getRequestHeaders());
+        assertEquals(headerEntries("a", "android"), stream.getRequestHeaders());
         assertEquals(null, stream.getErrorCode());
-        stream.reply(byteStringList("c", "cola"), true);
+        stream.reply(headerEntries("c", "cola"), true);
       }
     };
     new SpdyConnection.Builder(true, peer.openSocket()).handler(handler).build();
@@ -651,7 +651,7 @@ public final class SpdyConnectionTest {
   @Test public void remoteSendsDataAfterInFinished() throws Exception {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame().synReply(false, 1, byteStringList("a", "android"));
+    peer.sendFrame().synReply(false, 1, headerEntries("a", "android"));
     peer.sendFrame().data(true, 1, "robot".getBytes("UTF-8"));
     peer.sendFrame().data(true, 1, "c3po".getBytes("UTF-8")); // Ignored.
     peer.sendFrame().ping(false, 2, 0); // Ping just to make sure the stream was fastforwarded.
@@ -660,8 +660,8 @@ public final class SpdyConnectionTest {
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("b", "banana"), true, true);
-    assertEquals(byteStringList("a", "android"), stream.getResponseHeaders());
+    SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
+    assertEquals(headerEntries("a", "android"), stream.getResponseHeaders());
     assertStreamData("robot", stream.getInputStream());
 
     // verify the peer received what was expected
@@ -676,7 +676,7 @@ public final class SpdyConnectionTest {
   @Test public void remoteSendsTooMuchData() throws Exception {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame().synReply(false, 1, byteStringList("b", "banana"));
+    peer.sendFrame().synReply(false, 1, headerEntries("b", "banana"));
     peer.sendFrame().data(false, 1, new byte[64 * 1024 + 1]);
     peer.acceptFrame(); // RST_STREAM
     peer.sendFrame().ping(false, 2, 0); // Ping just to make sure the stream was fastforwarded.
@@ -685,8 +685,8 @@ public final class SpdyConnectionTest {
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("a", "android"), true, true);
-    assertEquals(byteStringList("b", "banana"), stream.getResponseHeaders());
+    SpdyStream stream = connection.newStream(headerEntries("a", "android"), true, true);
+    assertEquals(headerEntries("b", "banana"), stream.getResponseHeaders());
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame synStream = peer.takeFrame();
@@ -711,7 +711,7 @@ public final class SpdyConnectionTest {
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("a", "android"), true, true);
+    SpdyStream stream = connection.newStream(headerEntries("a", "android"), true, true);
     try {
       stream.getResponseHeaders();
       fail();
@@ -741,8 +741,8 @@ public final class SpdyConnectionTest {
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream1 = connection.newStream(byteStringList("a", "android"), true, true);
-    SpdyStream stream2 = connection.newStream(byteStringList("b", "banana"), true, true);
+    SpdyStream stream1 = connection.newStream(headerEntries("a", "android"), true, true);
+    SpdyStream stream2 = connection.newStream(headerEntries("b", "banana"), true, true);
     connection.ping().roundTripTime(); // Ensure that the GO_AWAY has been received.
     stream1.getOutputStream().write("abc".getBytes(UTF_8));
     try {
@@ -754,7 +754,7 @@ public final class SpdyConnectionTest {
     stream1.getOutputStream().write("def".getBytes(UTF_8));
     stream1.getOutputStream().close();
     try {
-      connection.newStream(byteStringList("c", "cola"), true, true);
+      connection.newStream(headerEntries("c", "cola"), true, true);
       fail();
     } catch (IOException expected) {
       assertEquals("shutdown", expected.getMessage());
@@ -779,13 +779,13 @@ public final class SpdyConnectionTest {
     peer.acceptFrame(); // SYN_STREAM 1
     peer.acceptFrame(); // GOAWAY
     peer.acceptFrame(); // PING
-    peer.sendFrame().synStream(false, false, 2, 0, 0, 0, byteStringList("b", "b")); // Should be ignored!
+    peer.sendFrame().synStream(false, false, 2, 0, 0, 0, headerEntries("b", "b")); // Should be ignored!
     peer.sendFrame().ping(true, 1, 0);
     peer.play();
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    connection.newStream(byteStringList("a", "android"), true, true);
+    connection.newStream(headerEntries("a", "android"), true, true);
     Ping ping = connection.ping();
     connection.shutdown(PROTOCOL_ERROR);
     assertEquals(1, connection.openStreamCount());
@@ -832,12 +832,12 @@ public final class SpdyConnectionTest {
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("a", "android"), true, true);
+    SpdyStream stream = connection.newStream(headerEntries("a", "android"), true, true);
     assertEquals(1, connection.openStreamCount());
     connection.close();
     assertEquals(0, connection.openStreamCount());
     try {
-      connection.newStream(byteStringList("b", "banana"), true, true);
+      connection.newStream(headerEntries("b", "banana"), true, true);
       fail();
     } catch (IOException expected) {
       assertEquals("shutdown", expected.getMessage());
@@ -882,14 +882,14 @@ public final class SpdyConnectionTest {
   @Test public void readTimeoutExpires() throws Exception {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame().synReply(false, 1, byteStringList("a", "android"));
+    peer.sendFrame().synReply(false, 1, headerEntries("a", "android"));
     peer.acceptFrame(); // PING
     peer.sendFrame().ping(true, 1, 0);
     peer.play();
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("b", "banana"), true, true);
+    SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
     stream.setReadTimeout(1000);
     InputStream in = stream.getInputStream();
     long startNanos = System.nanoTime();
@@ -912,16 +912,16 @@ public final class SpdyConnectionTest {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
     peer.acceptFrame(); // PING
-    peer.sendFrame().synReply(false, 1, byteStringList("a", "android"));
-    peer.sendFrame().headers(1, byteStringList("c", "c3po"));
+    peer.sendFrame().synReply(false, 1, headerEntries("a", "android"));
+    peer.sendFrame().headers(1, headerEntries("c", "c3po"));
     peer.sendFrame().ping(true, 1, 0);
     peer.play();
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("b", "banana"), true, true);
+    SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
     connection.ping().roundTripTime(); // Ensure that the HEADERS has been received.
-    assertEquals(byteStringList("a", "android", "c", "c3po"), stream.getResponseHeaders());
+    assertEquals(headerEntries("a", "android", "c", "c3po"), stream.getResponseHeaders());
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame synStream = peer.takeFrame();
@@ -935,14 +935,14 @@ public final class SpdyConnectionTest {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
     peer.acceptFrame(); // PING
-    peer.sendFrame().headers(1, byteStringList("c", "c3po"));
+    peer.sendFrame().headers(1, headerEntries("c", "c3po"));
     peer.acceptFrame(); // RST_STREAM
     peer.sendFrame().ping(true, 1, 0);
     peer.play();
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("b", "banana"), true, true);
+    SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
     connection.ping().roundTripTime(); // Ensure that the HEADERS has been received.
     try {
       stream.getResponseHeaders();
@@ -966,7 +966,7 @@ public final class SpdyConnectionTest {
     int windowUpdateThreshold = Variant.SPDY3.initialPeerSettings(true).getInitialWindowSize() / 2;
     // Write the mocking script.
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame().synReply(false, 1, byteStringList("a", "android"));
+    peer.sendFrame().synReply(false, 1, headerEntries("a", "android"));
     for (int i = 0; i < 3; i++) {
       peer.sendFrame().data(false, 1, new byte[windowUpdateThreshold]);
       peer.acceptFrame(); // WINDOW UPDATE
@@ -976,9 +976,9 @@ public final class SpdyConnectionTest {
 
     // Play it back.
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("b", "banana"), true, true);
+    SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
     assertEquals(windowUpdateThreshold, stream.windowUpdateThreshold);
-    assertEquals(byteStringList("a", "android"), stream.getResponseHeaders());
+    assertEquals(headerEntries("a", "android"), stream.getResponseHeaders());
     InputStream in = stream.getInputStream();
     int total = 0;
     byte[] buffer = new byte[1024];
@@ -1012,7 +1012,7 @@ public final class SpdyConnectionTest {
 
     // Play it back.
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("b", "banana"), true, true);
+    SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
     OutputStream out = stream.getOutputStream();
     out.write(new byte[windowSize]);
     interruptAfterDelay(500);
@@ -1033,14 +1033,14 @@ public final class SpdyConnectionTest {
   @Test public void testTruncatedDataFrame() throws Exception {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame().synReply(false, 1, byteStringList("a", "android"));
+    peer.sendFrame().synReply(false, 1, headerEntries("a", "android"));
     peer.sendTruncatedFrame(8 + 100).data(false, 1, new byte[1024]);
     peer.play();
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("b", "banana"), true, true);
-    assertEquals(byteStringList("a", "android"), stream.getResponseHeaders());
+    SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
+    assertEquals(headerEntries("a", "android"), stream.getResponseHeaders());
     InputStream in = stream.getInputStream();
     try {
       Util.readFully(in, new byte[101]);
@@ -1071,9 +1071,9 @@ public final class SpdyConnectionTest {
 
     // play it back
     SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
-    SpdyStream stream = connection.newStream(byteStringList("b", "banana"), true, true);
-    assertEquals("a", stream.getResponseHeaders().get(0).utf8());
-    assertEquals(60, stream.getResponseHeaders().get(1).size());
+    SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
+    assertEquals("a", stream.getResponseHeaders().get(0).name.utf8());
+    assertEquals(60, stream.getResponseHeaders().get(0).value.size());
     assertStreamData("robot", stream.getInputStream());
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -557,9 +557,9 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     if (append) {
       protocolsList.addAll(client.getProtocols());
     }
-    for (ByteString protocol : Util.byteStringList(protocolsString.split(",", -1))) {
+    for (String protocol : protocolsString.split(",", -1)) {
       try {
-        protocolsList.add(Protocol.find(protocol));
+        protocolsList.add(Protocol.find(ByteString.encodeUtf8(protocol)));
       } catch (IOException e) {
         throw new IllegalStateException(e);
       }

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
@@ -18,19 +18,19 @@ package com.squareup.okhttp.internal.http;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
-import com.squareup.okhttp.internal.ByteString;
 import com.squareup.okhttp.Protocol;
+import com.squareup.okhttp.internal.spdy.Header;
 import java.io.IOException;
 import java.util.List;
 import org.junit.Test;
 
-import static com.squareup.okhttp.internal.Util.byteStringList;
+import static com.squareup.okhttp.internal.Util.headerEntries;
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 
 public final class HeadersTest {
   @Test public void parseNameValueBlock() throws IOException {
-    List<ByteString> nameValueBlock = byteStringList(
+    List<Header> nameValueBlock = headerEntries(
         "cache-control", "no-cache, no-store",
         "set-cookie", "Cookie1\u0000Cookie2",
         ":status", "200 OK",
@@ -59,7 +59,7 @@ public final class HeadersTest {
   }
 
   @Test public void readNameValueBlockDropsForbiddenHeadersSpdy3() throws IOException {
-    List<ByteString> nameValueBlock = byteStringList(
+    List<Header> nameValueBlock = headerEntries(
         ":status", "200 OK",
         ":version", "HTTP/1.1",
         "connection", "close");
@@ -75,7 +75,7 @@ public final class HeadersTest {
   }
 
   @Test public void readNameValueBlockDropsForbiddenHeadersHttp2() throws IOException {
-    List<ByteString> nameValueBlock = byteStringList(
+    List<Header> nameValueBlock = headerEntries(
         ":status", "200 OK",
         ":version", "HTTP/1.1",
         "connection", "close");
@@ -98,9 +98,9 @@ public final class HeadersTest {
         .addHeader("set-cookie", "Cookie2")
         .header(":status", "200 OK")
         .build();
-    List<ByteString> nameValueBlock =
+    List<Header> nameValueBlock =
         SpdyTransport.writeNameValueBlock(request, Protocol.SPDY_3, "HTTP/1.1");
-    List<ByteString> expected = byteStringList(
+    List<Header> expected = headerEntries(
         ":method", "GET",
         ":path", "/",
         ":version", "HTTP/1.1",
@@ -118,7 +118,7 @@ public final class HeadersTest {
         .header("Connection", "close")
         .header("Transfer-Encoding", "chunked")
         .build();
-    List<ByteString> expected = byteStringList(
+    List<Header> expected = headerEntries(
         ":method", "GET",
         ":path", "/",
         ":version", "HTTP/1.1",
@@ -133,10 +133,9 @@ public final class HeadersTest {
         .header("Connection", "upgrade")
         .header("Upgrade", "websocket")
         .build();
-    List<ByteString> expected = byteStringList(
+    List<Header> expected = headerEntries(
         ":method", "GET",
         ":path", "/",
-        ":version", "HTTP/1.1",
         ":authority", "square.com",
         ":scheme", "http");
     assertEquals(expected,


### PR DESCRIPTION
Top-level immutable, internal HeaderEntry class to reduce duplication around ascii header names.  Do not emit :version in http/2.
