### PR TITLE
Teach MockWebServer to throttle the request body.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/Dispatcher.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/Dispatcher.java
@@ -24,11 +24,18 @@ public abstract class Dispatcher {
   public abstract MockResponse dispatch(RecordedRequest request) throws InterruptedException;
 
   /**
-   * Returns the socket policy of the next request.  Default implementation
-   * returns {@link SocketPolicy#KEEP_OPEN}. Mischievous implementations can
-   * return other values to test HTTP edge cases.
+   * Returns an early guess of the next response, used for policy on how an
+   * incoming request should be received. The default implementation returns an
+   * empty response. Mischievous implementations can return other values to test
+   * HTTP edge cases, such as unhappy socket policies or throttled request
+   * bodies.
    */
-  public SocketPolicy peekSocketPolicy() {
-    return SocketPolicy.KEEP_OPEN;
+  public MockResponse peek() {
+    return new MockResponse().setSocketPolicy(SocketPolicy.KEEP_OPEN);
+  }
+
+  /** @deprecated replaced with {@link #peek}. */
+  protected final SocketPolicy peekSocketPolicy() {
+    throw new UnsupportedOperationException("This API is obsolete. Override peek() instead!");
   }
 }

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/QueueDispatcher.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/QueueDispatcher.java
@@ -44,14 +44,11 @@ public class QueueDispatcher extends Dispatcher {
     return responseQueue.take();
   }
 
-  @Override public SocketPolicy peekSocketPolicy() {
+  @Override public MockResponse peek() {
     MockResponse peek = responseQueue.peek();
-    if (peek == null) {
-      return failFastResponse != null
-          ? failFastResponse.getSocketPolicy()
-          : SocketPolicy.KEEP_OPEN;
-    }
-    return peek.getSocketPolicy();
+    if (peek != null) return peek;
+    if (failFastResponse != null) return failFastResponse;
+    return super.peek();
   }
 
   public void enqueueResponse(MockResponse response) {

--- a/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/MockWebServerTest.java
@@ -28,7 +28,10 @@ import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import junit.framework.TestCase;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public final class MockWebServerTest extends TestCase {
 
@@ -285,5 +288,54 @@ public final class MockWebServerTest extends TestCase {
         assertEquals('C', in.read());
 
         assertEquals(-1, responseBody.read()); // The body is exhausted.
+    }
+
+    /**
+     * Throttle the request body by sleeping 500ms after every 3 bytes. With a
+     * 6-byte request, this should yield one sleep for a total delay of 500ms.
+     */
+    public void testThrottleRequest() throws Exception {
+        server.enqueue(new MockResponse()
+            .throttleBody(3, 500, TimeUnit.MILLISECONDS));
+        server.play();
+
+        long startNanos = System.nanoTime();
+        URLConnection connection = server.getUrl("/").openConnection();
+        connection.setDoOutput(true);
+        connection.getOutputStream().write("ABCDEF".getBytes("UTF-8"));
+        InputStream in = connection.getInputStream();
+        assertEquals(-1, in.read());
+        long elapsedNanos = System.nanoTime() - startNanos;
+        long elapsedMillis = NANOSECONDS.toMillis(elapsedNanos);
+
+        assertTrue(String.format("Request + Response: %sms", elapsedMillis), elapsedMillis >= 500);
+        assertTrue(String.format("Request + Response: %sms", elapsedMillis), elapsedMillis < 1000);
+    }
+
+    /**
+     * Throttle the response body by sleeping 500ms after every 3 bytes. With a
+     * 6-byte response, this should yield one sleep for a total delay of 500ms.
+     */
+    public void testThrottleResponse() throws Exception {
+        server.enqueue(new MockResponse()
+            .setBody("ABCDEF")
+            .throttleBody(3, 500, TimeUnit.MILLISECONDS));
+        server.play();
+
+        long startNanos = System.nanoTime();
+        URLConnection connection = server.getUrl("/").openConnection();
+        InputStream in = connection.getInputStream();
+        assertEquals('A', in.read());
+        assertEquals('B', in.read());
+        assertEquals('C', in.read());
+        assertEquals('D', in.read());
+        assertEquals('E', in.read());
+        assertEquals('F', in.read());
+        assertEquals(-1, in.read());
+        long elapsedNanos = System.nanoTime() - startNanos;
+        long elapsedMillis = NANOSECONDS.toMillis(elapsedNanos);
+
+        assertTrue(String.format("Request + Response: %sms", elapsedMillis), elapsedMillis >= 500);
+        assertTrue(String.format("Request + Response: %sms", elapsedMillis), elapsedMillis < 1000);
     }
 }


### PR DESCRIPTION
We use a single throttle for both request and response. This is
sufficient for all of our current needs.

This breaks API compatibility with previous custom dispatchers.
Dispatchers that override peekSocketPolicy() must now override
peek() instead.
