### PR TITLE
Remove 'jar-with-dependencies' qualifier from download link.

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -127,7 +127,7 @@
                 -->
 
             <h3 id="download">Download</h3>
-            <p><a href="http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.squareup.okhttp&a=okhttp&c=jar-with-dependencies&v=LATEST" class="dl version-href">&darr; <span class="version-tag">Latest</span> JAR</a></p>
+            <p><a href="http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.squareup.okhttp&a=okhttp&v=LATEST" class="dl version-href">&darr; <span class="version-tag">Latest</span> JAR</a></p>
             <p>The source code to the OkHttp, its samples, and this website is <a href="http://github.com/square/okhttp">available on GitHub</a>.</p>
 
             <h4>Maven</h4>


### PR DESCRIPTION
This link is used when the jQuery Maven Artifact plugin cannot resolve the absolute URL of the latest artifact.

@swankjesse 

Refs #660
