### PR TITLE
Don't honor the default java.net.ResponseCache.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
@@ -18,7 +18,6 @@ package com.squareup.okhttp;
 import com.squareup.okhttp.internal.RecordingAuthenticator;
 import com.squareup.okhttp.internal.http.RecordingProxySelector;
 import com.squareup.okhttp.internal.huc.AuthenticatorAdapter;
-import com.squareup.okhttp.internal.huc.CacheAdapter;
 import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
 import java.net.Authenticator;
 import java.net.CookieManager;
@@ -63,21 +62,18 @@ public final class OkHttpClientTest {
   @Test public void copyWithDefaultsWhenDefaultIsGlobal() throws Exception {
     ProxySelector proxySelector = new RecordingProxySelector();
     CookieManager cookieManager = new CookieManager();
-    ResponseCache responseCache = new AbstractResponseCache();
     Authenticator authenticator = new RecordingAuthenticator();
     SocketFactory socketFactory = SocketFactory.getDefault(); // Global isn't configurable.
     OkHostnameVerifier hostnameVerifier = OkHostnameVerifier.INSTANCE; // Global isn't configurable.
 
     CookieManager.setDefault(cookieManager);
     ProxySelector.setDefault(proxySelector);
-    ResponseCache.setDefault(responseCache);
     Authenticator.setDefault(authenticator);
 
     OkHttpClient client = new OkHttpClient().copyWithDefaults();
 
     assertSame(proxySelector, client.getProxySelector());
     assertSame(cookieManager, client.getCookieHandler());
-    assertSame(responseCache, ((CacheAdapter) client.internalCache()).getDelegate());
     assertSame(AuthenticatorAdapter.INSTANCE, client.getAuthenticator());
     assertSame(socketFactory, client.getSocketFactory());
     assertSame(hostnameVerifier, client.getHostnameVerifier());
@@ -87,6 +83,14 @@ public final class OkHttpClientTest {
   @Test public void copyWithDefaultsCacheIsNull() throws Exception {
     OkHttpClient client = new OkHttpClient().copyWithDefaults();
     assertNull(client.getCache());
+  }
+
+  @Test public void copyWithDefaultsDoesNotHonorGlobalResponseCache() throws Exception {
+    ResponseCache responseCache = new AbstractResponseCache();
+    ResponseCache.setDefault(responseCache);
+
+    OkHttpClient client = new OkHttpClient().copyWithDefaults();
+    assertNull(client.internalCache());
   }
 
   /**

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
@@ -112,7 +112,7 @@ public final class ResponseCacheTest {
 
     client = new OkHttpClient();
     cache = new InMemoryResponseCache();
-    ResponseCache.setDefault(cache);
+    Internal.instance.setResponseCache(client, cache);
   }
 
   @After public void tearDown() throws Exception {
@@ -121,19 +121,6 @@ public final class ResponseCacheTest {
 
   private HttpURLConnection openConnection(URL url) {
     return client.open(url);
-  }
-
-  @Test public void responseCacheAccessWithOkHttpMember() throws IOException {
-    ResponseCache.setDefault(null);
-    Internal.instance.setResponseCache(client, cache);
-    assertTrue(Internal.instance.internalCache(client) instanceof CacheAdapter);
-  }
-
-  @Test public void responseCacheAccessWithGlobalDefault() throws IOException {
-    ResponseCache.setDefault(cache);
-    Internal.instance.setResponseCache(client, null);
-    assertNull(Internal.instance.internalCache(client));
-    assertNull(client.getCache());
   }
 
   @Test public void responseCachingAndInputStreamSkipWithFixedLength() throws IOException {

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -491,11 +491,6 @@ public final class OkHttpClient implements URLStreamHandlerFactory, Cloneable {
     if (result.cookieHandler == null) {
       result.cookieHandler = CookieHandler.getDefault();
     }
-    if (result.cache == null && result.cacheAdapter == null) {
-      // TODO: drop support for the default response cache.
-      ResponseCache defaultCache = ResponseCache.getDefault();
-      result.cacheAdapter = defaultCache != null ? new CacheAdapter(defaultCache) : null;
-    }
     if (result.socketFactory == null) {
       result.socketFactory = SocketFactory.getDefault();
     }


### PR DESCRIPTION
Applications using ResponseCache.setDefault() will need to use OkHttp's
cache interface instead.

We no longer support any user-defined caches.
