### PR TITLE
Add ALPN support; Configure maven to use ALPN on OpenJDK 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ before_install:
 
 jdk:
   - oraclejdk7
+  - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Testing
 
 ### On the Desktop
 
-Run OkHttp tests on the desktop with Maven. Running SPDY tests on the desktop uses
-[Jetty-NPN][3] which requires OpenJDK 7.
+Run OkHttp tests on the desktop with Maven. Running HTTP/2 and SPDY tests on the desktop uses
+[Jetty-NPN][3] when running OpenJDK 7 or [Jetty-ALPN][4] when OpenJDK 8.
 
 ```
 mvn clean test
@@ -46,7 +46,7 @@ mvn clean test
 OkHttp's test suite creates an in-process HTTPS server. Prior to Android 2.3, SSL server sockets
 were broken, and so HTTPS tests will time out when run on such devices.
 
-Test on a USB-attached Android using [Vogar][4]. Unfortunately `dx` requires that you build with
+Test on a USB-attached Android using [Vogar][5]. Unfortunately `dx` requires that you build with
 Java 6, otherwise the test class will be silently omitted from the `.dex` file.
 
 ```
@@ -69,7 +69,7 @@ MockWebServer coupling with OkHttp is essential for proper testing of SPDY and H
 
 ### Download
 
-Download [the latest JAR][5] or grab via Maven:
+Download [the latest JAR][6] or grab via Maven:
 
 ```xml
 <dependency>
@@ -102,5 +102,6 @@ License
  [1]: http://square.github.io/okhttp
  [2]: http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.squareup.okhttp&a=okhttp&v=LATEST
  [3]: https://github.com/jetty-project/jetty-npn
- [4]: https://code.google.com/p/vogar/
- [5]: http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.squareup.okhttp&a=mockwebserver&v=LATEST
+ [4]: https://github.com/jetty-project/jetty-alpn
+ [5]: https://code.google.com/p/vogar/
+ [6]: http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.squareup.okhttp&a=mockwebserver&v=LATEST

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -39,11 +39,6 @@
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty.npn</groupId>
-      <artifactId>npn-boot</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
@@ -71,28 +66,70 @@
   </dependencies>
   <build>
     <plugins>
-    <plugin>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>exec-maven-plugin</artifactId>
-      <executions>
-        <execution>
-          <goals>
-            <goal>java</goal>
-          </goals>
-        </execution>
-      </executions>
-      <configuration>
-        <executable>java</executable>
-        <arguments>
-          <argument>-Xms512m</argument>
-          <argument>-Xmx512m</argument>
-          <commandlineArgs>-Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/npn/npn-boot/${npn.version}/npn-boot-${npn.version}.jar</commandlineArgs>
-          <argument>-classpath</argument>
-          <classpath/>
-          <argument>com.squareup.okhttp.benchmarks.Benchmark</argument>
-        </arguments>
-      </configuration>
-    </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>java</executable>
+          <arguments>
+            <argument>-Xms512m</argument>
+            <argument>-Xmx512m</argument>
+            <commandlineArgs>-Xbootclasspath/p:${bootclasspath}</commandlineArgs>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>com.squareup.okhttp.benchmarks.Benchmark</argument>
+          </arguments>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>npn-when-jdk7</id>
+      <activation>
+        <jdk>1.7</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.mortbay.jetty.npn</groupId>
+          <artifactId>npn-boot</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>alpn-when-jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.mortbay.jetty.alpn</groupId>
+          <artifactId>alpn-boot</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <!-- Fails on caliper's ASM on OpenJDK 8. -->
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>none</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/mockwebserver/pom.xml
+++ b/mockwebserver/pom.xml
@@ -23,11 +23,6 @@
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty.npn</groupId>
-      <artifactId>npn-boot</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <optional>true</optional>

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -110,7 +110,7 @@ public final class MockWebServer {
 
   private int port = -1;
   private boolean protocolNegotiationEnabled = true;
-  private List<Protocol> npnProtocols
+  private List<Protocol> protocols
       = Util.immutableList(Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1);
 
   public int getPort() {
@@ -209,7 +209,7 @@ public final class MockWebServer {
     if (protocols.contains(null)) {
       throw new IllegalArgumentException("protocols must not contain null");
     }
-    this.npnProtocols = protocols;
+    this.protocols = protocols;
   }
 
   /**
@@ -351,7 +351,7 @@ public final class MockWebServer {
           openClientSockets.put(socket, true);
 
           if (protocolNegotiationEnabled) {
-            Platform.get().setProtocols(sslSocket, npnProtocols);
+            Platform.get().setProtocols(sslSocket, protocols);
           }
 
           sslSocket.startHandshake();

--- a/okhttp-tests/pom.xml
+++ b/okhttp-tests/pom.xml
@@ -22,11 +22,6 @@
       <artifactId>okhttp</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.mortbay.jetty.npn</groupId>
-      <artifactId>npn-boot</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -92,12 +92,12 @@ public final class CallTest {
   }
 
   @Test public void get_SPDY_3() throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     get();
   }
 
   @Test public void get_HTTP_2() throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     get();
   }
 
@@ -123,12 +123,12 @@ public final class CallTest {
   }
 
   @Test public void head_SPDY_3() throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     head();
   }
 
   @Test public void head_HTTP_2() throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     head();
   }
 
@@ -153,12 +153,12 @@ public final class CallTest {
   }
 
   @Test public void post_SPDY_3() throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     post();
   }
 
   @Test public void post_HTTP_2() throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     post();
   }
 
@@ -183,12 +183,12 @@ public final class CallTest {
   }
 
   @Test public void postZeroLength_SPDY_3() throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     postZeroLength();
   }
 
   @Test public void postZerolength_HTTP_2() throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     postZeroLength();
   }
 
@@ -213,12 +213,12 @@ public final class CallTest {
   }
 
   @Test public void delete_SPDY_3() throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     delete();
   }
 
   @Test public void delete_HTTP_2() throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     delete();
   }
 
@@ -243,12 +243,12 @@ public final class CallTest {
   }
 
   @Test public void put_SPDY_3() throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     put();
   }
 
   @Test public void put_HTTP_2() throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     put();
   }
 
@@ -273,12 +273,12 @@ public final class CallTest {
   }
 
   @Test public void patch_SPDY_3() throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     patch();
   }
 
   @Test public void patch_HTTP_2() throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     patch();
   }
 
@@ -914,12 +914,12 @@ public final class CallTest {
   }
 
   @Test public void canceledBeforeIOSignalsOnFailure_HTTP_2() throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     canceledBeforeIOSignalsOnFailure();
   }
 
   @Test public void canceledBeforeIOSignalsOnFailure_SPDY_3() throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     canceledBeforeIOSignalsOnFailure();
   }
 
@@ -940,12 +940,12 @@ public final class CallTest {
   }
 
   @Test public void canceledBeforeResponseReadSignalsOnFailure_HTTP_2() throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     canceledBeforeResponseReadSignalsOnFailure();
   }
 
   @Test public void canceledBeforeResponseReadSignalsOnFailure_SPDY_3() throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     canceledBeforeResponseReadSignalsOnFailure();
   }
 
@@ -989,13 +989,13 @@ public final class CallTest {
 
   @Test public void canceledAfterResponseIsDeliveredBreaksStreamButSignalsOnce_HTTP_2()
       throws Exception {
-    enableNpn(Protocol.HTTP_2);
+    enableProtocol(Protocol.HTTP_2);
     canceledAfterResponseIsDeliveredBreaksStreamButSignalsOnce();
   }
 
   @Test public void canceledAfterResponseIsDeliveredBreaksStreamButSignalsOnce_SPDY_3()
       throws Exception {
-    enableNpn(Protocol.SPDY_3);
+    enableProtocol(Protocol.SPDY_3);
     canceledAfterResponseIsDeliveredBreaksStreamButSignalsOnce();
   }
 
@@ -1006,9 +1006,9 @@ public final class CallTest {
 
   /**
    * Tests that use this will fail unless boot classpath is set. Ex. {@code
-   * -Xbootclasspath/p:/tmp/npn-boot-1.1.7.v20140316.jar}
+   * -Xbootclasspath/p:/tmp/alpn-boot-8.0.0.v20140317}
    */
-  private void enableNpn(Protocol protocol) {
+  private void enableProtocol(Protocol protocol) {
     client.setSslSocketFactory(sslContext.getSocketFactory());
     client.setHostnameVerifier(new RecordingHostnameVerifier());
     client.setProtocols(Arrays.asList(protocol, Protocol.HTTP_1_1));

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -51,8 +51,8 @@ import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
  * <ul>
  *   <li>Server Name Indication (SNI) enables one IP address to negotiate secure
  *       connections for multiple domain names.
- *   <li>Next Protocol Negotiation (NPN) enables the HTTPS port (443) to be used
- *       for both HTTP and SPDY protocols.
+ *   <li>Application Layer Protocol Negotiation (ALPN) enables the HTTPS port
+ *       (443) to be used for different HTTP and SPDY protocols.
  * </ul>
  * Unfortunately, older HTTPS servers refuse to connect when such options are
  * presented. Rather than avoiding these options entirely, this class allows a

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -321,19 +321,17 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
    * <ul>
    *   <li><a href="http://www.w3.org/Protocols/rfc2616/rfc2616.html">http/1.1</a>
    *   <li><a href="http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1">spdy/3.1</a>
-   *   <li><a href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-09">HTTP-draft-09/2.0</a>
+   *   <li><a href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-10">h2-10</a>
    * </ul>
    *
    * <p><strong>This is an evolving set.</strong> Future releases may drop
-   * support for transitional protocols (like spdy/3.1), in favor of their
-   * successors (spdy/4 or hTTP/2). The http/1.1 transport will never be
-   * dropped.
+   * support for transitional protocols (like h2-10), in favor of their
+   * successors (h2). The http/1.1 transport will never be dropped.
    *
    * <p>If multiple protocols are specified, <a
-   * href="https://technotes.googlecode.com/git/nextprotoneg.html">NPN</a> will
-   * be used to negotiate a transport. Future releases may use another mechanism
-   * (such as <a href="http://tools.ietf.org/html/draft-friedl-tls-applayerprotoneg-02">ALPN</a>)
-   * to negotiate a transport.
+   * href="https://technotes.googlecode.com/git/nextprotoneg.html">NPN</a> or
+   * <a href="http://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg">ALPN</a>
+   * will be used to negotiate a transport.
    *
    * @param protocols the protocols to use, in order of preference. The list
    *     must contain {@link Protocol#HTTP_1_1}. It must not contain null.

--- a/okhttp/src/main/java/com/squareup/okhttp/Protocol.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Protocol.java
@@ -20,7 +20,8 @@ import java.io.IOException;
 /**
  * Protocols that OkHttp implements for <a
  * href="http://tools.ietf.org/html/draft-agl-tls-nextprotoneg-04">NPN</a> and
- * <a href="http://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg">ALPN</a>.
+ * <a href="http://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg">ALPN</a>
+ * selection.
  *
  * <h3>Protocol vs Scheme</h3>
  * Despite its name, {@link java.net.URL#getProtocol()} returns the

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
     <okio.version>0.8.0</okio.version>
     <!-- Targetted to jdk7u60-b13; Oracle jdk7u55-b13. -->
     <npn.version>1.1.7.v20140316</npn.version>
+    <!-- Targetted to OpenJDK 8 b132 -->
+    <alpn.version>8.0.0.v20140317</alpn.version>
     <bouncycastle.version>1.48</bouncycastle.version>
     <gson.version>2.2.3</gson.version>
     <apache.http.version>4.2.2</apache.http.version>
@@ -73,14 +75,19 @@
         <version>${okio.version}</version>
       </dependency>
       <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.mortbay.jetty.npn</groupId>
         <artifactId>npn-boot</artifactId>
         <version>${npn.version}</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
+        <groupId>org.mortbay.jetty.alpn</groupId>
+        <artifactId>alpn-boot</artifactId>
+        <version>${alpn.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
@@ -126,15 +133,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.16</version>
-          <configuration>
-            <argLine>-Xbootclasspath/p:${settings.localRepository}/org/mortbay/jetty/npn/npn-boot/${npn.version}/npn-boot-${npn.version}.jar</argLine>
-          </configuration>
+          <version>2.17</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>2.16</version>
+              <version>2.17</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -185,7 +189,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.10</version>
+        <version>1.11</version>
         <executions>
           <execution>
             <phase>test</phase>
@@ -204,5 +208,66 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>npn-when-jdk7</id>
+      <activation>
+        <jdk>1.7</jdk>
+      </activation>
+      <properties>
+        <bootclasspath>${settings.localRepository}/org/mortbay/jetty/npn/npn-boot/${npn.version}/npn-boot-${npn.version}.jar</bootclasspath>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <argLine>-Xbootclasspath/p:${bootclasspath}</argLine>
+              </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>org.mortbay.jetty.npn</groupId>
+                  <artifactId>npn-boot</artifactId>
+                  <version>${npn.version}</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>alpn-when-jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <bootclasspath>${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar</bootclasspath>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <argLine>-Xbootclasspath/p:${bootclasspath}</argLine>
+              </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>org.mortbay.jetty.alpn</groupId>
+                  <artifactId>alpn-boot</artifactId>
+                  <version>${alpn.version}</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>
 

--- a/website/index.html
+++ b/website/index.html
@@ -58,7 +58,7 @@
                 common connection problems. If your service has multiple IP addresses OkHttp will
                 attempt alternate addresses if the first connect fails. This is necessary for IPv4+IPv6
                 and for services hosted in redundant data centers. OkHttp initiates new connections
-                with modern TLS features (SNI, NPN), and falls back to SSLv3 if the handshake
+                with modern TLS features (SNI, ALPN), and falls back to SSLv3 if the handshake
                 fails.</p>
 
             <p>You can try OkHttp without rewriting your network code. The core module implements


### PR DESCRIPTION
fixes #671 

Supports ALPN which is needed for http/2 and running OpenJDK 8.

Retain NPN on okcurl as twitter and google still use this protocol publicly.
