### PR TITLE
Make HttpURLConnection streams throw IOException after close()

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
@@ -579,8 +579,8 @@ public final class HttpResponseCacheTest {
     in.close();
     try {
       in.read();
-      fail("Expected an IllegalStateException because the stream is closed.");
-    } catch (IllegalStateException expected) {
+      fail("Expected an IOException because the stream is closed.");
+    } catch (IOException expected) {
     }
 
     assertEquals(1, cache.getWriteAbortCount());

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ResponseCacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ResponseCacheTest.java
@@ -405,8 +405,8 @@ public final class ResponseCacheTest {
     in.close();
     try {
       in.read();
-      fail("Expected an IllegalStateException because the stream is closed.");
-    } catch (IllegalStateException expected) {
+      fail("Expected an IOException because the stream is closed.");
+    } catch (IOException expected) {
     }
 
     connection = openConnection(server.getUrl("/"));

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -951,7 +951,7 @@ public final class URLConnectionTest {
     try {
       in.read();
       fail("Expected a connection closed exception");
-    } catch (IllegalStateException expected) {
+    } catch (IOException expected) {
     }
   }
 
@@ -2169,9 +2169,8 @@ public final class URLConnectionTest {
     out.flush(); // Dubious but permitted.
     try {
       out.write("ghi".getBytes("UTF-8"));
-      out.flush();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (IOException expected) {
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -380,6 +380,13 @@ public class HttpEngine {
    * this engine, it is returned.
    */
   public final Connection close() {
+    if (bufferedRequestBody != null) {
+      // This also closes the wrapped requestBodyOut.
+      closeQuietly(bufferedRequestBody);
+    } else if (requestBodyOut != null) {
+      closeQuietly(requestBodyOut);
+    }
+
     // If this engine never achieved a response body, its connection cannot be reused.
     if (responseBody == null) {
       closeQuietly(connection);
@@ -523,7 +530,7 @@ public class HttpEngine {
     if (responseSource == null) throw new IllegalStateException("call sendRequest() first!");
     if (!responseSource.requiresConnection()) return;
 
-    // Flush the response body if there's data outstanding.
+    // Flush the request body if there's data outstanding.
     if (bufferedRequestBody != null && bufferedRequestBody.buffer().size() > 0) {
       bufferedRequestBody.flush();
     }
@@ -540,7 +547,12 @@ public class HttpEngine {
     }
 
     if (requestBodyOut != null) {
-      requestBodyOut.close();
+      if (bufferedRequestBody != null) {
+        // This also closes the wrapped requestBodyOut.
+        bufferedRequestBody.close();
+      } else {
+        requestBodyOut.close();
+      }
       if (requestBodyOut instanceof RetryableSink) {
         transport.writeRequestBody((RetryableSink) requestBodyOut);
       }

--- a/okio/src/test/java/okio/RealBufferedSinkTest.java
+++ b/okio/src/test/java/okio/RealBufferedSinkTest.java
@@ -162,6 +162,55 @@ public final class RealBufferedSinkTest {
     mockSink.assertLog("write(OkBuffer[size=1 data=61], 1)", "close()");
   }
 
+  @Test public void operationsAfterClose() throws IOException {
+    MockSink mockSink = new MockSink();
+    BufferedSink bufferedSink = new RealBufferedSink(mockSink);
+    bufferedSink.writeByte('a');
+    bufferedSink.close();
+
+    // Test a sample set of methods.
+    try {
+      bufferedSink.writeByte('a');
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    try {
+      bufferedSink.write(new byte[10]);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    try {
+      bufferedSink.emitCompleteSegments();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    try {
+      bufferedSink.flush();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    // Test a sample set of methods on the OutputStream.
+    OutputStream os = bufferedSink.outputStream();
+    try {
+      os.write('a');
+      fail();
+    } catch (IOException expected) {
+    }
+
+    try {
+      os.write(new byte[10]);
+      fail();
+    } catch (IOException expected) {
+    }
+
+    // Permitted
+    os.flush();
+  }
+
   private String repeat(char c, int count) {
     char[] array = new char[count];
     Arrays.fill(array, c);

--- a/okio/src/test/java/okio/RealBufferedSourceTest.java
+++ b/okio/src/test/java/okio/RealBufferedSourceTest.java
@@ -18,6 +18,7 @@ package okio;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Arrays;
 import org.junit.Test;
 
@@ -153,6 +154,51 @@ public final class RealBufferedSourceTest {
     bufferedSource.skip(2);
     assertEquals(0, bufferedSource.buffer().size());
     assertEquals(2, source.size());
+  }
+
+  @Test public void operationsAfterClose() throws IOException {
+    OkBuffer source = new OkBuffer();
+    BufferedSource bufferedSource = new RealBufferedSource(source);
+    bufferedSource.close();
+
+    // Test a sample set of methods.
+    try {
+      bufferedSource.seek((byte) 1);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    try {
+      bufferedSource.skip(1);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    try {
+      bufferedSource.readByte();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    try {
+      bufferedSource.readByteString(10);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    // Test a sample set of methods on the InputStream.
+    InputStream is = bufferedSource.inputStream();
+    try {
+      is.read();
+      fail();
+    } catch (IOException expected) {
+    }
+
+    try {
+      is.read(new byte[10]);
+      fail();
+    } catch (IOException expected) {
+    }
   }
 
   private String repeat(char c, int count) {


### PR DESCRIPTION
This is to revert to prior behavior found in earlier releases:
OkHttp changed to throw IllegalStateException.

HttpEngine has also been changed to explicitly close the request
body on disconnect() to ensure that these exceptions are thrown
at the expected moment (e.g. on write() on a closed, buffered
stream).

Additional close() checks have been added to okio classes and
tests have been added. The tests are probes for interesting
examples, not complete.
