### PR TITLE
Remove creation of 'fat' jar.

### DIFF
--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -34,24 +34,6 @@
           <excludePackageNames>com.squareup.okhttp.internal:com.squareup.okhttp.internal.*</excludePackageNames>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Since the 'okhttp-protocols' module no longer exists we do not need to create this.

@swankjesse 

Will cherry-pick to 1.5 after merged.
