### PR TITLE
Remove unknown clause from response code javadoc.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Response.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Response.java
@@ -83,7 +83,7 @@ public final class Response {
     return protocol;
   }
 
-  /** Returns the HTTP status code or -1 if it is unknown. */
+  /** Returns the HTTP status code. */
   public int code() {
     return code;
   }


### PR DESCRIPTION
The builder guarantees that the code is always positive.

Refs #816.
