### PR TITLE
Making a few classes/interfaces within SPDY public

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/HeadersMode.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/HeadersMode.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.okhttp.internal.spdy;
 
-enum HeadersMode {
+public enum HeadersMode {
   SPDY_SYN_STREAM,
   SPDY_REPLY,
   SPDY_HEADERS,

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
  * Settings describe characteristics of the sending peer, which are used by the receiving peer.
  * Settings are {@link com.squareup.okhttp.internal.spdy.SpdyConnection connection} scoped.
  */
-final class Settings {
+public final class Settings {
   /**
    * From the SPDY/3 and HTTP/2 specs, the default initial window size for all
    * streams is 64 KiB. (Chrome 25 uses 10 MiB).

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -33,7 +33,7 @@ import okio.Okio;
  * Read and write spdy/3.1 frames.
  * http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1
  */
-final class Spdy3 implements Variant {
+public final class Spdy3 implements Variant {
 
   @Override public Protocol getProtocol() {
     return Protocol.SPDY_3;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
@@ -20,7 +20,7 @@ import okio.BufferedSink;
 import okio.BufferedSource;
 
 /** A version and dialect of the framed socket protocol. */
-interface Variant {
+public interface Variant {
 
   /** The protocol as selected using NPN or ALPN. */
   Protocol getProtocol();


### PR DESCRIPTION
Allowing external access to the SPDY/HTTP2 framing layer so that it can be used directly for non-HTTP traffic.
