### PR TITLE
Don't double pool on a conditional cache hit.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpResponseCacheTest.java
@@ -16,6 +16,7 @@
 
 package com.squareup.okhttp.internal.http;
 
+import com.squareup.okhttp.ConnectionPool;
 import com.squareup.okhttp.HttpResponseCache;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.OkResponseCache;
@@ -964,6 +965,22 @@ public final class HttpResponseCacheTest {
     assertEquals("ABCABCABC", readAscii(openConnection(server.getUrl("/"))));
     assertEquals("ABCABCABC", readAscii(openConnection(server.getUrl("/"))));
     assertEquals("DEFDEFDEF", readAscii(openConnection(server.getUrl("/"))));
+  }
+
+  @Test public void conditionalCacheHitIsNotDoublePooled() throws Exception {
+    server.enqueue(new MockResponse().addHeader("ETag: v1").setBody("A"));
+    server.enqueue(new MockResponse()
+        .clearHeaders()
+        .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED));
+    server.play();
+
+    ConnectionPool pool = ConnectionPool.getDefault();
+    pool.evictAll();
+    client.setConnectionPool(pool);
+
+    assertEquals("A", readAscii(openConnection(server.getUrl("/"))));
+    assertEquals("A", readAscii(openConnection(server.getUrl("/"))));
+    assertEquals(1, client.getConnectionPool().getConnectionCount());
   }
 
   @Test public void expiresDateBeforeModifiedDate() throws Exception {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -371,7 +371,7 @@ public class HttpEngine {
    * be released immediately.
    */
   public final void releaseConnection() throws IOException {
-    if (transport != null) {
+    if (transport != null && connection != null) {
       transport.releaseConnectionOnIdle();
     }
     connection = null;


### PR DESCRIPTION
We were pooling the unused connection twice, and the pool was getting two
copies of the same connection. Bad consequences followed.
