### PR TITLE
Fix problems with connection recycling and recovery.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -98,6 +98,7 @@ public class HttpEngine {
    */
   public final boolean bufferRequestBody;
 
+  private Request originalRequest;
   private Request request;
   private Sink requestBodyOut;
   private BufferedSink bufferedRequestBody;
@@ -135,6 +136,7 @@ public class HttpEngine {
   public HttpEngine(OkHttpClient client, Request request, boolean bufferRequestBody,
       Connection connection, RouteSelector routeSelector, RetryableSink requestBodyOut) {
     this.client = client;
+    this.originalRequest = request;
     this.request = request;
     this.bufferRequestBody = bufferRequestBody;
     this.connection = connection;
@@ -328,7 +330,7 @@ public class HttpEngine {
     Connection connection = close();
 
     // For failure recovery, use the same route selector with a new connection.
-    return new HttpEngine(client, request, bufferRequestBody, connection, routeSelector,
+    return new HttpEngine(client, originalRequest, bufferRequestBody, connection, routeSelector,
         (RetryableSink) requestBodyOut);
   }
 


### PR DESCRIPTION
We were incorrectly attempting to recycle connections terminated by the end
of a socket stream.

And we were keeping the 'Accept-Encoding: gzip' header on a recovered request,
which was suppressing our transparentGzip flag from getting the 'true' value
it requires.
