### PR TITLE
Add -X to okcurl, permitting HEAD requests

### DIFF
--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -59,6 +59,10 @@ public class Main extends HelpOption implements Runnable, Response.Receiver {
         }));
   }
 
+  @Option(name = { "-X", "--request" }, description = "Specify request command to use",
+      allowedValues = { "GET", "HEAD" })
+  public String method = "GET";
+
   @Option(name = { "-H", "--header" }, description = "Custom header to pass to server")
   public List<String> headers;
 
@@ -130,6 +134,7 @@ public class Main extends HelpOption implements Runnable, Response.Receiver {
 
   private Request getConfiguredRequest() {
     Request.Builder request = new Request.Builder();
+    request.method(method, null);
     request.url(url);
     if (headers != null) {
       for (String header : headers) {


### PR DESCRIPTION
Handy for testing spdy (https://google.ca) and http/2 (https://twitter.com)

Ex.

``` bash
~/Development/okhttp/okcurl adrian.curl-X ./target/okcurl-2.0.0-SNAPSHOT-jar-with-dependencies.jar -X HEAD -i https://twitter.com
HTTP/1.1 200
OkHttp-Selected-Transport: HTTP-draft-09/2.0
OkHttp-Selected-Protocol: HTTP-draft-09/2.0
cache-control: no-cache, no-store, must-revalidate, pre-check=0, post-check=0
content-length: 51304
content-type: text/html;charset=utf-8
date: Tue, 11 Feb 2014 16:59:06 GMT
expires: Tue, 31 Mar 1981 05:00:00 GMT
last-modified: Tue, 11 Feb 2014 16:59:06 GMT
ms: S
pragma: no-cache
server: tfe
set-cookie: REDACTED
status: 200 OK
strict-transport-security: max-age=631138519
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-transaction: 81bc971b3d29aa7f
x-ua-compatible: IE=10,chrome=1
x-xss-protection: 1; mode=block
OkHttp-Sent-Millis: 1392137948438
OkHttp-Received-Millis: 1392137948528
OkHttp-Response-Source: NETWORK 200
```

cc @JakeWharton @jpinner
