### PR TITLE
Fix build removing obsolete okhttp-protocols dependency

### DIFF
--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -18,11 +18,6 @@
       <artifactId>okio</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp</groupId>
-      <artifactId>okhttp-protocols</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
The build fails with a clean local Maven repo due to this obsolete dependency.

I just signed the CLA.
