### PR TITLE
Add HTTP/2 PushObserver

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -729,7 +729,7 @@ public final class MockWebServer {
           if (headerParts.length != 2) {
             throw new AssertionError("Unexpected header: " + header);
           }
-          pushedHeaders.add(new Header(headerParts[0], headerParts[1]));
+          pushedHeaders.add(new Header(headerParts[0], headerParts[1].trim()));
         }
         String requestLine = pushPromise.getMethod() + ' ' + pushPromise.getPath() + " HTTP/1.1";
         List<Integer> chunkSizes = Collections.emptyList(); // No chunked encoding for SPDY.

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ExternalHttp2Example.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ExternalHttp2Example.java
@@ -30,7 +30,7 @@ import static com.squareup.okhttp.internal.http.OkHeaders.SELECTED_PROTOCOL;
 
 public final class ExternalHttp2Example {
   public static void main(String[] args) throws Exception {
-    URL url = new URL("https://twitter.com/");
+    URL url = new URL("https://http2.iijplus.jp/push/test1");
     HttpsURLConnection connection = (HttpsURLConnection) new OkHttpClient()
         .setProtocols(Protocol.HTTP2_AND_HTTP_11).open(url);
 
@@ -48,6 +48,7 @@ public final class ExternalHttp2Example {
     if (protocolValues != null && !protocolValues.isEmpty()) {
       System.out.println("PROTOCOL " + protocolValues.get(0));
     }
+
     BufferedReader reader =
         new BufferedReader(new InputStreamReader(connection.getInputStream(), "UTF-8"));
     String line;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/PushObserver.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/PushObserver.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.spdy;
+
+import java.io.IOException;
+import java.util.List;
+import okio.BufferedSource;
+
+/**
+ * {@link com.squareup.okhttp.Protocol#HTTP_2 HTTP/2} only.
+ * Processes server-initiated HTTP requestd on the client.
+ *
+ * <p>Use the stream ID to correlate response headers and data.
+ *
+ * <p>Return true to request cancellation of a pushed stream.  Note that this
+ * does not guarantee future frames won't arrive on the stream ID.
+ */
+public interface PushObserver {
+  /**
+   * Describes the request that the server intends to push a response for.
+   *
+   * @param streamId server-initiated stream ID: an even number.
+   * @param requestHeaders minimally includes {@code :method}, {@code :scheme},
+   * {@code :authority}, and (@code :path}.
+   */
+  boolean onRequest(int streamId, List<Header> requestHeaders);
+
+  /**
+   * The response headers corresponding to a pushed request.  When {@code last}
+   * is true, there are no data frames to follow.
+   *
+   * @param streamId server-initiated stream ID: an even number.
+   * @param responseHeaders minimally includes {@code :status}.
+   * @param last when true, there is no response data.
+   */
+  boolean onHeaders(int streamId, List<Header> responseHeaders, boolean last);
+
+  /**
+   * A chunk of response data corresponding to a pushed request.  This data
+   * must either be read or skipped.
+   *
+   * @param streamId server-initiated stream ID: an even number.
+   * @param source location of data corresponding with this stream ID.
+   * @param byteCount number of bytes to read or skip from the source.
+   * @param last when true, there are no data frames to follow.
+   */
+  boolean onData(int streamId, BufferedSource source, int byteCount, boolean last)
+      throws IOException;
+
+  /** Indicates the reason why this stream was cancelled. */
+  void onReset(int streamId, ErrorCode errorCode);
+
+  PushObserver CANCEL = new PushObserver() {
+
+    @Override public boolean onRequest(int streamId, List<Header> requestHeaders) {
+      return true;
+    }
+
+    @Override public boolean onHeaders(int streamId, List<Header> responseHeaders, boolean last) {
+      return true;
+    }
+
+    @Override public boolean onData(int streamId, BufferedSource source, int byteCount,
+        boolean last) throws IOException {
+      source.skip(byteCount);
+      return true;
+    }
+
+    @Override public void onReset(int streamId, ErrorCode errorCode) {
+    }
+  };
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -24,8 +24,10 @@ import java.io.InterruptedIOException;
 import java.net.Socket;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -83,6 +85,8 @@ public final class SpdyConnection implements Closeable {
 
   /** Lazily-created map of in-flight pings awaiting a response. Guarded by this. */
   private Map<Integer, Ping> pings;
+  /** User code to run in response to push promise events. */
+  private final PushObserver pushObserver;
   private int nextPingId;
 
   static final int INITIAL_WINDOW_SIZE = 65535;
@@ -123,6 +127,7 @@ public final class SpdyConnection implements Closeable {
 
   private SpdyConnection(Builder builder) {
     protocol = builder.protocol;
+    pushObserver = builder.pushObserver;
     client = builder.client;
     handler = builder.handler;
     nextStreamId = builder.client ? 1 : 2;
@@ -157,7 +162,7 @@ public final class SpdyConnection implements Closeable {
 
   /** The protocol as selected using NPN or ALPN. */
   public Protocol getProtocol() {
-     return protocol;
+    return protocol;
   }
 
   /**
@@ -208,6 +213,7 @@ public final class SpdyConnection implements Closeable {
   public SpdyStream pushStream(int associatedStreamId, List<Header> requestHeaders, boolean out)
       throws IOException {
     if (client) throw new IllegalStateException("Client cannot push requests.");
+    if (protocol != Protocol.HTTP_2) throw new IllegalStateException("protocol != HTTP_2");
     return newStream(associatedStreamId, requestHeaders, out, false);
   }
 
@@ -219,14 +225,13 @@ public final class SpdyConnection implements Closeable {
    * @param in true to create an input stream that the remote peer can use to send data to us.
    *     Corresponds to {@code FLAG_UNIDIRECTIONAL}.
    */
-  public SpdyStream newStream(List<Header> requestHeaders, boolean out,
-      boolean in) throws IOException {
+  public SpdyStream newStream(List<Header> requestHeaders, boolean out, boolean in)
+      throws IOException {
     return newStream(0, requestHeaders, out, in);
   }
 
   private SpdyStream newStream(int associatedStreamId, List<Header> requestHeaders, boolean out,
-      boolean in)
-      throws IOException {
+      boolean in) throws IOException {
     boolean outFinished = !out;
     boolean inFinished = !in;
     int priority = -1; // TODO: permit the caller to specify a priority?
@@ -250,7 +255,8 @@ public final class SpdyConnection implements Closeable {
       if (associatedStreamId == 0) {
         frameWriter.synStream(outFinished, inFinished, streamId, associatedStreamId, priority, slot,
             requestHeaders);
-      } else {
+      } else { // HTTP/2 has a PUSH_PROMISE frame.
+        if (client) throw new IOException("Client attempted to push stream: " + associatedStreamId);
         frameWriter.pushPromise(associatedStreamId, streamId, requestHeaders);
       }
     }
@@ -491,6 +497,7 @@ public final class SpdyConnection implements Closeable {
     private BufferedSink sink;
     private IncomingStreamHandler handler = IncomingStreamHandler.REFUSE_INCOMING_STREAMS;
     private Protocol protocol = Protocol.SPDY_3;
+    private PushObserver pushObserver = PushObserver.CANCEL;
     private boolean client;
 
     public Builder(boolean client, Socket socket) throws IOException {
@@ -516,6 +523,11 @@ public final class SpdyConnection implements Closeable {
 
     public Builder protocol(Protocol protocol) {
       this.protocol = protocol;
+      return this;
+    }
+
+    public Builder pushObserver(PushObserver pushObserver) {
+      this.pushObserver = pushObserver;
       return this;
     }
 
@@ -557,6 +569,10 @@ public final class SpdyConnection implements Closeable {
 
     @Override public void data(boolean inFinished, int streamId, BufferedSource source, int length)
         throws IOException {
+      if (pushedStream(streamId)) {
+        pushDataLater(streamId, source, length, inFinished);
+        return;
+      }
       SpdyStream dataStream = getStream(streamId);
       if (dataStream == null) {
         writeSynResetLater(streamId, ErrorCode.INVALID_STREAM);
@@ -570,8 +586,11 @@ public final class SpdyConnection implements Closeable {
     }
 
     @Override public void headers(boolean outFinished, boolean inFinished, int streamId,
-        int associatedStreamId, int priority, List<Header> headerBlock,
-        HeadersMode headersMode) {
+        int associatedStreamId, int priority, List<Header> headerBlock, HeadersMode headersMode) {
+      if (pushedStream(streamId)) {
+        pushHeadersLater(streamId, headerBlock, inFinished);
+        return;
+      }
       SpdyStream stream;
       synchronized (SpdyConnection.this) {
         // If we're shutdown, don't bother with this stream.
@@ -623,6 +642,10 @@ public final class SpdyConnection implements Closeable {
     }
 
     @Override public void rstStream(int streamId, ErrorCode errorCode) {
+      if (pushedStream(streamId)) {
+        pushResetLater(streamId, errorCode);
+        return;
+      }
       SpdyStream rstStream = removeStream(streamId);
       if (rstStream != null) {
         rstStream.receiveRstStream(errorCode);
@@ -730,21 +753,95 @@ public final class SpdyConnection implements Closeable {
     }
 
     @Override
-    public void pushPromise(int streamId, int promisedStreamId, List<Header> requestHeaders)
-        throws IOException {
-      // TODO: Wire up properly and only cancel when local settings disable push.
-      cancelStreamLater(promisedStreamId);
+    public void pushPromise(int streamId, int promisedStreamId, List<Header> requestHeaders) {
+      pushRequestLater(promisedStreamId, requestHeaders);
     }
+  }
 
-    private void cancelStreamLater(final int streamId) {
-      executor.submit(new NamedRunnable("OkHttp %s Cancelling Stream %s", hostName, streamId) {
-        @Override public void execute() {
-          try {
-            frameWriter.rstStream(streamId, ErrorCode.CANCEL);
-          } catch (IOException ignored) {
-          }
-        }
-      });
+  /** Even, positive numbered streams are pushed streams in HTTP/2. */
+  private boolean pushedStream(int streamId) {
+    return protocol == Protocol.HTTP_2 && streamId != 0 && (streamId & 1) == 0;
+  }
+
+  // Guarded by this.
+  private final Set<Integer> currentPushRequests = new LinkedHashSet<Integer>();
+
+  private void pushRequestLater(final int streamId, final List<Header> requestHeaders) {
+    synchronized (this) {
+      if (currentPushRequests.contains(streamId)) {
+        writeSynResetLater(streamId, ErrorCode.PROTOCOL_ERROR);
+        return;
+      }
+      currentPushRequests.add(streamId);
     }
+    executor.submit(new NamedRunnable("OkHttp %s Push Request[%s]", hostName, streamId) {
+      @Override public void execute() {
+        boolean cancel = pushObserver.onRequest(streamId, requestHeaders);
+        try {
+          if (cancel) {
+            frameWriter.rstStream(streamId, ErrorCode.CANCEL);
+            synchronized (SpdyConnection.this) {
+              currentPushRequests.remove(streamId);
+            }
+          }
+        } catch (IOException ignored) {
+        }
+      }
+    });
+  }
+
+  private void pushHeadersLater(final int streamId, final List<Header> requestHeaders,
+      final boolean inFinished) {
+    executor.submit(new NamedRunnable("OkHttp %s Push Headers[%s]", hostName, streamId) {
+      @Override public void execute() {
+        boolean cancel = pushObserver.onHeaders(streamId, requestHeaders, inFinished);
+        try {
+          if (cancel) frameWriter.rstStream(streamId, ErrorCode.CANCEL);
+          if (cancel || inFinished) {
+            synchronized (SpdyConnection.this) {
+              currentPushRequests.remove(streamId);
+            }
+          }
+        } catch (IOException ignored) {
+        }
+      }
+    });
+  }
+
+  /**
+   * Eagerly reads {@code byteCount} bytes from the source before launching a background task to
+   * process the data.  This avoids corrupting the stream.
+   */
+  private void pushDataLater(final int streamId, final BufferedSource source, final int byteCount,
+      final boolean inFinished) throws IOException {
+    final OkBuffer buffer = new OkBuffer();
+    source.require(byteCount); // Eagerly read the frame before firing client thread.
+    source.read(buffer, byteCount);
+    if (buffer.size() != byteCount) throw new IOException(buffer.size() + " != " + byteCount);
+    executor.submit(new NamedRunnable("OkHttp %s Push Data[%s]", hostName, streamId) {
+      @Override public void execute() {
+        try {
+          boolean cancel = pushObserver.onData(streamId, buffer, byteCount, inFinished);
+          if (cancel) frameWriter.rstStream(streamId, ErrorCode.CANCEL);
+          if (cancel || inFinished) {
+            synchronized (SpdyConnection.this) {
+              currentPushRequests.remove(streamId);
+            }
+          }
+        } catch (IOException ignored) {
+        }
+      }
+    });
+  }
+
+  private void pushResetLater(final int streamId, final ErrorCode errorCode) {
+    executor.submit(new NamedRunnable("OkHttp %s Push Reset[%s]", hostName, streamId) {
+      @Override public void execute() {
+        pushObserver.onReset(streamId, errorCode);
+        synchronized (SpdyConnection.this) {
+          currentPushRequests.remove(streamId);
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
`PushObserver` can be used to push server-initiated HTTP/2 requests into an `OkResponseCache`
