### PR TITLE
Basic support for OAuth and other arbitrary schemes in OkAuthenticator

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -2639,7 +2639,7 @@ public final class URLConnectionTest {
     fail("TODO");
   }
 
-  @Test public void customAuthenticator() throws Exception {
+  @Test public void customBasicAuthenticator() throws Exception {
     MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
         .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
         .setBody("Please authenticate.");
@@ -2661,6 +2661,30 @@ public final class URLConnectionTest {
     assertTrue(call, call.contains("proxy=DIRECT"));
     assertTrue(call, call.contains("url=" + server.getUrl("/private")));
     assertTrue(call, call.contains("challenges=[Basic realm=\"protected area\"]"));
+  }
+  
+  @Test public void customTokenAuthenticator() throws Exception {
+    MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
+            .addHeader("WWW-Authenticate: Bearer realm=\"oauthed\"")
+            .setBody("Please authenticate.");
+    server.enqueue(pleaseAuthenticate);
+    server.enqueue(new MockResponse().setBody("A"));
+    server.play();
+
+    Credential credential = Credential.oauth("oauthed", "abc123");
+    RecordingOkAuthenticator authenticator = new RecordingOkAuthenticator(credential);
+    client.setAuthenticator(authenticator);
+    assertContent("A", client.open(server.getUrl("/private")));
+
+    assertContainsNoneMatching(server.takeRequest().getHeaders(), "Authorization: .*");
+    assertContains(server.takeRequest().getHeaders(),
+            "Authorization: " + credential.getHeaderValue());
+
+    assertEquals(1, authenticator.calls.size());
+    String call = authenticator.calls.get(0);
+    assertTrue(call, call.contains("proxy=DIRECT"));
+    assertTrue(call, call.contains("url=" + server.getUrl("/private")));
+    assertTrue(call, call.contains("challenges=[Bearer realm=\"oauthed\"]"));
   }
 
   @Test public void npnSetsProtocolHeader_SPDY_3() throws Exception {

--- a/okhttp/src/main/java/com/squareup/okhttp/OkAuthenticator.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkAuthenticator.java
@@ -88,7 +88,7 @@ public interface OkAuthenticator {
   public final class Credential {
     private final String headerValue;
 
-    private Credential(String headerValue) {
+    public Credential(String headerValue) {
       this.headerValue = headerValue;
     }
 
@@ -102,6 +102,10 @@ public interface OkAuthenticator {
       } catch (UnsupportedEncodingException e) {
         throw new AssertionError();
       }
+    }
+
+    public static Credential oauth(String bearer, String token) {
+      return new Credential(bearer + " " + token);
     }
 
     public String getHeaderValue() {


### PR DESCRIPTION
Allows using OAuth tokens in `Credential` when providing an `OkAuthenticator` implementation.
- Made `Credential`'s constructor public so that arbitrary Authorization schemes are supported.
- Added static `Credential#oauth` method with bearer and token parameters.

Fixes #497
