### PR TITLE
Permit a dangling semicolon in media type parsing.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/MediaTypeTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/MediaTypeTest.java
@@ -54,6 +54,10 @@ public class MediaTypeTest {
     assertMediaType("text/plain; a=1; a=2; b=3");
     assertMediaType("text/plain; charset=utf-16");
     assertMediaType("text/plain; \t \n \r a=b");
+    assertMediaType("text/plain;");
+    assertMediaType("text/plain; ");
+    assertMediaType("text/plain; a=1;");
+    assertMediaType("text/plain; a=1; ");
   }
 
   @Test public void testInvalidParse() throws Exception {
@@ -64,14 +68,10 @@ public class MediaTypeTest {
     assertInvalid("text/");
     assertInvalid("te<t/plain");
     assertInvalid("text/pl@in");
-    assertInvalid("text/plain;");
-    assertInvalid("text/plain; ");
     assertInvalid("text/plain; a");
     assertInvalid("text/plain; a=");
     assertInvalid("text/plain; a=@");
     assertInvalid("text/plain; a=\"@");
-    assertInvalid("text/plain; a=1;");
-    assertInvalid("text/plain; a=1; ");
     assertInvalid("text/plain; a=1; b");
     assertInvalid("text/plain; a=1; b=");
     assertInvalid("text/plain; a=\u2025");
@@ -82,6 +82,8 @@ public class MediaTypeTest {
     assertInvalid("text/pl ain");
     assertInvalid("text/plain ");
     assertInvalid("text/plain ; a=1");
+    assertInvalid("text/plain; a=1;; b=2");
+    assertInvalid("text/plain;;");
   }
 
   @Test public void testParseWithSpecialCharacters() throws Exception {
@@ -138,6 +140,14 @@ public class MediaTypeTest {
     MediaType charset = MediaType.parse("text/plain; charset=iso-8859-1");
     assertEquals("ISO-8859-1", charset.charset(Util.UTF_8).name());
     assertEquals("ISO-8859-1", charset.charset(Charset.forName("US-ASCII")).name());
+  }
+
+  @Test public void testParseDanglingSemicolon() throws Exception {
+    MediaType mediaType = MediaType.parse("text/plain;");
+    assertEquals("text", mediaType.type());
+    assertEquals("plain", mediaType.subtype());
+    assertEquals(null, mediaType.charset());
+    assertEquals("text/plain;", mediaType.toString());
   }
 
   private void assertMediaType(String string) {

--- a/okhttp/src/main/java/com/squareup/okhttp/MediaType.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/MediaType.java
@@ -57,7 +57,11 @@ public final class MediaType {
     Matcher parameter = PARAMETER.matcher(string);
     for (int s = typeSubtype.end(); s < string.length(); s = parameter.end()) {
       parameter.region(s, string.length());
-      if (!parameter.lookingAt()) return null; // This is not a well-formed media type.
+      if (!parameter.lookingAt()) {
+        // This is not a well-formed media type. Permit a dangling semicolon but no more.
+        if (string.substring(s).matches(";\\s*")) break;
+        return null;
+      }
 
       String name = parameter.group(1);
       if (name == null || !name.equalsIgnoreCase("charset")) continue;


### PR DESCRIPTION
I found this in-the-wild with Crawler.
