### PR TITLE
Prevent leaking a Snapshot's InputStreams when metadata read fails.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpResponseCache.java
@@ -169,9 +169,15 @@ public final class HttpResponseCache extends ResponseCache implements OkResponse
       if (snapshot == null) {
         return null;
       }
-      entry = new Entry(snapshot.getInputStream(ENTRY_METADATA));
     } catch (IOException e) {
       // Give up because the cache cannot be read.
+      return null;
+    }
+
+    try {
+      entry = new Entry(snapshot.getInputStream(ENTRY_METADATA));
+    } catch (IOException e) {
+      Util.closeQuietly(snapshot);
       return null;
     }
 


### PR DESCRIPTION
Closes #215.
