### PR TITLE
GzipSource beginnings.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -404,4 +404,17 @@ public final class Util {
   public static byte asciiLowerCase(byte c) {
     return 'A' <= c && c <= 'Z' ? (byte) (c + 'a' - 'A') : c;
   }
+
+  public static int reverseBytesShort(short s) {
+    int i = s & 0xffff;
+    return (i & 0xff00) >>> 8
+        |  (i & 0x00ff) << 8;
+  }
+
+  public static int reverseBytesInt(int i) {
+    return (i & 0xff000000) >>> 24
+        |  (i & 0x00ff0000) >>> 8
+        |  (i & 0x0000ff00) << 8
+        |  (i & 0x000000ff) << 24;
+  }
 }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/GzipSource.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/GzipSource.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.bytes;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.zip.CRC32;
+import java.util.zip.Inflater;
+
+public final class GzipSource implements Source {
+  private static final byte FHCRC = 1;
+  private static final byte FEXTRA = 2;
+  private static final byte FNAME = 3;
+  private static final byte FCOMMENT = 4;
+
+  private static final byte SECTION_HEADER = 0;
+  private static final byte SECTION_BODY = 1;
+  private static final byte SECTION_TRAILER = 2;
+  private static final byte SECTION_DONE = 3;
+
+  /** The current section. Always progresses forward. */
+  private int section = SECTION_HEADER;
+
+  /**
+   * This buffer is carefully shared between this source and the InflaterSource
+   * it wraps. In particular, this source may read more bytes than necessary for
+   * the GZIP header; the InflaterSource will pick those up when it starts to
+   * read the compressed body. And the InflaterSource may read more bytes than
+   * necessary for the compressed body, and this source will pick those up for
+   * the GZIP trailer.
+   */
+  private final OkBuffer buffer = new OkBuffer();
+
+  /**
+   * Our source should yield a GZIP header (which we consume directly), followed
+   * by deflated bytes (which we consume via an InflaterSource), followed by a
+   * GZIP trailer (which we also consume directly).
+   */
+  private final Source source;
+
+  /** The inflater used to decompress the deflated body. */
+  private final Inflater inflater;
+
+  /**
+   * The inflater source takes care of moving data between compressed source and
+   * decompressed sink buffers.
+   */
+  private final InflaterSource inflaterSource;
+
+  /** Checksum used to check both the GZIP header and decompressed body. */
+  private final CRC32 crc = new CRC32();
+
+  public GzipSource(Source source) throws IOException {
+    this.inflater = new Inflater(true);
+    this.source = source;
+    this.inflaterSource = new InflaterSource(source, inflater, buffer);
+  }
+
+  @Override public long read(OkBuffer sink, long byteCount, Deadline deadline) throws IOException {
+    if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
+    if (byteCount == 0) return 0;
+
+    // If we haven't consumed the header, we must consume it before anything else.
+    if (section == SECTION_HEADER) {
+      consumeHeader(deadline);
+      section = SECTION_BODY;
+    }
+
+    // Attempt to read at least a byte of the body. If we do, we're done.
+    if (section == SECTION_BODY) {
+      long offset = sink.byteCount;
+      long result = inflaterSource.read(sink, byteCount, deadline);
+      if (result != -1) {
+        updateCrc(sink, offset, result);
+        return result;
+      }
+      section = SECTION_TRAILER;
+    }
+
+    // The body is exhausted; time to read the trailer. We always consume the
+    // trailer before returning a -1 exhausted result; that way if you read to
+    // the end of a GzipSource you guarantee that the CRC has been checked.
+    if (section == SECTION_TRAILER) {
+      consumeTrailer(deadline);
+      section = SECTION_DONE;
+    }
+
+    return -1;
+  }
+
+  private void consumeHeader(Deadline deadline) throws IOException {
+    // Read the 10-byte header. We peek at the flags byte first so we know if we
+    // need to CRC the entire header. Then we read the magic ID1ID2 sequence.
+    // We can skip everything else in the first 10 bytes.
+    // +---+---+---+---+---+---+---+---+---+---+
+    // |ID1|ID2|CM |FLG|     MTIME     |XFL|OS | (more-->)
+    // +---+---+---+---+---+---+---+---+---+---+
+    require(10, deadline);
+    byte flags = buffer.byteAt(3);
+    boolean fhcrc = ((flags >> FHCRC) & 1) == 1;
+    if (fhcrc) updateCrc(buffer, 0, 10);
+
+    short id1id2 = buffer.readShort();
+    checkEqual("ID1ID2", (short) 0x1f8b, id1id2);
+    buffer.skip(8);
+
+    // Skip optional extra fields.
+    // +---+---+=================================+
+    // | XLEN  |...XLEN bytes of "extra field"...| (more-->)
+    // +---+---+=================================+
+    if (((flags >> FEXTRA) & 1) == 1) {
+      require(2, deadline);
+      if (fhcrc) updateCrc(buffer, 0, 2);
+      int xlen = buffer.readShortLe() & 0xffff;
+      require(xlen, deadline);
+      if (fhcrc) updateCrc(buffer, 0, xlen);
+      buffer.skip(xlen);
+    }
+
+    // Skip an optional 0-terminated name.
+    // +=========================================+
+    // |...original file name, zero-terminated...| (more-->)
+    // +=========================================+
+    if (((flags >> FNAME) & 1) == 1) {
+      long index = seek((byte) 0, deadline);
+      if (fhcrc) updateCrc(buffer, 0, index + 1);
+      buffer.skip(index + 1);
+    }
+
+    // Skip an optional 0-terminated comment.
+    // +===================================+
+    // |...file comment, zero-terminated...| (more-->)
+    // +===================================+
+    if (((flags >> FCOMMENT) & 1) == 1) {
+      long index = seek((byte) 0, deadline);
+      if (fhcrc) updateCrc(buffer, 0, index + 1);
+      buffer.skip(index + 1);
+    }
+
+    // Confirm the optional header CRC.
+    // +---+---+
+    // | CRC16 |
+    // +---+---+
+    if (fhcrc) {
+      checkEqual("FHCRC", buffer.readShortLe(), (short) crc.getValue());
+      crc.reset();
+    }
+  }
+
+  private void consumeTrailer(Deadline deadline) throws IOException {
+    // Read the eight-byte trailer. Confirm the body's CRC and size.
+    // +---+---+---+---+---+---+---+---+
+    // |     CRC32     |     ISIZE     |
+    // +---+---+---+---+---+---+---+---+
+    require(8, deadline);
+    checkEqual("CRC", buffer.readIntLe(), (int) crc.getValue());
+    checkEqual("ISIZE", buffer.readIntLe(), inflater.getTotalOut());
+  }
+
+  @Override public void close(Deadline deadline) throws IOException {
+    inflaterSource.close(deadline);
+  }
+
+  /** Updates the CRC with the given bytes. */
+  private void updateCrc(OkBuffer buffer, long offset, long byteCount) {
+    for (Segment s = buffer.head; byteCount > 0; s = s.next) {
+      int segmentByteCount = s.limit - s.pos;
+      if (offset < segmentByteCount) {
+        int toUpdate = (int) Math.min(byteCount, segmentByteCount - offset);
+        crc.update(s.data, (int) (s.pos + offset), toUpdate);
+        byteCount -= toUpdate;
+      }
+      offset -= segmentByteCount; // Track the offset of the current segment.
+    }
+  }
+
+  /** Fills the buffer with at least {@code byteCount} bytes. */
+  private void require(int byteCount, Deadline deadline) throws IOException {
+    while (buffer.byteCount < byteCount) {
+      if (source.read(buffer, Segment.SIZE, deadline) == -1) throw new EOFException();
+    }
+  }
+
+  /** Returns the next index of {@code b}, reading data into the buffer as necessary. */
+  private long seek(byte b, Deadline deadline) throws IOException {
+    long start = 0;
+    long index;
+    while ((index = buffer.indexOf(b, start)) == -1) {
+      start = buffer.byteCount;
+      if (source.read(buffer, Segment.SIZE, deadline) == -1) throw new EOFException();
+    }
+    return index;
+  }
+
+  private void checkEqual(String name, int expected, int actual) throws IOException {
+    if (actual != expected) {
+      throw new IOException(String.format(
+          "%s: actual %#08x != expected %#08x", name, actual, expected));
+    }
+  }
+}

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/InflaterSource.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/InflaterSource.java
@@ -24,7 +24,8 @@ import java.util.zip.Inflater;
 public final class InflaterSource implements Source {
   private final Source source;
   private final Inflater inflater;
-  private final OkBuffer buffer = new OkBuffer();
+  /** This holds bytes read from the source, but not yet inflated. */
+  private final OkBuffer buffer;
 
   /**
    * When we call Inflater.setInput(), the inflater keeps our byte array until
@@ -35,10 +36,15 @@ public final class InflaterSource implements Source {
   private boolean closed;
 
   public InflaterSource(Source source, Inflater inflater) {
+    this(source, inflater, new OkBuffer());
+  }
+
+  InflaterSource(Source source, Inflater inflater, OkBuffer buffer) {
     if (source == null) throw new IllegalArgumentException("source == null");
     if (inflater == null) throw new IllegalArgumentException("inflater == null");
     this.source = source;
     this.inflater = inflater;
+    this.buffer = buffer;
   }
 
   @Override public long read(
@@ -50,16 +56,8 @@ public final class InflaterSource implements Source {
     while (true) {
       boolean sourceExhausted = false;
       if (inflater.needsInput()) {
-        // Release buffer bytes from the inflater.
-        if (bufferBytesHeldByInflater > 0) {
-          Segment head = buffer.head;
-          head.pos += bufferBytesHeldByInflater;
-          buffer.byteCount -= bufferBytesHeldByInflater;
-          if (head.pos == head.limit) {
-            buffer.head = head.pop();
-            SegmentPool.INSTANCE.recycle(head);
-          }
-        }
+        releaseInflatedBytes();
+        if (inflater.getRemaining() != 0) throw new IllegalStateException("?"); // TODO: possible?
 
         // Refill the buffer with compressed data from the source.
         if (buffer.byteCount == 0) {
@@ -83,7 +81,10 @@ public final class InflaterSource implements Source {
           sink.byteCount += bytesInflated;
           return bytesInflated;
         }
-        if (inflater.finished() || inflater.needsDictionary()) return -1;
+        if (inflater.finished() || inflater.needsDictionary()) {
+          releaseInflatedBytes();
+          return -1;
+        }
         if (sourceExhausted) throw new EOFException("source exhausted prematurely");
       } catch (DataFormatException e) {
         throw new IOException(e);
@@ -91,9 +92,18 @@ public final class InflaterSource implements Source {
     }
   }
 
+  /** When the inflater has processed compressed data, remove it from the buffer. */
+  private void releaseInflatedBytes() {
+    if (bufferBytesHeldByInflater == 0) return;
+    int toRelease = bufferBytesHeldByInflater - inflater.getRemaining();
+    bufferBytesHeldByInflater -= toRelease;
+    buffer.skip(toRelease);
+  }
+
   @Override public void close(Deadline deadline) throws IOException {
     if (closed) return;
     inflater.end();
+    buffer.clear();
     closed = true;
     source.close(deadline);
   }

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/OkBuffer.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/OkBuffer.java
@@ -53,7 +53,7 @@ public final class OkBuffer implements Source, Sink {
     return byteCount;
   }
 
-  /** Reads a byte from the front of this buffer and returns it. */
+  /** Removes a byte from the front of this buffer and returns it. */
   public byte readByte() {
     if (byteCount < 1) throw new IllegalArgumentException("byteCount < 1: " + byteCount);
 
@@ -75,7 +75,17 @@ public final class OkBuffer implements Source, Sink {
     return b;
   }
 
-  /** Reads a Big-Endian short from the front of this buffer and returns it. */
+  /** Returns the byte at {@code i}. */
+  public byte byteAt(long i) {
+    checkOffsetAndCount(byteCount, i, 1);
+    for (Segment s = head; true; s = s.next) {
+      int segmentByteCount = s.limit - s.pos;
+      if (i < segmentByteCount) return s.data[s.pos + (int) i];
+      i -= segmentByteCount;
+    }
+  }
+
+  /** Removes a Big-Endian short from the front of this buffer and returns it. */
   public short readShort() {
     if (byteCount < 2) throw new IllegalArgumentException("byteCount < 2: " + byteCount);
 
@@ -105,7 +115,7 @@ public final class OkBuffer implements Source, Sink {
     return (short) s;
   }
 
-  /** Reads a Big-Endian int from the front of this buffer and returns it. */
+  /** Removes a Big-Endian int from the front of this buffer and returns it. */
   public int readInt() {
     if (byteCount < 4) throw new IllegalArgumentException("byteCount < 4: " + byteCount);
 
@@ -136,6 +146,16 @@ public final class OkBuffer implements Source, Sink {
     }
 
     return i;
+  }
+
+  /** Removes a Little-Endian short from the front of this buffer and returns it. */
+  public int readShortLe() {
+    return Util.reverseBytesShort(readShort());
+  }
+
+  /** Removes a Little-Endian int from the front of this buffer and returns it. */
+  public int readIntLe() {
+    return Util.reverseBytesInt(readInt());
   }
 
   /** Removes {@code byteCount} bytes from this and returns them as a byte string. */
@@ -172,6 +192,32 @@ public final class OkBuffer implements Source, Sink {
     return result;
   }
 
+  /**
+   * Discards all bytes in this buffer. Calling this method when you're done
+   * with a buffer will return its segments to the pool.
+   */
+  public void clear() {
+    skip(byteCount);
+  }
+
+  /** Discards {@code byteCount} bytes from the head of this buffer. */
+  public void skip(long byteCount) {
+    checkOffsetAndCount(this.byteCount, 0, byteCount);
+
+    this.byteCount -= byteCount;
+    while (byteCount > 0) {
+      int toSkip = (int) Math.min(byteCount, head.limit - head.pos);
+      byteCount -= toSkip;
+      head.pos += toSkip;
+
+      if (head.pos == head.limit) {
+        Segment toRecycle = head;
+        head = toRecycle.pop();
+        SegmentPool.INSTANCE.recycle(toRecycle);
+      }
+    }
+  }
+
   /** Appends {@code byteString} to this. */
   public void write(ByteString byteString) {
     write(byteString.data, 0, byteString.data.length);
@@ -195,7 +241,7 @@ public final class OkBuffer implements Source, Sink {
       tail.limit += toCopy;
     }
 
-    this.byteCount += data.length;
+    this.byteCount += byteCount;
   }
 
   /** Appends a Big-Endian byte to the end of this buffer. */
@@ -309,7 +355,7 @@ public final class OkBuffer implements Source, Sink {
       // Is a prefix of the source's head segment all that we need to move?
       if (byteCount < (source.head.limit - source.head.pos)) {
         Segment tail = head.prev;
-        if (head == null || byteCount + (tail.limit - tail.pos) > Segment.SIZE) {
+        if (byteCount + (tail.limit - tail.pos) > Segment.SIZE) {
           // We're going to need another segment. Split the source's head
           // segment in two, then move the first of those two to this buffer.
           source.head = source.head.split((int) byteCount);
@@ -352,15 +398,29 @@ public final class OkBuffer implements Source, Sink {
    * contain {@code b}.
    */
   public long indexOf(byte b) throws IOException {
+    return indexOf(b, 0);
+  }
+
+  /**
+   * Returns the index of {@code b} in this at or beyond {@code fromIndex}, or
+   * -1 if this buffer does not contain {@code b} in that range.
+   */
+  public long indexOf(byte b, long fromIndex) throws IOException {
     Segment s = head;
     if (s == null) return -1L;
     long offset = 0L;
     do {
-      byte[] data = s.data;
-      for (int pos = s.pos, limit = s.limit; pos < limit; pos++) {
-        if (data[pos] == b) return offset + pos - s.pos;
+      int segmentByteCount = s.limit - s.pos;
+      if (fromIndex > segmentByteCount) {
+        fromIndex -= segmentByteCount;
+      } else {
+        byte[] data = s.data;
+        for (long pos = s.pos + fromIndex, limit = s.limit; pos < limit; pos++) {
+          if (data[(int) pos] == b) return offset + pos - s.pos;
+        }
+        fromIndex = 0;
       }
-      offset += s.limit - s.pos;
+      offset += segmentByteCount;
       s = s.next;
     } while (s != head);
     return -1L;

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/GzipSourceTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/GzipSourceTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.bytes;
+
+import com.squareup.okhttp.internal.Util;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.zip.CRC32;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class GzipSourceTest {
+
+  @Test public void gunzip() throws Exception {
+    OkBuffer gzipped = new OkBuffer();
+    gzipped.write(gzipHeader, 0, gzipHeader.length);
+    gzipped.write(deflated, 0, deflated.length);
+    gzipped.write(gzipTrailer, 0, gzipTrailer.length);
+    assertGzipped(gzipped);
+  }
+
+  @Test public void gunzip_withHCRC() throws Exception {
+    CRC32 hcrc = new CRC32();
+    hcrc.update(gzipHeaderWithFlags((byte) 0x02));
+
+    OkBuffer gzipped = new OkBuffer();
+    gzipped.write(gzipHeaderWithFlags((byte) 0x02), 0, gzipHeader.length);
+    gzipped.writeShort(Util.reverseBytesShort((short) hcrc.getValue())); // little endian
+    gzipped.write(deflated, 0, deflated.length);
+    gzipped.write(gzipTrailer, 0, gzipTrailer.length);
+    assertGzipped(gzipped);
+  }
+
+  @Test public void gunzip_withExtra() throws Exception {
+    OkBuffer gzipped = new OkBuffer();
+    gzipped.write(gzipHeaderWithFlags((byte) 0x04), 0, gzipHeader.length);
+    gzipped.writeShort(Util.reverseBytesShort((short) 7)); // little endian extra length
+    gzipped.write("blubber".getBytes(Util.US_ASCII), 0, 7);
+    gzipped.write(deflated, 0, deflated.length);
+    gzipped.write(gzipTrailer, 0, gzipTrailer.length);
+    assertGzipped(gzipped);
+  }
+
+  @Test public void gunzip_withName() throws Exception {
+    OkBuffer gzipped = new OkBuffer();
+    gzipped.write(gzipHeaderWithFlags((byte) 0x08), 0, gzipHeader.length);
+    gzipped.write("foo.txt".getBytes(Util.US_ASCII), 0, 7);
+    gzipped.writeByte(0); // zero-terminated
+    gzipped.write(deflated, 0, deflated.length);
+    gzipped.write(gzipTrailer, 0, gzipTrailer.length);
+    assertGzipped(gzipped);
+  }
+
+  @Test public void gunzip_withComment() throws Exception {
+    OkBuffer gzipped = new OkBuffer();
+    gzipped.write(gzipHeaderWithFlags((byte) 0x10), 0, gzipHeader.length);
+    gzipped.write("rubbish".getBytes(Util.US_ASCII), 0, 7);
+    gzipped.writeByte(0); // zero-terminated
+    gzipped.write(deflated, 0, deflated.length);
+    gzipped.write(gzipTrailer, 0, gzipTrailer.length);
+    assertGzipped(gzipped);
+  }
+
+  /**
+   * For portability, it is a good idea to export the gzipped bytes and try running gzip.  Ex.
+   * {@code echo gzipped | base64 --decode | gzip -l -v}
+   */
+  @Test public void gunzip_withAll() throws Exception {
+    OkBuffer gzipped = new OkBuffer();
+    gzipped.write(gzipHeaderWithFlags((byte) 0x1c), 0, gzipHeader.length);
+    gzipped.writeShort(Util.reverseBytesShort((short) 7)); // little endian extra length
+    gzipped.write("blubber".getBytes(Util.US_ASCII), 0, 7);
+    gzipped.write("foo.txt".getBytes(Util.US_ASCII), 0, 7);
+    gzipped.writeByte(0); // zero-terminated
+    gzipped.write("rubbish".getBytes(Util.US_ASCII), 0, 7);
+    gzipped.writeByte(0); // zero-terminated
+    gzipped.write(deflated, 0, deflated.length);
+    gzipped.write(gzipTrailer, 0, gzipTrailer.length);
+    assertGzipped(gzipped);
+  }
+
+  private void assertGzipped(OkBuffer gzipped) throws IOException {
+    OkBuffer gunzipped = gunzip(gzipped);
+    assertEquals("It's a UNIX system! I know this!",
+        gunzipped.readUtf8((int) gunzipped.byteCount()));
+  }
+
+  /**
+   * Note that you cannot test this with old versions of gzip, as they interpret flag bit 1 as
+   * CONTINUATION, not HCRC. For example, this is the case with the default gzip on osx.
+   */
+  @Test public void gunzipWhenHeaderCRCIncorrect() throws Exception {
+    OkBuffer gzipped = new OkBuffer();
+    gzipped.write(gzipHeaderWithFlags((byte) 0x02), 0, gzipHeader.length);
+    gzipped.writeShort((short) 0); // wrong HCRC!
+    gzipped.write(deflated, 0, deflated.length);
+    gzipped.write(gzipTrailer, 0, gzipTrailer.length);
+
+    try {
+      gunzip(gzipped);
+      fail();
+    } catch (IOException e) {
+      assertEquals("FHCRC: actual 0x00261d != expected 0x000000", e.getMessage());
+    }
+  }
+
+  @Test public void gunzipWhenCRCIncorrect() throws Exception {
+    OkBuffer gzipped = new OkBuffer();
+    gzipped.write(gzipHeader, 0, gzipHeader.length);
+    gzipped.write(deflated, 0, deflated.length);
+    gzipped.writeInt(Util.reverseBytesInt(0x1234567)); // wrong CRC
+    gzipped.write(gzipTrailer, 3, 4);
+
+    try {
+      gunzip(gzipped);
+      fail();
+    } catch (IOException e) {
+      assertEquals("CRC: actual 0x37ad8f8d != expected 0x1234567", e.getMessage());
+    }
+  }
+
+  @Test public void gunzipWhenLengthIncorrect() throws Exception {
+    OkBuffer gzipped = new OkBuffer();
+    gzipped.write(gzipHeader, 0, gzipHeader.length);
+    gzipped.write(deflated, 0, deflated.length);
+    gzipped.write(gzipTrailer, 0, 4);
+    gzipped.writeInt(Util.reverseBytesInt(0x123456)); // wrong length
+
+    try {
+      gunzip(gzipped);
+      fail();
+    } catch (IOException e) {
+      assertEquals("ISIZE: actual 0x000020 != expected 0x123456", e.getMessage());
+    }
+  }
+
+  private byte[] gzipHeaderWithFlags(byte flags) {
+    byte[] result = Arrays.copyOf(gzipHeader, gzipHeader.length);
+    result[3] = flags;
+    return result;
+  }
+
+  private final byte[] gzipHeader = new byte[] {
+      (byte) 0x1f, (byte) 0x8b, (byte) 0x08, 0, 0, 0, 0, 0, 0, 0
+  };
+
+  // deflated "It's a UNIX system! I know this!"
+  private final byte[] deflated = new byte[] {
+      (byte) 0xf3, (byte) 0x2c, (byte) 0x51, (byte) 0x2f, (byte) 0x56, (byte) 0x48, (byte) 0x54,
+      (byte) 0x08, (byte) 0xf5, (byte) 0xf3, (byte) 0x8c, (byte) 0x50, (byte) 0x28, (byte) 0xae,
+      (byte) 0x2c, (byte) 0x2e, (byte) 0x49, (byte) 0xcd, (byte) 0x55, (byte) 0x54, (byte) 0xf0,
+      (byte) 0x54, (byte) 0xc8, (byte) 0xce, (byte) 0xcb, (byte) 0x2f, (byte) 0x57, (byte) 0x28,
+      (byte) 0xc9, (byte) 0xc8, (byte) 0x2c, (byte) 0x56, (byte) 0x04, (byte) 0x00
+  };
+
+  private final byte[] gzipTrailer = new byte[] {
+      (byte) 0x8d, (byte) 0x8f, (byte) 0xad, (byte) 0x37, // checksum of deflated
+      0x20, 0, 0, 0, // 32 in little endian
+  };
+
+  private OkBuffer gunzip(OkBuffer gzipped) throws IOException {
+    OkBuffer result = new OkBuffer();
+    GzipSource source = new GzipSource(gzipped);
+    while (source.read(result, Integer.MAX_VALUE, Deadline.NONE) != -1) {
+    }
+    return result;
+  }
+}

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/InflaterSourceTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/InflaterSourceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.okhttp.internal.bytes;
 
 import com.squareup.okhttp.internal.Base64;


### PR DESCRIPTION
Needs tests in a follow up. In particular for the new
methods on OkBuffer (peekByte, skip, indexOf) and for
all of the weird header cases on gzip data (headers
that include names, comments, extra fields, header
CRCs), plus failing cases for header CRC, CRC and
ISIZE.
