### PR TITLE
Rename OkBuffer.byteCount() to size().

### DIFF
--- a/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
+++ b/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
@@ -87,7 +87,7 @@ public class MainTest {
     try {
       OkBuffer buffer = new OkBuffer();
       body.writeTo(buffer);
-      return new String(buffer.readByteString((int) buffer.byteCount()).toByteArray(),
+      return new String(buffer.readByteString((int) buffer.size()).toByteArray(),
           body.contentType().charset());
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft09.java
@@ -347,24 +347,24 @@ public final class Http20Draft09 implements Variant {
     @Override public synchronized void pushPromise(int streamId, int promisedStreamId,
         List<Header> requestHeaders) throws IOException {
       if (closed) throw new IOException("closed");
-      if (hpackBuffer.byteCount() != 0) throw new IllegalStateException();
+      if (hpackBuffer.size() != 0) throw new IllegalStateException();
       hpackWriter.writeHeaders(requestHeaders);
 
-      int length = (int) (4 + hpackBuffer.byteCount());
+      int length = (int) (4 + hpackBuffer.size());
       byte type = TYPE_PUSH_PROMISE;
       byte flags = FLAG_END_HEADERS;
       frameHeader(length, type, flags, streamId); // TODO: CONTINUATION
       sink.writeInt(promisedStreamId & 0x7fffffff);
-      sink.write(hpackBuffer, hpackBuffer.byteCount());
+      sink.write(hpackBuffer, hpackBuffer.size());
     }
 
     private void headers(boolean outFinished, int streamId, int priority,
         List<Header> headerBlock) throws IOException {
       if (closed) throw new IOException("closed");
-      if (hpackBuffer.byteCount() != 0) throw new IllegalStateException();
+      if (hpackBuffer.size() != 0) throw new IllegalStateException();
       hpackWriter.writeHeaders(headerBlock);
 
-      int length = (int) hpackBuffer.byteCount();
+      int length = (int) hpackBuffer.size();
       byte type = TYPE_HEADERS;
       byte flags = FLAG_END_HEADERS;
       if (outFinished) flags |= FLAG_END_STREAM;
@@ -372,7 +372,7 @@ public final class Http20Draft09 implements Variant {
       if (priority != -1) length += 4;
       frameHeader(length, type, flags, streamId); // TODO: CONTINUATION
       if (priority != -1) sink.writeInt(priority & 0x7fffffff);
-      sink.write(hpackBuffer, hpackBuffer.byteCount());
+      sink.write(hpackBuffer, hpackBuffer.size());
     }
 
     @Override public synchronized void rstStream(int streamId, ErrorCode errorCode)
@@ -390,7 +390,7 @@ public final class Http20Draft09 implements Variant {
 
     @Override public synchronized void data(boolean outFinished, int streamId, OkBuffer source)
         throws IOException {
-      data(outFinished, streamId, source, (int) source.byteCount());
+      data(outFinished, streamId, source, (int) source.size());
     }
 
     @Override public synchronized void data(boolean outFinished, int streamId, OkBuffer source,

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -331,7 +331,7 @@ final class Spdy3 implements Variant {
         throws IOException {
       if (closed) throw new IOException("closed");
       writeNameValueBlockToBuffer(headerBlock);
-      int length = (int) (10 + headerBlockBuffer.byteCount());
+      int length = (int) (10 + headerBlockBuffer.size());
       int type = TYPE_SYN_STREAM;
       int flags = (outFinished ? FLAG_FIN : 0) | (inFinished ? FLAG_UNIDIRECTIONAL : 0);
 
@@ -341,7 +341,7 @@ final class Spdy3 implements Variant {
       sink.writeInt(streamId & 0x7fffffff);
       sink.writeInt(associatedStreamId & 0x7fffffff);
       sink.writeShort((priority & 0x7) << 13 | (unused & 0x1f) << 8 | (slot & 0xff));
-      sink.write(headerBlockBuffer, headerBlockBuffer.byteCount());
+      sink.write(headerBlockBuffer, headerBlockBuffer.size());
       sink.flush();
     }
 
@@ -351,12 +351,12 @@ final class Spdy3 implements Variant {
       writeNameValueBlockToBuffer(headerBlock);
       int type = TYPE_SYN_REPLY;
       int flags = (outFinished ? FLAG_FIN : 0);
-      int length = (int) (headerBlockBuffer.byteCount() + 4);
+      int length = (int) (headerBlockBuffer.size() + 4);
 
       sink.writeInt(0x80000000 | (VERSION & 0x7fff) << 16 | type & 0xffff);
       sink.writeInt((flags & 0xff) << 24 | length & 0xffffff);
       sink.writeInt(streamId & 0x7fffffff);
-      sink.write(headerBlockBuffer, headerBlockBuffer.byteCount());
+      sink.write(headerBlockBuffer, headerBlockBuffer.size());
       sink.flush();
     }
 
@@ -366,12 +366,12 @@ final class Spdy3 implements Variant {
       writeNameValueBlockToBuffer(headerBlock);
       int flags = 0;
       int type = TYPE_HEADERS;
-      int length = (int) (headerBlockBuffer.byteCount() + 4);
+      int length = (int) (headerBlockBuffer.size() + 4);
 
       sink.writeInt(0x80000000 | (VERSION & 0x7fff) << 16 | type & 0xffff);
       sink.writeInt((flags & 0xff) << 24 | length & 0xffffff);
       sink.writeInt(streamId & 0x7fffffff);
-      sink.write(headerBlockBuffer, headerBlockBuffer.byteCount());
+      sink.write(headerBlockBuffer, headerBlockBuffer.size());
     }
 
     @Override public synchronized void rstStream(int streamId, ErrorCode errorCode)
@@ -390,7 +390,7 @@ final class Spdy3 implements Variant {
 
     @Override public synchronized void data(boolean outFinished, int streamId, OkBuffer source)
         throws IOException {
-      data(outFinished, streamId, source, (int) source.byteCount());
+      data(outFinished, streamId, source, (int) source.size());
     }
 
     @Override public synchronized void data(boolean outFinished, int streamId, OkBuffer source,
@@ -411,7 +411,7 @@ final class Spdy3 implements Variant {
     }
 
     private void writeNameValueBlockToBuffer(List<Header> headerBlock) throws IOException {
-      if (headerBlockBuffer.byteCount() != 0) throw new IllegalStateException();
+      if (headerBlockBuffer.size() != 0) throw new IllegalStateException();
       headerBlockOut.writeInt(headerBlock.size());
       for (int i = 0, size = headerBlock.size(); i < size; i++) {
         ByteString name = headerBlock.get(i).name;

--- a/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
+++ b/okhttp-protocols/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
@@ -363,10 +363,10 @@ public final class SpdyStream {
       synchronized (SpdyStream.this) {
         waitUntilReadable();
         checkNotClosed();
-        if (readBuffer.byteCount() == 0) return -1; // This source is exhausted.
+        if (readBuffer.size() == 0) return -1; // This source is exhausted.
 
         // Move bytes from the read buffer into the caller's buffer.
-        read = readBuffer.read(sink, Math.min(byteCount, readBuffer.byteCount()));
+        read = readBuffer.read(sink, Math.min(byteCount, readBuffer.size()));
 
         // Flow control: notify the peer that we're ready for more data!
         unacknowledgedBytesRead += read;
@@ -402,7 +402,7 @@ public final class SpdyStream {
         remaining = readTimeoutMillis;
       }
       try {
-        while (readBuffer.byteCount() == 0 && !finished && !closed && errorCode == null) {
+        while (readBuffer.size() == 0 && !finished && !closed && errorCode == null) {
           if (readTimeoutMillis == 0) {
             SpdyStream.this.wait();
           } else if (remaining > 0) {
@@ -425,7 +425,7 @@ public final class SpdyStream {
         boolean flowControlError;
         synchronized (SpdyStream.this) {
           finished = this.finished;
-          flowControlError = byteCount + readBuffer.byteCount() > maxByteCount;
+          flowControlError = byteCount + readBuffer.size() > maxByteCount;
         }
 
         // If the peer sends more data than we can handle, discard it and close the connection.
@@ -448,8 +448,8 @@ public final class SpdyStream {
 
         // Move the received data to the read buffer to the reader can read it.
         synchronized (SpdyStream.this) {
-          boolean wasEmpty = readBuffer.byteCount() == 0;
-          readBuffer.write(receiveBuffer, receiveBuffer.byteCount());
+          boolean wasEmpty = readBuffer.size() == 0;
+          readBuffer.write(receiveBuffer, receiveBuffer.size());
           if (wasEmpty) {
             SpdyStream.this.notifyAll();
           }
@@ -529,7 +529,7 @@ public final class SpdyStream {
       synchronized (SpdyStream.this) {
         checkOutNotClosed();
       }
-      writeFrame(false, buffer.byteCount());
+      writeFrame(false, buffer.size());
       connection.flush();
     }
 
@@ -544,7 +544,7 @@ public final class SpdyStream {
         if (closed) return;
       }
       if (!sink.finished) {
-        writeFrame(true, buffer.byteCount());
+        writeFrame(true, buffer.size());
       }
       synchronized (SpdyStream.this) {
         closed = true;

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/HpackDraft05Test.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/HpackDraft05Test.java
@@ -53,7 +53,7 @@ public class HpackDraft05Test {
     out.writeByte(0x0d); // Literal value (len = 13)
     out.writeUtf8("custom-header");
 
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.maxHeaderTableByteCount(1);
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
@@ -88,7 +88,7 @@ public class HpackDraft05Test {
     out.writeByte(0x0d); // Literal value (len = 13)
     out.writeUtf8("custom-header");
 
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     // Set to only support 110 bytes (enough for 2 headers).
     hpackReader.maxHeaderTableByteCount(110);
     hpackReader.readHeaders();
@@ -127,7 +127,7 @@ public class HpackDraft05Test {
       out.writeUtf8("custom-header");
     }
 
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.maxHeaderTableByteCount(16384); // Lots of headers need more room!
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
@@ -150,7 +150,7 @@ public class HpackDraft05Test {
         (byte) 0x25, (byte) 0xba, (byte) 0x7f};
     out.write(huffmanBytes, 0, huffmanBytes.length);
 
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
 
@@ -175,7 +175,7 @@ public class HpackDraft05Test {
     out.writeByte(0x0d); // Literal value (len = 13)
     out.writeUtf8("custom-header");
 
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
 
@@ -207,7 +207,7 @@ public class HpackDraft05Test {
     hpackWriter.writeHeaders(headerBlock);
     assertEquals(expectedBytes, bytesOut);
 
-    bytesIn.write(bytesOut, bytesOut.byteCount());
+    bytesIn.write(bytesOut, bytesOut.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
 
@@ -231,7 +231,7 @@ public class HpackDraft05Test {
     hpackWriter.writeHeaders(headerBlock);
     assertEquals(expectedBytes, bytesOut);
 
-    bytesIn.write(bytesOut, bytesOut.byteCount());
+    bytesIn.write(bytesOut, bytesOut.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
 
@@ -306,19 +306,19 @@ public class HpackDraft05Test {
    */
   @Test public void readRequestExamplesWithoutHuffman() throws IOException {
     OkBuffer out = firstRequestWithoutHuffman();
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
     checkReadFirstRequestWithoutHuffman();
 
     out = secondRequestWithoutHuffman();
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
     checkReadSecondRequestWithoutHuffman();
 
     out = thirdRequestWithoutHuffman();
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
     checkReadThirdRequestWithoutHuffman();
@@ -508,19 +508,19 @@ public class HpackDraft05Test {
    */
   @Test public void readRequestExamplesWithHuffman() throws IOException {
     OkBuffer out = firstRequestWithHuffman();
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
     checkReadFirstRequestWithHuffman();
 
     out = secondRequestWithHuffman();
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
     checkReadSecondRequestWithHuffman();
 
     out = thirdRequestWithHuffman();
-    bytesIn.write(out, out.byteCount());
+    bytesIn.write(out, out.size());
     hpackReader.readHeaders();
     hpackReader.emitReferenceSet();
     checkReadThirdRequestWithHuffman();
@@ -800,7 +800,7 @@ public class HpackDraft05Test {
 
   private void assertBytes(int... bytes) {
     ByteString expected = intArrayToByteArray(bytes);
-    ByteString actual = bytesOut.readByteString((int) bytesOut.byteCount());
+    ByteString actual = bytesOut.readByteString((int) bytesOut.size());
     assertEquals(expected, actual);
   }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Http20Draft09Test.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Http20Draft09Test.java
@@ -56,11 +56,11 @@ public class Http20Draft09Test {
     // Write the headers frame, specifying no more frames are expected.
     {
       OkBuffer headerBytes = literalHeaders(sentHeaders);
-      frame.writeShort((int) headerBytes.byteCount());
+      frame.writeShort((int) headerBytes.size());
       frame.writeByte(Http20Draft09.TYPE_HEADERS);
       frame.writeByte(Http20Draft09.FLAG_END_HEADERS | Http20Draft09.FLAG_END_STREAM);
       frame.writeInt(expectedStreamId & 0x7fffffff);
-      frame.write(headerBytes, headerBytes.byteCount());
+      frame.write(headerBytes, headerBytes.size());
     }
 
     FrameReader fr = new Http20Draft09.Reader(frame, 4096, false);
@@ -90,12 +90,12 @@ public class Http20Draft09Test {
 
     { // Write the headers frame, specifying priority flag and value.
       OkBuffer headerBytes = literalHeaders(sentHeaders);
-      frame.writeShort((int) (headerBytes.byteCount() + 4));
+      frame.writeShort((int) (headerBytes.size() + 4));
       frame.writeByte(Http20Draft09.TYPE_HEADERS);
       frame.writeByte(Http20Draft09.FLAG_END_HEADERS | Http20Draft09.FLAG_PRIORITY);
       frame.writeInt(expectedStreamId & 0x7fffffff);
       frame.writeInt(0); // Highest priority is 0.
-      frame.write(headerBytes, headerBytes.byteCount());
+      frame.write(headerBytes, headerBytes.size());
     }
 
     FrameReader fr = new Http20Draft09.Reader(frame, 4096, false);
@@ -126,19 +126,19 @@ public class Http20Draft09Test {
     // Decoding the first header will cross frame boundaries.
     OkBuffer headerBlock = literalHeaders(headerEntries("foo", "barrr", "baz", "qux"));
     { // Write the first headers frame.
-      frame.writeShort((int) (headerBlock.byteCount() / 2));
+      frame.writeShort((int) (headerBlock.size() / 2));
       frame.writeByte(Http20Draft09.TYPE_HEADERS);
       frame.writeByte(0); // no flags
       frame.writeInt(expectedStreamId & 0x7fffffff);
-      frame.write(headerBlock, headerBlock.byteCount() / 2);
+      frame.write(headerBlock, headerBlock.size() / 2);
     }
 
     { // Write the continuation frame, specifying no more frames are expected.
-      frame.writeShort((int) headerBlock.byteCount());
+      frame.writeShort((int) headerBlock.size());
       frame.writeByte(Http20Draft09.TYPE_CONTINUATION);
       frame.writeByte(Http20Draft09.FLAG_END_HEADERS);
       frame.writeInt(expectedStreamId & 0x7fffffff);
-      frame.write(headerBlock, headerBlock.byteCount());
+      frame.write(headerBlock, headerBlock.size());
     }
 
     FrameReader fr = new Http20Draft09.Reader(frame, 4096, false);
@@ -175,12 +175,12 @@ public class Http20Draft09Test {
 
     { // Write the push promise frame, specifying the associated stream ID.
       OkBuffer headerBytes = literalHeaders(pushPromise);
-      frame.writeShort((int) (headerBytes.byteCount() + 4));
+      frame.writeShort((int) (headerBytes.size() + 4));
       frame.writeByte(Http20Draft09.TYPE_PUSH_PROMISE);
       frame.writeByte(Http20Draft09.FLAG_END_PUSH_PROMISE);
       frame.writeInt(expectedStreamId & 0x7fffffff);
       frame.writeInt(expectedPromisedStreamId & 0x7fffffff);
-      frame.write(headerBytes, headerBytes.byteCount());
+      frame.write(headerBytes, headerBytes.size());
     }
 
     FrameReader fr = new Http20Draft09.Reader(frame, 4096, false);
@@ -211,7 +211,7 @@ public class Http20Draft09Test {
 
     // Decoding the first header will cross frame boundaries.
     OkBuffer headerBlock = literalHeaders(pushPromise);
-    int firstFrameLength = (int) (headerBlock.byteCount() - 1);
+    int firstFrameLength = (int) (headerBlock.size() - 1);
     { // Write the first headers frame.
       frame.writeShort(firstFrameLength + 4);
       frame.writeByte(Http20Draft09.TYPE_PUSH_PROMISE);
@@ -503,7 +503,7 @@ public class Http20Draft09Test {
   private OkBuffer sendDataFrame(OkBuffer data) throws IOException {
     OkBuffer out = new OkBuffer();
     new Http20Draft09.Writer(out, true).dataFrame(expectedStreamId, Http20Draft09.FLAG_NONE, data,
-        (int) data.byteCount());
+        (int) data.size());
     return out;
   }
 

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -69,7 +69,7 @@ public final class MockSpdyPeer implements Closeable {
   }
 
   public FrameWriter sendFrame() {
-    outFrames.add(new OutFrame(frameCount++, bytesOut.byteCount(), Integer.MAX_VALUE));
+    outFrames.add(new OutFrame(frameCount++, bytesOut.size(), Integer.MAX_VALUE));
     return frameWriter;
   }
 
@@ -78,7 +78,7 @@ public final class MockSpdyPeer implements Closeable {
    * won't be generated naturally.
    */
   public void sendFrame(byte[] frame) throws IOException {
-    outFrames.add(new OutFrame(frameCount++, bytesOut.byteCount(), Integer.MAX_VALUE));
+    outFrames.add(new OutFrame(frameCount++, bytesOut.size(), Integer.MAX_VALUE));
     bytesOut.write(frame);
   }
 
@@ -88,7 +88,7 @@ public final class MockSpdyPeer implements Closeable {
    * malformed.
    */
   public FrameWriter sendTruncatedFrame(int truncateToLength) {
-    outFrames.add(new OutFrame(frameCount++, bytesOut.byteCount(), truncateToLength));
+    outFrames.add(new OutFrame(frameCount++, bytesOut.size(), truncateToLength));
     return frameWriter;
   }
 
@@ -121,7 +121,7 @@ public final class MockSpdyPeer implements Closeable {
     FrameReader reader = variant.newReader(Okio.buffer(Okio.source(in)), client);
 
     Iterator<OutFrame> outFramesIterator = outFrames.iterator();
-    byte[] outBytes = bytesOut.readByteString((int) bytesOut.byteCount()).toByteArray();
+    byte[] outBytes = bytesOut.readByteString((int) bytesOut.size()).toByteArray();
     OutFrame nextOutFrame = null;
 
     for (int i = 0; i < frameCount; i++) {

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Spdy3Test.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/Spdy3Test.java
@@ -85,7 +85,7 @@ public class Spdy3Test {
 
   private void sendDataFrame(OkBuffer source) throws IOException {
     Spdy3.Writer writer = new Spdy3.Writer(new OkBuffer(), true);
-    writer.sendDataFrame(expectedStreamId, 0, source, (int) source.byteCount());
+    writer.sendDataFrame(expectedStreamId, 0, source, (int) source.size());
   }
 
   private void windowUpdate(long increment) throws IOException {

--- a/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
+++ b/okhttp-protocols/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
@@ -1073,7 +1073,7 @@ public final class SpdyConnectionTest {
     Source in = stream.getSource();
     OkBuffer buffer = new OkBuffer();
     while (in.read(buffer, 1024) != -1) {
-      if (buffer.byteCount() == 3 * windowUpdateThreshold) break;
+      if (buffer.size() == 3 * windowUpdateThreshold) break;
     }
     assertEquals(-1, in.read(buffer, 1));
 
@@ -1462,7 +1462,7 @@ public final class SpdyConnectionTest {
     OkBuffer buffer = new OkBuffer();
     while (source.read(buffer, Long.MAX_VALUE) != -1) {
     }
-    String actual = buffer.readUtf8((int) buffer.byteCount());
+    String actual = buffer.readUtf8((int) buffer.size());
     assertEquals(expected, actual);
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -322,7 +322,7 @@ public final class Connection implements Closeable {
         case HTTP_OK:
           // Assume the server won't send a TLS ServerHello until we send a TLS ClientHello. If that
           // happens, then we will have buffered bytes that are needed by the SSLSocket!
-          if (tunnelSource.buffer().byteCount() > 0) {
+          if (tunnelSource.buffer().size() > 0) {
             throw new IOException("TLS tunnel buffered too many bytes!");
           }
           return;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
@@ -255,7 +255,7 @@ public final class HttpConnection {
 
     @Override public void write(OkBuffer source, long byteCount) throws IOException {
       if (closed) throw new IllegalStateException("closed");
-      checkOffsetAndCount(source.byteCount(), 0, byteCount);
+      checkOffsetAndCount(source.size(), 0, byteCount);
       if (byteCount > bytesRemaining) {
         throw new ProtocolException("expected " + bytesRemaining
             + " bytes but received " + byteCount);
@@ -323,7 +323,7 @@ public final class HttpConnection {
     @Override public void write(OkBuffer source, long byteCount) throws IOException {
       if (closed) throw new IllegalStateException("closed");
       bufferedChunk.write(source, byteCount);
-      if (bufferedChunk.byteCount() > maxChunkLength) {
+      if (bufferedChunk.size() > maxChunkLength) {
         writeBufferedChunkToSocket();
       }
     }
@@ -343,11 +343,11 @@ public final class HttpConnection {
     }
 
     private void writeBufferedChunkToSocket() throws IOException {
-      int size = (int) bufferedChunk.byteCount();
+      int size = (int) bufferedChunk.size();
       if (size == 0) return;
 
       writeHex(size);
-      sink.write(bufferedChunk, bufferedChunk.byteCount());
+      sink.write(bufferedChunk, bufferedChunk.size());
       sink.writeUtf8(CRLF);
     }
 
@@ -383,7 +383,7 @@ public final class HttpConnection {
     /** Copy the last {@code byteCount} bytes of {@code source} to the cache body. */
     protected final void cacheWrite(OkBuffer source, long byteCount) throws IOException {
       if (cacheBody != null) {
-        Okio.copy(source, source.byteCount() - byteCount, byteCount, cacheBody);
+        Okio.copy(source, source.size() - byteCount, byteCount, cacheBody);
       }
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -525,7 +525,7 @@ public class HttpEngine {
     if (!responseSource.requiresConnection()) return;
 
     // Flush the response body if there's data outstanding.
-    if (bufferedRequestBody != null && bufferedRequestBody.buffer().byteCount() > 0) {
+    if (bufferedRequestBody != null && bufferedRequestBody.buffer().size() > 0) {
       bufferedRequestBody.flush();
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RetryableSink.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RetryableSink.java
@@ -46,16 +46,16 @@ final class RetryableSink implements Sink {
   @Override public void close() throws IOException {
     if (closed) return;
     closed = true;
-    if (content.byteCount() < limit) {
+    if (content.size() < limit) {
       throw new ProtocolException(
-          "content-length promised " + limit + " bytes, but received " + content.byteCount());
+          "content-length promised " + limit + " bytes, but received " + content.size());
     }
   }
 
   @Override public void write(OkBuffer source, long byteCount) throws IOException {
     if (closed) throw new IllegalStateException("closed");
-    checkOffsetAndCount(source.byteCount(), 0, byteCount);
-    if (limit != -1 && content.byteCount() > limit - byteCount) {
+    checkOffsetAndCount(source.size(), 0, byteCount);
+    if (limit != -1 && content.size() > limit - byteCount) {
       throw new ProtocolException("exceeded content-length limit of " + limit + " bytes");
     }
     content.write(source, byteCount);
@@ -69,11 +69,11 @@ final class RetryableSink implements Sink {
   }
 
   public long contentLength() throws IOException {
-    return content.byteCount();
+    return content.size();
   }
 
   public void writeToSocket(BufferedSink socketOut) throws IOException {
     // Clone the content; otherwise we won't have data to retry.
-    socketOut.write(content.clone(), content.byteCount());
+    socketOut.write(content.clone(), content.size());
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -274,7 +274,7 @@ public final class SpdyTransport implements Transport {
       }
 
       if (cacheBody != null) {
-        Okio.copy(sink, sink.byteCount() - read, read, cacheBody);
+        Okio.copy(sink, sink.size() - read, read, cacheBody);
       }
 
       return read;

--- a/okhttp/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -76,6 +76,6 @@ public final class RequestTest {
   private String bodyToHex(Request.Body body) throws IOException {
     OkBuffer buffer = new OkBuffer();
     body.writeTo(buffer);
-    return buffer.readByteString((int) buffer.byteCount()).hex();
+    return buffer.readByteString((int) buffer.size()).hex();
   }
 }

--- a/okio/src/main/java/okio/DeflaterSink.java
+++ b/okio/src/main/java/okio/DeflaterSink.java
@@ -46,7 +46,7 @@ public final class DeflaterSink implements Sink {
 
   @Override public void write(OkBuffer source, long byteCount)
       throws IOException {
-    checkOffsetAndCount(source.byteCount, 0, byteCount);
+    checkOffsetAndCount(source.size, 0, byteCount);
     while (byteCount > 0) {
       // Share bytes from the head segment of 'source' with the deflater.
       Segment head = source.head;
@@ -57,7 +57,7 @@ public final class DeflaterSink implements Sink {
       deflate(false);
 
       // Mark those bytes as read.
-      source.byteCount -= toDeflate;
+      source.size -= toDeflate;
       head.pos += toDeflate;
       if (head.pos == head.limit) {
         source.head = head.pop();
@@ -84,7 +84,7 @@ public final class DeflaterSink implements Sink {
 
       if (deflated == 0) return;
       s.limit += deflated;
-      buffer.byteCount += deflated;
+      buffer.size += deflated;
       sink.emitCompleteSegments();
     }
   }

--- a/okio/src/main/java/okio/GzipSource.java
+++ b/okio/src/main/java/okio/GzipSource.java
@@ -70,7 +70,7 @@ public final class GzipSource implements Source {
 
     // Attempt to read at least a byte of the body. If we do, we're done.
     if (section == SECTION_BODY) {
-      long offset = sink.byteCount;
+      long offset = sink.size;
       long result = inflaterSource.read(sink, byteCount);
       if (result != -1) {
         updateCrc(sink, offset, result);

--- a/okio/src/main/java/okio/InflaterSource.java
+++ b/okio/src/main/java/okio/InflaterSource.java
@@ -67,7 +67,7 @@ public final class InflaterSource implements Source {
         int bytesInflated = inflater.inflate(tail.data, tail.limit, Segment.SIZE - tail.limit);
         if (bytesInflated > 0) {
           tail.limit += bytesInflated;
-          sink.byteCount += bytesInflated;
+          sink.size += bytesInflated;
           return bytesInflated;
         }
         if (inflater.finished() || inflater.needsDictionary()) {

--- a/okio/src/main/java/okio/Okio.java
+++ b/okio/src/main/java/okio/Okio.java
@@ -36,7 +36,7 @@ public final class Okio {
   /** Copies bytes from {@code source} to {@code sink}. */
   public static void copy(OkBuffer source, long offset, long byteCount, OutputStream sink)
       throws IOException {
-    checkOffsetAndCount(source.byteCount, offset, byteCount);
+    checkOffsetAndCount(source.size, offset, byteCount);
 
     // Skip segments that we aren't copying from.
     Segment s = source.head;
@@ -62,7 +62,7 @@ public final class Okio {
 
       @Override public void write(OkBuffer source, long byteCount)
           throws IOException {
-        checkOffsetAndCount(source.byteCount, 0, byteCount);
+        checkOffsetAndCount(source.size, 0, byteCount);
         while (byteCount > 0) {
           deadline.throwIfReached();
           Segment head = source.head;
@@ -71,7 +71,7 @@ public final class Okio {
 
           head.pos += toCopy;
           byteCount -= toCopy;
-          source.byteCount -= toCopy;
+          source.size -= toCopy;
 
           if (head.pos == head.limit) {
             source.head = head.pop();
@@ -113,7 +113,7 @@ public final class Okio {
         int bytesRead = in.read(tail.data, tail.limit, maxToCopy);
         if (bytesRead == -1) return -1;
         tail.limit += bytesRead;
-        sink.byteCount += bytesRead;
+        sink.size += bytesRead;
         return bytesRead;
       }
 

--- a/okio/src/main/java/okio/RealBufferedSink.java
+++ b/okio/src/main/java/okio/RealBufferedSink.java
@@ -120,8 +120,8 @@ final class RealBufferedSink implements BufferedSink {
 
   @Override public void flush() throws IOException {
     if (closed) throw new IllegalStateException("closed");
-    if (buffer.byteCount > 0) {
-      sink.write(buffer, buffer.byteCount);
+    if (buffer.size > 0) {
+      sink.write(buffer, buffer.size);
     }
     sink.flush();
   }
@@ -132,8 +132,8 @@ final class RealBufferedSink implements BufferedSink {
     // If flushing throws, we still need to close the stream!
     Throwable thrown = null;
     try {
-      if (buffer.byteCount > 0) {
-        sink.write(buffer, buffer.byteCount);
+      if (buffer.size > 0) {
+        sink.write(buffer, buffer.size);
       }
     } catch (IOException e) {
       thrown = e;

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -45,12 +45,12 @@ final class RealBufferedSource implements BufferedSource {
     if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
     if (closed) throw new IllegalStateException("closed");
 
-    if (buffer.byteCount == 0) {
+    if (buffer.size == 0) {
       long read = source.read(buffer, Segment.SIZE);
       if (read == -1) return -1;
     }
 
-    long toRead = Math.min(byteCount, buffer.byteCount);
+    long toRead = Math.min(byteCount, buffer.size);
     return buffer.read(sink, toRead);
   }
 
@@ -59,7 +59,7 @@ final class RealBufferedSource implements BufferedSource {
   }
 
   @Override public void require(long byteCount) throws IOException {
-    while (buffer.byteCount < byteCount) {
+    while (buffer.size < byteCount) {
       if (source.read(buffer, Segment.SIZE) == -1) throw new EOFException();
     }
   }
@@ -83,10 +83,10 @@ final class RealBufferedSource implements BufferedSource {
     long start = 0;
     long newline;
     while ((newline = buffer.indexOf((byte) '\n', start)) == -1) {
-      start = buffer.byteCount;
+      start = buffer.size;
       if (source.read(buffer, Segment.SIZE) == -1) {
         if (throwOnEof) throw new EOFException();
-        return buffer.byteCount != 0 ? readUtf8((int) buffer.byteCount) : null;
+        return buffer.size != 0 ? readUtf8((int) buffer.size) : null;
       }
     }
 
@@ -126,10 +126,10 @@ final class RealBufferedSource implements BufferedSource {
 
   @Override public void skip(long byteCount) throws IOException {
     while (byteCount > 0) {
-      if (buffer.byteCount == 0 && source.read(buffer, Segment.SIZE) == -1) {
+      if (buffer.size == 0 && source.read(buffer, Segment.SIZE) == -1) {
         throw new EOFException();
       }
-      long toSkip = Math.min(byteCount, buffer.byteCount());
+      long toSkip = Math.min(byteCount, buffer.size());
       buffer.skip(toSkip);
       byteCount -= toSkip;
     }
@@ -139,7 +139,7 @@ final class RealBufferedSource implements BufferedSource {
     long start = 0;
     long index;
     while ((index = buffer.indexOf(b, start)) == -1) {
-      start = buffer.byteCount;
+      start = buffer.size;
       if (source.read(buffer, Segment.SIZE) == -1) throw new EOFException();
     }
     return index;
@@ -148,7 +148,7 @@ final class RealBufferedSource implements BufferedSource {
   @Override public InputStream inputStream() {
     return new InputStream() {
       @Override public int read() throws IOException {
-        if (buffer.byteCount == 0) {
+        if (buffer.size == 0) {
           long count = source.read(buffer, Segment.SIZE);
           if (count == -1) return -1;
         }
@@ -158,7 +158,7 @@ final class RealBufferedSource implements BufferedSource {
       @Override public int read(byte[] data, int offset, int byteCount) throws IOException {
         checkOffsetAndCount(data.length, offset, byteCount);
 
-        if (buffer.byteCount == 0) {
+        if (buffer.size == 0) {
           long count = source.read(buffer, Segment.SIZE);
           if (count == -1) return -1;
         }
@@ -167,7 +167,7 @@ final class RealBufferedSource implements BufferedSource {
       }
 
       @Override public int available() throws IOException {
-        return (int) Math.min(buffer.byteCount, Integer.MAX_VALUE);
+        return (int) Math.min(buffer.size, Integer.MAX_VALUE);
       }
 
       @Override public void close() throws IOException {

--- a/okio/src/test/java/okio/DeflaterSinkTest.java
+++ b/okio/src/test/java/okio/DeflaterSinkTest.java
@@ -33,10 +33,10 @@ public final class DeflaterSinkTest {
     data.writeUtf8(original);
     OkBuffer sink = new OkBuffer();
     DeflaterSink deflaterSink = new DeflaterSink(sink, new Deflater());
-    deflaterSink.write(data, data.byteCount());
+    deflaterSink.write(data, data.size());
     deflaterSink.close();
     OkBuffer inflated = inflate(sink);
-    assertEquals(original, inflated.readUtf8((int) inflated.byteCount()));
+    assertEquals(original, inflated.readUtf8((int) inflated.size()));
   }
 
   @Test public void deflateWithSyncFlush() throws Exception {
@@ -45,10 +45,10 @@ public final class DeflaterSinkTest {
     data.writeUtf8(original);
     OkBuffer sink = new OkBuffer();
     DeflaterSink deflaterSink = new DeflaterSink(sink, new Deflater());
-    deflaterSink.write(data, data.byteCount());
+    deflaterSink.write(data, data.size());
     deflaterSink.flush();
     OkBuffer inflated = inflate(sink);
-    assertEquals(original, inflated.readUtf8((int) inflated.byteCount()));
+    assertEquals(original, inflated.readUtf8((int) inflated.size()));
   }
 
   @Test public void deflateWellCompressed() throws IOException {
@@ -57,10 +57,10 @@ public final class DeflaterSinkTest {
     data.writeUtf8(original);
     OkBuffer sink = new OkBuffer();
     DeflaterSink deflaterSink = new DeflaterSink(sink, new Deflater());
-    deflaterSink.write(data, data.byteCount());
+    deflaterSink.write(data, data.size());
     deflaterSink.close();
     OkBuffer inflated = inflate(sink);
-    assertEquals(original, inflated.readUtf8((int) inflated.byteCount()));
+    assertEquals(original, inflated.readUtf8((int) inflated.size()));
   }
 
   @Test public void deflatePoorlyCompressed() throws IOException {
@@ -69,10 +69,10 @@ public final class DeflaterSinkTest {
     data.write(original);
     OkBuffer sink = new OkBuffer();
     DeflaterSink deflaterSink = new DeflaterSink(sink, new Deflater());
-    deflaterSink.write(data, data.byteCount());
+    deflaterSink.write(data, data.size());
     deflaterSink.close();
     OkBuffer inflated = inflate(sink);
-    assertEquals(original, inflated.readByteString((int) inflated.byteCount()));
+    assertEquals(original, inflated.readByteString((int) inflated.size()));
   }
 
   /**
@@ -85,7 +85,7 @@ public final class DeflaterSinkTest {
     InputStream inflatedIn = new InflaterInputStream(deflatedIn, inflater);
     OkBuffer result = new OkBuffer();
     byte[] buffer = new byte[8192];
-    while (!inflater.needsInput() || deflated.byteCount() > 0 || deflatedIn.available() > 0) {
+    while (!inflater.needsInput() || deflated.size() > 0 || deflatedIn.available() > 0) {
       int count = inflatedIn.read(buffer, 0, buffer.length);
       result.write(buffer, 0, count);
     }

--- a/okio/src/test/java/okio/GzipSourceTest.java
+++ b/okio/src/test/java/okio/GzipSourceTest.java
@@ -99,7 +99,7 @@ public class GzipSourceTest {
   private void assertGzipped(OkBuffer gzipped) throws IOException {
     OkBuffer gunzipped = gunzip(gzipped);
     assertEquals("It's a UNIX system! I know this!",
-        gunzipped.readUtf8((int) gunzipped.byteCount()));
+        gunzipped.readUtf8((int) gunzipped.size()));
   }
 
   /**

--- a/okio/src/test/java/okio/InflaterSourceTest.java
+++ b/okio/src/test/java/okio/InflaterSourceTest.java
@@ -71,7 +71,7 @@ public final class InflaterSourceTest {
     ByteString original = randomBytes(1024 * 1024);
     OkBuffer deflated = deflate(original);
     OkBuffer inflated = inflate(deflated);
-    assertEquals(original, inflated.readByteString((int) inflated.byteCount()));
+    assertEquals(original, inflated.readByteString((int) inflated.size()));
   }
 
   private OkBuffer decodeBase64(String s) {
@@ -79,7 +79,7 @@ public final class InflaterSourceTest {
   }
 
   private String readUtf8(OkBuffer buffer) {
-    return buffer.readUtf8((int) buffer.byteCount());
+    return buffer.readUtf8((int) buffer.size());
   }
 
   /** Use DeflaterOutputStream to deflate source. */

--- a/okio/src/test/java/okio/OkBufferTest.java
+++ b/okio/src/test/java/okio/OkBufferTest.java
@@ -30,13 +30,13 @@ public final class OkBufferTest {
   @Test public void readAndWriteUtf8() throws Exception {
     OkBuffer buffer = new OkBuffer();
     buffer.writeUtf8("ab");
-    assertEquals(2, buffer.byteCount());
+    assertEquals(2, buffer.size());
     buffer.writeUtf8("cdef");
-    assertEquals(6, buffer.byteCount());
+    assertEquals(6, buffer.size());
     assertEquals("abcd", buffer.readUtf8(4));
-    assertEquals(2, buffer.byteCount());
+    assertEquals(2, buffer.size());
     assertEquals("ef", buffer.readUtf8(2));
-    assertEquals(0, buffer.byteCount());
+    assertEquals(0, buffer.size());
     try {
       buffer.readUtf8(1);
       fail();
@@ -112,7 +112,7 @@ public final class OkBufferTest {
     assertEquals("c" + repeat('d', 10000) + "e", buffer.readUtf8(10002)); // cd...de
     assertEquals(repeat('e', 24998), buffer.readUtf8(24998)); // e...e
     assertEquals("e" + repeat('f', 50000), buffer.readUtf8(50001)); // ef...f
-    assertEquals(0, buffer.byteCount());
+    assertEquals(0, buffer.size());
   }
 
   @Test public void fillAndDrainPool() throws Exception {
@@ -165,7 +165,7 @@ public final class OkBufferTest {
     for (String s : contents) {
       OkBuffer source = new OkBuffer();
       source.writeUtf8(s);
-      buffer.write(source, source.byteCount());
+      buffer.write(source, source.size());
       expected.append(s);
     }
     List<Integer> segmentSizes = buffer.segmentSizes();
@@ -213,8 +213,8 @@ public final class OkBufferTest {
 
     assertEquals(asList(30), sink.segmentSizes());
     assertEquals(asList(Segment.SIZE - 20, Segment.SIZE), source.segmentSizes());
-    assertEquals(30, sink.byteCount());
-    assertEquals(Segment.SIZE * 2 - 20, source.byteCount());
+    assertEquals(30, sink.size());
+    assertEquals(Segment.SIZE * 2 - 20, source.size());
   }
 
   @Test public void writePrefixDoesntSplitButRequiresCompact() throws Exception {
@@ -228,8 +228,8 @@ public final class OkBufferTest {
 
     assertEquals(asList(30), sink.segmentSizes());
     assertEquals(asList(Segment.SIZE - 20, Segment.SIZE), source.segmentSizes());
-    assertEquals(30, sink.byteCount());
-    assertEquals(Segment.SIZE * 2 - 20, source.byteCount());
+    assertEquals(30, sink.size());
+    assertEquals(Segment.SIZE * 2 - 20, source.size());
   }
 
   @Test public void readExhaustedSource() throws Exception {
@@ -239,8 +239,8 @@ public final class OkBufferTest {
     OkBuffer source = new OkBuffer();
 
     assertEquals(-1, source.read(sink, 10));
-    assertEquals(10, sink.byteCount());
-    assertEquals(0, source.byteCount());
+    assertEquals(10, sink.size());
+    assertEquals(0, source.size());
   }
 
   @Test public void readZeroBytesFromSource() throws Exception {
@@ -252,8 +252,8 @@ public final class OkBufferTest {
     // Either 0 or -1 is reasonable here. For consistency with Android's
     // ByteArrayInputStream we return 0.
     assertEquals(-1, source.read(sink, 0));
-    assertEquals(10, sink.byteCount());
-    assertEquals(0, source.byteCount());
+    assertEquals(10, sink.size());
+    assertEquals(0, source.size());
   }
 
   @Test public void moveAllRequestedBytesWithRead() throws Exception {
@@ -264,8 +264,8 @@ public final class OkBufferTest {
     source.writeUtf8(repeat('b', 15));
 
     assertEquals(10, source.read(sink, 10));
-    assertEquals(20, sink.byteCount());
-    assertEquals(5, source.byteCount());
+    assertEquals(20, sink.size());
+    assertEquals(5, source.size());
     assertEquals(repeat('a', 10) + repeat('b', 10), sink.readUtf8(20));
   }
 
@@ -277,8 +277,8 @@ public final class OkBufferTest {
     source.writeUtf8(repeat('b', 20));
 
     assertEquals(20, source.read(sink, 25));
-    assertEquals(30, sink.byteCount());
-    assertEquals(0, source.byteCount());
+    assertEquals(30, sink.size());
+    assertEquals(0, source.size());
     assertEquals(repeat('a', 10) + repeat('b', 20), sink.readUtf8(30));
   }
 
@@ -397,7 +397,7 @@ public final class OkBufferTest {
     data.write(new byte[] { (byte) 0xab, (byte) 0xcd });
     assertEquals(0xab, data.readByte() & 0xff);
     assertEquals(0xcd, data.readByte() & 0xff);
-    assertEquals(0, data.byteCount());
+    assertEquals(0, data.size());
   }
 
   @Test public void readShort() throws Exception {
@@ -407,7 +407,7 @@ public final class OkBufferTest {
     });
     assertEquals((short) 0xabcd, data.readShort());
     assertEquals((short) 0xef01, data.readShort());
-    assertEquals(0, data.byteCount());
+    assertEquals(0, data.size());
   }
 
   @Test public void readShortSplitAcrossMultipleSegments() throws Exception {
@@ -416,7 +416,7 @@ public final class OkBufferTest {
     data.write(new byte[] { (byte) 0xab, (byte) 0xcd });
     data.readUtf8(Segment.SIZE - 1);
     assertEquals((short) 0xabcd, data.readShort());
-    assertEquals(0, data.byteCount());
+    assertEquals(0, data.size());
   }
 
   @Test public void readInt() throws Exception {
@@ -427,7 +427,7 @@ public final class OkBufferTest {
     });
     assertEquals(0xabcdef01, data.readInt());
     assertEquals(0x87654321, data.readInt());
-    assertEquals(0, data.byteCount());
+    assertEquals(0, data.size());
   }
 
   @Test public void readIntSplitAcrossMultipleSegments() throws Exception {
@@ -438,7 +438,7 @@ public final class OkBufferTest {
     });
     data.readUtf8(Segment.SIZE - 3);
     assertEquals(0xabcdef01, data.readInt());
-    assertEquals(0, data.byteCount());
+    assertEquals(0, data.size());
   }
 
   @Test public void byteAt() throws Exception {
@@ -448,9 +448,9 @@ public final class OkBufferTest {
     buffer.writeUtf8("c");
     assertEquals('a', buffer.getByte(0));
     assertEquals('a', buffer.getByte(0)); // getByte doesn't mutate!
-    assertEquals('c', buffer.getByte(buffer.byteCount - 1));
-    assertEquals('b', buffer.getByte(buffer.byteCount - 2));
-    assertEquals('b', buffer.getByte(buffer.byteCount - 3));
+    assertEquals('c', buffer.getByte(buffer.size - 1));
+    assertEquals('b', buffer.getByte(buffer.size - 2));
+    assertEquals('b', buffer.getByte(buffer.size - 3));
   }
 
   @Test public void getByteOfEmptyBuffer() throws Exception {
@@ -472,7 +472,7 @@ public final class OkBufferTest {
     buffer.skip(Segment.SIZE - 2);
     assertEquals('b', buffer.readByte() & 0xff);
     buffer.skip(1);
-    assertEquals(0, buffer.byteCount());
+    assertEquals(0, buffer.size());
   }
 
   @Test public void testWritePrefixToEmptyBuffer() {
@@ -487,7 +487,7 @@ public final class OkBufferTest {
     OkBuffer original = new OkBuffer();
     OkBuffer clone = original.clone();
     original.writeUtf8("abc");
-    assertEquals(0, clone.byteCount());
+    assertEquals(0, clone.size());
   }
 
   @Test public void cloneDoesNotObserveReadsFromOriginal() throws Exception {
@@ -495,7 +495,7 @@ public final class OkBufferTest {
     original.writeUtf8("abc");
     OkBuffer clone = original.clone();
     assertEquals("abc", original.readUtf8(3));
-    assertEquals(3, clone.byteCount());
+    assertEquals(3, clone.size());
     assertEquals("ab", clone.readUtf8(2));
   }
 
@@ -503,7 +503,7 @@ public final class OkBufferTest {
     OkBuffer original = new OkBuffer();
     OkBuffer clone = original.clone();
     clone.writeUtf8("abc");
-    assertEquals(0, original.byteCount());
+    assertEquals(0, original.size());
   }
 
   @Test public void originalDoesNotObserveReadsFromClone() throws Exception {
@@ -511,7 +511,7 @@ public final class OkBufferTest {
     original.writeUtf8("abc");
     OkBuffer clone = original.clone();
     assertEquals("abc", clone.readUtf8(3));
-    assertEquals(3, original.byteCount());
+    assertEquals(3, original.size());
     assertEquals("ab", original.readUtf8(2));
   }
 

--- a/okio/src/test/java/okio/OkioTest.java
+++ b/okio/src/test/java/okio/OkioTest.java
@@ -36,7 +36,7 @@ public final class OkioTest {
     Sink sink = Okio.sink(out);
     sink.write(data, 3);
     assertEquals("abb", out.toString("UTF-8"));
-    sink.write(data, data.byteCount());
+    sink.write(data, data.size());
     assertEquals("a" + repeat('b', 9998) + "c", out.toString("UTF-8"));
   }
 
@@ -54,11 +54,11 @@ public final class OkioTest {
 
     // Source: b...bc. Sink: b...b.
     assertEquals(Segment.SIZE, source.read(sink, 20000));
-    assertEquals(repeat('b', Segment.SIZE), sink.readUtf8((int) sink.byteCount()));
+    assertEquals(repeat('b', Segment.SIZE), sink.readUtf8((int) sink.size()));
 
     // Source: b...bc. Sink: b...bc.
     assertEquals(Segment.SIZE - 1, source.read(sink, 20000));
-    assertEquals(repeat('b', Segment.SIZE - 2) + "c", sink.readUtf8((int) sink.byteCount()));
+    assertEquals(repeat('b', Segment.SIZE - 2) + "c", sink.readUtf8((int) sink.size()));
 
     // Source and sink are empty.
     assertEquals(-1, source.read(sink, 1));

--- a/okio/src/test/java/okio/RealBufferedSinkTest.java
+++ b/okio/src/test/java/okio/RealBufferedSinkTest.java
@@ -49,35 +49,35 @@ public final class RealBufferedSinkTest {
     OkBuffer sink = new OkBuffer();
     BufferedSink bufferedSink = new RealBufferedSink(sink);
     bufferedSink.writeUtf8(repeat('a', Segment.SIZE - 1));
-    assertEquals(0, sink.byteCount());
+    assertEquals(0, sink.size());
     bufferedSink.writeByte(0);
-    assertEquals(Segment.SIZE, sink.byteCount());
-    assertEquals(0, bufferedSink.buffer().byteCount());
+    assertEquals(Segment.SIZE, sink.size());
+    assertEquals(0, bufferedSink.buffer().size());
   }
 
   @Test public void bufferedSinkEmitZero() throws IOException {
     OkBuffer sink = new OkBuffer();
     BufferedSink bufferedSink = new RealBufferedSink(sink);
     bufferedSink.writeUtf8("");
-    assertEquals(0, sink.byteCount());
+    assertEquals(0, sink.size());
   }
 
   @Test public void bufferedSinkEmitMultipleSegments() throws IOException {
     OkBuffer sink = new OkBuffer();
     BufferedSink bufferedSink = new RealBufferedSink(sink);
     bufferedSink.writeUtf8(repeat('a', Segment.SIZE * 4 - 1));
-    assertEquals(Segment.SIZE * 3, sink.byteCount());
-    assertEquals(Segment.SIZE - 1, bufferedSink.buffer().byteCount());
+    assertEquals(Segment.SIZE * 3, sink.size());
+    assertEquals(Segment.SIZE - 1, bufferedSink.buffer().size());
   }
 
   @Test public void bufferedSinkFlush() throws IOException {
     OkBuffer sink = new OkBuffer();
     BufferedSink bufferedSink = new RealBufferedSink(sink);
     bufferedSink.writeByte('a');
-    assertEquals(0, sink.byteCount());
+    assertEquals(0, sink.size());
     bufferedSink.flush();
-    assertEquals(0, bufferedSink.buffer().byteCount());
-    assertEquals(1, sink.byteCount());
+    assertEquals(0, bufferedSink.buffer().size());
+    assertEquals(1, sink.size());
   }
 
   @Test public void bytesEmittedToSinkWithFlush() throws Exception {
@@ -85,28 +85,28 @@ public final class RealBufferedSinkTest {
     BufferedSink bufferedSink = new RealBufferedSink(sink);
     bufferedSink.writeUtf8("abc");
     bufferedSink.flush();
-    assertEquals(3, sink.byteCount());
+    assertEquals(3, sink.size());
   }
 
   @Test public void bytesNotEmittedToSinkWithoutFlush() throws Exception {
     OkBuffer sink = new OkBuffer();
     BufferedSink bufferedSink = new RealBufferedSink(sink);
     bufferedSink.writeUtf8("abc");
-    assertEquals(0, sink.byteCount());
+    assertEquals(0, sink.size());
   }
 
   @Test public void completeSegmentsEmitted() throws Exception {
     OkBuffer sink = new OkBuffer();
     BufferedSink bufferedSink = new RealBufferedSink(sink);
     bufferedSink.writeUtf8(repeat('a', Segment.SIZE * 3));
-    assertEquals(Segment.SIZE * 3, sink.byteCount());
+    assertEquals(Segment.SIZE * 3, sink.size());
   }
 
   @Test public void incompleteSegmentsNotEmitted() throws Exception {
     OkBuffer sink = new OkBuffer();
     BufferedSink bufferedSink = new RealBufferedSink(sink);
     bufferedSink.writeUtf8(repeat('a', Segment.SIZE * 3 - 1));
-    assertEquals(Segment.SIZE * 2, sink.byteCount());
+    assertEquals(Segment.SIZE * 2, sink.size());
   }
 
   private String repeat(char c, int count) {

--- a/okio/src/test/java/okio/RealBufferedSourceTest.java
+++ b/okio/src/test/java/okio/RealBufferedSourceTest.java
@@ -34,32 +34,32 @@ public final class RealBufferedSourceTest {
 
     InputStream in = new RealBufferedSource(source).inputStream();
     assertEquals(0, in.available());
-    assertEquals(Segment.SIZE + 2, source.byteCount());
+    assertEquals(Segment.SIZE + 2, source.size());
 
     // Reading one byte buffers a full segment.
     assertEquals('a', in.read());
     assertEquals(Segment.SIZE - 1, in.available());
-    assertEquals(2, source.byteCount());
+    assertEquals(2, source.size());
 
     // Reading as much as possible reads the rest of that buffered segment.
     byte[] data = new byte[Segment.SIZE * 2];
     assertEquals(Segment.SIZE - 1, in.read(data, 0, data.length));
     assertEquals(repeat('b', Segment.SIZE - 1), new String(data, 0, Segment.SIZE - 1, UTF_8));
-    assertEquals(2, source.byteCount());
+    assertEquals(2, source.size());
 
     // Continuing to read buffers the next segment.
     assertEquals('b', in.read());
     assertEquals(1, in.available());
-    assertEquals(0, source.byteCount());
+    assertEquals(0, source.size());
 
     // Continuing to read reads from the buffer.
     assertEquals('c', in.read());
     assertEquals(0, in.available());
-    assertEquals(0, source.byteCount());
+    assertEquals(0, source.size());
 
     // Once we've exhausted the source, we're done.
     assertEquals(-1, in.read());
-    assertEquals(0, source.byteCount());
+    assertEquals(0, source.size());
   }
 
   @Test public void inputStreamFromSourceBounds() throws IOException {
@@ -81,8 +81,8 @@ public final class RealBufferedSourceTest {
     bufferedSource.buffer().writeUtf8("aa");
 
     bufferedSource.require(2);
-    assertEquals(2, bufferedSource.buffer().byteCount());
-    assertEquals(2, source.byteCount());
+    assertEquals(2, bufferedSource.buffer().size());
+    assertEquals(2, source.size());
   }
 
   @Test public void requireIncludesBufferBytes() throws Exception {
@@ -117,8 +117,8 @@ public final class RealBufferedSourceTest {
     BufferedSource bufferedSource = new RealBufferedSource(source);
 
     bufferedSource.require(2);
-    assertEquals(Segment.SIZE, source.byteCount());
-    assertEquals(Segment.SIZE, bufferedSource.buffer().byteCount());
+    assertEquals(Segment.SIZE, source.size());
+    assertEquals(Segment.SIZE, bufferedSource.buffer().size());
   }
 
   @Test public void skipInsufficientData() throws Exception {
@@ -139,8 +139,8 @@ public final class RealBufferedSourceTest {
     source.writeUtf8(repeat('b', Segment.SIZE));
     BufferedSource bufferedSource = new RealBufferedSource(source);
     bufferedSource.skip(2);
-    assertEquals(Segment.SIZE, source.byteCount());
-    assertEquals(Segment.SIZE - 2, bufferedSource.buffer().byteCount());
+    assertEquals(Segment.SIZE, source.size());
+    assertEquals(Segment.SIZE - 2, bufferedSource.buffer().size());
   }
 
   @Test public void skipTracksBufferFirst() throws Exception {
@@ -151,8 +151,8 @@ public final class RealBufferedSourceTest {
     bufferedSource.buffer().writeUtf8("aa");
 
     bufferedSource.skip(2);
-    assertEquals(0, bufferedSource.buffer().byteCount());
-    assertEquals(2, source.byteCount());
+    assertEquals(0, bufferedSource.buffer().size());
+    assertEquals(2, source.size());
   }
 
   private String repeat(char c, int count) {


### PR DESCRIPTION
Continue to use byteCount as a parameter name wherever we're
referring to the number of bytes to read or write.
