### PR TITLE
Avoid double array-copy when Huffman decoding

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/HuffmanTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/HuffmanTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Random;
 import org.junit.Test;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -35,7 +36,6 @@ public class HuffmanTest {
     for (int i = 0; i < s.length(); i++) {
       assertRoundTrip(s.substring(0, i).getBytes());
     }
-
     Random random = new Random(123456789L);
     byte[] buf = new byte[4096];
     random.nextBytes(buf);
@@ -49,7 +49,7 @@ public class HuffmanTest {
     Huffman.get().encode(buf, dos);
     assertEquals(baos.size(), Huffman.get().encodedLength(buf));
 
-    byte[] decodedBytes = Huffman.get().decode(baos.toByteArray());
-    assertTrue(Arrays.equals(buf, decodedBytes));
+    byte[] decodedBytes = Huffman.get().decode(baos.toByteArray()).toByteArray();
+    assertArrayEquals(buf, decodedBytes);
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/HpackDraft07.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/HpackDraft07.java
@@ -387,7 +387,7 @@ final class HpackDraft07 {
       int length = readInt(firstByte, PREFIX_7_BITS);
 
       if (huffmanDecode) {
-        return ByteString.of(Huffman.get().decode(source.readByteArray(length)));
+        return Huffman.get().decode(source.readByteArray(length));
       } else {
         return source.readByteString(length);
       }


### PR DESCRIPTION
I thought that it was over-polishing to take out the BAOS in Huffman, but actually, it can make a difference. We expect servers to use huffman with hpack in order to compress headers. If that's true, we will always call the huffman decoder for every value of a header we haven't seen, and any new header names not defined.  Thinking of very volatile headers such as Date, I think huffman will be hit very often.

The lowest hanging fruit left is to eliminate copying the array from the BAOS twice, once as BAOS.toByteArray, and again constructing the ByteString.

Here's the results of this elimination, going against the huffman examples from the hpack spec.

Current code:

```
Benchmark                             Mode   Samples         Mean   Mean error    Units
c.s.o.i.s.Hpackers.okHttpHuffman     thrpt        50     1241.927       17.834   ops/ms
```

This PR:

```
Benchmark                             Mode   Samples         Mean   Mean error    Units
c.s.o.i.s.Hpackers.okHttpHuffman     thrpt        50     1330.627       16.040   ops/ms
```
