### PR TITLE
Rename Request.Body to RequestBody and Response.Body to ResponseBody.

### DIFF
--- a/benchmarks/src/main/java/com/squareup/okhttp/benchmarks/OkHttpAsync.java
+++ b/benchmarks/src/main/java/com/squareup/okhttp/benchmarks/OkHttpAsync.java
@@ -20,6 +20,7 @@ import com.squareup.okhttp.Failure;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.internal.SslContextBuilder;
 import java.io.IOException;
 import java.net.URL;
@@ -69,7 +70,7 @@ class OkHttpAsync implements HttpClient {
       }
 
       @Override public void onResponse(Response response) throws IOException {
-        Response.Body body = response.body();
+        ResponseBody body = response.body();
         long total = SynchronousHttpClient.readAllAndClose(body.byteStream());
         long finish = System.nanoTime();
         if (VERBOSE) {

--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -22,6 +22,7 @@ import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 import com.squareup.okhttp.internal.http.StatusLine;
 import com.squareup.okhttp.internal.spdy.Http20Draft12;
@@ -187,7 +188,7 @@ public class Main extends HelpOption implements Runnable {
     return "GET";
   }
 
-  private Request.Body getRequestBody() {
+  private RequestBody getRequestBody() {
     if (data == null) {
       return null;
     }
@@ -205,7 +206,7 @@ public class Main extends HelpOption implements Runnable {
       }
     }
 
-    return Request.Body.create(MediaType.parse(mimeType), bodyData);
+    return RequestBody.create(MediaType.parse(mimeType), bodyData);
   }
 
   Request createRequest() {

--- a/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
+++ b/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
@@ -16,6 +16,7 @@
 package com.squareup.okhttp.curl;
 
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
 import java.io.IOException;
 import okio.Buffer;
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class MainTest {
 
   @Test public void dataPost() {
     Request request = fromArgs("-d", "foo", "http://example.com").createRequest();
-    Request.Body body = request.body();
+    RequestBody body = request.body();
     assertEquals("POST", request.method());
     assertEquals("http://example.com", request.urlString());
     assertEquals("application/x-form-urlencoded; charset=utf-8", body.contentType().toString());
@@ -50,7 +51,7 @@ public class MainTest {
 
   @Test public void dataPut() {
     Request request = fromArgs("-d", "foo", "-X", "PUT", "http://example.com").createRequest();
-    Request.Body body = request.body();
+    RequestBody body = request.body();
     assertEquals("PUT", request.method());
     assertEquals("http://example.com", request.urlString());
     assertEquals("application/x-form-urlencoded; charset=utf-8", body.contentType().toString());
@@ -60,7 +61,7 @@ public class MainTest {
   @Test public void contentTypeHeader() {
     Request request = fromArgs("-d", "foo", "-H", "Content-Type: application/json",
         "http://example.com").createRequest();
-    Request.Body body = request.body();
+    RequestBody body = request.body();
     assertEquals("POST", request.method());
     assertEquals("http://example.com", request.urlString());
     assertEquals("application/json; charset=utf-8", body.contentType().toString());
@@ -83,7 +84,7 @@ public class MainTest {
     assertNull(request.body());
   }
 
-  private static String bodyAsString(Request.Body body) {
+  private static String bodyAsString(RequestBody body) {
     try {
       Buffer buffer = new Buffer();
       body.writeTo(buffer);

--- a/okhttp-apache/src/main/java/com/squareup/okhttp/apache/HttpEntityBody.java
+++ b/okhttp-apache/src/main/java/com/squareup/okhttp/apache/HttpEntityBody.java
@@ -1,14 +1,14 @@
 package com.squareup.okhttp.apache;
 
 import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
 import java.io.IOException;
 import okio.BufferedSink;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 
-/** Adapts an {@link HttpEntity} to OkHttp's {@link Request.Body}. */
-final class HttpEntityBody extends Request.Body {
+/** Adapts an {@link HttpEntity} to OkHttp's {@link RequestBody}. */
+final class HttpEntityBody extends RequestBody {
   private static final String DEFAULT_MEDIA_TYPE = "application/octet-stream";
 
   private final HttpEntity entity;

--- a/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
+++ b/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
@@ -4,7 +4,9 @@ package com.squareup.okhttp.apache;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -48,7 +50,7 @@ public final class OkApacheClient implements HttpClient {
       builder.header(header.getName(), header.getValue());
     }
 
-    Request.Body body = null;
+    RequestBody body = null;
     if (request instanceof HttpEntityEnclosingRequest) {
       HttpEntity entity = ((HttpEntityEnclosingRequest) request).getEntity();
       if (entity != null) {
@@ -71,7 +73,7 @@ public final class OkApacheClient implements HttpClient {
     String message = response.message();
     BasicHttpResponse httpResponse = new BasicHttpResponse(HTTP_1_1, code, message);
 
-    Response.Body body = response.body();
+    ResponseBody body = response.body();
     InputStreamEntity entity = new InputStreamEntity(body.byteStream(), body.contentLength());
     httpResponse.setEntity(entity);
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -138,7 +138,7 @@ public final class CallTest {
 
     Request request = new Request.Builder()
         .url(server.getUrl("/"))
-        .post(Request.Body.create(MediaType.parse("text/plain"), "def"))
+        .post(RequestBody.create(MediaType.parse("text/plain"), "def"))
         .build();
 
     executeSynchronously(request)
@@ -228,7 +228,7 @@ public final class CallTest {
 
     Request request = new Request.Builder()
         .url(server.getUrl("/"))
-        .put(Request.Body.create(MediaType.parse("text/plain"), "def"))
+        .put(RequestBody.create(MediaType.parse("text/plain"), "def"))
         .build();
 
     executeSynchronously(request)
@@ -258,7 +258,7 @@ public final class CallTest {
 
     Request request = new Request.Builder()
         .url(server.getUrl("/"))
-        .patch(Request.Body.create(MediaType.parse("text/plain"), "def"))
+        .patch(RequestBody.create(MediaType.parse("text/plain"), "def"))
         .build();
 
     executeSynchronously(request)
@@ -544,7 +544,7 @@ public final class CallTest {
 
     Request request = new Request.Builder()
         .url(server.getUrl("/"))
-        .post(Request.Body.create(MediaType.parse("text/plain"), "def"))
+        .post(RequestBody.create(MediaType.parse("text/plain"), "def"))
         .build();
     client.newCall(request).enqueue(callback);
 
@@ -571,7 +571,7 @@ public final class CallTest {
 
     Request request2 = new Request.Builder()
         .url(server.getUrl("/"))
-        .post(Request.Body.create(MediaType.parse("text/plain"), "body!"))
+        .post(RequestBody.create(MediaType.parse("text/plain"), "body!"))
         .build();
     Response response2 = client.newCall(request2).execute();
     assertEquals("def", response2.body().string());
@@ -707,7 +707,7 @@ public final class CallTest {
 
     Response response = client.newCall(new Request.Builder()
         .url(server.getUrl("/page1"))
-        .post(Request.Body.create(MediaType.parse("text/plain"), "Request Body"))
+        .post(RequestBody.create(MediaType.parse("text/plain"), "Request Body"))
         .build()).execute();
     assertEquals("Page 2", response.body().string());
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RecordingCallback.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RecordingCallback.java
@@ -38,7 +38,7 @@ public class RecordingCallback implements Response.Callback {
 
   @Override public synchronized void onResponse(Response response) throws IOException {
     Buffer buffer = new Buffer();
-    Response.Body body = response.body();
+    ResponseBody body = response.body();
     body.source().readAll(buffer);
 
     responses.add(new RecordedResponse(response.request(), response, buffer.readUtf8(), null));

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertNull;
 public final class RequestTest {
   @Test public void string() throws Exception {
     MediaType contentType = MediaType.parse("text/plain; charset=utf-8");
-    Request.Body body = Request.Body.create(contentType, "abc".getBytes(Util.UTF_8));
+    RequestBody body = RequestBody.create(contentType, "abc".getBytes(Util.UTF_8));
     assertEquals(contentType, body.contentType());
     assertEquals(3, body.contentLength());
     assertEquals("616263", bodyToHex(body));
@@ -37,7 +37,7 @@ public final class RequestTest {
 
   @Test public void stringWithDefaultCharsetAdded() throws Exception {
     MediaType contentType = MediaType.parse("text/plain");
-    Request.Body body = Request.Body.create(contentType, "\u0800");
+    RequestBody body = RequestBody.create(contentType, "\u0800");
     assertEquals(MediaType.parse("text/plain; charset=utf-8"), body.contentType());
     assertEquals(3, body.contentLength());
     assertEquals("e0a080", bodyToHex(body));
@@ -45,7 +45,7 @@ public final class RequestTest {
 
   @Test public void stringWithNonDefaultCharsetSpecified() throws Exception {
     MediaType contentType = MediaType.parse("text/plain; charset=utf-16be");
-    Request.Body body = Request.Body.create(contentType, "\u0800");
+    RequestBody body = RequestBody.create(contentType, "\u0800");
     assertEquals(contentType, body.contentType());
     assertEquals(2, body.contentLength());
     assertEquals("0800", bodyToHex(body));
@@ -53,7 +53,7 @@ public final class RequestTest {
 
   @Test public void byteArray() throws Exception {
     MediaType contentType = MediaType.parse("text/plain");
-    Request.Body body = Request.Body.create(contentType, "abc".getBytes(Util.UTF_8));
+    RequestBody body = RequestBody.create(contentType, "abc".getBytes(Util.UTF_8));
     assertEquals(contentType, body.contentType());
     assertEquals(3, body.contentLength());
     assertEquals("616263", bodyToHex(body));
@@ -67,7 +67,7 @@ public final class RequestTest {
     writer.close();
 
     MediaType contentType = MediaType.parse("text/plain");
-    Request.Body body = Request.Body.create(contentType, file);
+    RequestBody body = RequestBody.create(contentType, file);
     assertEquals(contentType, body.contentType());
     assertEquals(3, body.contentLength());
     assertEquals("616263", bodyToHex(body));
@@ -77,7 +77,7 @@ public final class RequestTest {
   /** Common verbs used for apis such as GitHub, AWS, and Google Cloud. */
   @Test public void crudVerbs() {
     MediaType contentType = MediaType.parse("application/json");
-    Request.Body body = Request.Body.create(contentType, "{}");
+    RequestBody body = RequestBody.create(contentType, "{}");
 
     Request get = new Request.Builder().url("http://localhost/api").get().build();
     assertEquals("GET", get.method());
@@ -104,7 +104,7 @@ public final class RequestTest {
     assertEquals(body, patch.body());
   }
 
-  private String bodyToHex(Request.Body body) throws IOException {
+  private String bodyToHex(RequestBody body) throws IOException {
     Buffer buffer = new Buffer();
     body.writeTo(buffer);
     return buffer.readByteString().hex();

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/huc/JavaApiConverterTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/huc/JavaApiConverterTest.java
@@ -22,7 +22,9 @@ import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.internal.SslContextBuilder;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.mockwebserver.MockResponse;
@@ -432,7 +434,7 @@ public class JavaApiConverterTest {
   }
 
   @Test public void createJavaUrlConnection_responseHeadersOk() throws Exception {
-    Response.Body responseBody = createResponseBody("BodyText");
+    ResponseBody responseBody = createResponseBody("BodyText");
     Response okResponse = new Response.Builder()
         .request(createArbitraryOkRequest())
         .protocol(Protocol.HTTP_1_1)
@@ -609,7 +611,7 @@ public class JavaApiConverterTest {
             .url("http://insecure/request")
             .post(createRequestBody("RequestBody"))
             .build();
-    Response.Body responseBody = createResponseBody("ResponseBody");
+    ResponseBody responseBody = createResponseBody("ResponseBody");
     Response okResponse = createArbitraryOkResponse(okRequest).newBuilder()
         .protocol(Protocol.HTTP_1_1)
         .code(200)
@@ -633,7 +635,7 @@ public class JavaApiConverterTest {
             .url("https://secure/request")
             .post(createRequestBody("RequestBody") )
             .build();
-    Response.Body responseBody = createResponseBody("ResponseBody");
+    ResponseBody responseBody = createResponseBody("ResponseBody");
     Handshake handshake = Handshake.get("SecureCipher", Arrays.<Certificate>asList(SERVER_CERT),
         Arrays.<Certificate>asList(LOCAL_CERT));
     Response okResponse = createArbitraryOkResponse(okRequest).newBuilder()
@@ -770,14 +772,14 @@ public class JavaApiConverterTest {
     return createArbitraryOkResponse(createArbitraryOkRequest());
   }
 
-  private static Request.Body createRequestBody(String bodyText) {
-    return Request.Body.create(MediaType.parse("text/plain"), bodyText);
+  private static RequestBody createRequestBody(String bodyText) {
+    return RequestBody.create(MediaType.parse("text/plain"), bodyText);
   }
 
-  private static Response.Body createResponseBody(String bodyText) {
+  private static ResponseBody createResponseBody(String bodyText) {
     final Buffer source = new Buffer().writeUtf8(bodyText);
     final long contentLength = source.size();
-    return new Response.Body() {
+    return new ResponseBody() {
       @Override public MediaType contentType() {
         return MediaType.parse("text/plain; charset=utf-8");
       }

--- a/okhttp/src/main/java/com/squareup/okhttp/Cache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Cache.java
@@ -582,7 +582,7 @@ public final class Cache {
     }
   }
 
-  private static class CacheResponseBody extends Response.Body {
+  private static class CacheResponseBody extends ResponseBody {
     private final DiskLruCache.Snapshot snapshot;
     private final BufferedSource bodySource;
     private final String contentType;

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -58,7 +58,7 @@ public final class Call {
    *
    * <p>The caller may read the response body with the response's
    * {@link Response#body} method.  To facilitate connection recycling, callers
-   * should always {@link Response.Body#close() close the response body}.
+   * should always {@link ResponseBody#close() close the response body}.
    *
    * <p>Note that transport-layer success (receiving a HTTP response code,
    * headers and body) does not necessarily indicate application-layer success:
@@ -170,7 +170,7 @@ public final class Call {
    */
   private Response getResponse() throws IOException {
     // Copy body metadata to the appropriate request headers.
-    Request.Body body = request.body();
+    RequestBody body = request.body();
     RetryableSink requestBodyOut = null;
     if (body != null) {
       MediaType contentType = body.contentType();
@@ -243,7 +243,7 @@ public final class Call {
     }
   }
 
-  private static class RealResponseBody extends Response.Body {
+  private static class RealResponseBody extends ResponseBody {
     private final Response response;
     private final BufferedSource source;
 

--- a/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import com.squareup.okhttp.internal.Util;
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import okio.BufferedSink;
+import okio.Okio;
+import okio.Source;
+
+public abstract class RequestBody {
+  /** Returns the Content-Type header for this body. */
+  public abstract MediaType contentType();
+
+  /**
+   * Returns the number of bytes that will be written to {@code out} in a call
+   * to {@link #writeTo}, or -1 if that count is unknown.
+   */
+  public long contentLength() {
+    return -1;
+  }
+
+  /** Writes the content of this request to {@code out}. */
+  public abstract void writeTo(BufferedSink sink) throws IOException;
+
+  /**
+   * Returns a new request body that transmits {@code content}. If {@code
+   * contentType} lacks a charset, this will use UTF-8.
+   */
+  public static RequestBody create(MediaType contentType, String content) {
+    contentType = contentType.charset() != null
+        ? contentType
+        : MediaType.parse(contentType + "; charset=utf-8");
+    try {
+      byte[] bytes = content.getBytes(contentType.charset().name());
+      return create(contentType, bytes);
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError();
+    }
+  }
+
+  /** Returns a new request body that transmits {@code content}. */
+  public static RequestBody create(final MediaType contentType, final byte[] content) {
+    if (contentType == null) throw new NullPointerException("contentType == null");
+    if (content == null) throw new NullPointerException("content == null");
+
+    return new RequestBody() {
+      @Override public MediaType contentType() {
+        return contentType;
+      }
+
+      @Override public long contentLength() {
+        return content.length;
+      }
+
+      @Override public void writeTo(BufferedSink sink) throws IOException {
+        sink.write(content);
+      }
+    };
+  }
+
+  /** Returns a new request body that transmits the content of {@code file}. */
+  public static RequestBody create(final MediaType contentType, final File file) {
+    if (contentType == null) throw new NullPointerException("contentType == null");
+    if (file == null) throw new NullPointerException("content == null");
+
+    return new RequestBody() {
+      @Override public MediaType contentType() {
+        return contentType;
+      }
+
+      @Override public long contentLength() {
+        return file.length();
+      }
+
+      @Override public void writeTo(BufferedSink sink) throws IOException {
+        Source source = null;
+        try {
+          source = Okio.source(file);
+          sink.writeAll(source);
+        } finally {
+          Util.closeQuietly(source);
+        }
+      }
+    };
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/ResponseBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ResponseBody.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import com.squareup.okhttp.internal.Util;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import okio.BufferedSource;
+
+import static com.squareup.okhttp.internal.Util.UTF_8;
+
+public abstract class ResponseBody implements Closeable {
+  /** Multiple calls to {@link #charStream()} must return the same instance. */
+  private Reader reader;
+
+  public abstract MediaType contentType();
+
+  /**
+   * Returns the number of bytes in that will returned by {@link #bytes}, or
+   * {@link #byteStream}, or -1 if unknown.
+   */
+  public abstract long contentLength();
+
+  public final InputStream byteStream() {
+    return source().inputStream();
+  }
+
+  public abstract BufferedSource source();
+
+  public final byte[] bytes() throws IOException {
+    long contentLength = contentLength();
+    if (contentLength > Integer.MAX_VALUE) {
+      throw new IOException("Cannot buffer entire body for content length: " + contentLength);
+    }
+
+    BufferedSource source = source();
+    byte[] bytes;
+    try {
+      bytes = source.readByteArray();
+    } finally {
+      Util.closeQuietly(source);
+    }
+    if (contentLength != -1 && contentLength != bytes.length) {
+      throw new IOException("Content-Length and stream length disagree");
+    }
+    return bytes;
+  }
+
+  /**
+   * Returns the response as a character stream decoded with the charset
+   * of the Content-Type header. If that header is either absent or lacks a
+   * charset, this will attempt to decode the response body as UTF-8.
+   */
+  public final Reader charStream() {
+    Reader r = reader;
+    return r != null ? r : (reader = new InputStreamReader(byteStream(), charset()));
+  }
+
+  /**
+   * Returns the response as a string decoded with the charset of the
+   * Content-Type header. If that header is either absent or lacks a charset,
+   * this will attempt to decode the response body as UTF-8.
+   */
+  public final String string() throws IOException {
+    return new String(bytes(), charset().name());
+  }
+
+  private Charset charset() {
+    MediaType contentType = contentType();
+    return contentType != null ? contentType.charset(UTF_8) : UTF_8;
+  }
+
+  @Override public void close() throws IOException {
+    source().close();
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
@@ -5,6 +5,7 @@ import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.ResponseSource;
 import java.net.HttpURLConnection;
 import java.util.Date;
@@ -22,7 +23,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * response (if the cached data is potentially stale).
  */
 public final class CacheStrategy {
-  private static final Response.Body EMPTY_BODY = new Response.Body() {
+  private static final ResponseBody EMPTY_BODY = new ResponseBody() {
     @Override public MediaType contentType() {
       return null;
     }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/huc/JavaApiConverter.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/huc/JavaApiConverter.java
@@ -20,6 +20,7 @@ import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.ResponseSource;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.OkHeaders;
@@ -82,7 +83,7 @@ public final class JavaApiConverter {
     okResponseBuilder.setResponseSource(ResponseSource.NETWORK);
 
     // Response body
-    Response.Body okBody = createOkBody(okHeaders, urlConnection.getInputStream());
+    ResponseBody okBody = createOkBody(okHeaders, urlConnection.getInputStream());
     okResponseBuilder.body(okBody);
 
     // Handle SSL handshake information as needed.
@@ -132,7 +133,7 @@ public final class JavaApiConverter {
     okResponseBuilder.setResponseSource(ResponseSource.CACHE);
 
     // Response body
-    Response.Body okBody = createOkBody(okHeaders, javaResponse.getBody());
+    ResponseBody okBody = createOkBody(okHeaders, javaResponse.getBody());
     okResponseBuilder.body(okBody);
 
     // Handle SSL handshake information as needed.
@@ -185,7 +186,7 @@ public final class JavaApiConverter {
    */
   public static CacheResponse createJavaCacheResponse(final Response response) {
     final Headers headers = response.headers();
-    final Response.Body body = response.body();
+    final ResponseBody body = response.body();
     if (response.request().isHttps()) {
       final Handshake handshake = response.handshake();
       return new SecureCacheResponse() {
@@ -345,9 +346,9 @@ public final class JavaApiConverter {
   /**
    * Creates an OkHttp Response.Body containing the supplied information.
    */
-  private static Response.Body createOkBody(final Headers okHeaders, InputStream body) {
+  private static ResponseBody createOkBody(final Headers okHeaders, InputStream body) {
     final BufferedSource source = Okio.buffer(Okio.source(body));
-    return new Response.Body() {
+    return new ResponseBody() {
       @Override public MediaType contentType() {
         String contentTypeHeader = okHeaders.get("Content-Type");
         return contentTypeHeader == null ? null : MediaType.parse(contentTypeHeader);

--- a/samples/guide/src/main/java/com/squareup/okhttp/guide/PostExample.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/guide/PostExample.java
@@ -3,6 +3,7 @@ package com.squareup.okhttp.guide;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 import java.io.IOException;
 
@@ -11,7 +12,7 @@ public class PostExample {
 
   void run() throws IOException {
     String json = bowlingJson("Jesse", "Jake");
-    Request.Body body = Request.Body.create(MediaType.parse("application/json"), json);
+    RequestBody body = RequestBody.create(MediaType.parse("application/json"), json);
     Request request = new Request.Builder().url("http://www.roundsapp.com/post").post(body).build();
 
     Response response = client.newCall(request).execute();


### PR DESCRIPTION
Compelling alternative is ReadableBody and WritableBody, or BodySource and BodySink.
Which in theory permits reuse for serverside body makers. But I don't like those names
as much.
