### PR TITLE
Don't require OkBuffer callers to cast.

### DIFF
--- a/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
+++ b/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
@@ -87,7 +87,7 @@ public class MainTest {
     try {
       OkBuffer buffer = new OkBuffer();
       body.writeTo(buffer);
-      return new String(buffer.readByteString((int) buffer.size()).toByteArray(),
+      return new String(buffer.readByteString(buffer.size()).toByteArray(),
           body.contentType().charset());
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -76,6 +76,6 @@ public final class RequestTest {
   private String bodyToHex(Request.Body body) throws IOException {
     OkBuffer buffer = new OkBuffer();
     body.writeTo(buffer);
-    return buffer.readByteString((int) buffer.size()).hex();
+    return buffer.readByteString(buffer.size()).hex();
   }
 }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/HpackDraft05Test.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/HpackDraft05Test.java
@@ -800,7 +800,7 @@ public class HpackDraft05Test {
 
   private void assertBytes(int... bytes) {
     ByteString expected = intArrayToByteArray(bytes);
-    ByteString actual = bytesOut.readByteString((int) bytesOut.size());
+    ByteString actual = bytesOut.readByteString(bytesOut.size());
     assertEquals(expected, actual);
   }
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -121,7 +121,7 @@ public final class MockSpdyPeer implements Closeable {
     FrameReader reader = variant.newReader(Okio.buffer(Okio.source(in)), client);
 
     Iterator<OutFrame> outFramesIterator = outFrames.iterator();
-    byte[] outBytes = bytesOut.readByteString((int) bytesOut.size()).toByteArray();
+    byte[] outBytes = bytesOut.readByteString(bytesOut.size()).toByteArray();
     OutFrame nextOutFrame = null;
 
     for (int i = 0; i < frameCount; i++) {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/SpdyConnectionTest.java
@@ -1462,7 +1462,7 @@ public final class SpdyConnectionTest {
     OkBuffer buffer = new OkBuffer();
     while (source.read(buffer, Long.MAX_VALUE) != -1) {
     }
-    String actual = buffer.readUtf8((int) buffer.size());
+    String actual = buffer.readUtf8(buffer.size());
     assertEquals(expected, actual);
   }
 

--- a/okio/src/main/java/okio/BufferedSource.java
+++ b/okio/src/main/java/okio/BufferedSource.java
@@ -63,13 +63,13 @@ public interface BufferedSource extends Source {
   void skip(long byteCount) throws IOException;
 
   /** Removes {@code byteCount} bytes from this and returns them as a byte string. */
-  ByteString readByteString(int byteCount) throws IOException;
+  ByteString readByteString(long byteCount) throws IOException;
 
   /**
    * Removes {@code byteCount} bytes from this, decodes them as UTF-8 and
    * returns the string.
    */
-  String readUtf8(int byteCount) throws IOException;
+  String readUtf8(long byteCount) throws IOException;
 
   /**
    * Removes and returns characters up to but not including the next line break.

--- a/okio/src/main/java/okio/RealBufferedSource.java
+++ b/okio/src/main/java/okio/RealBufferedSource.java
@@ -69,12 +69,12 @@ final class RealBufferedSource implements BufferedSource {
     return buffer.readByte();
   }
 
-  @Override public ByteString readByteString(int byteCount) throws IOException {
+  @Override public ByteString readByteString(long byteCount) throws IOException {
     require(byteCount);
     return buffer.readByteString(byteCount);
   }
 
-  @Override public String readUtf8(int byteCount) throws IOException {
+  @Override public String readUtf8(long byteCount) throws IOException {
     require(byteCount);
     return buffer.readUtf8(byteCount);
   }
@@ -86,19 +86,19 @@ final class RealBufferedSource implements BufferedSource {
       start = buffer.size;
       if (source.read(buffer, Segment.SIZE) == -1) {
         if (throwOnEof) throw new EOFException();
-        return buffer.size != 0 ? readUtf8((int) buffer.size) : null;
+        return buffer.size != 0 ? readUtf8(buffer.size) : null;
       }
     }
 
     if (newline > 0 && buffer.getByte(newline - 1) == '\r') {
       // Read everything until '\r\n', then skip the '\r\n'.
-      String result = readUtf8((int) (newline - 1));
+      String result = readUtf8((newline - 1));
       skip(2);
       return result;
 
     } else {
       // Read everything until '\n', then skip the '\n'.
-      String result = readUtf8((int) (newline));
+      String result = readUtf8((newline));
       skip(1);
       return result;
     }

--- a/okio/src/test/java/okio/DeflaterSinkTest.java
+++ b/okio/src/test/java/okio/DeflaterSinkTest.java
@@ -36,7 +36,7 @@ public final class DeflaterSinkTest {
     deflaterSink.write(data, data.size());
     deflaterSink.close();
     OkBuffer inflated = inflate(sink);
-    assertEquals(original, inflated.readUtf8((int) inflated.size()));
+    assertEquals(original, inflated.readUtf8(inflated.size()));
   }
 
   @Test public void deflateWithSyncFlush() throws Exception {
@@ -48,7 +48,7 @@ public final class DeflaterSinkTest {
     deflaterSink.write(data, data.size());
     deflaterSink.flush();
     OkBuffer inflated = inflate(sink);
-    assertEquals(original, inflated.readUtf8((int) inflated.size()));
+    assertEquals(original, inflated.readUtf8(inflated.size()));
   }
 
   @Test public void deflateWellCompressed() throws IOException {
@@ -60,7 +60,7 @@ public final class DeflaterSinkTest {
     deflaterSink.write(data, data.size());
     deflaterSink.close();
     OkBuffer inflated = inflate(sink);
-    assertEquals(original, inflated.readUtf8((int) inflated.size()));
+    assertEquals(original, inflated.readUtf8(inflated.size()));
   }
 
   @Test public void deflatePoorlyCompressed() throws IOException {
@@ -72,7 +72,7 @@ public final class DeflaterSinkTest {
     deflaterSink.write(data, data.size());
     deflaterSink.close();
     OkBuffer inflated = inflate(sink);
-    assertEquals(original, inflated.readByteString((int) inflated.size()));
+    assertEquals(original, inflated.readByteString(inflated.size()));
   }
 
   /**

--- a/okio/src/test/java/okio/GzipSourceTest.java
+++ b/okio/src/test/java/okio/GzipSourceTest.java
@@ -98,8 +98,7 @@ public class GzipSourceTest {
 
   private void assertGzipped(OkBuffer gzipped) throws IOException {
     OkBuffer gunzipped = gunzip(gzipped);
-    assertEquals("It's a UNIX system! I know this!",
-        gunzipped.readUtf8((int) gunzipped.size()));
+    assertEquals("It's a UNIX system! I know this!", gunzipped.readUtf8(gunzipped.size()));
   }
 
   /**

--- a/okio/src/test/java/okio/InflaterSourceTest.java
+++ b/okio/src/test/java/okio/InflaterSourceTest.java
@@ -71,7 +71,7 @@ public final class InflaterSourceTest {
     ByteString original = randomBytes(1024 * 1024);
     OkBuffer deflated = deflate(original);
     OkBuffer inflated = inflate(deflated);
-    assertEquals(original, inflated.readByteString((int) inflated.size()));
+    assertEquals(original, inflated.readByteString(inflated.size()));
   }
 
   private OkBuffer decodeBase64(String s) {
@@ -79,7 +79,7 @@ public final class InflaterSourceTest {
   }
 
   private String readUtf8(OkBuffer buffer) {
-    return buffer.readUtf8((int) buffer.size());
+    return buffer.readUtf8(buffer.size());
   }
 
   /** Use DeflaterOutputStream to deflate source. */

--- a/okio/src/test/java/okio/OkBufferTest.java
+++ b/okio/src/test/java/okio/OkBufferTest.java
@@ -124,11 +124,11 @@ public final class OkBufferTest {
     assertEquals(0, SegmentPool.INSTANCE.byteCount);
 
     // Recycle MAX_SIZE segments. They're all in the pool.
-    buffer.readByteString((int) SegmentPool.MAX_SIZE);
+    buffer.readByteString(SegmentPool.MAX_SIZE);
     assertEquals(SegmentPool.MAX_SIZE, SegmentPool.INSTANCE.byteCount);
 
     // Recycle MAX_SIZE more segments. The pool is full so they get garbage collected.
-    buffer.readByteString((int) SegmentPool.MAX_SIZE);
+    buffer.readByteString(SegmentPool.MAX_SIZE);
     assertEquals(SegmentPool.MAX_SIZE, SegmentPool.INSTANCE.byteCount);
 
     // Take MAX_SIZE segments to drain the pool.

--- a/okio/src/test/java/okio/OkioTest.java
+++ b/okio/src/test/java/okio/OkioTest.java
@@ -54,11 +54,11 @@ public final class OkioTest {
 
     // Source: b...bc. Sink: b...b.
     assertEquals(Segment.SIZE, source.read(sink, 20000));
-    assertEquals(repeat('b', Segment.SIZE), sink.readUtf8((int) sink.size()));
+    assertEquals(repeat('b', Segment.SIZE), sink.readUtf8(sink.size()));
 
     // Source: b...bc. Sink: b...bc.
     assertEquals(Segment.SIZE - 1, source.read(sink, 20000));
-    assertEquals(repeat('b', Segment.SIZE - 2) + "c", sink.readUtf8((int) sink.size()));
+    assertEquals(repeat('b', Segment.SIZE - 2) + "c", sink.readUtf8(sink.size()));
 
     // Source and sink are empty.
     assertEquals(-1, source.read(sink, 1));


### PR DESCRIPTION
The casting masks bugs. Instead accept a long and do a range check in
OkBuffer.
