### PR TITLE
Throw CancellationException when blocking call canceled as opposed to returning null

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -29,6 +29,7 @@ import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -619,7 +620,11 @@ public final class CallTest {
     Call call = client.newCall(new Request.Builder().url(server.getUrl("/a")).build());
     call.cancel();
 
-    assertNull(call.execute());
+    try {
+      call.execute();
+      fail();
+    } catch (CancellationException e){
+    }
     assertEquals(0, server.getRequestCount());
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -63,7 +63,7 @@ public final class Call {
    * {@code response} may still indicate an unhappy HTTP response code like 404
    * or 500.
    *
-   * @return null if the call was canceled.
+   * @throws CancellationException if the call was canceled.
    *
    * @throws IOException if the request could not be executed due to a
    *     connectivity problem or timeout. Because networks can fail during an
@@ -77,8 +77,9 @@ public final class Call {
       if (executed) throw new IllegalStateException("Already Executed");
       executed = true;
     }
-    Response result = getResponse(); // Since we don't cancel, this won't be null.
+    Response result = getResponse();
     engine.releaseConnection(); // Transfer ownership of the body to the caller.
+    if (result == null) throw new CancellationException("Cancelled");
     return result;
   }
 


### PR DESCRIPTION
@jhump raised a good point that returning null can lead to NPEs, CancellationExceptions would be more helpful.
