### PR TITLE
Disconnect on OkHttpClient.cancel

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -3086,7 +3086,7 @@ public final class URLConnectionTest {
 
   /**
    * Tests that use this will fail unless boot classpath is set. Ex. {@code
-   * -Xbootclasspath/p:/tmp/npn-boot-8.1.2.v20120308.jar}
+   * -Xbootclasspath/p:/tmp/npn-boot-1.1.7.v20140316.jar}
    */
   private void enableNpn(Protocol protocol) {
     client.setSslSocketFactory(sslContext.getSocketFactory());

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -416,9 +416,12 @@ public final class HttpEngine {
    * the caller's responsibility to close the request body and response body
    * streams; otherwise resources may be leaked.
    */
-  public void disconnect() throws IOException {
+  public void disconnect() {
     if (transport != null) {
-      transport.disconnect(this);
+      try {
+        transport.disconnect(this);
+      } catch (IOException ignored) {
+      }
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -107,10 +107,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     // Calling disconnect() before a connection exists should have no effect.
     if (httpEngine == null) return;
 
-    try {
-      httpEngine.disconnect();
-    } catch (IOException ignored) {
-    }
+    httpEngine.disconnect();
 
     // This doesn't close the stream because doing so would require all stream
     // access to be synchronized. It's expected that the thread using the

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Ping.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Ping.java
@@ -49,7 +49,7 @@ public final class Ping {
   /**
    * Returns the round trip time for this ping in nanoseconds, waiting for the
    * response to arrive if necessary. Returns -1 if the response was
-   * cancelled.
+   * canceled.
    */
   public long roundTripTime() throws InterruptedException {
     latch.await();
@@ -58,7 +58,7 @@ public final class Ping {
 
   /**
    * Returns the round trip time for this ping in nanoseconds, or -1 if the
-   * response was cancelled, or -2 if the timeout elapsed before the round
+   * response was canceled, or -2 if the timeout elapsed before the round
    * trip completed.
    */
   public long roundTripTime(long timeout, TimeUnit unit) throws InterruptedException {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/PushObserver.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/PushObserver.java
@@ -60,7 +60,7 @@ public interface PushObserver {
   boolean onData(int streamId, BufferedSource source, int byteCount, boolean last)
       throws IOException;
 
-  /** Indicates the reason why this stream was cancelled. */
+  /** Indicates the reason why this stream was canceled. */
   void onReset(int streamId, ErrorCode errorCode);
 
   PushObserver CANCEL = new PushObserver() {


### PR DESCRIPTION
Before this change, cancel would apply either before the request was made, or after the response was received.  This change allows it to apply to an in-flight request.

Here are the most important scenarios:
- Canceled before any I/O. We send onFailure with `CancellationException`
- Canceled before we call onResponse. We send onFailure with `CancellationException`
- Canceled after we call onResponse. The stream may break with `IOException`
