### PR TITLE
Small cleanups.

### DIFF
--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -26,6 +26,9 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <excludePackageNames>com.squareup.okhttp.internal:com.squareup.okhttp.internal.*</excludePackageNames>
+          <links>
+            <link>http://square.github.io/okio/</link>
+          </links>
         </configuration>
       </plugin>
     </plugins>

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -236,9 +236,6 @@ public final class Call {
         throw new ProtocolException("Too many redirects: " + redirectionCount);
       }
 
-      // TODO: drop from POST to GET when redirected? HttpURLConnection does.
-      // TODO: confirm that Cookies are not retained across hosts.
-
       if (!engine.sameConnection(followUp)) {
         engine.releaseConnection();
       }

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -78,12 +78,13 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
    *
    * @see URLConnection#setConnectTimeout(int)
    */
-  public void setConnectTimeout(long timeout, TimeUnit unit) {
+  public OkHttpClient setConnectTimeout(long timeout, TimeUnit unit) {
     if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
     if (unit == null) throw new IllegalArgumentException("unit == null");
     long millis = unit.toMillis(timeout);
     if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
     connectTimeout = (int) millis;
+    return this;
   }
 
   /** Default connect timeout (in milliseconds). */
@@ -96,12 +97,13 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
    *
    * @see URLConnection#setReadTimeout(int)
    */
-  public void setReadTimeout(long timeout, TimeUnit unit) {
+  public OkHttpClient setReadTimeout(long timeout, TimeUnit unit) {
     if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
     if (unit == null) throw new IllegalArgumentException("unit == null");
     long millis = unit.toMillis(timeout);
     if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
     readTimeout = (int) millis;
+    return this;
   }
 
   /** Default read timeout (in milliseconds). */
@@ -112,12 +114,13 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
   /**
    * Sets the default write timeout for new connections. A value of 0 means no timeout.
    */
-  public void setWriteTimeout(long timeout, TimeUnit unit) {
+  public OkHttpClient setWriteTimeout(long timeout, TimeUnit unit) {
     if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
     if (unit == null) throw new IllegalArgumentException("unit == null");
     long millis = unit.toMillis(timeout);
     if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
     writeTimeout = (int) millis;
+    return this;
   }
 
   /** Default write timeout (in milliseconds). */
@@ -365,8 +368,9 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
    * Cancels all scheduled tasks tagged with {@code tag}. Requests that are already
    * complete cannot be canceled.
    */
-  public void cancel(Object tag) {
+  public OkHttpClient cancel(Object tag) {
     dispatcher.cancel(tag);
+    return this;
   }
 
   public HttpURLConnection open(URL url) {


### PR DESCRIPTION
Return the OkHttpClient on setters.
Remove some completed TODOs in Call.
Link to Okio in Javadoc.
