### PR TITLE
Document that OkHttpClient is thread-safe

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -44,6 +44,12 @@ import okio.ByteString;
  * Configures and creates HTTP connections. Most applications can use a single
  * OkHttpClient for all of their HTTP requests - benefiting from a shared
  * response cache, thread pool, connection re-use, etc.
+ *
+ * Instances of OkHttpClient are intended to be fully configured before they're
+ * shared - once shared they should be treated as immutable and can safely be used
+ * to concurrently open new connections. If required, threads can call
+ * {@link #clone()} to make a shallow copy of the OkHttpClient that can be
+ * safely modified with further configuration changes.
  */
 public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
 
@@ -421,9 +427,6 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
     dispatcher.cancel(tag);
   }
 
-  /**
-   * This method is thread-safe.
-   */
   public HttpURLConnection open(URL url) {
     return open(url, proxy);
   }


### PR DESCRIPTION
While investigating a race-condition, I was momentarily worried when I couldn't find any documentation actually stating that OkHttpClient is thread-safe, apart from this Google+ post:

https://plus.google.com/118239425803358296962/posts/5nzAvPaitHu

...if I'm not the only person asking this question, probably best to document it!
