### PR TITLE
Rename redirectedBy to priorResponse.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RecordedResponse.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RecordedResponse.java
@@ -65,7 +65,7 @@ public class RecordedResponse {
    * response for the original request.
    */
   public RecordedResponse redirectedBy() {
-    Response redirectedBy = response.redirectedBy();
+    Response redirectedBy = response.priorResponse();
     assertNotNull(redirectedBy);
     assertNull(redirectedBy.body());
     return new RecordedResponse(redirectedBy.request(), redirectedBy, null, null);

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -24,7 +24,6 @@ import com.squareup.okhttp.Credentials;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Response;
-import com.squareup.okhttp.internal.Dns;
 import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.RecordingAuthenticator;
 import com.squareup.okhttp.internal.RecordingHostnameVerifier;
@@ -2758,7 +2757,7 @@ public final class URLConnectionTest {
     Response challengeResponse = authenticator.responses.get(0);
     assertEquals("/b", challengeResponse.request().url().getPath());
 
-    Response redirectedBy = challengeResponse.redirectedBy();
+    Response redirectedBy = challengeResponse.priorResponse();
     assertEquals("/a", redirectedBy.request().url().getPath());
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Response.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Response.java
@@ -40,7 +40,7 @@ public final class Response {
   private final Handshake handshake;
   private final Headers headers;
   private final ResponseBody body;
-  private final Response redirectedBy;
+  private final Response priorResponse;
 
   private volatile CacheControl cacheControl; // Lazily initialized.
 
@@ -52,7 +52,7 @@ public final class Response {
     this.handshake = builder.handshake;
     this.headers = builder.headers.build();
     this.body = builder.body;
-    this.redirectedBy = builder.redirectedBy;
+    this.priorResponse = builder.priorResponse;
   }
 
   /**
@@ -142,8 +142,8 @@ public final class Response {
    * automatic retry. The body of the returned response should not be read
    * because it has already been consumed by the redirecting client.
    */
-  public Response redirectedBy() {
-    return redirectedBy;
+  public Response priorResponse() {
+    return priorResponse;
   }
 
   /**
@@ -194,7 +194,7 @@ public final class Response {
     private Handshake handshake;
     private Headers.Builder headers;
     private ResponseBody body;
-    private Response redirectedBy;
+    private Response priorResponse;
 
     public Builder() {
       headers = new Headers.Builder();
@@ -208,7 +208,7 @@ public final class Response {
       this.handshake = response.handshake;
       this.headers = response.headers.newBuilder();
       this.body = response.body;
-      this.redirectedBy = response.redirectedBy;
+      this.priorResponse = response.priorResponse;
     }
 
     public Builder request(Request request) {
@@ -275,8 +275,8 @@ public final class Response {
       return header(OkHeaders.RESPONSE_SOURCE, responseSource + " " + code);
     }
 
-    public Builder redirectedBy(Response redirectedBy) {
-      this.redirectedBy = redirectedBy;
+    public Builder priorResponse(Response priorResponse) {
+      this.priorResponse = priorResponse;
       return this;
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -280,7 +280,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   }
 
   private HttpEngine newHttpEngine(String method, Connection connection,
-      RetryableSink requestBody, Response redirectedBy) {
+      RetryableSink requestBody, Response priorResponse) {
     Request.Builder builder = new Request.Builder()
         .url(getURL())
         .method(method, null /* No body; that's passed separately. */);
@@ -309,7 +309,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     }
 
     return new HttpEngine(engineClient, request, bufferRequestBody, connection, null, requestBody,
-        redirectedBy);
+        priorResponse);
   }
 
   /**


### PR DESCRIPTION
I'm not completely in love with the name prior response, but it's better
than redirected by because it covers both redirects and authentication
challenges.
