### PR TITLE
Fix a regression in connection cleanup.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
@@ -411,7 +411,7 @@ public final class HttpConnection {
         Internal.instance.recycle(pool, connection);
       } else if (onIdle == ON_IDLE_CLOSE) {
         state = STATE_CLOSED;
-        connection.getSocket();
+        connection.getSocket().close();
       }
     }
 


### PR DESCRIPTION
We don't test that connections actually get closed, and this was
broken by a refactoring that dropped close() on Connection.
