### PR TITLE
Scrub StatusLine from the public API.

### DIFF
--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -23,6 +23,7 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.internal.http.StatusLine;
 import io.airlift.command.Arguments;
 import io.airlift.command.Command;
 import io.airlift.command.HelpOption;
@@ -127,7 +128,7 @@ public class Main extends HelpOption implements Runnable {
     try {
       Response response = client.execute(request);
       if (showHeaders) {
-        System.out.println(response.statusLine());
+        System.out.println(StatusLine.get(response));
         Headers headers = response.headers();
         for (int i = 0, count = headers.size(); i < count; i++) {
           System.out.println(headers.name(i) + ": " + headers.value(i));

--- a/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
+++ b/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
@@ -68,7 +68,7 @@ public final class OkApacheClient implements HttpClient {
 
   private static HttpResponse transformResponse(Response response) {
     int code = response.code();
-    String message = response.statusMessage();
+    String message = response.message();
     BasicHttpResponse httpResponse = new BasicHttpResponse(HTTP_1_1, code, message);
 
     Response.Body body = response.body();

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
@@ -40,7 +40,9 @@ public final class HeadersTest {
         SpdyTransport.readNameValueBlock(headerBlock, Protocol.SPDY_3).request(request).build();
     Headers headers = response.headers();
     assertEquals(4, headers.size());
-    assertEquals("HTTP/1.1 200 OK", response.statusLine());
+    assertEquals(Protocol.HTTP_1_1, response.protocol());
+    assertEquals(200, response.code());
+    assertEquals("OK", response.message());
     assertEquals("no-cache, no-store", headers.get("cache-control"));
     assertEquals("Cookie2", headers.get("set-cookie"));
     assertEquals(Protocol.SPDY_3.toString(), headers.get(OkHeaders.SELECTED_PROTOCOL));

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/StatusLineTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/StatusLineTest.java
@@ -28,19 +28,19 @@ public final class StatusLineTest {
     String message = "Temporary Redirect";
     int version = 1;
     int code = 200;
-    StatusLine statusLine = new StatusLine("HTTP/1." + version + " " + code + " " + message);
-    assertEquals(message, statusLine.message());
-    assertEquals(Protocol.HTTP_1_1, statusLine.protocol());
-    assertEquals(code, statusLine.code());
+    StatusLine statusLine = StatusLine.parse("HTTP/1." + version + " " + code + " " + message);
+    assertEquals(message, statusLine.message);
+    assertEquals(Protocol.HTTP_1_1, statusLine.protocol);
+    assertEquals(code, statusLine.code);
   }
 
   @Test public void emptyMessage() throws IOException {
     int version = 1;
     int code = 503;
-    StatusLine statusLine = new StatusLine("HTTP/1." + version + " " + code + " ");
-    assertEquals("", statusLine.message());
-    assertEquals(Protocol.HTTP_1_1, statusLine.protocol());
-    assertEquals(code, statusLine.code());
+    StatusLine statusLine = StatusLine.parse("HTTP/1." + version + " " + code + " ");
+    assertEquals("", statusLine.message);
+    assertEquals(Protocol.HTTP_1_1, statusLine.protocol);
+    assertEquals(code, statusLine.code);
   }
 
   /**
@@ -51,18 +51,18 @@ public final class StatusLineTest {
   @Test public void emptyMessageAndNoLeadingSpace() throws IOException {
     int version = 1;
     int code = 503;
-    StatusLine statusLine = new StatusLine("HTTP/1." + version + " " + code);
-    assertEquals("", statusLine.message());
-    assertEquals(Protocol.HTTP_1_1, statusLine.protocol());
-    assertEquals(code, statusLine.code());
+    StatusLine statusLine = StatusLine.parse("HTTP/1." + version + " " + code);
+    assertEquals("", statusLine.message);
+    assertEquals(Protocol.HTTP_1_1, statusLine.protocol);
+    assertEquals(code, statusLine.code);
   }
 
   // https://github.com/square/okhttp/issues/386
   @Test public void shoutcast() throws IOException {
-    StatusLine statusLine = new StatusLine("ICY 200 OK");
-    assertEquals("OK", statusLine.message());
-    assertEquals(Protocol.HTTP_1_0, statusLine.protocol());
-    assertEquals(200, statusLine.code());
+    StatusLine statusLine = StatusLine.parse("ICY 200 OK");
+    assertEquals("OK", statusLine.message);
+    assertEquals(Protocol.HTTP_1_0, statusLine.protocol);
+    assertEquals(200, statusLine.code);
   }
 
   @Test public void missingProtocol() throws IOException {
@@ -110,7 +110,7 @@ public final class StatusLineTest {
 
   private void assertInvalid(String statusLine) throws IOException {
     try {
-      new StatusLine(statusLine);
+      StatusLine.parse(statusLine);
       fail();
     } catch (ProtocolException expected) {
     }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
@@ -2,11 +2,11 @@ package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.CacheControl;
 import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 import com.squareup.okhttp.ResponseSource;
 import com.squareup.okhttp.internal.Util;
-import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Date;
 import okio.BufferedSource;
@@ -34,15 +34,6 @@ public final class CacheStrategy {
       return Okio.buffer(Util.EMPTY_SOURCE);
     }
   };
-
-  private static final StatusLine GATEWAY_TIMEOUT_STATUS_LINE;
-  static {
-    try {
-      GATEWAY_TIMEOUT_STATUS_LINE = new StatusLine("HTTP/1.1 504 Gateway Timeout");
-    } catch (IOException e) {
-      throw new AssertionError();
-    }
-  }
 
   public final Request request;
   public final Response response;
@@ -166,7 +157,9 @@ public final class CacheStrategy {
         // We're forbidden from using the network, but the cache is insufficient.
         Response noneResponse = new Response.Builder()
             .request(candidate.request)
-            .statusLine(GATEWAY_TIMEOUT_STATUS_LINE)
+            .protocol(Protocol.HTTP_1_1)
+            .code(504)
+            .message("Gateway Timeout")
             .setResponseSource(ResponseSource.NONE)
             .body(EMPTY_BODY)
             .build();

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
@@ -183,18 +183,19 @@ public final class HttpConnection {
     }
 
     while (true) {
-      String statusLineString = source.readUtf8LineStrict();
-      StatusLine statusLine = new StatusLine(statusLineString);
+      StatusLine statusLine = StatusLine.parse(source.readUtf8LineStrict());
 
       Response.Builder responseBuilder = new Response.Builder()
-          .statusLine(statusLine);
+          .protocol(statusLine.protocol)
+          .code(statusLine.code)
+          .message(statusLine.message);
 
       Headers.Builder headersBuilder = new Headers.Builder();
       readHeaders(headersBuilder);
-      headersBuilder.add(OkHeaders.SELECTED_PROTOCOL, statusLine.protocol().toString());
+      headersBuilder.add(OkHeaders.SELECTED_PROTOCOL, statusLine.protocol.toString());
       responseBuilder.headers(headersBuilder.build());
 
-      if (statusLine.code() != HTTP_CONTINUE) {
+      if (statusLine.code != HTTP_CONTINUE) {
         state = STATE_OPEN_RESPONSE_BODY;
         return responseBuilder;
       }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -158,7 +158,9 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   @Override public final String getHeaderField(String fieldName) {
     try {
       Response response = getResponse().getResponse();
-      return fieldName == null ? response.statusLine() : response.headers().get(fieldName);
+      return fieldName == null
+          ? StatusLine.get(response).toString()
+          : response.headers().get(fieldName);
     } catch (IOException e) {
       return null;
     }
@@ -175,7 +177,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   @Override public final Map<String, List<String>> getHeaderFields() {
     try {
       Response response = getResponse().getResponse();
-      return OkHeaders.toMultimap(response.headers(), response.statusLine());
+      return OkHeaders.toMultimap(response.headers(), StatusLine.get(response).toString());
     } catch (IOException e) {
       return Collections.emptyMap();
     }
@@ -488,7 +490,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   }
 
   @Override public String getResponseMessage() throws IOException {
-    return getResponse().getResponse().statusMessage();
+    return getResponse().getResponse().message();
   }
 
   @Override public final int getResponseCode() throws IOException {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/JavaApiConverter.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/JavaApiConverter.java
@@ -67,8 +67,10 @@ public final class JavaApiConverter {
     okResponseBuilder.request(okRequest);
 
     // Status line
-    String statusLine = extractStatusLine(httpUrlConnection);
-    okResponseBuilder.statusLine(statusLine);
+    StatusLine statusLine = StatusLine.parse(extractStatusLine(httpUrlConnection));
+    okResponseBuilder.protocol(statusLine.protocol);
+    okResponseBuilder.code(statusLine.code);
+    okResponseBuilder.message(statusLine.message);
 
     // Response headers
     Headers okHeaders = extractOkResponseHeaders(httpUrlConnection);
@@ -115,7 +117,10 @@ public final class JavaApiConverter {
     okResponseBuilder.request(request);
 
     // Status line: Java has this as one of the headers.
-    okResponseBuilder.statusLine(extractStatusLine(javaResponse));
+    StatusLine statusLine = StatusLine.parse(extractStatusLine(javaResponse));
+    okResponseBuilder.protocol(statusLine.protocol);
+    okResponseBuilder.code(statusLine.code);
+    okResponseBuilder.message(statusLine.message);
 
     // Response headers
     Headers okHeaders = extractOkHeaders(javaResponse);
@@ -218,7 +223,7 @@ public final class JavaApiConverter {
         @Override
         public Map<String, List<String>> getHeaders() throws IOException {
           // Java requires that the entry with a null key be the status line.
-          return OkHeaders.toMultimap(headers, response.statusLine());
+          return OkHeaders.toMultimap(headers, StatusLine.get(response).toString());
         }
 
         @Override
@@ -232,7 +237,7 @@ public final class JavaApiConverter {
         @Override
         public Map<String, List<String>> getHeaders() throws IOException {
           // Java requires that the entry with a null key be the status line.
-          return OkHeaders.toMultimap(headers, response.statusLine());
+          return OkHeaders.toMultimap(headers, StatusLine.get(response).toString());
         }
 
         @Override
@@ -474,19 +479,21 @@ public final class JavaApiConverter {
         throw new IllegalArgumentException("Invalid header index: " + position);
       }
       if (position == 0) {
-        return response.statusLine();
+        return StatusLine.get(response).toString();
       }
       return response.headers().value(position - 1);
     }
 
     @Override
     public String getHeaderField(String fieldName) {
-      return fieldName == null ? response.statusLine() : response.headers().get(fieldName);
+      return fieldName == null
+          ? StatusLine.get(response).toString()
+          : response.headers().get(fieldName);
     }
 
     @Override
     public Map<String, List<String>> getHeaderFields() {
-      return OkHeaders.toMultimap(response.headers(), response.statusLine());
+      return OkHeaders.toMultimap(response.headers(), StatusLine.get(response).toString());
     }
 
     @Override
@@ -496,7 +503,7 @@ public final class JavaApiConverter {
 
     @Override
     public String getResponseMessage() throws IOException {
-      return response.statusMessage();
+      return response.message();
     }
 
     @Override

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -202,8 +202,11 @@ public final class SpdyTransport implements Transport {
     if (status == null) throw new ProtocolException("Expected ':status' header not present");
     if (version == null) throw new ProtocolException("Expected ':version' header not present");
 
+    StatusLine statusLine = StatusLine.parse(version + " " + status);
     return new Response.Builder()
-        .statusLine(new StatusLine(version + " " + status))
+        .protocol(statusLine.protocol)
+        .code(statusLine.code)
+        .message(statusLine.message)
         .headers(headersBuilder.build());
   }
 


### PR DESCRIPTION
The status line is an unnecessary grouping of three otherwise-independent
fields: the protocol, code and message.

Combining them in the API doesn't provide much value. In SPDY and HTTP/2
these are broken apart anyway.
