### PR TITLE
Strip auth headers when redirected to another host.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -50,7 +50,6 @@ import okio.GzipSink;
 import okio.Okio;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.net.CookiePolicy.ACCEPT_ORIGINAL_SERVER;
@@ -908,7 +907,6 @@ public final class CallTest {
     assertContainsNoneMatching(request2.getHeaders(), "Cookie.*");
   }
 
-  @Ignore // https://github.com/square/okhttp/issues/810
   @Test public void redirectsDoNotIncludeTooManyAuthHeaders() throws Exception {
     server2.enqueue(new MockResponse().setBody("Page 2"));
     server2.play();

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -1854,7 +1854,6 @@ public final class URLConnectionTest {
     server2.shutdown();
   }
 
-  @Ignore // https://github.com/square/okhttp/issues/810
   @Test public void redirectWithAuthentication() throws Exception {
     server2.enqueue(new MockResponse().setBody("Page 2"));
     server2.play();

--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -357,7 +357,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
         throw new HttpRetryException("Cannot retry streamed HTTP body", responseCode);
       }
 
-      if (!httpEngine.sameConnection(followUp)) {
+      if (!httpEngine.sameConnection(followUp.url())) {
         httpEngine.releaseConnection();
       }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -227,7 +227,7 @@ public final class Call {
         throw new ProtocolException("Too many redirects: " + redirectionCount);
       }
 
-      if (!engine.sameConnection(followUp)) {
+      if (!engine.sameConnection(followUp.url())) {
         engine.releaseConnection();
       }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -883,6 +883,13 @@ public final class HttpEngine {
           requestBuilder.removeHeader("Content-Type");
         }
 
+        // When redirecting across hosts, drop all authentication headers. This
+        // is potentially annoying to the application layer since they have no
+        // way to retain them.
+        if (!sameConnection(url)) {
+          requestBuilder.removeHeader("Authorization");
+        }
+
         return requestBuilder.url(url).build();
 
       default:
@@ -891,14 +898,13 @@ public final class HttpEngine {
   }
 
   /**
-   * Returns true if an HTTP request for {@code followUp} can use the same
-   * engine as this connection.
+   * Returns true if an HTTP request for {@code followUp} can reuse the
+   * connection used by this engine.
    */
-  public boolean sameConnection(Request followUp) {
-    URL a = userRequest.url();
-    URL b = followUp.url();
-    return a.getHost().equals(b.getHost())
-        && getEffectivePort(a) == getEffectivePort(b)
-        && a.getProtocol().equals(b.getProtocol());
+  public boolean sameConnection(URL followUp) {
+    URL url = userRequest.url();
+    return url.getHost().equals(followUp.getHost())
+        && getEffectivePort(url) == getEffectivePort(followUp)
+        && url.getProtocol().equals(followUp.getProtocol());
   }
 }


### PR DESCRIPTION
These are potentially private and we don't want to leak them to another
host, regardless of whether they're created by the calling application or
by the Authenticator.
