### PR TITLE
Simplify settings and hide SPDY Variant construction

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
@@ -38,11 +38,7 @@ public final class Http20Draft09 implements Variant {
   }
 
   // http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.5
-  @Override public Settings defaultOkHttpSettings(boolean client) {
-    return initialPeerSettings(client);
-  }
-
-  @Override public Settings initialPeerSettings(boolean client) {
+  static Settings defaultSettings(boolean client) {
     Settings settings = new Settings();
     settings.set(Settings.HEADER_TABLE_SIZE, 0, 4096);
     if (client) { // client specifies whether or not it accepts push.
@@ -74,11 +70,11 @@ public final class Http20Draft09 implements Variant {
   static final int FLAG_PRIORITY = 0x8;
   static final int FLAG_ACK = 0x1;
 
-  @Override public FrameReader newReader(InputStream in, Settings peerSettings, boolean client) {
-    return new Reader(in, peerSettings.getHeaderTableSize(), client);
+  @Override public FrameReader newReader(InputStream in, boolean client) {
+    return new Reader(in, 4096, client);
   }
 
-  @Override public FrameWriter newWriter(OutputStream out, Settings ignored, boolean client) {
+  @Override public FrameWriter newWriter(OutputStream out, boolean client) {
     return new Writer(out, client);
   }
 

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -36,11 +36,7 @@ final class Spdy3 implements Variant {
     return Protocol.SPDY_3;
   }
 
-  @Override public Settings defaultOkHttpSettings(boolean client) {
-    return initialPeerSettings(client); // no difference in defaults.
-  }
-
-  @Override public Settings initialPeerSettings(boolean client) {
+  static Settings defaultSettings(boolean client) {
     Settings settings = new Settings();
     settings.set(Settings.INITIAL_WINDOW_SIZE, 0, 65535);
     return settings;
@@ -104,11 +100,11 @@ final class Spdy3 implements Variant {
     }
   }
 
-  @Override public FrameReader newReader(InputStream in, Settings ignored, boolean client) {
+  @Override public FrameReader newReader(InputStream in, boolean client) {
     return new Reader(in, client);
   }
 
-  @Override public FrameWriter newWriter(OutputStream out, Settings ignored, boolean client) {
+  @Override public FrameWriter newWriter(OutputStream out, boolean client) {
     return new Writer(out, client);
   }
 

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
@@ -21,34 +21,17 @@ import java.io.OutputStream;
 
 /** A version and dialect of the framed socket protocol. */
 interface Variant {
-  Variant SPDY3 = new Spdy3();
-  Variant HTTP_20_DRAFT_09 = new Http20Draft09();
 
   /** The protocol as selected using NPN or ALPN. */
   Protocol getProtocol();
 
   /**
-   * Default settings used for reading or writing frames to the peer.
-   * @param client true if these settings apply to writing requests, false if responses.
-   */
-  Settings defaultOkHttpSettings(boolean client);
-
-  /**
-   * Initial settings used for reading frames from the peer until we are sent
-   * a Settings frame.
-   * @param client true if these settings apply to reading responses, false if requests.
-   */
-  Settings initialPeerSettings(boolean client);
-
-  /**
-   * @param peerSettings potentially stale settings that reflect the remote peer.
    * @param client true if this is the HTTP client's reader, reading frames from a server.
    */
-  FrameReader newReader(InputStream in, Settings peerSettings, boolean client);
+  FrameReader newReader(InputStream in, boolean client);
 
   /**
-   * @param okHttpSettings settings sent to the peer, such compression header table size.
    * @param client true if this is the HTTP client's writer, writing frames to a server.
    */
-  FrameWriter newWriter(OutputStream out, Settings okHttpSettings, boolean client);
+  FrameWriter newWriter(OutputStream out, boolean client);
 }

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Http20Draft09Test.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Http20Draft09Test.java
@@ -456,8 +456,7 @@ public class Http20Draft09Test {
   }
 
   private Http20Draft09.Reader newReader(ByteArrayOutputStream out) {
-    return new Http20Draft09.Reader(new ByteArrayInputStream(out.toByteArray()),
-        Variant.HTTP_20_DRAFT_09.initialPeerSettings(false).getHeaderTableSize(), false);
+    return new Http20Draft09.Reader(new ByteArrayInputStream(out.toByteArray()), 4096, false);
   }
 
   private byte[] literalHeaders(List<Header> sentHeaders) throws IOException {

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -50,7 +50,7 @@ public final class MockSpdyPeer implements Closeable {
   public MockSpdyPeer(Variant variant, boolean client) {
     this.client = client;
     this.variant = variant;
-    this.frameWriter = variant.newWriter(bytesOut, variant.defaultOkHttpSettings(client), client);
+    this.frameWriter = variant.newWriter(bytesOut, client);
   }
 
   public void acceptFrame() {
@@ -110,7 +110,7 @@ public final class MockSpdyPeer implements Closeable {
     socket = serverSocket.accept();
     OutputStream out = socket.getOutputStream();
     InputStream in = socket.getInputStream();
-    FrameReader reader = variant.newReader(in, variant.initialPeerSettings(client), client);
+    FrameReader reader = variant.newReader(in, client);
 
     Iterator<OutFrame> outFramesIterator = outFrames.iterator();
     byte[] outBytes = bytesOut.toByteArray();


### PR DESCRIPTION
TL;DR

This undoes a little of #456 coming out of http/2 working group.  Basically, this removes settings from the contract of Variant, FrameReader, and FrameWriter construction.  It does not disable setting synchronization.

Background.

It seems that the header table size parameter will become descoped from the connection-level settings exchange in the next draft (and into a header-specific opcode).  This removes a lot of the race conditions and makes things like ack even more advisory.  A side effect is that we don't need to be as explicit about settings in the interface.

We will need to construct variants with settings such as table size, but adding that to the contract of the variant seems heavy handed, especially with less importance to synchronization.  This implies either retaining our somewhat confusing newReader/Writer or allowing Variants to be created with customized settings, or handling it internally.

I'm going with handling internally, and reducing the configuration to protocol selection only for now.  At some point, we'll open config to users, and then we might expose variant config in the Protocol enum or some other way that is least touch. 
