### PR TITLE
Fix some OkBuffer bugs.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/GzipSource.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/GzipSource.java
@@ -135,7 +135,7 @@ public final class GzipSource implements Source {
     // |...original file name, zero-terminated...| (more-->)
     // +=========================================+
     if (((flags >> FNAME) & 1) == 1) {
-      long index = seek((byte) 0, deadline);
+      long index = OkBuffers.seek(buffer, (byte) 0, source, deadline);
       if (fhcrc) updateCrc(buffer, 0, index + 1);
       buffer.skip(index + 1);
     }
@@ -145,7 +145,7 @@ public final class GzipSource implements Source {
     // |...file comment, zero-terminated...| (more-->)
     // +===================================+
     if (((flags >> FCOMMENT) & 1) == 1) {
-      long index = seek((byte) 0, deadline);
+      long index = OkBuffers.seek(buffer, (byte) 0, source, deadline);
       if (fhcrc) updateCrc(buffer, 0, index + 1);
       buffer.skip(index + 1);
     }
@@ -194,21 +194,10 @@ public final class GzipSource implements Source {
     }
   }
 
-  /** Returns the next index of {@code b}, reading data into the buffer as necessary. */
-  private long seek(byte b, Deadline deadline) throws IOException {
-    long start = 0;
-    long index;
-    while ((index = buffer.indexOf(b, start)) == -1) {
-      start = buffer.byteCount;
-      if (source.read(buffer, Segment.SIZE, deadline) == -1) throw new EOFException();
-    }
-    return index;
-  }
-
   private void checkEqual(String name, int expected, int actual) throws IOException {
     if (actual != expected) {
       throw new IOException(String.format(
-          "%s: actual %#08x != expected %#08x", name, actual, expected));
+          "%s: actual 0x%08x != expected 0x%08x", name, actual, expected));
     }
   }
 }

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/GzipSourceTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/GzipSourceTest.java
@@ -115,7 +115,7 @@ public class GzipSourceTest {
       gunzip(gzipped);
       fail();
     } catch (IOException e) {
-      assertEquals("FHCRC: actual 0x00261d != expected 0x000000", e.getMessage());
+      assertEquals("FHCRC: actual 0x0000261d != expected 0x00000000", e.getMessage());
     }
   }
 
@@ -130,7 +130,7 @@ public class GzipSourceTest {
       gunzip(gzipped);
       fail();
     } catch (IOException e) {
-      assertEquals("CRC: actual 0x37ad8f8d != expected 0x1234567", e.getMessage());
+      assertEquals("CRC: actual 0x37ad8f8d != expected 0x01234567", e.getMessage());
     }
   }
 
@@ -145,7 +145,7 @@ public class GzipSourceTest {
       gunzip(gzipped);
       fail();
     } catch (IOException e) {
-      assertEquals("ISIZE: actual 0x000020 != expected 0x123456", e.getMessage());
+      assertEquals("ISIZE: actual 0x00000020 != expected 0x00123456", e.getMessage());
     }
   }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/OkBufferTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/OkBufferTest.java
@@ -47,6 +47,19 @@ public final class OkBufferTest {
     }
   }
 
+  @Test public void readUtf8SpansSegments() throws Exception {
+    OkBuffer buffer = new OkBuffer();
+    buffer.writeUtf8(repeat('a', Segment.SIZE * 2));
+    buffer.readUtf8(Segment.SIZE - 1);
+    assertEquals("aa", buffer.readUtf8(2));
+  }
+
+  @Test public void readUtf8EntireBuffer() throws Exception {
+    OkBuffer buffer = new OkBuffer();
+    buffer.writeUtf8(repeat('a', Segment.SIZE));
+    assertEquals(repeat('a', Segment.SIZE), buffer.readUtf8(Segment.SIZE));
+  }
+
   @Test public void bufferToString() throws Exception {
     OkBuffer buffer = new OkBuffer();
     buffer.writeUtf8("\u0000\u0001\u0002\u007f");
@@ -465,8 +478,8 @@ public final class OkBufferTest {
   @Test public void readByte() throws Exception {
     OkBuffer data = new OkBuffer();
     data.write(new ByteString(new byte[] { (byte) 0xab, (byte) 0xcd }));
-    assertEquals((byte) 0xab, data.readByte());
-    assertEquals((byte) 0xcd, data.readByte());
+    assertEquals(0xab, data.readByte() & 0xff);
+    assertEquals(0xcd, data.readByte() & 0xff);
     assertEquals(0, data.byteCount());
   }
 
@@ -538,11 +551,19 @@ public final class OkBufferTest {
     buffer.writeUtf8(repeat('b', Segment.SIZE));
     buffer.writeUtf8("c");
     buffer.skip(1);
-    assertEquals('b', buffer.readByte());
+    assertEquals('b', buffer.readByte() & 0xff);
     buffer.skip(Segment.SIZE - 2);
-    assertEquals('b', buffer.readByte());
+    assertEquals('b', buffer.readByte() & 0xff);
     buffer.skip(1);
     assertEquals(0, buffer.byteCount());
+  }
+
+  @Test public void testWritePrefixToEmptyBuffer() {
+    OkBuffer sink = new OkBuffer();
+    OkBuffer source = new OkBuffer();
+    source.writeUtf8("abcd");
+    sink.write(source, 2, Deadline.NONE);
+    assertEquals("ab", sink.readUtf8(2));
   }
 
   private String repeat(char c, int count) {


### PR DESCRIPTION
GzipSource exceptions used six hex digits instead of
8 to print ints.

readUtf8 always did an extra copy of the bytes being
read.

Moving bytes between buffers crashed when the destination
was empty and the source was a prefix.

InputStream reading returned values in -128..127 instead
of in 0..255.
