### PR TITLE
Prefer org.junit over junit.framework for OkHttp code.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
@@ -25,8 +25,8 @@ import java.util.List;
 import org.junit.Test;
 
 import static com.squareup.okhttp.internal.Util.headerEntries;
-import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public final class HeadersTest {
   @Test public void parseNameValueBlock() throws IOException {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/StatusLineTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/StatusLineTest.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 import java.net.ProtocolException;
 import org.junit.Test;
 
-import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public final class StatusLineTest {
   @Test public void parse() throws IOException {

--- a/okio/src/test/java/okio/OkBufferTest.java
+++ b/okio/src/test/java/okio/OkBufferTest.java
@@ -21,8 +21,8 @@ import java.util.Random;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
-import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 


### PR DESCRIPTION
Noticed a few out-of-place imports.

MockWebServer still uses old packages in a couple of places and I didn't touch those.
