### PR TITLE
When a SPDY client, do not flow-control the server

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -18,6 +18,12 @@
       <artifactId>caliper</artifactId>
       <version>1.0-beta-1</version>
     </dependency>
+    <!-- caliper needs to be updated to be compatible with guava 16 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>14.0.1</version>
+    </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp</artifactId>

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -127,6 +127,15 @@ public final class SpdyConnection implements Closeable {
     handler = builder.handler;
     nextStreamId = builder.client ? 1 : 2;
     nextPingId = builder.client ? 1 : 2;
+
+    // Flow control was designed more for servers, or proxies than edge clients.
+    // If we are a client, set the flow control window to 16MiB.  This avoids
+    // thrashing window updates every 64KiB, yet small enough to avoid blowing
+    // up the heap.
+    if (builder.client) {
+      okHttpSettings.set(Settings.INITIAL_WINDOW_SIZE, 0, 16 * 1024 * 1024);
+    }
+
     hostName = builder.hostName;
 
     Variant variant;


### PR DESCRIPTION
When speaking to @jpinner, I found out that only servers or intermediaries have a use case for small flow control windows.  This pull request (effectively) disables flow control when a client, by setting the window update size to max (2GB).

With this change, a sample caliper bench of spdy/3.1 on my laptop recovered 13 requests per second with concurrency set to 10 and body size 1048576.
