### PR TITLE
Move Vary headers and Last-Modified out of the public API.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Headers.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Headers.java
@@ -17,9 +17,11 @@
 
 package com.squareup.okhttp;
 
+import com.squareup.okhttp.internal.http.HttpDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -52,6 +54,16 @@ public final class Headers {
   /** Returns the last value corresponding to the specified field, or null. */
   public String get(String fieldName) {
     return get(namesAndValues, fieldName);
+  }
+
+  /**
+   * Returns the last value corresponding to the specified field parsed as an
+   * HTTP date, or null if either the field is absent or cannot be parsed as a
+   * date.
+   */
+  public Date getDate(String fieldName) {
+    String value = get(fieldName);
+    return value != null ? HttpDate.parse(value) : null;
   }
 
   /** Returns the number of field values. */

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -22,6 +22,7 @@ import com.squareup.okhttp.internal.http.HttpMethod;
 import com.squareup.okhttp.internal.http.HttpURLConnectionImpl;
 import com.squareup.okhttp.internal.http.HttpsURLConnectionImpl;
 import com.squareup.okhttp.internal.http.JavaApiConverter;
+import com.squareup.okhttp.internal.http.OkHeaders;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -208,7 +209,7 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
       return null;
     }
 
-    if (response.hasVaryAll()) {
+    if (OkHeaders.hasVaryAll(response)) {
       return null;
     }
 
@@ -481,7 +482,7 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
 
     public Entry(Response response) {
       this.url = response.request().urlString();
-      this.varyHeaders = response.request().headers().getAll(response.getVaryFields());
+      this.varyHeaders = response.request().headers().getAll(OkHeaders.varyFields(response));
       this.requestMethod = response.request().method();
       this.statusLine = response.statusLine();
       this.responseHeaders = response.headers();
@@ -552,7 +553,7 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
     public boolean matches(Request request, Response response) {
       return url.equals(request.urlString())
           && requestMethod.equals(request.method())
-          && response.varyMatches(varyHeaders, request);
+          && OkHeaders.varyMatches(response, varyHeaders, request);
     }
 
     public Response response(Request request, DiskLruCache.Snapshot snapshot) {


### PR DESCRIPTION
These fields and behaviors are needed for HTTP caching. If we want
to expose certain headers to the application layer, we should do it
more thoughtfully.
