### PR TITLE
Use IOE for canceled streams

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -29,7 +29,6 @@ import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -623,7 +622,7 @@ public final class CallTest {
     try {
       call.execute();
       fail();
-    } catch (CancellationException e){
+    } catch (IOException e){
     }
     assertEquals(0, server.getRequestCount());
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -20,7 +20,6 @@ import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.OkHeaders;
 import java.io.IOException;
 import java.net.ProtocolException;
-import java.util.concurrent.CancellationException;
 import okio.BufferedSink;
 import okio.BufferedSource;
 
@@ -63,12 +62,10 @@ public final class Call {
    * {@code response} may still indicate an unhappy HTTP response code like 404
    * or 500.
    *
-   * @throws CancellationException if the call was canceled.
-   *
-   * @throws IOException if the request could not be executed due to a
-   *     connectivity problem or timeout. Because networks can fail during an
-   *     exchange, it is possible that the remote server accepted the request
-   *     before the failure.
+   * @throws IOException if the request could not be executed due to
+   *     cancellation, a connectivity problem or timeout. Because networks can
+   *     fail during an exchange, it is possible that the remote server
+   *     accepted the request before the failure.
    *
    * @throws IllegalStateException when the call has already been executed.
    */
@@ -79,7 +76,7 @@ public final class Call {
     }
     Response result = getResponse();
     engine.releaseConnection(); // Transfer ownership of the body to the caller.
-    if (result == null) throw new CancellationException("Cancelled");
+    if (result == null) throw new IOException("Canceled");
     return result;
   }
 
@@ -145,7 +142,7 @@ public final class Call {
           signalledCallback = true;
           responseCallback.onFailure(new Failure.Builder()
               .request(request)
-              .exception(new CancellationException("Canceled"))
+              .exception(new IOException("Canceled"))
               .build());
         } else {
           signalledCallback = true;

--- a/okhttp/src/main/java/com/squareup/okhttp/Response.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Response.java
@@ -263,9 +263,10 @@ public final class Response {
 
   public interface Callback {
     /**
-     * Called when the request could not be executed due to a connectivity
-     * problem or timeout. Because networks can fail during an exchange, it is
-     * possible that the remote server accepted the request before the failure.
+     * Called when the request could not be executed due to cancellation, a
+     * connectivity problem or timeout. Because networks can fail during an
+     * exchange, it is possible that the remote server accepted the request
+     * before the failure.
      */
     void onFailure(Failure failure);
 


### PR DESCRIPTION
When a stream is canceled while reading a response body, or the peer cancels the request, we get an IOE.  Rather than have a mix of CancelationException or IOException depending on context, let's just use IOE.

cc @jhump 
