### PR TITLE
Fix HTTP post retransmit in the new API.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -395,6 +395,10 @@ public final class MockWebServer {
         requestCount.incrementAndGet();
         requestQueue.add(request);
         MockResponse response = dispatcher.dispatch(request);
+        if (response.getSocketPolicy() == SocketPolicy.DISCONNECT_AFTER_REQUEST) {
+          socket.close();
+          return false;
+        }
         writeResponse(out, response);
         if (response.getSocketPolicy() == SocketPolicy.DISCONNECT_AT_END) {
           in.close();

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/SocketPolicy.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/SocketPolicy.java
@@ -44,6 +44,12 @@ public enum SocketPolicy {
    */
   DISCONNECT_AT_START,
 
+  /**
+   * Close connection after reading the request but before writing the response.
+   * Use this to simulate late connection pool failures.
+   */
+  DISCONNECT_AFTER_REQUEST,
+
   /** Don't trust the client during the SSL handshake. */
   FAIL_HANDSHAKE,
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/AsyncApiTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/AsyncApiTest.java
@@ -402,39 +402,6 @@ public final class AsyncApiTest {
     assertEquals(1, server.takeRequest().getSequenceNumber()); // Connection reuse!
   }
 
-  @Test public void postBodyRetransmittedOnRedirect() throws Exception {
-    server.enqueue(new MockResponse()
-        .setResponseCode(302)
-        .addHeader("Location: /b")
-        .setBody("Moved to /b !"));
-    server.enqueue(new MockResponse()
-        .setBody("This is b."));
-    server.play();
-
-    Request request = new Request.Builder()
-        .url(server.getUrl("/"))
-        .post(Request.Body.create(MediaType.parse("text/plain"), "body!"))
-        .build();
-    client.enqueue(request, receiver);
-
-    receiver.await(server.getUrl("/b"))
-        .assertCode(200)
-        .assertBody("This is b.");
-
-    RecordedRequest request1 = server.takeRequest();
-    assertEquals("body!", request1.getUtf8Body());
-    assertEquals("5", request1.getHeader("Content-Length"));
-    assertEquals("text/plain; charset=utf-8", request1.getHeader("Content-Type"));
-    assertEquals(0, request1.getSequenceNumber());
-
-    RecordedRequest request2 = server.takeRequest();
-    assertEquals("body!", request2.getUtf8Body());
-    assertEquals("5", request2.getHeader("Content-Length"));
-    assertEquals("text/plain; charset=utf-8", request2.getHeader("Content-Type"));
-    assertEquals(1, request2.getSequenceNumber());
-  }
-
-
   /**
    * Tests that use this will fail unless boot classpath is set. Ex. {@code
    * -Xbootclasspath/p:/tmp/npn-boot-1.1.7.v20140316.jar}

--- a/okhttp/src/main/java/com/squareup/okhttp/Job.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Job.java
@@ -130,7 +130,7 @@ final class Job extends NamedRunnable {
 
         engine.readResponse();
       } catch (IOException e) {
-        HttpEngine retryEngine = engine.recover(e);
+        HttpEngine retryEngine = engine.recover(e, null);
         if (retryEngine != null) {
           engine = retryEngine;
           continue;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -339,9 +339,10 @@ public final class HttpEngine {
   /**
    * Report and attempt to recover from {@code e}. Returns a new HTTP engine
    * that should be used for the retry if {@code e} is recoverable, or null if
-   * the failure is permanent.
+   * the failure is permanent. Requests with a body can only be recovered if the
+   * body is buffered.
    */
-  public HttpEngine recover(IOException e) {
+  public HttpEngine recover(IOException e, Sink requestBodyOut) {
     if (routeSelector != null && connection != null) {
       routeSelector.connectFailed(connection, e);
     }
@@ -359,6 +360,10 @@ public final class HttpEngine {
     // For failure recovery, use the same route selector with a new connection.
     return new HttpEngine(client, originalRequest, bufferRequestBody, connection, routeSelector,
         (RetryableSink) requestBodyOut);
+  }
+
+  public HttpEngine recover(IOException e) {
+    return recover(e, requestBodyOut);
   }
 
   private boolean isRecoverable(IOException e) {


### PR DESCRIPTION
We don't buffer response bodies in the new API. But we should retransmit
POST bodies when a request fails.
