### PR TITLE
Add HTTP/2 GOAWAY frame

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
@@ -61,13 +61,25 @@ public interface FrameReader extends Closeable {
      *  set. The data is opaque binary, and there are no rules on the content.
      */
     void ping(boolean ack, int payload1, int payload2);
-    void goAway(int lastGoodStreamId, ErrorCode errorCode);
+
+    /**
+     * The peer tells us to stop creating streams.  It is safe to replay
+     * streams with {@code ID > lastGoodStreamId} on a new connection.  In-
+     * flight streams with {@code ID <= lastGoodStreamId} can only be replayed
+     * on a new connection if they are idempotent.
+     *
+     * @param lastGoodStreamId the last stream ID the peer processed before
+     * sending this message. If {@lastGoodStreamId} is zero, the peer processed no frames.
+     * @param errorCode reason for closing the connection.
+     * @param debugData only valid for http/2; opaque debug data to send.
+     */
+    void goAway(int lastGoodStreamId, ErrorCode errorCode, byte[] debugData);
 
     /**
      * Notifies that an additional {@code windowSizeIncrement} bytes can be
-     * sent on {@code streamId} or the connection, if {@code streamId} is zero.
+     * sent on {@code streamId}, or the connection if {@code streamId} is zero.
      */
-    void windowUpdate(int streamId, int windowSizeIncrement);
+    void windowUpdate(int streamId, long windowSizeIncrement);
     void priority(int streamId, int priority);
 
     /**

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
@@ -65,6 +65,7 @@ public interface FrameWriter extends Closeable {
    */
   void data(boolean outFinished, int streamId, byte[] data, int offset, int byteCount)
       throws IOException;
+
   /** Write okhttp's settings to the peer. */
   void settings(Settings okHttpSettings) throws IOException;
   void noop() throws IOException;
@@ -81,10 +82,21 @@ public interface FrameWriter extends Closeable {
    *  sent.  The data is opaque binary, and there are no rules on the content.
    */
   void ping(boolean ack, int payload1, int payload2) throws IOException;
-  void goAway(int lastGoodStreamId, ErrorCode errorCode) throws IOException;
+
+  /**
+   * Tell the peer to stop creating streams and that we last processed
+   * {@code lastGoodStreamId}, or zero if no streams were processed.
+   *
+   * @param lastGoodStreamId the last stream ID processed, or zero if no
+   * streams were processed.
+   * @param errorCode reason for closing the connection.
+   * @param debugData only valid for http/2; opaque debug data to send.
+   */
+  void goAway(int lastGoodStreamId, ErrorCode errorCode, byte[] debugData) throws IOException;
+
   /**
    * Inform peer that an additional {@code windowSizeIncrement} bytes can be
-   * sent on {@code streamId} or the connection, if {@code streamId} is zero.
+   * sent on {@code streamId}, or the connection if {@code streamId} is zero.
    */
-  void windowUpdate(int streamId, int windowSizeIncrement) throws IOException;
+  void windowUpdate(int streamId, long windowSizeIncrement) throws IOException;
 }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -252,7 +252,7 @@ final class Spdy3 implements Variant {
       int w1 = in.readInt();
       int w2 = in.readInt();
       int streamId = w1 & 0x7fffffff;
-      int increment = w2 & 0x7fffffff;
+      long increment = w2 & 0x7fffffff;
       if (increment == 0) throw ioException("windowSizeIncrement was 0", increment);
       handler.windowUpdate(streamId, increment);
     }
@@ -272,7 +272,7 @@ final class Spdy3 implements Variant {
       if (errorCode == null) {
         throw ioException("TYPE_GOAWAY unexpected error code: %d", errorCodeInt);
       }
-      handler.goAway(lastGoodStreamId, errorCode);
+      handler.goAway(lastGoodStreamId, errorCode, Util.EMPTY_BYTE_ARRAY);
     }
 
     private void readSettings(Handler handler, int flags, int length) throws IOException {
@@ -411,9 +411,8 @@ final class Spdy3 implements Variant {
 
     void sendDataFrame(int streamId, int flags, byte[] data, int offset, int byteCount)
         throws IOException {
-      if ((byteCount & 0xffffffffL) > 0xffffffL) {
-        throw new IllegalArgumentException(
-            "FRAME_TOO_LARGE max size is 16Mib: " + (byteCount & 0xffffffffL));
+      if (byteCount > 0xffffffL) {
+        throw new IllegalArgumentException("FRAME_TOO_LARGE max size is 16Mib: " + byteCount);
       }
       out.writeInt(streamId & 0x7fffffff);
       out.writeInt((flags & 0xff) << 24 | byteCount & 0xffffff);
@@ -473,9 +472,12 @@ final class Spdy3 implements Variant {
       out.flush();
     }
 
-    @Override public synchronized void goAway(int lastGoodStreamId, ErrorCode errorCode)
+    @Override
+    public synchronized void goAway(int lastGoodStreamId, ErrorCode errorCode, byte[] ignored)
         throws IOException {
-      if (errorCode.spdyGoAwayCode == -1) throw new IllegalArgumentException();
+      if (errorCode.spdyGoAwayCode == -1) {
+        throw new IllegalArgumentException("errorCode.spdyGoAwayCode == -1");
+      }
       int type = TYPE_GOAWAY;
       int flags = 0;
       int length = 8;
@@ -486,11 +488,11 @@ final class Spdy3 implements Variant {
       out.flush();
     }
 
-    @Override public synchronized void windowUpdate(int streamId, int increment)
+    @Override public synchronized void windowUpdate(int streamId, long increment)
         throws IOException {
-      if (increment == 0 || (increment & 0xffffffffL) > 0x7fffffffL) {
+      if (increment == 0 || increment > 0x7fffffffL) {
         throw new IllegalArgumentException(
-            "windowSizeIncrement must be between 1 and 0x7fffffff: " + (increment & 0xffffffffL));
+            "windowSizeIncrement must be between 1 and 0x7fffffff: " + increment);
       }
       int type = TYPE_WINDOW_UPDATE;
       int flags = 0;
@@ -498,7 +500,7 @@ final class Spdy3 implements Variant {
       out.writeInt(0x80000000 | (VERSION & 0x7fff) << 16 | type & 0xffff);
       out.writeInt((flags & 0xff) << 24 | length & 0xffffff);
       out.writeInt(streamId);
-      out.writeInt(increment);
+      out.writeInt((int) increment);
       out.flush();
     }
 

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -303,7 +303,8 @@ public final class SpdyConnection implements Closeable {
         shutdown = true;
         lastGoodStreamId = this.lastGoodStreamId;
       }
-      frameWriter.goAway(lastGoodStreamId, statusCode);
+      // TODO: propagate exception message into debugData
+      frameWriter.goAway(lastGoodStreamId, statusCode, Util.EMPTY_BYTE_ARRAY);
     }
   }
 
@@ -597,7 +598,10 @@ public final class SpdyConnection implements Closeable {
       }
     }
 
-    @Override public void goAway(int lastGoodStreamId, ErrorCode errorCode) {
+    @Override
+    public void goAway(int lastGoodStreamId, ErrorCode errorCode, byte[] debugData) {
+      if (debugData.length > 0) { // TODO: log the debugData
+      }
       synchronized (SpdyConnection.this) {
         shutdown = true;
 
@@ -614,7 +618,7 @@ public final class SpdyConnection implements Closeable {
       }
     }
 
-    @Override public void windowUpdate(int streamId, int windowSizeIncrement) {
+    @Override public void windowUpdate(int streamId, long windowSizeIncrement) {
       if (streamId == 0) {
         // TODO: honor connection-level flow control
         return;

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
@@ -325,7 +325,7 @@ public final class SpdyStream {
     notifyAll();
   }
 
-  synchronized void receiveWindowUpdate(int windowSizeIncrement) {
+  synchronized void receiveWindowUpdate(long windowSizeIncrement) {
     out.unacknowledgedBytes -= windowSizeIncrement;
     notifyAll();
   }
@@ -594,7 +594,7 @@ public final class SpdyStream {
      * acknowledged with an incoming {@code WINDOW_UPDATE} frame. Writes
      * block if they cause this to exceed the {@code WINDOW_SIZE}.
      */
-    private int unacknowledgedBytes = 0;
+    private long unacknowledgedBytes = 0;
 
     @Override public void write(int b) throws IOException {
       Util.writeSingleByte(this, b);

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
@@ -49,12 +49,13 @@ class BaseTestHandler implements FrameReader.Handler {
     fail();
   }
 
-  @Override public void goAway(int lastGoodStreamId, ErrorCode errorCode) {
+  @Override
+  public void goAway(int lastGoodStreamId, ErrorCode errorCode, byte[] debugData) {
     fail();
   }
 
   @Override
-  public void windowUpdate(int streamId, int windowSizeIncrement) {
+  public void windowUpdate(int streamId, long windowSizeIncrement) {
     fail();
   }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -185,7 +185,7 @@ public final class MockSpdyPeer implements Closeable {
     public int associatedStreamId;
     public int priority;
     public ErrorCode errorCode;
-    public int windowSizeIncrement;
+    public long windowSizeIncrement;
     public List<Header> headerBlock;
     public byte[] data;
     public Settings settings;
@@ -250,14 +250,16 @@ public final class MockSpdyPeer implements Closeable {
       this.type = Spdy3.TYPE_NOOP;
     }
 
-    @Override public void goAway(int lastGoodStreamId, ErrorCode errorCode) {
+    @Override
+    public void goAway(int lastGoodStreamId, ErrorCode errorCode, byte[] debugData) {
       if (this.type != -1) throw new IllegalStateException();
       this.type = Spdy3.TYPE_GOAWAY;
       this.streamId = lastGoodStreamId;
       this.errorCode = errorCode;
+      this.data = debugData;
     }
 
-    @Override public void windowUpdate(int streamId, int windowSizeIncrement) {
+    @Override public void windowUpdate(int streamId, long windowSizeIncrement) {
       if (this.type != -1) throw new IllegalStateException();
       this.type = Spdy3.TYPE_WINDOW_UPDATE;
       this.streamId = streamId;

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Spdy3Test.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Spdy3Test.java
@@ -15,10 +15,14 @@
  */
 package com.squareup.okhttp.internal.spdy;
 
+import com.squareup.okhttp.internal.Util;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -30,7 +34,7 @@ public class Spdy3Test {
       sendDataFrame(new byte[0x1000000]);
       fail();
     } catch (IllegalArgumentException e) {
-      assertEquals("FRAME_TOO_LARGE max size is 16Mib: 16777216", e.getMessage());
+      assertEquals("FRAME_TOO_LARGE max size is 16Mib: " + 0x1000000L, e.getMessage());
     }
   }
 
@@ -42,12 +46,48 @@ public class Spdy3Test {
       assertEquals("windowSizeIncrement must be between 1 and 0x7fffffff: 0", e.getMessage());
     }
     try {
-      windowUpdate(0x80000000);
+      windowUpdate(0x80000000L);
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("windowSizeIncrement must be between 1 and 0x7fffffff: 2147483648",
           e.getMessage());
     }
+  }
+
+  @Test public void goAwayRoundTrip() throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputStream dataOut = new DataOutputStream(out);
+
+    final ErrorCode expectedError = ErrorCode.PROTOCOL_ERROR;
+
+    // Compose the expected GOAWAY frame without debug data
+    // |C| Version(15bits) | Type(16bits) |
+    dataOut.writeInt(0x80000000 | (Spdy3.VERSION & 0x7fff) << 16 | Spdy3.TYPE_GOAWAY & 0xffff);
+    // | Flags (8)  |  Length (24 bits)   |
+    dataOut.writeInt(8); // no flags and length is 8.
+    dataOut.writeInt(expectedStreamId); // last good stream.
+    dataOut.writeInt(expectedError.spdyGoAwayCode);
+
+    // Check writer sends the same bytes.
+    assertArrayEquals(out.toByteArray(),
+        sendGoAway(expectedStreamId, expectedError, Util.EMPTY_BYTE_ARRAY));
+
+    // SPDY/3 does not send debug data, so bytes should be same!
+    assertArrayEquals(out.toByteArray(), sendGoAway(expectedStreamId, expectedError, new byte[8]));
+
+    FrameReader fr = newReader(out);
+
+    fr.nextFrame(new BaseTestHandler() { // Consume the goAway frame.
+      @Override public void goAway(int lastGoodStreamId, ErrorCode errorCode, byte[] debugData) {
+        assertEquals(expectedStreamId, lastGoodStreamId);
+        assertEquals(expectedError, errorCode);
+        assertEquals(0, debugData.length);
+      }
+    });
+  }
+
+  private Spdy3.Reader newReader(ByteArrayOutputStream out) {
+    return new Spdy3.Reader(new ByteArrayInputStream(out.toByteArray()), false);
   }
 
   private byte[] sendDataFrame(byte[] data) throws IOException {
@@ -60,9 +100,16 @@ public class Spdy3Test {
     return out.toByteArray();
   }
 
-  private byte[] windowUpdate(int increment) throws IOException {
+  private byte[] windowUpdate(long increment) throws IOException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     new Spdy3.Writer(out, true).windowUpdate(expectedStreamId, increment);
+    return out.toByteArray();
+  }
+
+  private byte[] sendGoAway(int lastGoodStreamId, ErrorCode errorCode, byte[] debugData)
+      throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new Spdy3.Writer(out, true).goAway(lastGoodStreamId, errorCode, debugData);
     return out.toByteArray();
   }
 }


### PR DESCRIPTION
This builds on #475 and completes the last mandatory frame for http/2.  It also bumps debugData to being generic in the handler as future variants will include it.
