### PR TITLE
Don't coerce HTTP/2 response headers to lowercase.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft12.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft12.java
@@ -200,7 +200,6 @@ public final class Http20Draft12 implements Variant {
 
     private List<Header> readHeaderBlock(short length, short padding, byte flags, int streamId)
         throws IOException {
-
       continuation.length = continuation.left = length;
       continuation.padding = padding;
       continuation.flags = flags;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Huffman.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Huffman.java
@@ -18,7 +18,6 @@ package com.squareup.okhttp.internal.spdy;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import okio.ByteString;
 
 /**
  * This class was originally composed from the following classes in
@@ -124,10 +123,6 @@ class Huffman {
     }
 
     return (int) ((len + 7) >> 3);
-  }
-
-  ByteString decode(ByteString buf) throws IOException {
-    return ByteString.of(decode(buf.toByteArray()));
   }
 
   byte[] decode(byte[] buf) throws IOException {


### PR DESCRIPTION
This enforces that we should only receive lowercase headers, as it says in the spec.  I've verified that twitter and netty follow this rule.
