### PR TITLE
Introduce Call for async invocations.

### DIFF
--- a/benchmarks/src/main/java/com/squareup/okhttp/benchmarks/OkHttpAsync.java
+++ b/benchmarks/src/main/java/com/squareup/okhttp/benchmarks/OkHttpAsync.java
@@ -38,7 +38,7 @@ class OkHttpAsync implements HttpClient {
   private final AtomicInteger requestsInFlight = new AtomicInteger();
 
   private OkHttpClient client;
-  private Response.Receiver receiver;
+  private Response.Callback callback;
   private int concurrencyLevel;
   private int targetBacklog;
 
@@ -63,7 +63,7 @@ class OkHttpAsync implements HttpClient {
       client.setHostnameVerifier(hostnameVerifier);
     }
 
-    receiver = new Response.Receiver() {
+    callback = new Response.Callback() {
       @Override public void onFailure(Failure failure) {
         System.out.println("Failed: " + failure.exception());
       }
@@ -84,7 +84,7 @@ class OkHttpAsync implements HttpClient {
 
   @Override public void enqueue(URL url) throws Exception {
     requestsInFlight.incrementAndGet();
-    client.enqueue(new Request.Builder().tag(System.nanoTime()).url(url).build(), receiver);
+    client.call(new Request.Builder().tag(System.nanoTime()).url(url).build()).execute(callback);
   }
 
   @Override public synchronized boolean acceptingJobs() {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RecordingCallback.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RecordingCallback.java
@@ -26,7 +26,7 @@ import okio.Buffer;
 /**
  * Records received HTTP responses so they can be later retrieved by tests.
  */
-public class RecordingReceiver implements Response.Receiver {
+public class RecordingCallback implements Response.Callback {
   public static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(10);
 
   private final List<RecordedResponse> responses = new ArrayList<RecordedResponse>();

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+/**
+ * A call is an asynchronous {@code request} that has been prepared for
+ * execution. Once executed, a call can be cancelled. As this object represents
+ * a single request/response pair (or stream), it cannot be executed twice.
+ */
+public final class Call {
+  private final OkHttpClient client;
+  private final Dispatcher dispatcher;
+  private final Request request;
+
+  public Call(OkHttpClient client, Dispatcher dispatcher,
+      Request request) {
+    this.client = client;
+    this.dispatcher = dispatcher;
+    this.request = request;
+  }
+
+  /**
+   * Schedules the {@code request} to be executed at some point in the future.
+   * The {@link OkHttpClient#getDispatcher dispatcher} defines when the request
+   * will run: usually immediately unless there are several other requests
+   * currently being executed.
+   *
+   * <p>This client will later call back {@code responseCallback} with either
+   * an HTTP response or a failure exception. If you {@link #cancel} a request
+   * before it completes the callback will not be invoked.
+   */
+  public void execute(Response.Callback responseCallback) {
+    dispatcher.enqueue(client, request, responseCallback);
+  }
+
+  /**
+   * Cancels the request, if possible. Requests that are already complete cannot
+   * be canceled.
+   */
+  public void cancel() {
+    dispatcher.cancel(request.tag());
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/Dispatcher.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Dispatcher.java
@@ -100,11 +100,11 @@ public final class Dispatcher {
     return maxRequestsPerHost;
   }
 
-  synchronized void enqueue(OkHttpClient client, Request request, Response.Receiver receiver) {
+  synchronized void enqueue(OkHttpClient client, Request request, Response.Callback callback) {
     // Copy the client. Otherwise changes (socket factory, redirect policy,
     // etc.) may incorrectly be reflected in the request when it is executed.
     client = client.copyWithDefaults();
-    Job job = new Job(this, client, request, receiver);
+    Job job = new Job(this, client, request, callback);
 
     if (runningJobs.size() < maxRequests && runningJobsForHost(job) < maxRequestsPerHost) {
       runningJobs.add(job);

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -381,17 +381,10 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
   }
 
   /**
-   * Schedules {@code request} to be executed at some point in the future. The
-   * {@link #getDispatcher dispatcher} defines when the request will run:
-   * usually immediately unless there are several other requests currently being
-   * executed.
-   *
-   * <p>This client will later call back {@code responseReceiver} with either an
-   * HTTP response or a failure exception. If you {@link #cancel} a request
-   * before it completes the receiver will not be called back.
+   * Prepares the {@code request} to be executed at some point in the future.
    */
-  public void enqueue(Request request, Response.Receiver responseReceiver) {
-    dispatcher.enqueue(this, request, responseReceiver);
+  public Call call(Request request) {
+    return new Call(this, dispatcher, request);
   }
 
   /**

--- a/okhttp/src/main/java/com/squareup/okhttp/Response.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Response.java
@@ -271,7 +271,7 @@ public final class Response {
         + '}';
   }
 
-  public interface Receiver {
+  public interface Callback {
     /**
      * Called when the request could not be executed due to a connectivity
      * problem or timeout. Because networks can fail during an exchange, it is
@@ -281,7 +281,7 @@ public final class Response {
 
     /**
      * Called when the HTTP response was successfully returned by the remote
-     * server. The receiver may proceed to read the response body with the
+     * server. The callback may proceed to read the response body with the
      * response's {@link #body} method.
      *
      * <p>Note that transport-layer success (receiving a HTTP response code,


### PR DESCRIPTION
Breaking out preparation from invocation gives us the ability to cancel an asynchronous request, and in the future expose things like metrics.

``` java
Call call = client.call(request); // nothing, yet.
call.execute(callback); // off it goes.
call.cancel(); // whoops..
```
