### PR TITLE
fix #627: Merge SPDY settings when clear flag set. 

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/SettingsTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/SettingsTest.java
@@ -17,6 +17,7 @@ package com.squareup.okhttp.internal.spdy;
 
 import org.junit.Test;
 
+import static com.squareup.okhttp.internal.spdy.Settings.DEFAULT_INITIAL_WINDOW_SIZE;
 import static com.squareup.okhttp.internal.spdy.Settings.DOWNLOAD_BANDWIDTH;
 import static com.squareup.okhttp.internal.spdy.Settings.DOWNLOAD_RETRANS_RATE;
 import static com.squareup.okhttp.internal.spdy.Settings.MAX_CONCURRENT_STREAMS;
@@ -68,9 +69,10 @@ public final class SettingsTest {
     settings.set(DOWNLOAD_RETRANS_RATE, 0, 97);
     assertEquals(97, settings.getDownloadRetransRate(-3));
 
-    assertEquals(-1, settings.getInitialWindowSize());
+    assertEquals(DEFAULT_INITIAL_WINDOW_SIZE,
+        settings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE));
     settings.set(Settings.INITIAL_WINDOW_SIZE, 0, 108);
-    assertEquals(108, settings.getInitialWindowSize());
+    assertEquals(108, settings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE));
 
     assertEquals(-3, settings.getClientCertificateVectorSize(-3));
     settings.set(Settings.CLIENT_CERTIFICATE_VECTOR_SIZE, 0, 117);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
@@ -22,6 +22,12 @@ import java.util.Arrays;
  * Settings are {@link com.squareup.okhttp.internal.spdy.SpdyConnection connection} scoped.
  */
 final class Settings {
+  /**
+   * From the SPDY/3 and HTTP/2 specs, the default initial window size for all
+   * streams is 64 KiB. (Chrome 25 uses 10 MiB).
+   */
+  static final int DEFAULT_INITIAL_WINDOW_SIZE = 64 * 1024;
+
   /** Peer request to clear durable settings. */
   static final int FLAG_CLEAR_PREVIOUSLY_PERSISTED_SETTINGS = 0x1;
 
@@ -171,11 +177,9 @@ final class Settings {
     return (bit & set) != 0 ? values[DOWNLOAD_RETRANS_RATE] : defaultValue;
   }
 
-  // TODO: honor this setting in http/2.
-  /** Returns -1 if unset. */
-  int getInitialWindowSize() {
+  int getInitialWindowSize(int defaultValue) {
     int bit = 1 << INITIAL_WINDOW_SIZE;
-    return (bit & set) != 0 ? values[INITIAL_WINDOW_SIZE] : -1;
+    return (bit & set) != 0 ? values[INITIAL_WINDOW_SIZE] : defaultValue;
   }
 
   /** spdy/3 only. */

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -38,6 +38,8 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import static com.squareup.okhttp.internal.spdy.Settings.DEFAULT_INITIAL_WINDOW_SIZE;
+
 /**
  * A socket connection to a remote peer. A connection hosts streams which can
  * send and receive data.
@@ -89,8 +91,6 @@ public final class SpdyConnection implements Closeable {
   private final PushObserver pushObserver;
   private int nextPingId;
 
-  static final int INITIAL_WINDOW_SIZE = 65535;
-
   /**
    * The total number of bytes consumed by the application, but not yet
    * acknowledged by sending a {@code WINDOW_UPDATE} frame on this connection.
@@ -107,15 +107,12 @@ public final class SpdyConnection implements Closeable {
 
   /** Settings we communicate to the peer. */
   // TODO: Do we want to dynamically adjust settings, or KISS and only set once?
-  final Settings okHttpSettings = new Settings()
-      .set(Settings.INITIAL_WINDOW_SIZE, 0, INITIAL_WINDOW_SIZE);
-      // TODO: implement stream limit
+  final Settings okHttpSettings = new Settings();
       // okHttpSettings.set(Settings.MAX_CONCURRENT_STREAMS, 0, max);
 
   /** Settings we receive from the peer. */
   // TODO: MWS will need to guard on this setting before attempting to push.
-  final Settings peerSettings = new Settings()
-      .set(Settings.INITIAL_WINDOW_SIZE, 0, INITIAL_WINDOW_SIZE);
+  final Settings peerSettings = new Settings();
 
   private boolean receivedInitialPeerSettings = false;
   final FrameReader frameReader;
@@ -151,7 +148,7 @@ public final class SpdyConnection implements Closeable {
     } else {
       throw new AssertionError(protocol);
     }
-    bytesLeftInWriteWindow = peerSettings.getInitialWindowSize();
+    bytesLeftInWriteWindow = peerSettings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE);
     frameReader = variant.newReader(builder.source, client);
     frameWriter = variant.newWriter(builder.sink, client);
     maxFrameSize = variant.maxFrameSize();
@@ -657,16 +654,13 @@ public final class SpdyConnection implements Closeable {
       long delta = 0;
       SpdyStream[] streamsToNotify = null;
       synchronized (SpdyConnection.this) {
-        int priorWriteWindowSize = peerSettings.getInitialWindowSize();
-        if (clearPrevious) {
-          peerSettings.clear();
-        } else {
-          peerSettings.merge(newSettings);
-        }
+        int priorWriteWindowSize = peerSettings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE);
+        if (clearPrevious) peerSettings.clear();
+        peerSettings.merge(newSettings);
         if (getProtocol() == Protocol.HTTP_2) {
           ackSettingsLater();
         }
-        int peerInitialWindowSize = peerSettings.getInitialWindowSize();
+        int peerInitialWindowSize = peerSettings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE);
         if (peerInitialWindowSize != -1 && peerInitialWindowSize != priorWriteWindowSize) {
           delta = peerInitialWindowSize - priorWriteWindowSize;
           if (!receivedInitialPeerSettings) {


### PR DESCRIPTION
Revert Settings.DEFAULT_INITIAL_WINDOW_SIZE.
