### PR TITLE
Suggested improvement to journal file: flush more often

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/DiskLruCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/DiskLruCache.java
@@ -430,6 +430,7 @@ public final class DiskLruCache implements Closeable {
 
     redundantOpCount++;
     journalWriter.writeUtf8(READ + ' ' + key + '\n');
+    journalWriter.flush();
     if (journalRebuildRequired()) {
       executorService.execute(cleanupRunnable);
     }
@@ -588,6 +589,7 @@ public final class DiskLruCache implements Closeable {
 
     redundantOpCount++;
     journalWriter.writeUtf8(REMOVE + ' ' + key + '\n');
+    journalWriter.flush();
     lruEntries.remove(key);
 
     if (journalRebuildRequired()) {


### PR DESCRIPTION
to avoid pending writes.

In the event of process termination the journal file
is force-closed. Any journal writes that are buffered but
not yet flushed to disk will be missing. There are a couple
of places where a write to the journal file is not flushed
immediately to disk.

One of the cases (writeUtf8(REMOVE, ...) is called in a loop
as part of trimToSize(), which could lead to a substantial
number of deletes having taken place without
being flushed to the journal. I assume
the write would be flushed eventually when the 8k buffer is
filled (?) or until another write takes place that _is_
flushed.

This change may make cache read and deletion slower but lead to
reduced journal truncation in the event of a failure.

Both the cases are open for debate:

I can see the REMOVE case being flushed after the trimToSize()
rather than after each individual removal. Flushing after the
trimToSize() would still be an improvement, IMO.

I could see the READ case not needing to be flushed at all in the
name of performance. Not flushing in this case would, presumably,
just lead to out-of-date LRU information on restart.
