### PR TITLE
Fix header frame processing in http/2

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
@@ -44,7 +44,7 @@ public interface FrameReader extends Closeable {
      * (highest) thru 2^31-1 (lowest), defaulting to 2^30.
      */
     void headers(boolean outFinished, boolean inFinished, int streamId, int associatedStreamId,
-        int priority, List<Header> nameValueBlock, HeadersMode headersMode);
+        int priority, List<Header> headerBlock, HeadersMode headersMode);
     void rstStream(int streamId, ErrorCode errorCode);
     void settings(boolean clearPrevious, Settings settings);
     void noop();

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
@@ -29,10 +29,10 @@ public interface FrameWriter extends Closeable {
   /** SPDY/3 only. */
   void flush() throws IOException;
   void synStream(boolean outFinished, boolean inFinished, int streamId, int associatedStreamId,
-      int priority, int slot, List<Header> nameValueBlock) throws IOException;
-  void synReply(boolean outFinished, int streamId, List<Header> nameValueBlock)
+      int priority, int slot, List<Header> headerBlock) throws IOException;
+  void synReply(boolean outFinished, int streamId, List<Header> headerBlock)
       throws IOException;
-  void headers(int streamId, List<Header> nameValueBlock) throws IOException;
+  void headers(int streamId, List<Header> headerBlock) throws IOException;
   void rstStream(int streamId, ErrorCode errorCode) throws IOException;
   void data(boolean outFinished, int streamId, byte[] data) throws IOException;
   void data(boolean outFinished, int streamId, byte[] data, int offset, int byteCount)

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
@@ -20,6 +20,7 @@ import com.squareup.okhttp.internal.Util;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -94,6 +95,7 @@ public final class Http20Draft09 implements Variant {
 
   static final class Reader implements FrameReader {
     private final DataInputStream in;
+    private final ContinuationInputStream continuation;
     private final boolean client;
 
     // Visible for testing.
@@ -101,8 +103,9 @@ public final class Http20Draft09 implements Variant {
 
     Reader(InputStream in, int headerTableSize, boolean client) {
       this.in = new DataInputStream(in);
+      this.continuation = new ContinuationInputStream(this.in);
       this.client = client;
-      this.hpackReader = new HpackDraft05.Reader(client, headerTableSize, this.in);
+      this.hpackReader = new HpackDraft05.Reader(client, headerTableSize, continuation);
     }
 
     @Override public void readConnectionHeader() throws IOException {
@@ -174,41 +177,29 @@ public final class Http20Draft09 implements Variant {
 
     private void readHeaders(Handler handler, int flags, int length, int streamId)
         throws IOException {
-      if (streamId == 0) throw ioException("TYPE_HEADERS streamId == 0");
+      if (streamId == 0) throw ioException("PROTOCOL_ERROR: TYPE_HEADERS streamId == 0");
 
+      boolean endHeaders = (flags & FLAG_END_HEADERS) != 0;
       boolean endStream = (flags & FLAG_END_STREAM) != 0;
       int priority = ((flags & FLAG_PRIORITY) != 0) ? in.readInt() & 0x7fffffff : -1;
 
-      while (true) {
-        hpackReader.readHeaders(length);
+      List<Header> headerBlock = readHeaderBlock(length, endHeaders, streamId);
 
-        if ((flags & FLAG_END_HEADERS) != 0) {
-          hpackReader.emitReferenceSet();
-          List<Header> nameValueBlock = hpackReader.getAndReset();
-          // TODO: Concat multi-value headers with 0x0, except COOKIE, which uses 0x3B, 0x20.
-          // http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-8.1.3
-          handler.headers(false, endStream, streamId, -1, priority, nameValueBlock,
-              HeadersMode.HTTP_20_HEADERS);
-          return;
-        }
+      handler.headers(false, endStream, streamId, -1, priority, headerBlock,
+          HeadersMode.HTTP_20_HEADERS);
+    }
 
-        // Read another continuation frame.
-        int w1 = in.readInt();
-        int w2 = in.readInt();
+    private List<Header> readHeaderBlock(int length, boolean endHeaders, int streamId)
+        throws IOException {
+      continuation.bytesLeft = length;
+      continuation.endHeaders = endHeaders;
+      continuation.streamId = streamId;
 
-        // boolean r = (w1 & 0xc0000000) != 0; // Reserved.
-        length = (w1 & 0x3fff0000) >> 16; // 14-bit unsigned.
-        int newType = (w1 & 0xff00) >> 8;
-        flags = w1 & 0xff;
-
-        // boolean u = (w2 & 0x80000000) != 0; // Unused.
-        int newStreamId = (w2 & 0x7fffffff);
-
-        if (newType != TYPE_CONTINUATION) {
-          throw ioException("TYPE_CONTINUATION didn't have FLAG_END_HEADERS");
-        }
-        if (newStreamId != streamId) throw ioException("TYPE_CONTINUATION streamId changed");
-      }
+      hpackReader.readHeaders();
+      hpackReader.emitReferenceSet();
+      // TODO: Concat multi-value headers with 0x0, except COOKIE, which uses 0x3B, 0x20.
+      // http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-8.1.3
+      return hpackReader.getAndReset();
     }
 
     private void readData(Handler handler, int flags, int length, int streamId) throws IOException {
@@ -334,26 +325,26 @@ public final class Http20Draft09 implements Variant {
 
     @Override
     public synchronized void synStream(boolean outFinished, boolean inFinished, int streamId,
-        int associatedStreamId, int priority, int slot, List<Header> nameValueBlock)
+        int associatedStreamId, int priority, int slot, List<Header> headerBlock)
         throws IOException {
       if (inFinished) throw new UnsupportedOperationException();
-      headers(outFinished, streamId, priority, nameValueBlock);
+      headers(outFinished, streamId, priority, headerBlock);
     }
 
     @Override public synchronized void synReply(boolean outFinished, int streamId,
-        List<Header> nameValueBlock) throws IOException {
-      headers(outFinished, streamId, -1, nameValueBlock);
+        List<Header> headerBlock) throws IOException {
+      headers(outFinished, streamId, -1, headerBlock);
     }
 
-    @Override public synchronized void headers(int streamId, List<Header> nameValueBlock)
+    @Override public synchronized void headers(int streamId, List<Header> headerBlock)
         throws IOException {
-      headers(false, streamId, -1, nameValueBlock);
+      headers(false, streamId, -1, headerBlock);
     }
 
     private void headers(boolean outFinished, int streamId, int priority,
-        List<Header> nameValueBlock) throws IOException {
+        List<Header> headerBlock) throws IOException {
       hpackBuffer.reset();
-      hpackWriter.writeHeaders(nameValueBlock);
+      hpackWriter.writeHeaders(headerBlock);
       int type = TYPE_HEADERS;
       // TODO: implement CONTINUATION
       int length = hpackBuffer.size();
@@ -439,5 +430,76 @@ public final class Http20Draft09 implements Variant {
 
   private static IOException ioException(String message, Object... args) throws IOException {
     throw new IOException(String.format(message, args));
+  }
+
+  /**
+   * Decompression of the header block occurs above the framing layer.  This
+   * class lazily reads continuation frames as they are needed by
+   * {@link HpackDraft05.Reader#readHeaders()}.
+   */
+  static final class ContinuationInputStream extends InputStream {
+    private final DataInputStream in;
+
+    int bytesLeft;
+    boolean endHeaders;
+    int streamId;
+
+    ContinuationInputStream(DataInputStream in) {
+      this.in = in;
+    }
+
+    @Override public int read() throws IOException {
+      if (bytesLeft == 0) {
+        if (endHeaders) {
+          return -1;
+        } else {
+          readContinuationHeader();
+        }
+      }
+      bytesLeft--;
+      int result = in.read();
+      if (result == -1) throw new EOFException();
+      return result;
+    }
+
+    @Override public int read(byte[] dst, int offset, int byteCount) throws IOException {
+      if (byteCount > bytesLeft) {
+        if (endHeaders) {
+          throw new EOFException(
+              String.format("Attempted to read %s bytes, when only %s left", byteCount, bytesLeft));
+        } else {
+          int beforeContinuation = bytesLeft;
+          Util.readFully(in, dst, offset, bytesLeft);
+          readContinuationHeader();
+          int afterContinuation = byteCount - beforeContinuation;
+          offset += beforeContinuation;
+          bytesLeft -= afterContinuation;
+          Util.readFully(in, dst, offset, afterContinuation);
+          return byteCount;
+        }
+      } else {
+        bytesLeft -= byteCount;
+        Util.readFully(in, dst, offset, byteCount);
+        return byteCount;
+      }
+    }
+
+    private void readContinuationHeader() throws IOException {
+      int w1 = in.readInt();
+      int w2 = in.readInt();
+
+      // boolean r = (w1 & 0xc0000000) != 0; // Reserved.
+      bytesLeft = (w1 & 0x3fff0000) >> 16; // 14-bit unsigned.
+      int newType = (w1 & 0xff00) >> 8;
+      endHeaders = (w1 & 0xff & FLAG_END_HEADERS) != 0;
+
+      // boolean u = (w2 & 0x80000000) != 0; // Unused.
+      int newStreamId = (w2 & 0x7fffffff);
+
+      if (newType != TYPE_CONTINUATION) {
+        throw ioException("TYPE_CONTINUATION didn't have FLAG_END_HEADERS");
+      }
+      if (newStreamId != streamId) throw ioException("TYPE_CONTINUATION streamId changed");
+    }
   }
 }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -482,7 +482,7 @@ public final class SpdyConnection implements Closeable {
     }
 
     @Override public void headers(boolean outFinished, boolean inFinished, int streamId,
-        int associatedStreamId, int priority, List<Header> nameValueBlock,
+        int associatedStreamId, int priority, List<Header> headerBlock,
         HeadersMode headersMode) {
       SpdyStream stream;
       synchronized (SpdyConnection.this) {
@@ -506,7 +506,7 @@ public final class SpdyConnection implements Closeable {
 
           // Create a stream.
           final SpdyStream newStream = new SpdyStream(streamId, SpdyConnection.this, outFinished,
-              inFinished, priority, nameValueBlock, peerSettings);
+              inFinished, priority, headerBlock, peerSettings);
           lastGoodStreamId = streamId;
           streams.put(streamId, newStream);
           executor.submit(new NamedRunnable("OkHttp %s stream %d", hostName, streamId) {
@@ -530,7 +530,7 @@ public final class SpdyConnection implements Closeable {
       }
 
       // Update an existing stream.
-      stream.receiveHeaders(nameValueBlock, headersMode);
+      stream.receiveHeaders(headerBlock, headersMode);
       if (inFinished) stream.receiveFin();
     }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
@@ -29,7 +29,7 @@ class BaseTestHandler implements FrameReader.Handler {
 
   @Override
   public void headers(boolean outFinished, boolean inFinished, int streamId, int associatedStreamId,
-      int priority, List<Header> nameValueBlock, HeadersMode headersMode) {
+      int priority, List<Header> headerBlock, HeadersMode headersMode) {
     fail();
   }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/ContinuationInputStreamTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/ContinuationInputStreamTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.spdy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.Test;
+
+import static com.squareup.okhttp.internal.spdy.HpackDraft05Test.MutableByteArrayInputStream;
+import static com.squareup.okhttp.internal.spdy.Http20Draft09.ContinuationInputStream;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class ContinuationInputStreamTest {
+  private final MutableByteArrayInputStream bytesIn = new MutableByteArrayInputStream();
+  private final ContinuationInputStream continuation =
+      new ContinuationInputStream(new DataInputStream(bytesIn));
+
+  @Test public void read() throws IOException {
+
+    // When there are bytes left this frame, read one.
+    continuation.bytesLeft = 2;
+    bytesIn.set(new byte[] {1, 2});
+    assertEquals(1, continuation.read());
+    assertEquals(1, continuation.bytesLeft);
+
+    // When there are bytes left this frame, but none on the remote stream, EOF!
+    continuation.bytesLeft = 2;
+    bytesIn.set(new byte[] {});
+    try {
+      continuation.read();
+      fail();
+    } catch (EOFException expected) {
+    }
+
+    // When there are no bytes left in the last header frame, return -1.
+    continuation.bytesLeft = 0;
+    continuation.endHeaders = true;
+    assertEquals(-1, continuation.read());
+    assertEquals(0, continuation.bytesLeft);
+
+    // When there are no bytes left in this frame, but it isn't the last, read continuation.
+    continuation.bytesLeft = 0;
+    continuation.endHeaders = false; // Read continuation.
+    bytesIn.set(lastContinuationFrame(new byte[] {1}));
+    assertEquals(1, continuation.read());
+    assertEquals(0, continuation.bytesLeft);
+  }
+
+  @Test public void readArray() throws IOException {
+    byte[] buff = new byte[3];
+
+    // When there are bytes left this frame, read them.
+    continuation.bytesLeft = 3;
+    continuation.endHeaders = true;
+    bytesIn.set(new byte[] {1, 2, 3});
+    assertEquals(3, continuation.read(buff));
+    assertEquals(0, continuation.bytesLeft);
+    assertTrue(Arrays.equals(buff, new byte[] {1, 2, 3}));
+
+    // When there are no bytes left in the last header frame, EOF.
+    Arrays.fill(buff, (byte) -1);
+    continuation.bytesLeft = 0;
+    continuation.endHeaders = true;
+    bytesIn.set(new byte[] {});
+    try {
+      continuation.read(buff);
+      fail();
+    } catch (EOFException expected) {
+    }
+
+    // When there are no bytes left in this frame, but it isn't the last, read continuation.
+    Arrays.fill(buff, (byte) -1);
+    continuation.bytesLeft = 0;
+    continuation.endHeaders = false; // Read continuation.
+    bytesIn.set(lastContinuationFrame(new byte[] {1, 2, 3}));
+    assertEquals(3, continuation.read(buff));
+    assertTrue(Arrays.equals(buff, new byte[] {1, 2, 3}));
+    assertEquals(0, continuation.bytesLeft);
+  }
+
+  static byte[] lastContinuationFrame(byte[] headerBlock) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputStream dataOut = new DataOutputStream(out);
+    dataOut.writeShort(headerBlock.length);
+    dataOut.write(Http20Draft09.TYPE_CONTINUATION);
+    dataOut.write(Http20Draft09.FLAG_END_HEADERS);
+    dataOut.writeInt(0);
+    dataOut.write(headerBlock);
+    return out.toByteArray();
+  }
+}

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -186,7 +186,7 @@ public final class MockSpdyPeer implements Closeable {
     public int priority;
     public ErrorCode errorCode;
     public int deltaWindowSize;
-    public List<Header> nameValueBlock;
+    public List<Header> headerBlock;
     public byte[] data;
     public Settings settings;
     public HeadersMode headersMode;
@@ -204,7 +204,7 @@ public final class MockSpdyPeer implements Closeable {
     }
 
     @Override public void headers(boolean outFinished, boolean inFinished, int streamId,
-        int associatedStreamId, int priority, List<Header> nameValueBlock,
+        int associatedStreamId, int priority, List<Header> headerBlock,
         HeadersMode headersMode) {
       if (this.type != -1) throw new IllegalStateException();
       this.type = Spdy3.TYPE_HEADERS;
@@ -213,7 +213,7 @@ public final class MockSpdyPeer implements Closeable {
       this.streamId = streamId;
       this.associatedStreamId = associatedStreamId;
       this.priority = priority;
-      this.nameValueBlock = nameValueBlock;
+      this.headerBlock = headerBlock;
       this.headersMode = headersMode;
     }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
@@ -90,7 +90,7 @@ public final class SpdyConnectionTest {
     assertFalse(synStream.outFinished);
     assertEquals(1, synStream.streamId);
     assertEquals(0, synStream.associatedStreamId);
-    assertEquals(headerEntries("b", "banana"), synStream.nameValueBlock);
+    assertEquals(headerEntries("b", "banana"), synStream.headerBlock);
     MockSpdyPeer.InFrame requestData = peer.takeFrame();
     assertTrue(Arrays.equals("c3po".getBytes("UTF-8"), requestData.data));
   }
@@ -155,7 +155,7 @@ public final class SpdyConnectionTest {
     assertEquals(HeadersMode.SPDY_REPLY, reply.headersMode);
     assertFalse(reply.inFinished);
     assertEquals(2, reply.streamId);
-    assertEquals(headerEntries("b", "banana"), reply.nameValueBlock);
+    assertEquals(headerEntries("b", "banana"), reply.headerBlock);
     assertEquals(1, receiveCount.get());
   }
 
@@ -180,7 +180,7 @@ public final class SpdyConnectionTest {
     assertEquals(TYPE_HEADERS, reply.type);
     assertEquals(HeadersMode.SPDY_REPLY, reply.headersMode);
     assertTrue(reply.inFinished);
-    assertEquals(headerEntries("b", "banana"), reply.nameValueBlock);
+    assertEquals(headerEntries("b", "banana"), reply.headerBlock);
     assertEquals(1, receiveCount.get());
   }
 
@@ -1049,7 +1049,7 @@ public final class SpdyConnectionTest {
   }
 
   /** https://github.com/square/okhttp/issues/333 */
-  @Test public void nameValueBlockHasTrailingCompressedBytes() throws Exception {
+  @Test public void headerBlockHasTrailingCompressedBytes() throws Exception {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
     // This specially-formatted frame has trailing deflated bytes after the name value block.

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -153,7 +153,7 @@ public final class SpdyTransport implements Transport {
   }
 
   /** Returns headers for a name value block containing a SPDY response. */
-  public static Response.Builder readNameValueBlock(List<Header> nameValueBlock,
+  public static Response.Builder readNameValueBlock(List<Header> headerBlock,
       Protocol protocol) throws IOException {
     String status = null;
     String version = "HTTP/1.1"; // :version present only in spdy/3.
@@ -161,9 +161,9 @@ public final class SpdyTransport implements Transport {
     Headers.Builder headersBuilder = new Headers.Builder();
     headersBuilder.set(OkHeaders.SELECTED_TRANSPORT, protocol.name.utf8());
     headersBuilder.set(OkHeaders.SELECTED_PROTOCOL, protocol.name.utf8());
-    for (int i = 0; i < nameValueBlock.size(); i++) {
-      ByteString name = nameValueBlock.get(i).name;
-      String values = nameValueBlock.get(i).value.utf8();
+    for (int i = 0; i < headerBlock.size(); i++) {
+      ByteString name = headerBlock.get(i).name;
+      String values = headerBlock.get(i).value.utf8();
       for (int start = 0; start < values.length(); ) {
         int end = values.indexOf('\0', start);
         if (end == -1) {

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
@@ -30,14 +30,14 @@ import static org.junit.Assert.assertEquals;
 
 public final class HeadersTest {
   @Test public void parseNameValueBlock() throws IOException {
-    List<Header> nameValueBlock = headerEntries(
+    List<Header> headerBlock = headerEntries(
         "cache-control", "no-cache, no-store",
         "set-cookie", "Cookie1\u0000Cookie2",
         ":status", "200 OK",
         ":version", "HTTP/1.1");
     Request request = new Request.Builder().url("http://square.com/").build();
     Response response =
-        SpdyTransport.readNameValueBlock(nameValueBlock, Protocol.SPDY_3).request(request).build();
+        SpdyTransport.readNameValueBlock(headerBlock, Protocol.SPDY_3).request(request).build();
     Headers headers = response.headers();
     assertEquals(5, headers.size());
     assertEquals("HTTP/1.1 200 OK", response.statusLine());
@@ -59,13 +59,13 @@ public final class HeadersTest {
   }
 
   @Test public void readNameValueBlockDropsForbiddenHeadersSpdy3() throws IOException {
-    List<Header> nameValueBlock = headerEntries(
+    List<Header> headerBlock = headerEntries(
         ":status", "200 OK",
         ":version", "HTTP/1.1",
         "connection", "close");
     Request request = new Request.Builder().url("http://square.com/").build();
     Response response =
-        SpdyTransport.readNameValueBlock(nameValueBlock, Protocol.SPDY_3).request(request).build();
+        SpdyTransport.readNameValueBlock(headerBlock, Protocol.SPDY_3).request(request).build();
     Headers headers = response.headers();
     assertEquals(2, headers.size());
     assertEquals(OkHeaders.SELECTED_TRANSPORT, headers.name(0));
@@ -75,12 +75,12 @@ public final class HeadersTest {
   }
 
   @Test public void readNameValueBlockDropsForbiddenHeadersHttp2() throws IOException {
-    List<Header> nameValueBlock = headerEntries(
+    List<Header> headerBlock = headerEntries(
         ":status", "200 OK",
         ":version", "HTTP/1.1",
         "connection", "close");
     Request request = new Request.Builder().url("http://square.com/").build();
-    Response response = SpdyTransport.readNameValueBlock(nameValueBlock, Protocol.HTTP_2)
+    Response response = SpdyTransport.readNameValueBlock(headerBlock, Protocol.HTTP_2)
         .request(request).build();
     Headers headers = response.headers();
     assertEquals(2, headers.size());
@@ -98,7 +98,7 @@ public final class HeadersTest {
         .addHeader("set-cookie", "Cookie2")
         .header(":status", "200 OK")
         .build();
-    List<Header> nameValueBlock =
+    List<Header> headerBlock =
         SpdyTransport.writeNameValueBlock(request, Protocol.SPDY_3, "HTTP/1.1");
     List<Header> expected = headerEntries(
         ":method", "GET",
@@ -109,7 +109,7 @@ public final class HeadersTest {
         "cache-control", "no-cache, no-store",
         "set-cookie", "Cookie1\u0000Cookie2",
         ":status", "200 OK");
-    assertEquals(expected, nameValueBlock);
+    assertEquals(expected, headerBlock);
   }
 
   @Test public void toNameValueBlockDropsForbiddenHeadersSpdy3() {


### PR DESCRIPTION
This fixes 2 issues which could lead to corrupt connections, and are the base for implementing push promise.
1. We were ignoring the priority flag, which could lead to accidentally reading priority as a part of the header block.
2. We decompressing headers frame-by-frame eventhough the spec says compression occurs before framing.
