### PR TITLE
 Backfill test and implementation window update on http/2.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
@@ -62,7 +62,12 @@ public interface FrameReader extends Closeable {
      */
     void ping(boolean ack, int payload1, int payload2);
     void goAway(int lastGoodStreamId, ErrorCode errorCode);
-    void windowUpdate(int streamId, int deltaWindowSize, boolean endFlowControl);
+
+    /**
+     * Notifies that an additional {@code windowSizeIncrement} bytes can be
+     * sent on {@code streamId} or the connection, if {@code streamId} is zero.
+     */
+    void windowUpdate(int streamId, int windowSizeIncrement);
     void priority(int streamId, int priority);
 
     /**

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
@@ -82,5 +82,9 @@ public interface FrameWriter extends Closeable {
    */
   void ping(boolean ack, int payload1, int payload2) throws IOException;
   void goAway(int lastGoodStreamId, ErrorCode errorCode) throws IOException;
-  void windowUpdate(int streamId, int deltaWindowSize) throws IOException;
+  /**
+   * Inform peer that an additional {@code windowSizeIncrement} bytes can be
+   * sent on {@code streamId} or the connection, if {@code streamId} is zero.
+   */
+  void windowUpdate(int streamId, int windowSizeIncrement) throws IOException;
 }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -252,8 +252,9 @@ final class Spdy3 implements Variant {
       int w1 = in.readInt();
       int w2 = in.readInt();
       int streamId = w1 & 0x7fffffff;
-      int deltaWindowSize = w2 & 0x7fffffff;
-      handler.windowUpdate(streamId, deltaWindowSize, false);
+      int increment = w2 & 0x7fffffff;
+      if (increment == 0) throw ioException("windowSizeIncrement was 0", increment);
+      handler.windowUpdate(streamId, increment);
     }
 
     private void readPing(Handler handler, int flags, int length) throws IOException {
@@ -410,8 +411,9 @@ final class Spdy3 implements Variant {
 
     void sendDataFrame(int streamId, int flags, byte[] data, int offset, int byteCount)
         throws IOException {
-      if (byteCount > 0xffffff) {
-        throw new IOException("FRAME_TOO_LARGE max size is 16Mib: " + byteCount);
+      if ((byteCount & 0xffffffffL) > 0xffffffL) {
+        throw new IllegalArgumentException(
+            "FRAME_TOO_LARGE max size is 16Mib: " + (byteCount & 0xffffffffL));
       }
       out.writeInt(streamId & 0x7fffffff);
       out.writeInt((flags & 0xff) << 24 | byteCount & 0xffffff);
@@ -484,15 +486,19 @@ final class Spdy3 implements Variant {
       out.flush();
     }
 
-    @Override public synchronized void windowUpdate(int streamId, int deltaWindowSize)
+    @Override public synchronized void windowUpdate(int streamId, int increment)
         throws IOException {
+      if (increment == 0 || (increment & 0xffffffffL) > 0x7fffffffL) {
+        throw new IllegalArgumentException(
+            "windowSizeIncrement must be between 1 and 0x7fffffff: " + (increment & 0xffffffffL));
+      }
       int type = TYPE_WINDOW_UPDATE;
       int flags = 0;
       int length = 8;
       out.writeInt(0x80000000 | (VERSION & 0x7fff) << 16 | type & 0xffff);
       out.writeInt((flags & 0xff) << 24 | length & 0xffffff);
       out.writeInt(streamId);
-      out.writeInt(deltaWindowSize);
+      out.writeInt(increment);
       out.flush();
     }
 

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -218,19 +218,19 @@ public final class SpdyConnection implements Closeable {
     frameWriter.rstStream(streamId, statusCode);
   }
 
-  void writeWindowUpdateLater(final int streamId, final int deltaWindowSize) {
+  void writeWindowUpdateLater(final int streamId, final int windowSizeIncrement) {
     executor.submit(new NamedRunnable("OkHttp %s stream %d", hostName, streamId) {
       @Override public void execute() {
         try {
-          writeWindowUpdate(streamId, deltaWindowSize);
+          writeWindowUpdate(streamId, windowSizeIncrement);
         } catch (IOException ignored) {
         }
       }
     });
   }
 
-  void writeWindowUpdate(int streamId, int deltaWindowSize) throws IOException {
-    frameWriter.windowUpdate(streamId, deltaWindowSize);
+  void writeWindowUpdate(int streamId, int windowSizeIncrement) throws IOException {
+    frameWriter.windowUpdate(streamId, windowSizeIncrement);
   }
 
   /**
@@ -614,16 +614,16 @@ public final class SpdyConnection implements Closeable {
       }
     }
 
-    @Override public void windowUpdate(int streamId, int deltaWindowSize, boolean endFlowControl) {
+    @Override public void windowUpdate(int streamId, int windowSizeIncrement) {
       if (streamId == 0) {
-        // TODO: honor whole-stream flow control
+        // TODO: honor connection-level flow control
         return;
       }
 
       // TODO: honor endFlowControl
       SpdyStream stream = getStream(streamId);
       if (stream != null) {
-        stream.receiveWindowUpdate(deltaWindowSize);
+        stream.receiveWindowUpdate(windowSizeIncrement);
       }
     }
 

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
@@ -325,8 +325,8 @@ public final class SpdyStream {
     notifyAll();
   }
 
-  synchronized void receiveWindowUpdate(int deltaWindowSize) {
-    out.unacknowledgedBytes -= deltaWindowSize;
+  synchronized void receiveWindowUpdate(int windowSizeIncrement) {
+    out.unacknowledgedBytes -= windowSizeIncrement;
     notifyAll();
   }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
@@ -54,7 +54,7 @@ class BaseTestHandler implements FrameReader.Handler {
   }
 
   @Override
-  public void windowUpdate(int streamId, int deltaWindowSize, boolean endFlowControl) {
+  public void windowUpdate(int streamId, int windowSizeIncrement) {
     fail();
   }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -185,7 +185,7 @@ public final class MockSpdyPeer implements Closeable {
     public int associatedStreamId;
     public int priority;
     public ErrorCode errorCode;
-    public int deltaWindowSize;
+    public int windowSizeIncrement;
     public List<Header> headerBlock;
     public byte[] data;
     public Settings settings;
@@ -257,11 +257,11 @@ public final class MockSpdyPeer implements Closeable {
       this.errorCode = errorCode;
     }
 
-    @Override public void windowUpdate(int streamId, int deltaWindowSize, boolean endFlowControl) {
+    @Override public void windowUpdate(int streamId, int windowSizeIncrement) {
       if (this.type != -1) throw new IllegalStateException();
       this.type = Spdy3.TYPE_WINDOW_UPDATE;
       this.streamId = streamId;
-      this.deltaWindowSize = deltaWindowSize;
+      this.windowSizeIncrement = windowSizeIncrement;
     }
 
     @Override public void priority(int streamId, int priority) {

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Spdy3Test.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Spdy3Test.java
@@ -29,8 +29,24 @@ public class Spdy3Test {
     try {
       sendDataFrame(new byte[0x1000000]);
       fail();
-    } catch (IOException e) {
+    } catch (IllegalArgumentException e) {
       assertEquals("FRAME_TOO_LARGE max size is 16Mib: 16777216", e.getMessage());
+    }
+  }
+
+  @Test public void badWindowSizeIncrement() throws IOException {
+    try {
+      windowUpdate(0);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("windowSizeIncrement must be between 1 and 0x7fffffff: 0", e.getMessage());
+    }
+    try {
+      windowUpdate(0x80000000);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertEquals("windowSizeIncrement must be between 1 and 0x7fffffff: 2147483648",
+          e.getMessage());
     }
   }
 
@@ -41,6 +57,12 @@ public class Spdy3Test {
   private byte[] sendDataFrame(byte[] data, int offset, int byteCount) throws IOException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     new Spdy3.Writer(out, true).sendDataFrame(expectedStreamId, 0, data, offset, byteCount);
+    return out.toByteArray();
+  }
+
+  private byte[] windowUpdate(int increment) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new Spdy3.Writer(out, true).windowUpdate(expectedStreamId, increment);
     return out.toByteArray();
   }
 }

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.okhttp.internal.spdy;
 
-import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.internal.Base64;
 import com.squareup.okhttp.internal.Util;
 import java.io.ByteArrayOutputStream;
@@ -27,6 +26,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.squareup.okhttp.internal.Util.UTF_8;
@@ -189,9 +189,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection =
-        new SpdyConnection.Builder(true, peer.openSocket()).handler(REJECT_INCOMING_STREAMS)
-            .build();
+    SpdyConnection connection = connection(peer, Variant.SPDY3);
     connection.noop();
 
     // verify the peer received what was expected
@@ -206,7 +204,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    new SpdyConnection.Builder(true, peer.openSocket()).handler(REJECT_INCOMING_STREAMS).build();
+    connection(peer, Variant.SPDY3);
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame ping = peer.takeFrame();
@@ -225,7 +223,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    http2Connection(peer);
+    connection(peer, Variant.HTTP_20_DRAFT_09);
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame ping = peer.takeFrame();
@@ -243,9 +241,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
-        .handler(REJECT_INCOMING_STREAMS)
-        .build();
+    SpdyConnection connection = connection(peer, Variant.SPDY3);
     Ping ping = connection.ping();
     assertTrue(ping.roundTripTime() > 0);
     assertTrue(ping.roundTripTime() < TimeUnit.SECONDS.toNanos(1));
@@ -267,7 +263,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = http2Connection(peer);
+    SpdyConnection connection = connection(peer, Variant.HTTP_20_DRAFT_09);
     Ping ping = connection.ping();
     assertTrue(ping.roundTripTime() > 0);
     assertTrue(ping.roundTripTime() < TimeUnit.SECONDS.toNanos(1));
@@ -290,7 +286,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    new SpdyConnection.Builder(true, peer.openSocket()).handler(REJECT_INCOMING_STREAMS).build();
+    connection(peer, Variant.SPDY3);
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame ping2 = peer.takeFrame();
@@ -338,9 +334,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
-        .handler(REJECT_INCOMING_STREAMS)
-        .build();
+    SpdyConnection connection = connection(peer, Variant.SPDY3);
 
     peer.takeFrame(); // Guarantees that the peer Settings frame has been processed.
     synchronized (connection) {
@@ -365,9 +359,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
-        .handler(REJECT_INCOMING_STREAMS)
-        .build();
+    SpdyConnection connection = connection(peer, Variant.SPDY3);
 
     peer.takeFrame(); // Guarantees that the Settings frame has been processed.
     synchronized (connection) {
@@ -391,7 +383,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    new SpdyConnection.Builder(true, peer.openSocket()).handler(REJECT_INCOMING_STREAMS).build();
+    connection(peer, Variant.SPDY3);
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame rstStream = peer.takeFrame();
@@ -411,7 +403,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    new SpdyConnection.Builder(true, peer.openSocket()).handler(REJECT_INCOMING_STREAMS).build();
+    connection(peer, Variant.SPDY3);
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame rstStream = peer.takeFrame();
@@ -433,9 +425,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
-        .handler(REJECT_INCOMING_STREAMS)
-        .build();
+    SpdyConnection connection = connection(peer, Variant.SPDY3);
     SpdyStream stream = connection.newStream(headerEntries("a", "android"), true, false);
     OutputStream out = stream.getOutputStream();
     out.write("square".getBytes(UTF_8));
@@ -479,9 +469,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
-        .handler(REJECT_INCOMING_STREAMS)
-        .build();
+    SpdyConnection connection = connection(peer, Variant.SPDY3);
     SpdyStream stream = connection.newStream(headerEntries("a", "android"), true, true);
     OutputStream out = stream.getOutputStream();
     connection.ping().roundTripTime(); // Ensure that the RST_CANCEL has been received.
@@ -521,9 +509,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
-        .handler(REJECT_INCOMING_STREAMS)
-        .build();
+    SpdyConnection connection = connection(peer, Variant.SPDY3);
     SpdyStream stream = connection.newStream(headerEntries("a", "android"), false, true);
     InputStream in = stream.getInputStream();
     OutputStream out = stream.getOutputStream();
@@ -566,9 +552,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
-        .handler(REJECT_INCOMING_STREAMS)
-        .build();
+    SpdyConnection connection = connection(peer, Variant.SPDY3);
     SpdyStream stream = connection.newStream(headerEntries("a", "android"), true, true);
     InputStream in = stream.getInputStream();
     OutputStream out = stream.getOutputStream();
@@ -610,9 +594,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket())
-        .handler(REJECT_INCOMING_STREAMS)
-        .build();
+    SpdyConnection connection = connection(peer, Variant.SPDY3);
     SpdyStream stream = connection.newStream(headerEntries("a", "android"), false, true);
     InputStream in = stream.getInputStream();
     assertStreamData("square", in);
@@ -1006,7 +988,24 @@ public final class SpdyConnectionTest {
   }
 
   @Test public void readSendsWindowUpdate() throws Exception {
-    int windowUpdateThreshold = Variant.SPDY3.initialPeerSettings(true).getInitialWindowSize() / 2;
+    readSendsWindowUpdate(Variant.SPDY3);
+  }
+
+  /**
+   * This test fails on http/2 as it tries to send too large data frame.  In
+   * practice, {@link SpdyStream#OUTPUT_BUFFER_SIZE} prevents us from sending
+   * too large frames.  The test should probably be rewritten to take into
+   * account max frame size per variant.
+   */
+  @Test @Ignore public void readSendsWindowUpdateHttp2() throws Exception {
+    readSendsWindowUpdate(Variant.HTTP_20_DRAFT_09);
+  }
+
+  private void readSendsWindowUpdate(Variant variant)
+      throws IOException, InterruptedException {
+    MockSpdyPeer peer = new MockSpdyPeer(variant, false);
+    int windowUpdateThreshold = variant.initialPeerSettings(true).getInitialWindowSize() / 2;
+
     // Write the mocking script.
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().synReply(false, 1, headerEntries("a", "android"));
@@ -1018,7 +1017,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // Play it back.
-    SpdyConnection connection = new SpdyConnection.Builder(true, peer.openSocket()).build();
+    SpdyConnection connection = connection(peer, variant);
     SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
     assertEquals(windowUpdateThreshold, stream.windowUpdateThreshold);
     assertEquals(headerEntries("a", "android"), stream.getResponseHeaders());
@@ -1039,7 +1038,7 @@ public final class SpdyConnectionTest {
       MockSpdyPeer.InFrame windowUpdate = peer.takeFrame();
       assertEquals(TYPE_WINDOW_UPDATE, windowUpdate.type);
       assertEquals(1, windowUpdate.streamId);
-      assertEquals(windowUpdateThreshold, windowUpdate.deltaWindowSize);
+      assertEquals(windowUpdateThreshold, windowUpdate.windowSizeIncrement);
     }
   }
 
@@ -1112,7 +1111,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = http2Connection(peer);
+    SpdyConnection connection = connection(peer, Variant.HTTP_20_DRAFT_09);
     SpdyStream stream = connection.newStream(headerEntries("b", "banana"), true, true);
     OutputStream out = stream.getOutputStream();
     out.write(buff);
@@ -1172,7 +1171,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    http2Connection(peer);
+    connection(peer, Variant.HTTP_20_DRAFT_09);
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame rstStream = peer.takeFrame();
@@ -1189,7 +1188,7 @@ public final class SpdyConnectionTest {
     peer.play();
 
     // play it back
-    SpdyConnection connection = http2Connection(peer);
+    SpdyConnection connection = connection(peer, Variant.HTTP_20_DRAFT_09);
 
     // verify the peer received the ACK
     MockSpdyPeer.InFrame pingFrame = peer.takeFrame();
@@ -1201,9 +1200,9 @@ public final class SpdyConnectionTest {
     return connection;
   }
 
-  private SpdyConnection http2Connection(MockSpdyPeer peer) throws IOException {
+  private SpdyConnection connection(MockSpdyPeer peer, Variant variant) throws IOException {
     return new SpdyConnection.Builder(true, peer.openSocket())
-        .protocol(Protocol.HTTP_2)
+        .protocol(variant.getProtocol())
         .handler(REJECT_INCOMING_STREAMS).build();
   }
 


### PR DESCRIPTION
Also removes `FLAG_END_FLOW_CONTROL` as it is no longer in http/2. 
