### PR TITLE
Update to spdy/3.1 and ignore old spdy frames.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/Protocol.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/Protocol.java
@@ -30,12 +30,12 @@ import java.util.List;
  * <h3>Protocol vs Scheme</h3>
  * Despite its name, {@link java.net.URL#getProtocol()} returns the
  * {@link java.net.URI#getScheme() scheme} (http, https, etc.) of the URL, not
- * the protocol (http/1.1, spdy/3, etc.).  OkHttp uses the word protocol to
+ * the protocol (http/1.1, spdy/3.1, etc.).  OkHttp uses the word protocol to
  * indicate how HTTP messages are framed.
  */
 public enum Protocol {
   HTTP_2("HTTP-draft-09/2.0", true),
-  SPDY_3("spdy/3", true),
+  SPDY_3("spdy/3.1", true),
   HTTP_11("http/1.1", false);
 
   public static final List<Protocol> HTTP2_SPDY3_AND_HTTP =

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -340,7 +340,7 @@ public class Platform {
         if (!provider.unsupported && provider.selected == null) {
           Logger logger = Logger.getLogger("com.squareup.okhttp.OkHttpClient");
           logger.log(Level.INFO,
-              "NPN callback dropped so SPDY is disabled. " + "Is npn-boot on the boot class path?");
+              "NPN callback dropped so SPDY is disabled. Is npn-boot on the boot class path?");
           return null;
         }
         return provider.unsupported ? null : ByteString.encodeUtf8(provider.selected);

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameReader.java
@@ -51,9 +51,6 @@ public interface FrameReader extends Closeable {
     /** HTTP/2 only. */
     void ackSettings();
 
-    /** SPDY/3 only. */
-    void noop();
-
     /**
      *  Read a connection-level ping from the peer.  {@code ack} indicates this
      *  is a reply.  Payload parameters are different between SPDY/3 and HTTP/2.

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
@@ -69,9 +69,6 @@ public interface FrameWriter extends Closeable {
   /** Write okhttp's settings to the peer. */
   void settings(Settings okHttpSettings) throws IOException;
 
-  /** SPDY/3 only. */
-  void noop() throws IOException;
-
   /**
    *  Send a connection-level ping to the peer.  {@code ack} indicates this is
    *  a reply.  Payload parameters are different between SPDY/3 and HTTP/2.

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
@@ -411,10 +411,6 @@ public final class Http20Draft09 implements Variant {
       }
     }
 
-    @Override public synchronized void noop() throws IOException {
-      throw new UnsupportedOperationException();
-    }
-
     @Override public synchronized void ping(boolean ack, int payload1, int payload2)
         throws IOException {
       int length = 8;

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -348,11 +348,6 @@ public final class SpdyConnection implements Closeable {
     return pings != null ? pings.remove(id) : null;
   }
 
-  /** Sends a noop frame to the peer. */
-  public void noop() throws IOException {
-    frameWriter.noop();
-  }
-
   public void flush() throws IOException {
     frameWriter.flush();
   }
@@ -656,9 +651,6 @@ public final class SpdyConnection implements Closeable {
 
     @Override public void ackSettings() {
       // TODO: If we don't get this callback after sending settings to the peer, SETTINGS_TIMEOUT.
-    }
-
-    @Override public void noop() {
     }
 
     @Override public void ping(boolean reply, int payload1, int payload2) {

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/BaseTestHandler.java
@@ -45,10 +45,6 @@ class BaseTestHandler implements FrameReader.Handler {
     fail();
   }
 
-  @Override public void noop() {
-    fail();
-  }
-
   @Override public void ping(boolean ack, int payload1, int payload2) {
     fail();
   }

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -256,11 +256,6 @@ public final class MockSpdyPeer implements Closeable {
       this.payload2 = payload2;
     }
 
-    @Override public void noop() {
-      if (this.type != -1) throw new IllegalStateException();
-      this.type = Spdy3.TYPE_NOOP;
-    }
-
     @Override
     public void goAway(int lastGoodStreamId, ErrorCode errorCode, byte[] debugData) {
       if (this.type != -1) throw new IllegalStateException();

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
@@ -42,7 +42,6 @@ import static com.squareup.okhttp.internal.spdy.SpdyStream.OUTPUT_BUFFER_SIZE;
 import static com.squareup.okhttp.internal.spdy.Spdy3.TYPE_DATA;
 import static com.squareup.okhttp.internal.spdy.Spdy3.TYPE_GOAWAY;
 import static com.squareup.okhttp.internal.spdy.Spdy3.TYPE_HEADERS;
-import static com.squareup.okhttp.internal.spdy.Spdy3.TYPE_NOOP;
 import static com.squareup.okhttp.internal.spdy.Spdy3.TYPE_PING;
 import static com.squareup.okhttp.internal.spdy.Spdy3.TYPE_RST_STREAM;
 import static com.squareup.okhttp.internal.spdy.Spdy3.TYPE_SETTINGS;
@@ -196,20 +195,6 @@ public final class SpdyConnectionTest {
     assertEquals(headerEntries("b", "banana"), reply.headerBlock);
     assertEquals(1, receiveCount.get());
     return reply;
-  }
-
-  @Test public void noop() throws Exception {
-    // write the mocking script
-    peer.acceptFrame(); // NOOP
-    peer.play();
-
-    // play it back
-    SpdyConnection connection = connection(peer, SPDY3);
-    connection.noop();
-
-    // verify the peer received what was expected
-    MockSpdyPeer.InFrame ping = peer.takeFrame();
-    assertEquals(TYPE_NOOP, ping.type);
   }
 
   @Test public void serverPingsClient() throws Exception {

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -323,12 +323,12 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
    * <p>The following protocols are currently supported:
    * <ul>
    *   <li><a href="http://www.w3.org/Protocols/rfc2616/rfc2616.html">http/1.1</a>
-   *   <li><a href="http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3">spdy/3</a>
+   *   <li><a href="http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1">spdy/3.1</a>
    *   <li><a href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-09">HTTP-draft-09/2.0</a>
    * </ul>
    *
    * <p><strong>This is an evolving set.</strong> Future releases may drop
-   * support for transitional protocols (like spdy/3), in favor of their
+   * support for transitional protocols (like spdy/3.1), in favor of their
    * successors (spdy/4 or http/2.0). The http/1.1 transport will never be
    * dropped.
    *

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkHeaders.java
@@ -58,7 +58,7 @@ public final class OkHeaders {
 
   /**
    * Synthetic response header: the selected
-   * {@link com.squareup.okhttp.Protocol protocol} ("spdy/3", "http/1.1", etc).
+   * {@link com.squareup.okhttp.Protocol protocol} ("spdy/3.1", "http/1.1", etc).
    */
   public static final String SELECTED_PROTOCOL = PREFIX + "-Selected-Protocol";
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -98,8 +98,7 @@ public final class SpdyTransport implements Transport {
     // TODO: make the known header names constants.
     List<Header> result = new ArrayList<Header>(headers.size() + 10);
     result.add(new Header(TARGET_METHOD, request.method()));
-    result.add(
-        new Header(TARGET_PATH, RequestLine.requestPath(request.url())));
+    result.add(new Header(TARGET_PATH, RequestLine.requestPath(request.url())));
     String host = HttpEngine.hostHeader(request.url());
     if (Protocol.SPDY_3 == protocol) {
       result.add(new Header(VERSION, version));
@@ -201,7 +200,7 @@ public final class SpdyTransport implements Transport {
   private static boolean isProhibitedHeader(Protocol protocol, ByteString name) {
     boolean prohibited = false;
     if (protocol == Protocol.SPDY_3) {
-      // http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3#TOC-3.2.1-Request
+      // http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1#TOC-3.2.1-Request
       if (name.equalsAscii("connection")
           || name.equalsAscii("host")
           || name.equalsAscii("keep-alive")

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/ExternalHttp2Example.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/ExternalHttp2Example.java
@@ -17,6 +17,7 @@
 package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Protocol;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -30,7 +31,8 @@ import static com.squareup.okhttp.internal.http.OkHeaders.SELECTED_PROTOCOL;
 public final class ExternalHttp2Example {
   public static void main(String[] args) throws Exception {
     URL url = new URL("https://twitter.com/");
-    HttpsURLConnection connection = (HttpsURLConnection) new OkHttpClient().open(url);
+    HttpsURLConnection connection = (HttpsURLConnection) new OkHttpClient()
+        .setProtocols(Protocol.HTTP2_AND_HTTP_11).open(url);
 
     connection.setHostnameVerifier(new HostnameVerifier() {
       @Override public boolean verify(String s, SSLSession sslSession) {

--- a/okhttp/src/test/java/com/squareup/okhttp/internal/http/ExternalSpdyExample.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/internal/http/ExternalSpdyExample.java
@@ -17,6 +17,7 @@
 package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Protocol;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -30,7 +31,8 @@ import static com.squareup.okhttp.internal.http.OkHeaders.SELECTED_PROTOCOL;
 public final class ExternalSpdyExample {
   public static void main(String[] args) throws Exception {
     URL url = new URL("https://www.google.ca/");
-    HttpsURLConnection connection = (HttpsURLConnection) new OkHttpClient().open(url);
+    HttpsURLConnection connection = (HttpsURLConnection) new OkHttpClient()
+        .setProtocols(Protocol.SPDY3_AND_HTTP11).open(url);
 
     connection.setHostnameVerifier(new HostnameVerifier() {
       @Override public boolean verify(String s, SSLSession sslSession) {


### PR DESCRIPTION
related to issue #354

Spdy 3.1 supports connection-level flow control, which allows you to limit bandwidth without limiting parallelism.

This implementation ignores deprecated NOOP (spdy/2) and CREDENTIALS (spdy/3) frames.

Tested via `ExternalSpdyExample` on google.ca and twitter.com
