### PR TITLE
Remove FIXME from Huffman as it is good enough.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Huffman.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Huffman.java
@@ -126,7 +126,6 @@ class Huffman {
   }
 
   byte[] decode(byte[] buf) throws IOException {
-    // FIXME
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     Node node = root;
     int current = 0;


### PR DESCRIPTION
Using this PR to capture rationale.

Huffman header decoding involves the following operations.
- read a byte array of encoded data from the buffered source
- create a BAOS with default length of 32bytes.
- scan the input byte array and put each decoded byte into the BAOS
- copy the array from the BAOS into the byte string that represents a header name or value.

This process is used when we don't already have an hpack index of the name or value reference.  After looking into it, not only is the above implementation fast and not a limiting factor, it is also pretty byte efficient.  Many header names and values are less than 32 bytes, so for example, the BAOS will not grow except during cases such as cookies.  Guessing the decoded length to avoid growing is possible, but borders on (or is) over-optimization.

After some investigation, I think we should remove the FIXME on the BAOS as we've other fish to fry.
