### PR TITLE
Fix a crash on conditional cache hits for new API.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RecordingReceiver.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RecordingReceiver.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,8 +74,10 @@ public class RecordingReceiver implements Response.Receiver {
   public synchronized RecordedResponse await(URL url) throws Exception {
     long timeoutMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) + TIMEOUT_MILLIS;
     while (true) {
-      for (RecordedResponse recordedResponse : responses) {
+      for (Iterator<RecordedResponse> i = responses.iterator(); i.hasNext(); ) {
+        RecordedResponse recordedResponse = i.next();
         if (recordedResponse.request.url().equals(url)) {
+          i.remove();
           return recordedResponse;
         }
       }

--- a/okhttp/src/main/java/com/squareup/okhttp/Job.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Job.java
@@ -149,10 +149,7 @@ final class Job extends NamedRunnable {
       if (redirect == null) {
         engine.releaseConnection();
         return response.newBuilder()
-            // Cache body includes original content-length and content-type data.
-            .body(engine.responseSource().usesCache()
-                ? engine.getResponse().body()
-                : new RealResponseBody(response, engine.getResponseBody()))
+            .body(new RealResponseBody(response, engine.getResponseBody()))
             .redirectedBy(redirectedBy)
             .build();
       }


### PR DESCRIPTION
Previously we were returning null when a 304 didn't validate. The problem
was caused by a bad test that specified Content-Length: 0 for a 304, which
isn't appropriate.
