### PR TITLE
In HttpURLConnection, pay attention when fixedContentLength is set to zero

### DIFF
--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -272,7 +272,9 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
           throw new ProtocolException(method + " does not support writing");
         }
       }
-      httpEngine = newHttpEngine(method, null, null, null);
+      // If the user set content length to zero, we know there will not be a request body.
+      RetryableSink requestBody = doOutput && fixedContentLength == 0 ? Util.emptySink() : null;
+      httpEngine = newHttpEngine(method, null, requestBody, null);
     } catch (IOException e) {
       httpEngineFailure = e;
       throw e;


### PR DESCRIPTION
fixes #855, presuming the user calls `connection.setFixedLengthStreamingMode(0)`. 
