### PR TITLE
Give Base64 lots of love.

### DIFF
--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/ByteString.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/bytes/ByteString.java
@@ -64,6 +64,24 @@ public final class ByteString {
   }
 
   /**
+   * Returns this byte string encoded as <a
+   * href="http://www.ietf.org/rfc/rfc2045.txt">Base64</a>. In violation of the
+   * RFC, the returned string does not wrap lines at 76 columns.
+   */
+  public String base64() {
+    return Base64.encode(data);
+  }
+
+  /**
+   * Decodes the Base64-encoded bytes and returns their value as a byte string.
+   * Returns null if {@code base64} is not a Base64-encoded sequence of bytes.
+   */
+  public static ByteString decodeBase64(String base64) {
+    byte[] decoded = Base64.decode(base64);
+    return decoded != null ? new ByteString(decoded) : null;
+  }
+
+  /**
    * Returns true when {@code ascii} is not null and equals the bytes wrapped
    * by this byte string.
    */

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/InflaterSourceTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/bytes/InflaterSourceTest.java
@@ -15,8 +15,6 @@
  */
 package com.squareup.okhttp.internal.bytes;
 
-import com.squareup.okhttp.internal.Base64;
-import com.squareup.okhttp.internal.Util;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.Arrays;
@@ -78,8 +76,7 @@ public class InflaterSourceTest {
 
   private OkBuffer decodeBase64(String s) {
     OkBuffer result = new OkBuffer();
-    byte[] data = Base64.decode(s.getBytes(Util.UTF_8));
-    result.write(data, 0, data.length);
+    result.write(ByteString.decodeBase64(s));
     return result;
   }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
@@ -15,8 +15,8 @@
  */
 package com.squareup.okhttp.internal.spdy;
 
-import com.squareup.okhttp.internal.Base64;
 import com.squareup.okhttp.internal.Util;
+import com.squareup.okhttp.internal.bytes.ByteString;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1393,7 +1393,7 @@ public final class SpdyConnectionTest {
   private void headerBlockHasTrailingCompressedBytes(String frame, int length) throws IOException {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
-    peer.sendFrame(Base64.decode(frame.getBytes(UTF_8)));
+    peer.sendFrame(ByteString.decodeBase64(frame).toByteArray());
     peer.sendFrame().data(true, 1, "robot".getBytes("UTF-8"));
     peer.acceptFrame(); // DATA
     peer.play();

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -16,10 +16,10 @@
 
 package com.squareup.okhttp;
 
-import com.squareup.okhttp.internal.Base64;
 import com.squareup.okhttp.internal.DiskLruCache;
 import com.squareup.okhttp.internal.StrictLineReader;
 import com.squareup.okhttp.internal.Util;
+import com.squareup.okhttp.internal.bytes.ByteString;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -495,7 +495,7 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
         List<Certificate> result = new ArrayList<Certificate>(length);
         for (int i = 0; i < length; i++) {
           String line = reader.readLine();
-          byte[] bytes = Base64.decode(line.getBytes("US-ASCII"));
+          byte[] bytes = ByteString.decodeBase64(line).toByteArray();
           result.add(certificateFactory.generateCertificate(new ByteArrayInputStream(bytes)));
         }
         return result;
@@ -509,7 +509,7 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
         writer.write(Integer.toString(certificates.size()) + '\n');
         for (int i = 0, size = certificates.size(); i < size; i++) {
           byte[] bytes = certificates.get(i).getEncoded();
-          String line = Base64.encode(bytes);
+          String line = ByteString.of(bytes).base64();
           writer.write(line + '\n');
         }
       } catch (CertificateEncodingException e) {

--- a/okhttp/src/main/java/com/squareup/okhttp/OkAuthenticator.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkAuthenticator.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.okhttp;
 
-import com.squareup.okhttp.internal.Base64;
+import com.squareup.okhttp.internal.bytes.ByteString;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.Proxy;
@@ -97,7 +97,7 @@ public interface OkAuthenticator {
       try {
         String usernameAndPassword = userName + ":" + password;
         byte[] bytes = usernameAndPassword.getBytes("ISO-8859-1");
-        String encoded = Base64.encode(bytes);
+        String encoded = ByteString.of(bytes).base64();
         return new Credential("Basic " + encoded);
       } catch (UnsupportedEncodingException e) {
         throw new AssertionError();


### PR DESCRIPTION
Fix some bugs, such as decoding of input that contains lots
of padding or whitespace. See
https://code.google.com/p/android/issues/detail?id=66078

Improve performance by correctly guessing the output array
size whenever the input doesn't contain whitespace.

Build Base64 into ByteString, and expose it through there
only.

Use more reasonable names in the implementation.
