### PR TITLE
Track redirectedBy in HttpEngine.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/RecordingOkAuthenticator.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/RecordingOkAuthenticator.java
@@ -23,28 +23,35 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class RecordingOkAuthenticator implements OkAuthenticator {
-  public final List<String> calls = new ArrayList<String>();
+  public final List<Response> responses = new ArrayList<Response>();
+  public final List<Proxy> proxies = new ArrayList<Proxy>();
   public final String credential;
 
   public RecordingOkAuthenticator(String credential) {
     this.credential = credential;
   }
 
+  public Response onlyResponse() {
+    if (responses.size() != 1) throw new IllegalStateException();
+    return responses.get(0);
+  }
+
+  public Proxy onlyProxy() {
+    if (proxies.size() != 1) throw new IllegalStateException();
+    return proxies.get(0);
+  }
+
   @Override public Request authenticate(Proxy proxy, Response response) {
-    calls.add("authenticate"
-        + " proxy=" + proxy.type()
-        + " url=" + response.request().url()
-        + " challenges=" + response.challenges());
+    responses.add(response);
+    proxies.add(proxy);
     return response.request().newBuilder()
         .addHeader("Authorization", credential)
         .build();
   }
 
   @Override public Request authenticateProxy(Proxy proxy, Response response) {
-    calls.add("authenticateProxy"
-        + " proxy=" + proxy.type()
-        + " url=" + response.request().url()
-        + " challenges=" + response.challenges());
+    responses.add(response);
+    proxies.add(proxy);
     return response.request().newBuilder()
         .addHeader("Proxy-Authorization", credential)
         .build();

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -272,7 +272,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
           throw new ProtocolException(method + " does not support writing");
         }
       }
-      httpEngine = newHttpEngine(method, null, null);
+      httpEngine = newHttpEngine(method, null, null, null);
     } catch (IOException e) {
       httpEngineFailure = e;
       throw e;
@@ -280,7 +280,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   }
 
   private HttpEngine newHttpEngine(String method, Connection connection,
-      RetryableSink requestBody) {
+      RetryableSink requestBody, Response redirectedBy) {
     Request.Builder builder = new Request.Builder()
         .url(getURL())
         .method(method, null /* No body; that's passed separately. */);
@@ -308,7 +308,8 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       engineClient = client.clone().setCache(null);
     }
 
-    return new HttpEngine(engineClient, request, bufferRequestBody, connection, null, requestBody);
+    return new HttpEngine(engineClient, request, bufferRequestBody, connection, null, requestBody,
+        redirectedBy);
   }
 
   /**
@@ -361,7 +362,8 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       }
 
       Connection connection = httpEngine.close();
-      httpEngine = newHttpEngine(followUp.method(), connection, (RetryableSink) requestBody);
+      httpEngine = newHttpEngine(followUp.method(), connection, (RetryableSink) requestBody,
+          response);
     }
   }
 


### PR DESCRIPTION
Tracking it in Call meant we would need to duplicate code
in HttpURLConnection if we wanted the same behavior.
