### PR TITLE
Return HttpResponseCache to previous (e.g. KitKat) behavior

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/JavaApiConverterTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/JavaApiConverterTest.java
@@ -49,7 +49,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -432,9 +432,9 @@ public class JavaApiConverterTest {
     // Check retrieval using a Map.
     Map<String, List<String>> responseHeaders = httpUrlConnection.getHeaderFields();
     assertEquals(Arrays.asList(statusLine), responseHeaders.get(null));
-    assertEquals(newSet("c", "e"), new HashSet<String>(responseHeaders.get("A")));
+    assertEquals(newSet("c", "e"), newSet(responseHeaders.get("A")));
     // OkHttp supports case-insensitive matching here. The RI does not.
-    assertEquals(newSet("c", "e"), new HashSet<String>(responseHeaders.get("a")));
+    assertEquals(newSet("c", "e"), newSet(responseHeaders.get("a")));
 
     // Check the Map iterator contains the expected mappings.
     assertHeadersContainsMapping(responseHeaders, null, statusLine);
@@ -485,7 +485,7 @@ public class JavaApiConverterTest {
   private void assertHeadersContainsMapping(Map<String, List<String>> headers, String expectedKey,
       String... expectedValues) {
     assertTrue(headers.containsKey(expectedKey));
-    assertEquals(newSet(expectedValues), new HashSet<String>(headers.get(expectedKey)));
+    assertEquals(newSet(expectedValues), newSet(headers.get(expectedKey)));
   }
 
   @Test public void createJavaUrlConnection_accessibleRequestInfo_GET() throws Exception {
@@ -717,8 +717,12 @@ public class JavaApiConverterTest {
     }
   }
 
-  private static Set<String> newSet(String... elements) {
-    return new HashSet<String>(Arrays.asList(elements));
+  private static <T> Set<T> newSet(T... elements) {
+    return newSet(Arrays.asList(elements));
+  }
+
+  private static <T> Set<T> newSet(List<T> elements) {
+    return new LinkedHashSet<T>(elements);
   }
 
   private static Request createArbitraryOkRequest() {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ResponseCacheAdapterTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ResponseCacheAdapterTest.java
@@ -55,8 +55,8 @@ import static org.junit.Assert.fail;
  * <ul>
  *   <li>{@link ResponseCacheTest} for black-box tests that check that {@link ResponseCache}
  *   classes are called correctly by OkHttp.</li>
- *   <li>{@link JavaApiConverterTest} for tests that check Java API classes <-> OkHttp conversion logic.
- *   </li>
+ *   <li>{@link JavaApiConverterTest} for tests that check Java API classes / OkHttp conversion
+ *   logic. </li>
  * </ul>
  */
 public class ResponseCacheAdapterTest {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/JavaApiConverter.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/JavaApiConverter.java
@@ -52,10 +52,6 @@ public final class JavaApiConverter {
   /**
    * Creates an OkHttp {@link Response} using the supplied {@link URI} and {@link URLConnection}
    * to supply the data. The URLConnection is assumed to already be connected.
-   *
-   * <p>Note: Because this method is used by HttpResponseCache, this class is intended for use with
-   * any Java-API compliant HttpURLConnection / HttpsURLConnection and not just ones implemented by
-   * OkHttp.
    */
   public static Response createOkResponse(URI uri, URLConnection urlConnection) throws IOException {
     HttpURLConnection httpUrlConnection = (HttpURLConnection) urlConnection;


### PR DESCRIPTION
This change required to handle this Android scenario:

When this version of OkHttp is packaged into Android in a future
release (in com.android.okhttp...) there is a possibility that
an older version of OkHttp bundled with application
(in com.squareup.okhttp...) will pick up the newer HttpResponseCache
via ResponseCache.getDefault(). It will attempt to use the get() / put()
methods. Commit e2599be9e073f1be8e929597c358e2664ab0c9a9 was
intended to restore HttpResponseCache get() and put() and avoid the
UnsupportedOperationException that would be thrown.

Unfortunately, it didn't quite do it:

In KitKat and older versions OkHttp, in HttpResponseCache the behavior
was to ignore calls to put(URI, URLConnection) including
any HttpURLConnection/HttpsURLConnection that wasn't its own
(i.e. only ones from com.android.okhttp would be cached). The previous
fix to HttpResponseCache re-introduced get()/put() but didn't implement
the necessary instanceof checks.

Jesse also informs me that coexistance with other implementations
of HttpURLConnection is not required (since OkHttp replaces the
HTTP implementation on the desktop). I have also since discovered
that HttpResponseCache didn't implement the cache-control logic
required to follow the letter of the Java API anyway, which means
that HttpResponseCache is not suitable for use in cases where
the Http(s)URLConnection implementation expects a fully compliant
implementation.

Also addressed nits from e2599be9e073f1be8e929597c358e2664ab0c9a9.
