### PR TITLE
Correct accidental rename of reflected method.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -148,7 +148,7 @@ public class Platform {
       Method getNpnSelectedProtocol = null;
       try {
         setNpnProtocols = openSslSocketClass.getMethod("setNpnProtocols", byte[].class);
-        getNpnSelectedProtocol = openSslSocketClass.getMethod("getSelectedProtocol");
+        getNpnSelectedProtocol = openSslSocketClass.getMethod("getNpnSelectedProtocol");
       } catch (NoSuchMethodException ignored) {
       }
 


### PR DESCRIPTION
Broken in 022173a44406f1492c674dc9450423581a21d675.

Closes #852.
