### PR TITLE
Always configure NPN.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -174,10 +174,9 @@ public final class Connection {
     SSLSocket sslSocket = (SSLSocket) socket;
     platform.configureTls(sslSocket, route.address.uriHost, route.tlsVersion);
 
-    boolean useNpn = false;
-    if (route.supportsNpn() && route.address.protocols.size() > 1) {
+    boolean useNpn = route.supportsNpn();
+    if (useNpn) {
       platform.setProtocols(sslSocket, route.address.protocols);
-      useNpn = true;
     }
 
     // Force handshake. This can throw!


### PR DESCRIPTION
Without this, we get a hard SSL crash when a server returns NPN
information that was unsolicited.

https://github.com/square/okhttp/issues/890
