### PR TITLE
Rename byteAt to getByte.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/GzipSource.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/GzipSource.java
@@ -109,7 +109,7 @@ public final class GzipSource implements Source {
     // |ID1|ID2|CM |FLG|     MTIME     |XFL|OS | (more-->)
     // +---+---+---+---+---+---+---+---+---+---+
     require(10, deadline);
-    byte flags = buffer.byteAt(3);
+    byte flags = buffer.getByte(3);
     boolean fhcrc = ((flags >> FHCRC) & 1) == 1;
     if (fhcrc) updateCrc(buffer, 0, 10);
 

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/OkBuffer.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/OkBuffer.java
@@ -76,7 +76,7 @@ public final class OkBuffer implements Source, Sink {
   }
 
   /** Returns the byte at {@code i}. */
-  public byte byteAt(long i) {
+  public byte getByte(long i) {
     checkOffsetAndCount(byteCount, i, 1);
     for (Segment s = head; true; s = s.next) {
       int segmentByteCount = s.limit - s.pos;

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/OkBufferTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/OkBufferTest.java
@@ -516,17 +516,17 @@ public final class OkBufferTest {
     buffer.writeUtf8("a");
     buffer.writeUtf8(repeat('b', Segment.SIZE));
     buffer.writeUtf8("c");
-    assertEquals('a', buffer.byteAt(0));
-    assertEquals('a', buffer.byteAt(0)); // Peek doesn't mutate!
-    assertEquals('c', buffer.byteAt(buffer.byteCount - 1));
-    assertEquals('b', buffer.byteAt(buffer.byteCount - 2));
-    assertEquals('b', buffer.byteAt(buffer.byteCount - 3));
+    assertEquals('a', buffer.getByte(0));
+    assertEquals('a', buffer.getByte(0)); // getByte doesn't mutate!
+    assertEquals('c', buffer.getByte(buffer.byteCount - 1));
+    assertEquals('b', buffer.getByte(buffer.byteCount - 2));
+    assertEquals('b', buffer.getByte(buffer.byteCount - 3));
   }
 
-  @Test public void byteAtOfEmptyBuffer() throws Exception {
+  @Test public void getByteOfEmptyBuffer() throws Exception {
     OkBuffer buffer = new OkBuffer();
     try {
-      buffer.byteAt(0);
+      buffer.getByte(0);
       fail();
     } catch (IndexOutOfBoundsException expected) {
     }


### PR DESCRIPTION
Should we later support random access for other primitives
or random bulk access, I'd like the prefix to stay constant
(getByte, getInt, getLong, getBytes) vs. the suffix (byteAt,
intAt, longAt). Prefixing may work better for autocomplete
in IDEs, particularly since we already use a prefix for our
consuming reads (readByte, readInt, readLong).
