### PR TITLE
Change spdy and http/2 headers to always lowercase

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -622,16 +622,16 @@ public final class MockWebServer {
       String path = "<:path omitted>";
       String version = protocol == Protocol.SPDY_3 ? "<:version omitted>" : "HTTP/1.1";
       for (int i = 0, size = spdyHeaders.size(); i < size; i++) {
-        String name = spdyHeaders.get(i).name.utf8();
+        ByteString name = spdyHeaders.get(i).name;
         String value = spdyHeaders.get(i).value.utf8();
-        if (":method".equals(name)) {
+        if (name.equals(Header.TARGET_METHOD)) {
           method = value;
-        } else if (":path".equals(name)) {
+        } else if (name.equals(Header.TARGET_PATH)) {
           path = value;
-        } else if (":version".equals(name)) {
+        } else if (name.equals(Header.VERSION)) {
           version = value;
         } else {
-          httpHeaders.add(name + ": " + value);
+          httpHeaders.add(name.utf8() + ": " + value);
         }
       }
 
@@ -670,8 +670,7 @@ public final class MockWebServer {
         if (headerParts.length != 2) {
           throw new AssertionError("Unexpected header: " + header);
         }
-        spdyHeaders.add(new Header(headerParts[0].toLowerCase(Locale.US).trim(),
-            headerParts[1].trim()));
+        spdyHeaders.add(new Header(headerParts[0], headerParts[1]));
       }
       byte[] body = response.getBody();
       stream.reply(spdyHeaders, body.length > 0);

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -408,4 +408,15 @@ public final class Util {
     }
     return result;
   }
+
+  /** Mutates the byte array to ensure all characters are lowercase. */
+  public static void asciiLowerCase(byte[] bytes) {
+    for (int i = 0; i < bytes.length; i++) {
+      bytes[i] = asciiLowerCase(bytes[i]);
+    }
+  }
+
+  public static byte asciiLowerCase(byte c) {
+    return 'A' <= c && c <= 'Z' ? (byte) (c + 'a' - 'A') : c;
+  }
 }

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/ByteStringTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/ByteStringTest.java
@@ -41,10 +41,17 @@ public class ByteStringTest {
 
   @Test public void utf8() throws Exception {
     ByteString byteString = ByteString.encodeUtf8(bronzeHorseman);
-    assertByteArraysEquals(byteString.toByteArray(), bronzeHorseman.getBytes("UTF-8"));
-    assertTrue(byteString.equals(ByteString.of(bronzeHorseman.getBytes("UTF-8"))));
-    assertTrue(byteString.utf8Equals(bronzeHorseman));
+    assertByteArraysEquals(byteString.toByteArray(), bronzeHorseman.getBytes(Util.UTF_8));
+    assertTrue(byteString.equals(ByteString.of(bronzeHorseman.getBytes(Util.UTF_8))));
     assertEquals(byteString.utf8(), bronzeHorseman);
+  }
+
+  @Test public void equalsAscii() throws Exception {
+    ByteString byteString = ByteString.encodeUtf8("Content-Length");
+    assertTrue(byteString.equalsAscii("Content-Length"));
+    assertFalse(byteString.equalsAscii("content-length"));
+    assertFalse(byteString.equalsAscii(bronzeHorseman));
+    assertFalse(ByteString.encodeUtf8("Content-Length").equalsAscii("content-length"));
   }
 
   @Test public void testHashCode() throws Exception {
@@ -54,10 +61,17 @@ public class ByteStringTest {
   }
 
   @Test public void read() throws Exception {
-    InputStream in = new ByteArrayInputStream("abc".getBytes("UTF-8"));
+    InputStream in = new ByteArrayInputStream("abc".getBytes(Util.UTF_8));
     assertEquals(ByteString.of((byte) 0x61, (byte) 0x62), ByteString.read(in, 2));
     assertEquals(ByteString.of((byte) 0x63), ByteString.read(in, 1));
     assertEquals(ByteString.of(), ByteString.read(in, 0));
+  }
+
+  @Test public void readLowerCase() throws Exception {
+    InputStream in = new ByteArrayInputStream("ABC".getBytes(Util.UTF_8));
+    assertEquals(ByteString.of((byte) 0x61, (byte) 0x62), ByteString.readLowerCase(in, 2));
+    assertEquals(ByteString.of((byte) 0x63), ByteString.readLowerCase(in, 1));
+    assertEquals(ByteString.of(), ByteString.readLowerCase(in, 0));
   }
 
   @Test public void write() throws Exception {

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/HpackDraft05Test.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/HpackDraft05Test.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import static com.squareup.okhttp.internal.Util.headerEntries;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class HpackDraft05Test {
@@ -757,13 +758,14 @@ public class HpackDraft05Test {
   @Test public void headerName() throws IOException {
     hpackWriter.writeByteString(ByteString.encodeUtf8("foo"));
     assertBytes(3, 'f', 'o', 'o');
-    assertEquals("foo", newReader(byteStream(3, 'f', 'o', 'o')).readString().utf8());
+    assertEquals("foo", newReader(byteStream(3, 'F', 'o', 'o')).readByteString(true).utf8());
   }
 
   @Test public void emptyHeaderName() throws IOException {
     hpackWriter.writeByteString(ByteString.encodeUtf8(""));
     assertBytes(0);
-    assertEquals("", newReader(byteStream(0)).readString().utf8());
+    assertSame(ByteString.EMPTY, newReader(byteStream(0)).readByteString(true));
+    assertSame(ByteString.EMPTY, newReader(byteStream(0)).readByteString(false));
   }
 
   @Test public void headersRoundTrip() throws IOException {


### PR DESCRIPTION
Change spdy and http/2 headers to always lowercase header names.  This introduces `ByteString.equalsAscii` which compares bytes read and down cased from the wire with an existing ByteString without needing to allocate a String to do so.
