### PR TITLE
Fix bug in ByteString.equalsAscii when param is null and ByteString not yet initialized.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/ByteString.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/ByteString.java
@@ -67,11 +67,11 @@ public final class ByteString {
    * by this byte string.
    */
   public boolean equalsAscii(String ascii) {
-    if (ascii == this.utf8) {
-      return true;
-    }
     if (ascii == null || data.length != ascii.length()) {
       return false;
+    }
+    if (ascii == this.utf8) {
+      return true;
     }
     for (int i = 0; i < data.length; i++) {
       if (data[i] != ascii.charAt(i)) return false;

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/ByteStringTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/ByteStringTest.java
@@ -50,6 +50,7 @@ public class ByteStringTest {
     ByteString byteString = ByteString.encodeUtf8("Content-Length");
     assertTrue(byteString.equalsAscii("Content-Length"));
     assertFalse(byteString.equalsAscii("content-length"));
+    assertFalse(ByteString.of((byte) 0x63).equalsAscii(null));
     assertFalse(byteString.equalsAscii(bronzeHorseman));
     assertFalse(ByteString.encodeUtf8("Content-Length").equalsAscii("content-length"));
   }


### PR DESCRIPTION
@ChristianBecker
