### PR TITLE
Move awkward bulk-read method out of Headers.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Headers.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Headers.java
@@ -112,19 +112,6 @@ public final class Headers {
         : Collections.<String>emptyList();
   }
 
-  /** @param fieldNames a case-insensitive set of HTTP header field names. */
-  // TODO: it is very weird to request a case-insensitive set as a parameter.
-  public Headers getAll(Set<String> fieldNames) {
-    Builder result = new Builder();
-    for (int i = 0; i < namesAndValues.length; i += 2) {
-      String fieldName = namesAndValues[i];
-      if (fieldNames.contains(fieldName)) {
-        result.add(fieldName, namesAndValues[i + 1]);
-      }
-    }
-    return result.build();
-  }
-
   public Builder newBuilder() {
     Builder result = new Builder();
     result.namesAndValues.addAll(Arrays.asList(namesAndValues));

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -482,7 +482,7 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
 
     public Entry(Response response) {
       this.url = response.request().urlString();
-      this.varyHeaders = response.request().headers().getAll(OkHeaders.varyFields(response));
+      this.varyHeaders = OkHeaders.varyHeaders(response);
       this.requestMethod = response.request().method();
       this.statusLine = response.statusLine();
       this.responseHeaders = response.headers();

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkHeaders.java
@@ -150,7 +150,7 @@ public final class OkHeaders {
     return varyFields(response).contains("*");
   }
 
-  public static Set<String> varyFields(Response response) {
+  private static Set<String> varyFields(Response response) {
     Set<String> result = Collections.emptySet();
     Headers headers = response.headers();
     for (int i = 0; i < headers.size(); i++) {
@@ -165,5 +165,24 @@ public final class OkHeaders {
       }
     }
     return result;
+  }
+
+  /**
+   * Returns the subset of the headers in {@code response}'s request that
+   * impact the content of response's body.
+   */
+  public static Headers varyHeaders(Response response) {
+    Set<String> varyFields = varyFields(response);
+    if (varyFields.isEmpty()) return new Headers.Builder().build();
+
+    Headers.Builder result = new Headers.Builder();
+    Headers requestHeaders = response.request().headers();
+    for (int i = 0; i < requestHeaders.size(); i++) {
+      String fieldName = requestHeaders.name(i);
+      if (varyFields.contains(fieldName)) {
+        result.add(fieldName, requestHeaders.value(i));
+      }
+    }
+    return result.build();
   }
 }


### PR DESCRIPTION
This was used for Vary only. Moving it into the callsite simplifies
both.
