### PR TITLE
Allow transparent GZIP to be disabled

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -1202,6 +1202,20 @@ public final class URLConnectionTest {
     assertEquals(0, server.takeRequest().getSequenceNumber()); // Connection is not pooled.
   }
 
+  @Test public void disableTransparentGzip() throws Exception {
+    client.setTransparentGzip(false);
+
+    server.enqueue(new MockResponse()
+        .setBody("a"));
+    server.play();
+
+    assertContent("a", client.open(server.getUrl("/")));
+
+    // no encoding header
+    RecordedRequest get = server.takeRequest();
+    assertContainsNoneMatching(get.getHeaders(), "Accept-Encoding.*");
+  }
+
   @Test public void endOfStreamResponseIsNotPooled() throws Exception {
     server.enqueue(new MockResponse()
         .setBody("{}")

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -150,6 +150,7 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
   private int connectTimeout;
   private int readTimeout;
   private int writeTimeout;
+  private boolean enabledTransparentGzip = true;
 
   public OkHttpClient() {
     routeDatabase = new RouteDatabase();
@@ -360,6 +361,21 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
 
   public ConnectionPool getConnectionPool() {
     return connectionPool;
+  }
+
+  /**
+   * Allows transparent GZIP to be turned off to save extra bytes for
+   * small requests.
+   *
+   * <p>If unset, transparent GZIP compression is on.
+   */
+  public boolean hasTransparentGzip() {
+    return enabledTransparentGzip;
+  }
+
+  public OkHttpClient setTransparentGzip(boolean enabledTransparentGzip) {
+    this.enabledTransparentGzip = enabledTransparentGzip;
+    return this;
   }
 
   /**

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -556,7 +556,7 @@ public final class HttpEngine {
       result.header("Connection", "Keep-Alive");
     }
 
-    if (request.header("Accept-Encoding") == null) {
+    if (client.hasTransparentGzip() && request.header("Accept-Encoding") == null) {
       transparentGzip = true;
       result.header("Accept-Encoding", "gzip");
     }


### PR DESCRIPTION
For small requests, GZIP can actually make requests larger. This allows the client to be configured to skip transparent GZIP.
