### PR TITLE
Test copyWithDefaults.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/AbstractResponseCache.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/AbstractResponseCache.java
@@ -26,7 +26,7 @@ import java.net.URLConnection;
 import java.util.List;
 import java.util.Map;
 
-public abstract class AbstractResponseCache extends ResponseCache {
+public class AbstractResponseCache extends ResponseCache {
   @Override public CacheResponse get(URI uri, String requestMethod,
       Map<String, List<String>> requestHeaders) throws IOException {
     return null;

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import com.squareup.okhttp.internal.RecordingAuthenticator;
+import com.squareup.okhttp.internal.http.RecordingProxySelector;
+import com.squareup.okhttp.internal.huc.AuthenticatorAdapter;
+import com.squareup.okhttp.internal.huc.CacheAdapter;
+import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
+import java.net.Authenticator;
+import java.net.CookieManager;
+import java.net.ProxySelector;
+import java.net.ResponseCache;
+import java.util.Arrays;
+import javax.net.SocketFactory;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public final class OkHttpClientTest {
+  @After public void tearDown() throws Exception {
+    ProxySelector.setDefault(null);
+    CookieManager.setDefault(null);
+    ResponseCache.setDefault(null);
+    Authenticator.setDefault(null);
+  }
+
+  /** Confirm that {@code copyWithDefaults} gets expected constant values. */
+  @Test public void copyWithDefaultsWhenDefaultIsAConstant() throws Exception {
+    OkHttpClient client = new OkHttpClient().copyWithDefaults();
+    assertNull(client.internalCache());
+    assertEquals(0, client.getConnectTimeout());
+    assertEquals(0, client.getReadTimeout());
+    assertEquals(0, client.getWriteTimeout());
+    assertTrue(client.getFollowSslRedirects());
+    assertNull(client.getProxy());
+    assertEquals(Arrays.asList(Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1),
+        client.getProtocols());
+  }
+
+  /**
+   * Confirm that {@code copyWithDefaults} gets some default implementations
+   * from the core library.
+   */
+  @Test public void copyWithDefaultsWhenDefaultIsGlobal() throws Exception {
+    ProxySelector proxySelector = new RecordingProxySelector();
+    CookieManager cookieManager = new CookieManager();
+    ResponseCache responseCache = new AbstractResponseCache();
+    Authenticator authenticator = new RecordingAuthenticator();
+    SocketFactory socketFactory = SocketFactory.getDefault(); // Global isn't configurable.
+    OkHostnameVerifier hostnameVerifier = OkHostnameVerifier.INSTANCE; // Global isn't configurable.
+
+    CookieManager.setDefault(cookieManager);
+    ProxySelector.setDefault(proxySelector);
+    ResponseCache.setDefault(responseCache);
+    Authenticator.setDefault(authenticator);
+
+    OkHttpClient client = new OkHttpClient().copyWithDefaults();
+
+    assertSame(proxySelector, client.getProxySelector());
+    assertSame(cookieManager, client.getCookieHandler());
+    assertSame(responseCache, ((CacheAdapter) client.internalCache()).getDelegate());
+    assertSame(AuthenticatorAdapter.INSTANCE, client.getAuthenticator());
+    assertSame(socketFactory, client.getSocketFactory());
+    assertSame(hostnameVerifier, client.getHostnameVerifier());
+  }
+
+  /** There is no default cache. */
+  @Test public void copyWithDefaultsCacheIsNull() throws Exception {
+    OkHttpClient client = new OkHttpClient().copyWithDefaults();
+    assertNull(client.getCache());
+  }
+
+  /**
+   * When copying the client, stateful things like the connection pool are
+   * shared across all clients.
+   */
+  @Test public void cloneSharesStatefulInstances() throws Exception {
+    OkHttpClient client = new OkHttpClient();
+
+    // Values should be non-null.
+    OkHttpClient a = client.clone().copyWithDefaults();
+    assertNotNull(a.getRoutesDatabase());
+    assertNotNull(a.getDispatcher());
+    assertNotNull(a.getConnectionPool());
+    assertNotNull(a.getSslSocketFactory());
+
+    // Multiple clients share the instances.
+    OkHttpClient b = client.clone().copyWithDefaults();
+    assertSame(a.getRoutesDatabase(), b.getRoutesDatabase());
+    assertSame(a.getDispatcher(), b.getDispatcher());
+    assertSame(a.getConnectionPool(), b.getConnectionPool());
+    assertSame(a.getSslSocketFactory(), b.getSslSocketFactory());
+  }
+}

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RecordingProxySelector.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RecordingProxySelector.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public final class RecordingProxySelector extends ProxySelector {
+  final List<URI> requestedUris = new ArrayList<URI>();
+  List<Proxy> proxies = new ArrayList<Proxy>();
+  final List<String> failures = new ArrayList<String>();
+
+  @Override public List<Proxy> select(URI uri) {
+    requestedUris.add(uri);
+    return proxies;
+  }
+
+  public void assertRequests(URI... expectedUris) {
+    assertEquals(Arrays.asList(expectedUris), requestedUris);
+    requestedUris.clear();
+  }
+
+  @Override public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+    InetSocketAddress socketAddress = (InetSocketAddress) sa;
+    failures.add(
+        String.format("%s %s:%d %s", uri, socketAddress.getHostName(), socketAddress.getPort(),
+            ioe.getMessage()));
+  }
+}

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.net.ProxySelector;
-import java.net.SocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -85,7 +83,7 @@ public final class RouteSelectorTest {
   private final OkAuthenticator authenticator = AuthenticatorAdapter.INSTANCE;
   private final List<Protocol> protocols = Arrays.asList(Protocol.HTTP_1_1);
   private final FakeDns dns = new FakeDns();
-  private final FakeProxySelector proxySelector = new FakeProxySelector();
+  private final RecordingProxySelector proxySelector = new RecordingProxySelector();
 
   @Test public void singleRoute() throws Exception {
     Address address = new Address(uriHost, uriPort, socketFactory, null, null, authenticator, null,
@@ -440,29 +438,6 @@ public final class RouteSelectorTest {
     public void assertRequests(String... expectedHosts) {
       assertEquals(Arrays.asList(expectedHosts), requestedHosts);
       requestedHosts.clear();
-    }
-  }
-
-  private static class FakeProxySelector extends ProxySelector {
-    List<URI> requestedUris = new ArrayList<URI>();
-    List<Proxy> proxies = new ArrayList<Proxy>();
-    List<String> failures = new ArrayList<String>();
-
-    @Override public List<Proxy> select(URI uri) {
-      requestedUris.add(uri);
-      return proxies;
-    }
-
-    public void assertRequests(URI... expectedUris) {
-      assertEquals(Arrays.asList(expectedUris), requestedUris);
-      requestedUris.clear();
-    }
-
-    @Override public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
-      InetSocketAddress socketAddress = (InetSocketAddress) sa;
-      failures.add(
-          String.format("%s %s:%d %s", uri, socketAddress.getHostName(), socketAddress.getPort(),
-              ioe.getMessage()));
     }
   }
 }


### PR DESCRIPTION
Also change initialization of the default SSL factory to be a global
constant rather than a per-client constant. Otherwise two clones of
the same client won't share an SSLSocketFactory.
