### PR TITLE
Fix the socket policy to fix a flaky test.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -2503,7 +2503,7 @@ public final class URLConnectionTest {
 
   private void reusedConnectionFailsWithPost(TransferKind transferKind, int requestSize)
       throws Exception {
-    server.enqueue(new MockResponse().setBody("A").setSocketPolicy(SHUTDOWN_INPUT_AT_END));
+    server.enqueue(new MockResponse().setBody("A").setSocketPolicy(DISCONNECT_AT_END));
     server.enqueue(new MockResponse().setBody("B"));
     server.enqueue(new MockResponse().setBody("C"));
     server.play();


### PR DESCRIPTION
postFailsWithChunkedRequestForSmallRequest was flaky because the socket policy
wasn't triggering the expected exception at the expected time. Changing to
a different socket policy should fix flakiness.

https://github.com/square/okhttp/issues/651
