### PR TITLE
Fix problems with DeflaterSink.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/okio/RealBufferedSinkTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/okio/RealBufferedSinkTest.java
@@ -17,11 +17,7 @@ package com.squareup.okhttp.internal.okio;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.Test;
 
 import static com.squareup.okhttp.internal.okio.Util.UTF_8;
@@ -215,44 +211,5 @@ public final class RealBufferedSinkTest {
     char[] array = new char[count];
     Arrays.fill(array, c);
     return new String(array);
-  }
-
-  /** A scriptable sink. Like Mockito, but worse and requiring less configuration. */
-  private static class MockSink implements Sink {
-    private final List<String> log = new ArrayList<String>();
-    private final Map<Integer, IOException> callThrows = new LinkedHashMap<Integer, IOException>();
-
-    public void assertLog(String... messages) {
-      assertEquals(Arrays.asList(messages), log);
-    }
-
-    public void scheduleThrow(int call, IOException e) {
-      callThrows.put(call, e);
-    }
-
-    private void throwIfScheduled() throws IOException {
-      IOException exception = callThrows.get(log.size() - 1);
-      if (exception != null) throw exception;
-    }
-
-    @Override public void write(OkBuffer source, long byteCount) throws IOException {
-      log.add("write(" + source + ", " + byteCount + ")");
-      throwIfScheduled();
-    }
-
-    @Override public void flush() throws IOException {
-      log.add("flush()");
-      throwIfScheduled();
-    }
-
-    @Override public Sink deadline(Deadline deadline) {
-      log.add("deadline()");
-      return this;
-    }
-
-    @Override public void close() throws IOException {
-      log.add("close()");
-      throwIfScheduled();
-    }
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/okio/DeflaterSink.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/okio/DeflaterSink.java
@@ -38,6 +38,7 @@ import static com.squareup.okhttp.internal.okio.Util.checkOffsetAndCount;
 public final class DeflaterSink implements Sink {
   private final BufferedSink sink;
   private final Deflater deflater;
+  private boolean closed;
 
   public DeflaterSink(Sink sink, Deflater deflater) {
     this.sink = Okio.buffer(sink);
@@ -82,10 +83,13 @@ public final class DeflaterSink implements Sink {
           ? deflater.deflate(s.data, s.limit, Segment.SIZE - s.limit, Deflater.SYNC_FLUSH)
           : deflater.deflate(s.data, s.limit, Segment.SIZE - s.limit);
 
-      if (deflated == 0) return;
-      s.limit += deflated;
-      buffer.size += deflated;
-      sink.emitCompleteSegments();
+      if (deflated > 0) {
+        s.limit += deflated;
+        buffer.size += deflated;
+        sink.emitCompleteSegments();
+      } else if (deflater.needsInput()) {
+        return;
+      }
     }
   }
 
@@ -95,9 +99,32 @@ public final class DeflaterSink implements Sink {
   }
 
   @Override public void close() throws IOException {
-    deflater.finish();
-    deflate(false);
-    sink.close();
+    if (closed) return;
+
+    // Emit deflated data to the underlying sink. If this fails, we still need
+    // to close the deflater and the sink; otherwise we risk leaking resources.
+    Throwable thrown = null;
+    try {
+      deflater.finish();
+      deflate(false);
+    } catch (Throwable e) {
+      thrown = e;
+    }
+
+    try {
+      deflater.end();
+    } catch (Throwable e) {
+      if (thrown == null) thrown = e;
+    }
+
+    try {
+      sink.close();
+    } catch (Throwable e) {
+      if (thrown == null) thrown = e;
+    }
+    closed = true;
+
+    if (thrown != null) Util.sneakyRethrow(thrown);
   }
 
   @Override public Sink deadline(Deadline deadline) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/okio/OkBuffer.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/okio/OkBuffer.java
@@ -328,9 +328,8 @@ public final class OkBuffer implements BufferedSource, BufferedSink, Cloneable {
 
   /** Like {@link InputStream#read}. */
   int read(byte[] sink, int offset, int byteCount) {
-    if (byteCount == 0) return -1;
-
     Segment s = this.head;
+    if (s == null) return -1;
     int toCopy = Math.min(byteCount, s.limit - s.pos);
     System.arraycopy(s.data, s.pos, sink, offset, toCopy);
 

--- a/okio/src/test/java/okio/MockSink.java
+++ b/okio/src/test/java/okio/MockSink.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okio;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** A scriptable sink. Like Mockito, but worse and requiring less configuration. */
+class MockSink implements Sink {
+  private final List<String> log = new ArrayList<String>();
+  private final Map<Integer, IOException> callThrows = new LinkedHashMap<Integer, IOException>();
+
+  public void assertLog(String... messages) {
+    assertEquals(Arrays.asList(messages), log);
+  }
+
+  public void assertLogContains(String message) {
+    assertTrue(log.contains(message));
+  }
+
+  public void scheduleThrow(int call, IOException e) {
+    callThrows.put(call, e);
+  }
+
+  private void throwIfScheduled() throws IOException {
+    IOException exception = callThrows.get(log.size() - 1);
+    if (exception != null) throw exception;
+  }
+
+  @Override public void write(OkBuffer source, long byteCount) throws IOException {
+    log.add("write(" + source + ", " + byteCount + ")");
+    source.skip(byteCount);
+    throwIfScheduled();
+  }
+
+  @Override public void flush() throws IOException {
+    log.add("flush()");
+    throwIfScheduled();
+  }
+
+  @Override public Sink deadline(Deadline deadline) {
+    log.add("deadline()");
+    return this;
+  }
+
+  @Override public void close() throws IOException {
+    log.add("close()");
+    throwIfScheduled();
+  }
+}


### PR DESCRIPTION
We weren't checking Deflater.needsInput() in the deflate loop. This is
necessary on the RI, which returns 0 even when a subsequent call will
deflate data.
