### PR TITLE
ByteString should be java.io.Serializable

### DIFF
--- a/okio/src/main/java/okio/ByteString.java
+++ b/okio/src/main/java/okio/ByteString.java
@@ -40,7 +40,7 @@ public final class ByteString implements Serializable {
       { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
   /** A singleton empty {@code ByteString}. */
-  public static final ByteString EMPTY = ByteString.of();
+  public static final ByteString EMPTY = new ByteString(new byte[0]);
   static final long serialVersionUID = 1L;
 
   final byte[] data;
@@ -55,6 +55,7 @@ public final class ByteString implements Serializable {
    * Returns a new byte string containing a clone of the bytes of {@code data}.
    */
   public static ByteString of(byte... data) {
+    if (data.length == 0) return EMPTY;
     return new ByteString(data.clone());
   }
 

--- a/okio/src/test/java/okio/ByteStringTest.java
+++ b/okio/src/test/java/okio/ByteStringTest.java
@@ -18,11 +18,14 @@ package okio;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -174,6 +177,37 @@ public class ByteStringTest {
   @Test public void toStringOnLargeByteStringIncludesMd5() {
     assertEquals("ByteString[size=17 md5=2c9728a2138b2f25e9f89f99bdccf8db]",
         ByteString.encodeUtf8("12345678901234567").toString());
+  }
+
+  @Test public void javaSerializationTestNonEmpty() throws Exception {
+    ByteString original = ByteString.encodeUtf8(bronzeHorseman);
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream out = new ObjectOutputStream(bytes);
+    out.writeObject(original);
+    ObjectInputStream in = new ObjectInputStream(
+        new ByteArrayInputStream(bytes.toByteArray()));
+    Object roundTrippedObject = in.readObject();
+    assertNotNull(roundTrippedObject);
+    assertTrue("Round tripped object wasn't a ByteString but a " +
+        roundTrippedObject.getClass(), roundTrippedObject instanceof ByteString);
+    assertEquals(original, roundTrippedObject);
+    assertEquals("hashCodes", original.hashCode(), roundTrippedObject.hashCode());
+  }
+
+  @Test public void javaSerializationTestEmpty() throws Exception {
+    ByteString original = ByteString.of();
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream out = new ObjectOutputStream(bytes);
+    out.writeObject(original);
+    ObjectInputStream in = new ObjectInputStream(
+        new ByteArrayInputStream(bytes.toByteArray()));
+    Object roundTrippedObject = in.readObject();
+    assertNotNull(roundTrippedObject);
+    assertTrue("Round tripped object wasn't a ByteString but a " +
+        roundTrippedObject.getClass(), roundTrippedObject instanceof ByteString);
+    assertEquals(original, roundTrippedObject);
+    assertEquals("hashCodes", original.hashCode(), roundTrippedObject.hashCode());
+    assertSame("There can be only one EMPTY", original, roundTrippedObject);
   }
 
   private static void assertByteArraysEquals(byte[] a, byte[] b) {


### PR DESCRIPTION
I know, java serialization is an awful world of pain, but so many frameworks that otherwise require custom serialization-like interface implementations will have a default implementation for java serialization that it's a good idea for libraries to pay the java serialization tax on behalf of users.

Also included in here is a change making `ByteString.EMPTY` the singleton the javadoc implies that it is.
