### PR TITLE
Allow optional content-type for RequestBody.create with file param

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
@@ -76,7 +76,6 @@ public abstract class RequestBody {
 
   /** Returns a new request body that transmits the content of {@code file}. */
   public static RequestBody create(final MediaType contentType, final File file) {
-    if (contentType == null) throw new NullPointerException("contentType == null");
     if (file == null) throw new NullPointerException("content == null");
 
     return new RequestBody() {


### PR DESCRIPTION
This is addition to pull request from @swankjesse #900. He forgot to fix RequestBody.create with file param.

Related to #899 issue.
