### PR TITLE
Push promise

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
@@ -52,5 +52,23 @@ public interface FrameReader extends Closeable {
     void goAway(int lastGoodStreamId, ErrorCode errorCode);
     void windowUpdate(int streamId, int deltaWindowSize, boolean endFlowControl);
     void priority(int streamId, int priority);
+
+    /**
+     * HTTP/2 only. Receive a push promise header block.
+     * <p/>
+     * A push promise contains all the headers that pertain to a server-initiated
+     * request, and a {@code promisedStreamId} to which response frames will be
+     * delivered. Push promise frames are sent as a part of the response to
+     * {@code streamId}.  The {@code promisedStreamId} has a priority of one
+     * greater than {@code streamId}.
+     *
+     * @param streamId client-initiated stream ID.  Must be an odd number.
+     * @param promisedStreamId server-initiated stream ID.  Must be an even
+     * number.
+     * @param requestHeaders minimally includes {@code :method}, {@code :scheme},
+     * {@code :authority}, and (@code :path}.
+     */
+    void pushPromise(int streamId, int promisedStreamId, List<Header> requestHeaders)
+        throws IOException;
   }
 }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
@@ -26,6 +26,24 @@ public interface FrameWriter extends Closeable {
   void connectionHeader() throws IOException;
   void ackSettings() throws IOException;
 
+  /**
+   * HTTP/2 only. Send a push promise header block.
+   * <p/>
+   * A push promise contains all the headers that pertain to a server-initiated
+   * request, and a {@code promisedStreamId} to which response frames will be
+   * delivered. Push promise frames are sent as a part of the response to
+   * {@code streamId}.  The {@code promisedStreamId} has a priority of one
+   * greater than {@code streamId}.
+   *
+   * @param streamId client-initiated stream ID.  Must be an odd number.
+   * @param promisedStreamId server-initiated stream ID.  Must be an even
+   * number.
+   * @param requestHeaders minimally includes {@code :method}, {@code :scheme},
+   * {@code :authority}, and (@code :path}.
+   */
+  void pushPromise(int streamId, int promisedStreamId, List<Header> requestHeaders)
+      throws IOException;
+
   /** SPDY/3 only. */
   void flush() throws IOException;
   void synStream(boolean outFinished, boolean inFinished, int streamId, int associatedStreamId,

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -322,6 +322,12 @@ final class Spdy3 implements Variant {
       // Do nothing: no ACK for SPDY/3 settings.
     }
 
+    @Override
+    public void pushPromise(int streamId, int promisedStreamId, List<Header> requestHeaders)
+        throws IOException {
+      // Do nothing: no push promise for SPDY/3.
+    }
+
     @Override public synchronized void connectionHeader() {
       // Do nothing: no connection header for SPDY/3.
     }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -630,5 +630,23 @@ public final class SpdyConnection implements Closeable {
     @Override public void priority(int streamId, int priority) {
       // TODO: honor priority.
     }
+
+    @Override
+    public void pushPromise(int streamId, int promisedStreamId, List<Header> requestHeaders)
+        throws IOException {
+      // TODO: Wire up properly and only cancel when local settings disable push.
+      cancelStreamLater(promisedStreamId);
+    }
+
+    private void cancelStreamLater(final int streamId) {
+      executor.submit(new NamedRunnable("OkHttp %s Cancelling Stream %s", hostName, streamId) {
+        @Override public void execute() {
+          try {
+            frameWriter.rstStream(streamId, ErrorCode.CANCEL);
+          } catch (IOException ignored) {
+          }
+        }
+      });
+    }
   }
 }

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
@@ -61,4 +61,9 @@ class BaseTestHandler implements FrameReader.Handler {
   @Override public void priority(int streamId, int priority) {
     fail();
   }
+
+  @Override
+  public void pushPromise(int streamId, int associatedStreamId, List<Header> headerBlock) {
+    fail();
+  }
 }

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -262,5 +262,13 @@ public final class MockSpdyPeer implements Closeable {
     @Override public void priority(int streamId, int priority) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void pushPromise(int streamId, int associatedStreamId, List<Header> headerBlock) {
+      this.type = Http20Draft09.TYPE_PUSH_PROMISE;
+      this.streamId = streamId;
+      this.associatedStreamId = associatedStreamId;
+      this.headerBlock = headerBlock;
+    }
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -333,7 +333,7 @@ public class HttpEngine {
 
   private boolean isRecoverable(IOException e) {
     // If the problem was a CertificateException from the X509TrustManager,
-    // do not retry, we didn't have an abrupt server initiated exception.
+    // do not retry, we didn't have an abrupt server-initiated exception.
     boolean sslFailure =
         e instanceof SSLHandshakeException && e.getCause() instanceof CertificateException;
     boolean protocolFailure = e instanceof ProtocolException;


### PR DESCRIPTION
This builds on #469 and adds basic reading and writing of push promise frames.  Reading is important as before, any push promise frame we encountered would have corrupted the connection.

I'm going to ask @swankjesse to help wire this in sensibly (if he has patience for it).  For now, I'm just canceling any pushes we receive.
