### PR TITLE
Move connection pooling logic.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/ConnectionPool.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ConnectionPool.java
@@ -244,12 +244,9 @@ public class ConnectionPool {
    * Shares the SPDY connection with the pool. Callers to this method may
    * continue to use {@code connection}.
    */
-  public void maybeShare(Connection connection) {
+  public void share(Connection connection) {
+    if (!connection.isSpdy()) throw new IllegalArgumentException();
     executorService.execute(connectionsCleanupRunnable);
-    if (!connection.isSpdy()) {
-      // Only SPDY connections are sharable.
-      return;
-    }
     if (connection.isAlive()) {
       synchronized (this) {
         connections.addFirst(connection);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
@@ -117,7 +117,7 @@ public final class RouteSelector {
           if (!hasNextPostponed()) {
             throw new NoSuchElementException();
           }
-          return new Connection(nextPostponed());
+          return new Connection(pool, nextPostponed());
         }
         lastProxy = nextProxy();
         resetNextInetSocketAddress(lastProxy);
@@ -135,7 +135,7 @@ public final class RouteSelector {
       return next(method);
     }
 
-    return new Connection(route);
+    return new Connection(pool, route);
   }
 
   /**

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
@@ -65,12 +65,20 @@ interface Transport {
   Response.Builder readResponseHeaders() throws IOException;
 
   /** Notify the transport that no response body will be read. */
-  void emptyTransferStream();
+  void emptyTransferStream() throws IOException;
 
   // TODO: make this the content stream?
   InputStream getTransferStream(CacheRequest cacheRequest) throws IOException;
 
-  /** Returns true if the underlying connection can be recycled. */
-  boolean makeReusable(boolean streamCanceled, OutputStream requestBodyOut,
-      InputStream responseBodyIn);
+  /**
+   * Configures the response body to pool or close the socket connection when
+   * the response body is closed.
+   */
+  void releaseConnectionOnIdle() throws IOException;
+
+  /**
+   * Returns true if the socket connection held by this transport can be reused
+   * for a follow-up exchange.
+   */
+  boolean canReuseConnection();
 }


### PR DESCRIPTION
Previously we had this ugly, awkward release() method that
attempted to manage connection pooling, discarding streams
for caching, and closing broken streams.

Move connection reuse to HttpConnection, with policy informed
by HttpEngine. It specifies what to do when the connection
becomes idle: pool, close or hold. The connection does what
it's told.
