### PR TITLE
Use 'Protocol' to describe framing.

### DIFF
--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -147,7 +147,7 @@ public class Main extends HelpOption implements Runnable {
 
   private OkHttpClient createClient() {
     OkHttpClient client = new OkHttpClient();
-    client.setFollowProtocolRedirects(followRedirects);
+    client.setFollowSslRedirects(followRedirects);
     if (connectTimeout != DEFAULT_TIMEOUT) {
       client.setConnectTimeout(connectTimeout, SECONDS);
     }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/AsyncApiTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/AsyncApiTest.java
@@ -231,7 +231,7 @@ public final class AsyncApiTest {
   }
 
   @Test public void redirectWithRedirectsDisabled() throws Exception {
-    client.setFollowProtocolRedirects(false);
+    client.setFollowSslRedirects(false);
     server.enqueue(new MockResponse()
         .setResponseCode(301)
         .addHeader("Location: /b")

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/SyncApiTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/SyncApiTest.java
@@ -202,7 +202,7 @@ public final class SyncApiTest {
   }
 
   @Test public void redirectWithRedirectsDisabled() throws Exception {
-    client.setFollowProtocolRedirects(false);
+    client.setFollowSslRedirects(false);
     server.enqueue(new MockResponse()
         .setResponseCode(301)
         .addHeader("Location: /b")

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -1715,7 +1715,7 @@ public final class URLConnectionTest {
         .setBody("This page has moved!"));
     server.play();
 
-    client.setFollowProtocolRedirects(false);
+    client.setFollowSslRedirects(false);
     client.setSslSocketFactory(sslContext.getSocketFactory());
     client.setHostnameVerifier(new RecordingHostnameVerifier());
     connection = client.open(server.getUrl("/"));
@@ -1728,7 +1728,7 @@ public final class URLConnectionTest {
         .setBody("This page has moved!"));
     server.play();
 
-    client.setFollowProtocolRedirects(false);
+    client.setFollowSslRedirects(false);
     connection = client.open(server.getUrl("/"));
     assertEquals("This page has moved!", readAscii(connection.getInputStream(), Integer.MAX_VALUE));
   }
@@ -1746,7 +1746,7 @@ public final class URLConnectionTest {
 
     client.setSslSocketFactory(sslContext.getSocketFactory());
     client.setHostnameVerifier(new RecordingHostnameVerifier());
-    client.setFollowProtocolRedirects(true);
+    client.setFollowSslRedirects(true);
     HttpsURLConnection connection = (HttpsURLConnection) client.open(server.getUrl("/"));
     assertContent("This is insecure HTTP!", connection);
     assertNull(connection.getCipherSuite());
@@ -1769,7 +1769,7 @@ public final class URLConnectionTest {
 
     client.setSslSocketFactory(sslContext.getSocketFactory());
     client.setHostnameVerifier(new RecordingHostnameVerifier());
-    client.setFollowProtocolRedirects(true);
+    client.setFollowSslRedirects(true);
     connection = client.open(server.getUrl("/"));
     assertContent("This is secure HTTPS!", connection);
     assertFalse(connection instanceof HttpsURLConnection);

--- a/okhttp/src/main/java/com/squareup/okhttp/Job.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Job.java
@@ -192,7 +192,7 @@ final class Job extends NamedRunnable {
       case HTTP_MOVED_TEMP:
       case HTTP_SEE_OTHER:
       case HTTP_TEMP_REDIRECT:
-        if (!client.getFollowProtocolRedirects()) {
+        if (!client.getFollowSslRedirects()) {
           return null; // This client has is configured to not follow redirects.
         }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -32,7 +32,6 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 import java.security.GeneralSecurityException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.net.SocketFactory;
@@ -65,7 +64,7 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
   private HostnameVerifier hostnameVerifier;
   private OkAuthenticator authenticator;
   private ConnectionPool connectionPool;
-  private boolean followProtocolRedirects = true;
+  private boolean followSslRedirects = true;
   private int connectTimeout;
   private int readTimeout;
   private int writeTimeout;
@@ -282,13 +281,13 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
    * <p>If unset, protocol redirects will be followed. This is different than
    * the built-in {@code HttpURLConnection}'s default.
    */
-  public OkHttpClient setFollowProtocolRedirects(boolean followProtocolRedirects) {
-    this.followProtocolRedirects = followProtocolRedirects;
+  public OkHttpClient setFollowSslRedirects(boolean followProtocolRedirects) {
+    this.followSslRedirects = followProtocolRedirects;
     return this;
   }
 
-  public boolean getFollowProtocolRedirects() {
-    return followProtocolRedirects;
+  public boolean getFollowSslRedirects() {
+    return followSslRedirects;
   }
 
   public RouteDatabase getRoutesDatabase() {
@@ -307,24 +306,6 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
 
   public Dispatcher getDispatcher() {
     return dispatcher;
-  }
-
-  /**
-   * @deprecated OkHttp 1.5 enforces an enumeration of {@link Protocol
-   *     protocols} that can be selected. Please switch to {@link
-   *     #setProtocols(java.util.List)}.
-   */
-  @Deprecated
-  public OkHttpClient setTransports(List<String> transports) {
-    List<Protocol> protocols = new ArrayList<Protocol>(transports.size());
-    for (int i = 0, size = transports.size(); i < size; i++) {
-      try {
-        protocols.add(Protocol.get(transports.get(i)));
-      } catch (IOException e) {
-        throw new IllegalArgumentException(e);
-      }
-    }
-    return setProtocols(protocols);
   }
 
   /**
@@ -365,20 +346,6 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
     }
     this.protocols = Util.immutableList(protocols);
     return this;
-  }
-
-  /**
-   * @deprecated OkHttp 1.5 enforces an enumeration of {@link Protocol
-   *     protocols} that can be selected. Please switch to {@link
-   *     #getProtocols()}.
-   */
-  @Deprecated
-  public List<String> getTransports() {
-    List<String> transports = new ArrayList<String>(protocols.size());
-    for (int i = 0, size = protocols.size(); i < size; i++) {
-      transports.add(protocols.get(i).toString());
-    }
-    return transports;
   }
 
   public List<Protocol> getProtocols() {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -453,7 +453,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
           return Retry.NONE; // Don't follow redirects to unsupported protocols.
         }
         boolean sameProtocol = previousUrl.getProtocol().equals(url.getProtocol());
-        if (!sameProtocol && !client.getFollowProtocolRedirects()) {
+        if (!sameProtocol && !client.getFollowSslRedirects()) {
           return Retry.NONE; // This client doesn't follow redirects across protocols.
         }
         boolean sameHost = previousUrl.getHost().equals(url.getHost());


### PR DESCRIPTION
Drop setTransports/getTransports which was deprecated in favor
of protocols.

Rename setFollowProtocolRedirects to setFollowSslRedirects. I decided
to use SSL rather than TLS for consistency with nearby APIs.
