### PR TITLE
Change HttpResponseCache to not implement java.net.ResponseCache.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/AbstractResponseCache.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/AbstractResponseCache.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import java.io.IOException;
+import java.net.CacheRequest;
+import java.net.CacheResponse;
+import java.net.ResponseCache;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractResponseCache extends ResponseCache {
+  @Override public CacheResponse get(URI uri, String requestMethod,
+      Map<String, List<String>> requestHeaders) throws IOException {
+    return null;
+  }
+
+  @Override public CacheRequest put(URI uri, URLConnection connection) throws IOException {
+    return null;
+  }
+
+  public static URI toUri(URL serverUrl) {
+    try {
+      return serverUrl.toURI();
+    } catch (URISyntaxException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -595,7 +595,7 @@ public final class CallTest {
         .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED));
     server.play();
 
-    client.setOkResponseCache(cache);
+    client.setCache(cache);
 
     executeSynchronously(new Request.Builder().url(server.getUrl("/")).build())
         .assertCode(200).assertBody("A");
@@ -613,7 +613,7 @@ public final class CallTest {
         .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED));
     server.play();
 
-    client.setOkResponseCache(cache);
+    client.setCache(cache);
 
     Request request1 = new Request.Builder()
         .url(server.getUrl("/"))
@@ -635,7 +635,7 @@ public final class CallTest {
     server.enqueue(new MockResponse().setBody("B"));
     server.play();
 
-    client.setOkResponseCache(cache);
+    client.setCache(cache);
 
     executeSynchronously(new Request.Builder().url(server.getUrl("/")).build())
         .assertCode(200).assertBody("A");
@@ -651,7 +651,7 @@ public final class CallTest {
     server.enqueue(new MockResponse().setBody("B"));
     server.play();
 
-    client.setOkResponseCache(cache);
+    client.setCache(cache);
 
     Request request1 = new Request.Builder()
         .url(server.getUrl("/"))

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpOverSpdyTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpOverSpdyTest.java
@@ -351,7 +351,7 @@ public abstract class HttpOverSpdyTest {
   }
 
   @Test public void responsesAreCached() throws IOException {
-    client.setOkResponseCache(cache);
+    client.setCache(cache);
 
     server.enqueue(new MockResponse().addHeader("cache-control: max-age=60").setBody("A"));
     server.play();
@@ -368,7 +368,7 @@ public abstract class HttpOverSpdyTest {
   }
 
   @Test public void conditionalCache() throws IOException {
-    client.setOkResponseCache(cache);
+    client.setCache(cache);
 
     server.enqueue(new MockResponse().addHeader("ETag: v1").setBody("A"));
     server.enqueue(new MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED));
@@ -385,7 +385,7 @@ public abstract class HttpOverSpdyTest {
   }
 
   @Test public void responseCachedWithoutConsumingFullBody() throws IOException {
-    client.setOkResponseCache(cache);
+    client.setCache(cache);
 
     server.enqueue(new MockResponse().addHeader("cache-control: max-age=60").setBody("ABCD"));
     server.enqueue(new MockResponse().addHeader("cache-control: max-age=60").setBody("EFGH"));

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -16,6 +16,7 @@
 
 package com.squareup.okhttp.internal.http;
 
+import com.squareup.okhttp.AbstractResponseCache;
 import com.squareup.okhttp.ConnectionPool;
 import com.squareup.okhttp.Credentials;
 import com.squareup.okhttp.HttpResponseCache;
@@ -36,7 +37,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Authenticator;
 import java.net.CacheRequest;
-import java.net.CacheResponse;
 import java.net.ConnectException;
 import java.net.HttpRetryException;
 import java.net.HttpURLConnection;
@@ -44,7 +44,6 @@ import java.net.InetAddress;
 import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.ProxySelector;
-import java.net.ResponseCache;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URL;
@@ -839,7 +838,7 @@ public final class URLConnectionTest {
     String tmp = System.getProperty("java.io.tmpdir");
     File cacheDir = new File(tmp, "HttpCache-" + UUID.randomUUID());
     cache = new HttpResponseCache(cacheDir, Integer.MAX_VALUE);
-    client.setOkResponseCache(cache);
+    client.setCache(cache);
   }
 
   /** Test which headers are sent unencrypted to the HTTP proxy. */
@@ -2315,12 +2314,7 @@ public final class URLConnectionTest {
   /** Don't explode if the cache returns a null body. http://b/3373699 */
   @Test public void responseCacheReturnsNullOutputStream() throws Exception {
     final AtomicBoolean aborted = new AtomicBoolean();
-    client.setResponseCache(new ResponseCache() {
-      @Override public CacheResponse get(URI uri, String requestMethod,
-          Map<String, List<String>> requestHeaders) throws IOException {
-        return null;
-      }
-
+    client.setResponseCache(new AbstractResponseCache() {
       @Override public CacheRequest put(URI uri, URLConnection connection) throws IOException {
         return new CacheRequest() {
           @Override public void abort() {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLEncodingTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLEncodingTest.java
@@ -16,16 +16,14 @@
 
 package com.squareup.okhttp.internal.http;
 
+import com.squareup.okhttp.AbstractResponseCache;
 import com.squareup.okhttp.OkHttpClient;
 import java.io.IOException;
-import java.net.CacheRequest;
 import java.net.CacheResponse;
 import java.net.HttpURLConnection;
-import java.net.ResponseCache;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -124,11 +122,7 @@ public final class URLEncodingTest {
     final AtomicReference<URI> uriReference = new AtomicReference<URI>();
 
     OkHttpClient client = new OkHttpClient();
-    client.setResponseCache(new ResponseCache() {
-      @Override public CacheRequest put(URI uri, URLConnection connection) throws IOException {
-        return null;
-      }
-
+    client.setResponseCache(new AbstractResponseCache() {
       @Override public CacheResponse get(URI uri, String requestMethod,
           Map<String, List<String>> requestHeaders) throws IOException {
         uriReference.set(uri);

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
@@ -126,13 +126,13 @@ public final class ResponseCacheTest {
     ResponseCache.setDefault(null);
     client.setResponseCache(cache);
     assertSame(cache, client.getResponseCache());
-    assertTrue(client.getOkResponseCache() instanceof ResponseCacheAdapter);
+    assertTrue(client.internalCache() instanceof ResponseCacheAdapter);
   }
 
   @Test public void responseCacheAccessWithGlobalDefault() throws IOException {
     ResponseCache.setDefault(cache);
     client.setResponseCache(null);
-    assertNull(client.getOkResponseCache());
+    assertNull(client.internalCache());
     assertNull(client.getResponseCache());
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -180,22 +180,34 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
   /**
    * Sets the response cache to be used to read and write cached responses.
    */
+  @Deprecated // internal only.
   public OkHttpClient setResponseCache(ResponseCache responseCache) {
-    return setOkResponseCache(toOkResponseCache(responseCache));
+    this.responseCache = responseCache == null || responseCache instanceof OkResponseCache
+        ? (OkResponseCache) responseCache
+        : new ResponseCacheAdapter(responseCache);
+    return this;
   }
 
+  @Deprecated // internal only.
   public ResponseCache getResponseCache() {
     return responseCache instanceof ResponseCacheAdapter
         ? ((ResponseCacheAdapter) responseCache).getDelegate()
         : null;
   }
 
-  public OkHttpClient setOkResponseCache(OkResponseCache responseCache) {
+  public OkHttpClient setCache(HttpResponseCache responseCache) {
     this.responseCache = responseCache;
     return this;
   }
 
-  public OkResponseCache getOkResponseCache() {
+  public HttpResponseCache getCache() {
+    return responseCache instanceof HttpResponseCache
+        ? (HttpResponseCache) responseCache
+        : null;
+  }
+
+  @Deprecated // internal only.
+  public OkResponseCache internalCache() {
     return responseCache;
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -178,7 +178,7 @@ public final class HttpEngine {
     if (transport != null) throw new IllegalStateException();
 
     prepareRawRequestHeaders();
-    OkResponseCache responseCache = client.getOkResponseCache();
+    OkResponseCache responseCache = client.internalCache();
 
     Response cacheResponse = responseCache != null
         ? responseCache.get(request)
@@ -384,7 +384,7 @@ public final class HttpEngine {
   }
 
   private void maybeCache() throws IOException {
-    OkResponseCache responseCache = client.getOkResponseCache();
+    OkResponseCache responseCache = client.internalCache();
     if (responseCache == null) return;
 
     // Should we cache this response for this request?
@@ -644,7 +644,7 @@ public final class HttpEngine {
 
         // Update the cache after combining headers but before stripping the
         // Content-Encoding header (as performed by initContentStream()).
-        OkResponseCache responseCache = client.getOkResponseCache();
+        OkResponseCache responseCache = client.internalCache();
         responseCache.trackConditionalCacheHit();
         responseCache.update(validatingResponse, cacheableResponse());
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RetryableSink.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RetryableSink.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.net.ProtocolException;
 import okio.Buffer;
 import okio.BufferedSink;
-import okio.Timeout;
 import okio.Sink;
+import okio.Timeout;
 
 import static com.squareup.okhttp.internal.Util.checkOffsetAndCount;
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -303,8 +303,8 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
 
     // If we're currently not using caches, make sure the engine's client doesn't have one.
     OkHttpClient engineClient = client;
-    if (engineClient.getOkResponseCache() != null && !getUseCaches()) {
-      engineClient = client.clone().setOkResponseCache(null);
+    if (engineClient.internalCache() != null && !getUseCaches()) {
+      engineClient = client.clone().setCache(null);
     }
 
     return new HttpEngine(engineClient, request, bufferRequestBody, connection, null, requestBody);

--- a/samples/crawler/src/main/java/com/squareup/okhttp/sample/Crawler.java
+++ b/samples/crawler/src/main/java/com/squareup/okhttp/sample/Crawler.java
@@ -122,7 +122,7 @@ public final class Crawler {
 
     OkHttpClient client = new OkHttpClient();
     HttpResponseCache httpResponseCache = new HttpResponseCache(new File(args[0]), cacheByteCount);
-    client.setOkResponseCache(httpResponseCache);
+    client.setCache(httpResponseCache);
 
     Crawler crawler = new Crawler(client);
     crawler.queue.add(new URL(args[1]));


### PR DESCRIPTION
This marks some methods as @Deprecated and internal-only.
Unfortunately we don't have a great mechanism to hide them from
the documented API.
