### PR TITLE
support token Credential and open up cstor

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -2663,6 +2663,30 @@ public final class URLConnectionTest {
     assertTrue(call, call.contains("challenges=[Basic realm=\"protected area\"]"));
   }
 
+  @Test public void tokenAuthenticator() throws Exception {
+    MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
+        .addHeader("WWW-Authenticate: Bearer realm=\"oauthed\"")
+        .setBody("Please authenticate.");
+    server.enqueue(pleaseAuthenticate);
+    server.enqueue(new MockResponse().setBody("A"));
+    server.play();
+
+    Credential credential = Credential.oauth("oauthed", "abc123");
+    RecordingOkAuthenticator authenticator = new RecordingOkAuthenticator(credential);
+    client.setAuthenticator(authenticator);
+    assertContent("A", client.open(server.getUrl("/private")));
+
+    assertContainsNoneMatching(server.takeRequest().getHeaders(), "Authorization: .*");
+    assertContains(server.takeRequest().getHeaders(),
+        "Authorization: " + credential.getHeaderValue());
+
+    assertEquals(1, authenticator.calls.size());
+    String call = authenticator.calls.get(0);
+    assertTrue(call, call.contains("proxy=DIRECT"));
+    assertTrue(call, call.contains("url=" + server.getUrl("/private")));
+    assertTrue(call, call.contains("challenges=[Bearer realm=\"oauthed\"]"));
+  }
+
   @Test public void npnSetsProtocolHeader_SPDY_3() throws Exception {
     npnSetsProtocolHeader(Protocol.SPDY_3);
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/OkAuthenticator.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkAuthenticator.java
@@ -88,7 +88,7 @@ public interface OkAuthenticator {
   public final class Credential {
     private final String headerValue;
 
-    private Credential(String headerValue) {
+    public Credential(String headerValue) {
       this.headerValue = headerValue;
     }
 
@@ -102,6 +102,10 @@ public interface OkAuthenticator {
       } catch (UnsupportedEncodingException e) {
         throw new AssertionError();
       }
+    }
+
+    public static Credential oauth(String bearer, String token) {
+      return new Credential(bearer + " " + token);
     }
 
     public String getHeaderValue() {


### PR DESCRIPTION
allows providing oauth tokens, but does not solve the bigger issues of
refresh/signin
- make Credential's constructor public so that arbitrary Authorization
  schemes are supported.
- explicitly add static Credential.oauth method with bearer and token
  params

fixes #497
