### PR TITLE
New approach to hiding implementation details.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -22,6 +22,7 @@ import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.HttpTransport;
 import com.squareup.okhttp.internal.http.OkHeaders;
 import com.squareup.okhttp.internal.http.SpdyTransport;
+import com.squareup.okhttp.internal.http.Transport;
 import com.squareup.okhttp.internal.spdy.SpdyConnection;
 import java.io.Closeable;
 import java.io.IOException;
@@ -273,7 +274,7 @@ public final class Connection implements Closeable {
   }
 
   /** Returns the transport appropriate for this connection. */
-  public Object newTransport(HttpEngine httpEngine) throws IOException {
+  Transport newTransport(HttpEngine httpEngine) throws IOException {
     return (spdyConnection != null)
         ? new SpdyTransport(httpEngine, spdyConnection)
         : new HttpTransport(httpEngine, httpConnection);

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -15,13 +15,17 @@
  */
 package com.squareup.okhttp;
 
+import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.InternalCache;
 import com.squareup.okhttp.internal.Util;
+import com.squareup.okhttp.internal.http.HttpEngine;
+import com.squareup.okhttp.internal.http.Transport;
 import com.squareup.okhttp.internal.huc.AuthenticatorAdapter;
 import com.squareup.okhttp.internal.huc.CacheAdapter;
 import com.squareup.okhttp.internal.huc.HttpURLConnectionImpl;
 import com.squareup.okhttp.internal.huc.HttpsURLConnectionImpl;
 import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
+import java.io.IOException;
 import java.net.CookieHandler;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
@@ -51,6 +55,14 @@ import javax.net.ssl.SSLSocketFactory;
  * safely modified with further configuration changes.
  */
 public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
+  static {
+    Internal.instance = new Internal() {
+      @Override public Transport newTransport(
+          Connection connection, HttpEngine httpEngine) throws IOException {
+        return connection.newTransport(httpEngine);
+      }
+    };
+  }
 
   private final RouteDatabase routeDatabase;
   private Dispatcher dispatcher;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal;
+
+import com.squareup.okhttp.Connection;
+import com.squareup.okhttp.internal.http.HttpEngine;
+import com.squareup.okhttp.internal.http.Transport;
+import java.io.IOException;
+
+/**
+ * Escalate internal APIs in {@code com.squareup.okhttp} so they can be used
+ * from OkHttp's implementation packages. The only implementation of this
+ * interface is in {@link com.squareup.okhttp.OkHttpClient}.
+ */
+public abstract class Internal {
+  public static Internal instance;
+
+  public abstract Transport newTransport(Connection connection, HttpEngine httpEngine)
+      throws IOException;
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -27,6 +27,7 @@ import com.squareup.okhttp.Response;
 import com.squareup.okhttp.ResponseSource;
 import com.squareup.okhttp.Route;
 import com.squareup.okhttp.internal.Dns;
+import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.InternalCache;
 import com.squareup.okhttp.internal.Util;
 import java.io.IOException;
@@ -209,7 +210,7 @@ public final class HttpEngine {
       // Blow up if we aren't the current owner of the connection.
       if (connection.getOwner() != this && !connection.isSpdy()) throw new AssertionError();
 
-      transport = (Transport) connection.newTransport(this);
+      transport = Internal.instance.newTransport(connection, this);
 
       // Create a request body if we don't have one already. We'll already have
       // one if we're retrying a failed POST.

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
@@ -23,7 +23,7 @@ import java.net.CacheRequest;
 import okio.Sink;
 import okio.Source;
 
-interface Transport {
+public interface Transport {
   /**
    * The timeout to use while discarding a stream of input data. Since this is
    * used for connection reuse, this timeout should be significantly less than


### PR DESCRIPTION
This relies on the happy accident that OkHttpClient.class will be initialized
before any attempt to use internal APIs.
