### PR TITLE
Fix a bug when a POST was redirected to a GET.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -284,15 +284,15 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       builder.addHeader(headers.name(i), headers.value(i));
     }
 
-    boolean bufferRequestBody;
-    if (fixedContentLength != -1) {
-      bufferRequestBody = false;
-      builder.header("Content-Length", Long.toString(fixedContentLength));
-    } else if (chunkLength > 0) {
-      bufferRequestBody = false;
-      builder.header("Transfer-Encoding", "chunked");
-    } else {
-      bufferRequestBody = true;
+    boolean bufferRequestBody = false;
+    if (HttpMethod.hasRequestBody(method)) {
+      if (fixedContentLength != -1) {
+        builder.header("Content-Length", Long.toString(fixedContentLength));
+      } else if (chunkLength > 0) {
+        builder.header("Transfer-Encoding", "chunked");
+      } else {
+        bufferRequestBody = true;
+      }
     }
 
     Request request = builder.build();


### PR DESCRIPTION
We were keeping the Content-Length header, leading to conflicting
body information.
