### PR TITLE
Fix for NPE when the OpenSSLSocketImpl returns null from getNpnSelectedProtocol

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -293,7 +293,9 @@ public class Platform {
           byte[] alpnResult = (byte[]) getAlpnSelectedProtocol.invoke(socket);
           if (alpnResult != null) return ByteString.of(alpnResult);
         }
-        return ByteString.of((byte[]) getNpnSelectedProtocol.invoke(socket));
+        byte[] npnResult = (byte[]) getNpnSelectedProtocol.invoke(socket);
+        if (npnResult == null) return null;
+        return ByteString.of(npnResult);
       } catch (InvocationTargetException e) {
         throw new RuntimeException(e);
       } catch (IllegalAccessException e) {


### PR DESCRIPTION
I [detailed this issue here](https://gist.github.com/adamsp/7ffd33906abf9b1a5df3) when trying to track down a different issue (which I'm working through with Jesse [on StackOverflow](http://stackoverflow.com/questions/20306498/unable-to-close-chunkedinputstream-quickly-on-android-4-4-kitkat)).
