### PR TITLE
Added missing setting for compressed data frames.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http20Draft12Test.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http20Draft12Test.java
@@ -285,13 +285,15 @@ public class Http20Draft12Test {
 
     final int reducedTableSizeBytes = 16;
 
-    frame.writeShort(10); // 2 settings * 1 bytes for the code and 4 for the value.
+    frame.writeShort(15); // 3 settings * 1 bytes for the code and 4 for the value.
     frame.writeByte(Http20Draft12.TYPE_SETTINGS);
     frame.writeByte(0); // No flags
     frame.writeInt(0); // Settings are always on the connection stream 0.
     frame.writeByte(1); // SETTINGS_HEADER_TABLE_SIZE
     frame.writeInt(reducedTableSizeBytes);
     frame.writeByte(2); // SETTINGS_ENABLE_PUSH
+    frame.writeInt(0);
+    frame.writeByte(5); // SETTINGS_COMPRESS_DATA
     frame.writeInt(0);
 
     final Http20Draft12.Reader fr = new Http20Draft12.Reader(frame, 4096, false);
@@ -302,6 +304,7 @@ public class Http20Draft12Test {
         assertFalse(clearPrevious); // No clearPrevious in HTTP/2.
         assertEquals(reducedTableSizeBytes, settings.getHeaderTableSize());
         assertEquals(false, settings.getEnablePush(true));
+        assertEquals(false, settings.getCompressData(true));
       }
     });
   }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/SettingsTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/SettingsTest.java
@@ -46,12 +46,13 @@ public final class SettingsTest {
     assertEquals(8096, settings.getHeaderTableSize());
 
     // WARNING: clash on flags between spdy/3 and HTTP/2!
-    assertEquals(-3, settings.getDownloadBandwidth(-3));
     assertEquals(true, settings.getEnablePush(true));
+    settings.set(Settings.ENABLE_PUSH, 0, 1);
+    assertEquals(true, settings.getEnablePush(false));
+    settings.clear();
+    assertEquals(-3, settings.getDownloadBandwidth(-3));
     settings.set(DOWNLOAD_BANDWIDTH, 0, 53);
     assertEquals(53, settings.getDownloadBandwidth(-3));
-    settings.set(Settings.ENABLE_PUSH, 0, 0);
-    assertEquals(false, settings.getEnablePush(true));
 
     assertEquals(-3, settings.getRoundTripTime(-3));
     settings.set(Settings.ROUND_TRIP_TIME, 0, 64);
@@ -61,9 +62,14 @@ public final class SettingsTest {
     settings.set(MAX_CONCURRENT_STREAMS, 0, 75);
     assertEquals(75, settings.getMaxConcurrentStreams(-3));
 
+    // WARNING: clash on flags between spdy/3 and HTTP/2!
     assertEquals(-3, settings.getCurrentCwnd(-3));
     settings.set(Settings.CURRENT_CWND, 0, 86);
     assertEquals(86, settings.getCurrentCwnd(-3));
+    settings.clear();
+    assertEquals(true, settings.getCompressData(true));
+    settings.set(Settings.COMPRESS_DATA, 0, 1);
+    assertEquals(true, settings.getCompressData(false));
 
     assertEquals(-3, settings.getDownloadRetransRate(-3));
     settings.set(DOWNLOAD_RETRANS_RATE, 0, 97);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft12.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft12.java
@@ -288,6 +288,8 @@ public final class Http20Draft12 implements Variant {
               throw ioException("PROTOCOL_ERROR SETTINGS_INITIAL_WINDOW_SIZE > 2^31 - 1");
             }
             break;
+          case 5: // SETTINGS_COMPRESS_DATA
+            break;
           default:
             throw ioException("PROTOCOL_ERROR invalid settings id: %s", id);
         }
@@ -349,7 +351,7 @@ public final class Http20Draft12 implements Variant {
 
     private void readAlternateService(Handler handler, short length, byte flags, int streamId)
         throws IOException {
-      long maxAge = source.readInt() & 0xffffffff;
+      long maxAge = source.readInt() & 0xffff;
       int port = source.readShort() & 0xffff;
       source.readByte(); // Reserved.
       int protocolLength = source.readByte() & 0xff;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Settings.java
@@ -42,7 +42,7 @@ public final class Settings {
   static final int HEADER_TABLE_SIZE = 1;
   /** spdy/3: Sender's estimate of max outgoing kbps. */
   static final int DOWNLOAD_BANDWIDTH = 2;
-  /** HTTP/2: An endpoint must not send a PUSH_PROMISE frame when this is 0. */
+  /** HTTP/2: The peer must not send a PUSH_PROMISE frame when this is 0. */
   static final int ENABLE_PUSH = 2;
   /** spdy/3: Sender's estimate of millis between sending a request and receiving a response. */
   static final int ROUND_TRIP_TIME = 3;
@@ -50,6 +50,8 @@ public final class Settings {
   static final int MAX_CONCURRENT_STREAMS = 4;
   /** spdy/3: Current CWND in Packets. */
   static final int CURRENT_CWND = 5;
+  /** HTTP/2: The peer must not gzip a DATA frame when this is 0. */
+  static final int COMPRESS_DATA = 5;
   /** spdy/3: Retransmission rate. Percentage */
   static final int DOWNLOAD_RETRANS_RATE = 6;
   /** Window size in bytes. */
@@ -169,6 +171,13 @@ public final class Settings {
   int getCurrentCwnd(int defaultValue) {
     int bit = 1 << CURRENT_CWND;
     return (bit & set) != 0 ? values[CURRENT_CWND] : defaultValue;
+  }
+
+  /** HTTP/2 only. */
+  // TODO: honor this setting in HTTP/2.
+  boolean getCompressData(boolean defaultValue) {
+    int bit = 1 << COMPRESS_DATA;
+    return ((bit & set) != 0 ? values[COMPRESS_DATA] : defaultValue ? 1 : 0) == 1;
   }
 
   /** spdy/3 only. */


### PR DESCRIPTION
Eventhough we don't send the setting that allows http frame compression, we may receive one.  This test ensures we can parse that setting.
