### PR TITLE
#821 Fixing proxy auth test to pass inside local networks

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -1382,8 +1382,7 @@ public final class URLConnectionTest {
     String call = calls.get(0);
     assertTrue(call, call.contains("host=" + url.getHost()));
     assertTrue(call, call.contains("port=" + url.getPort()));
-    InetAddress inetAddress = InetAddress.getByName(url.getHost());
-    assertThat(call, containsString("site=" + inetAddress.getCanonicalHostName() + "/" + inetAddress.getHostAddress()));
+    assertThat(call, containsString("site=" + getProxySite(url.getHost())));
     assertTrue(call, call.contains("url=http://android.com"));
     assertTrue(call, call.contains("type=" + Authenticator.RequestorType.PROXY));
     assertTrue(call, call.contains("prompt=Bar"));
@@ -1410,6 +1409,15 @@ public final class URLConnectionTest {
     }
     assertEquals(responseCode, connection.getResponseCode());
     return authenticator.calls;
+  }
+
+  private String getProxySite(String host) throws UnknownHostException {
+    InetAddress inetAddress = InetAddress.getByName(host);
+    if ((Character.digit(host.charAt(0), 16) != -1
+        || (host.charAt(0) == ':'))) {
+      return inetAddress.getCanonicalHostName() + "/" + inetAddress.getHostAddress();
+    }
+    return inetAddress.toString();
   }
 
   @Test public void setValidRequestMethod() throws Exception {


### PR DESCRIPTION
Javadoc for `InetAddress -> toString()` method gives an explanation to the issue:     

```
    /**
     * Converts this IP address to a {@code String}. The
     * string returned is of the form: hostname / literal IP
     * address.
     *
     * If the host name is unresolved, no reverse name service lookup
     * is performed. The hostname part will be represented by an empty string.
     *
     * @return  a string representation of this IP address.
     */
```

Looks like the implementation of okhttp library performs a reverse name service lookup of the proxy even if its host name represented by an IP address, but the assertion in the test doesn't do this.
The reverse lookup is performed in `resetNextInetSocketAddress` method of `RouteSelector` class. I forced the test to perform a reverse lookup as well by calling `getCanonicalHostName()`.
