### PR TITLE
Add --frames arg to okcurl, which sends HTTP/2 frame metadata to STDERR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Testing
 ### On the Desktop
 
 Run OkHttp tests on the desktop with Maven. Running SPDY tests on the desktop uses
-[Jetty-NPN][3] which requires OpenJDK 7+.
+[Jetty-NPN][3] which requires OpenJDK 7.
 
 ```
 mvn clean test
@@ -101,6 +101,6 @@ License
 
  [1]: http://square.github.io/okhttp
  [2]: http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.squareup.okhttp&a=okhttp&v=LATEST
- [3]: http://wiki.eclipse.org/Jetty/Feature/NPN
+ [3]: https://github.com/jetty-project/jetty-npn
  [4]: https://code.google.com/p/vogar/
  [5]: http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.squareup.okhttp&a=mockwebserver&v=LATEST


### PR DESCRIPTION
Also reworks SpdyServer to also work with HTTP/2.

``` bash
$ okhttp/okcurl/target/okcurl-2.0.0-SNAPSHOT-jar-with-dependencies.jar --frames -k  https://localhost:8888/ >/dev/null
>> CONNECTION 505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
>> 0x00000000     5 SETTINGS      
<< 0x00000000     0 SETTINGS      ACK
>> 0x00000003    60 HEADERS       END_STREAM|END_HEADERS
<< 0x00000003    50 HEADERS       END_HEADERS
<< 0x00000003  1468 DATA          
<< 0x00000003     0 DATA          END_STREAM
>> 0x00000000     8 GOAWAY  
```
