### PR TITLE
Send window update after the peer sends half the limit on a stream or connection

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
@@ -76,9 +76,9 @@ final class Settings {
     Arrays.fill(values, 0);
   }
 
-  void set(int id, int idFlags, int value) {
+  Settings set(int id, int idFlags, int value) {
     if (id >= values.length) {
-      return; // Discard unknown settings.
+      return this; // Discard unknown settings.
     }
 
     int bit = 1 << id;
@@ -95,6 +95,7 @@ final class Settings {
     }
 
     values[id] = value;
+    return this;
   }
 
   /** Returns true if a value has been assigned for the setting {@code id}. */


### PR DESCRIPTION
This is the final change for connection-level flow control in spdy or http/2.
