### PR TITLE
Modify HttpURLConnection to provide status line.

### DIFF
--- a/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
+++ b/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
@@ -161,6 +161,12 @@ public class OkApacheClient implements HttpClient {
     for (int i = 0; true; i++) {
       String name = connection.getHeaderFieldKey(i);
       if (name == null) {
+        // Header zero is permitted to be the status line and is defined as having a null key.
+        // Skip it if it is encountered and continue collecting headers.
+        if (i == 0) {
+          continue;
+        }
+        // Other null keys are interpreted as having run out of response headers.
         break;
       }
       BasicHeader header = new BasicHeader(name, connection.getHeaderField(i));

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -135,8 +135,12 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
    * are fewer than {@code position} headers.
    */
   @Override public final String getHeaderField(int position) {
+    if (position < 0) {
+      throw new IllegalArgumentException("Invalid position: " + position);
+    }
     try {
-      return getResponse().getResponse().headers().value(position);
+      Response response = getResponse().getResponse();
+      return position == 0 ? response.statusLine() : response.headers().value(position - 1);
     } catch (IOException e) {
       return null;
     }
@@ -157,8 +161,12 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   }
 
   @Override public final String getHeaderFieldKey(int position) {
+    if (position < 0) {
+      throw new IllegalArgumentException("Invalid position: " + position);
+    }
     try {
-      return getResponse().getResponse().headers().name(position);
+      Response response = getResponse().getResponse();
+      return position == 0 ? null : response.headers().name(position - 1);
     } catch (IOException e) {
       return null;
     }


### PR DESCRIPTION
java.net.CacheResponse is specified to always return the response
headers with an entry of null -> status line.

For URLConnection / HttpURLConnection:
getHeaderField(int) / getHeaderFieldKey(int): The RI docs specify
that implementations _may_ treat the 0th header as the status line
with a null key.
getHeaderField(String) or getHeaderFields(): The RI does not
specify the status line behavior for although both methods
appear to return the null mapping in the implementation I looked
at.

Before this change OkHttp treats getHeaderField(String) as having the
null mapping but other methods do not.

This change makes it consistent so that all HttpURLConnection
getHeader*() methods behave as if this mapping exists.
