### PR TITLE
Revert builder-esque return types from OkHttpClient.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -161,13 +161,12 @@ public final class OkHttpClient implements Cloneable {
    *
    * @see URLConnection#setConnectTimeout(int)
    */
-  public OkHttpClient setConnectTimeout(long timeout, TimeUnit unit) {
+  public void setConnectTimeout(long timeout, TimeUnit unit) {
     if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
     if (unit == null) throw new IllegalArgumentException("unit == null");
     long millis = unit.toMillis(timeout);
     if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
     connectTimeout = (int) millis;
-    return this;
   }
 
   /** Default connect timeout (in milliseconds). */
@@ -180,13 +179,12 @@ public final class OkHttpClient implements Cloneable {
    *
    * @see URLConnection#setReadTimeout(int)
    */
-  public OkHttpClient setReadTimeout(long timeout, TimeUnit unit) {
+  public void setReadTimeout(long timeout, TimeUnit unit) {
     if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
     if (unit == null) throw new IllegalArgumentException("unit == null");
     long millis = unit.toMillis(timeout);
     if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
     readTimeout = (int) millis;
-    return this;
   }
 
   /** Default read timeout (in milliseconds). */
@@ -197,13 +195,12 @@ public final class OkHttpClient implements Cloneable {
   /**
    * Sets the default write timeout for new connections. A value of 0 means no timeout.
    */
-  public OkHttpClient setWriteTimeout(long timeout, TimeUnit unit) {
+  public void setWriteTimeout(long timeout, TimeUnit unit) {
     if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
     if (unit == null) throw new IllegalArgumentException("unit == null");
     long millis = unit.toMillis(timeout);
     if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
     writeTimeout = (int) millis;
-    return this;
   }
 
   /** Default write timeout (in milliseconds). */
@@ -261,10 +258,9 @@ public final class OkHttpClient implements Cloneable {
   }
 
   /** Sets the response cache to be used to read and write cached responses. */
-  OkHttpClient setInternalCache(InternalCache internalCache) {
+  void setInternalCache(InternalCache internalCache) {
     this.internalCache = internalCache;
     this.cache = null;
-    return this;
   }
 
   InternalCache internalCache() {

--- a/samples/guide/src/main/java/com/squareup/okhttp/recipes/PerCallSettings.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/recipes/PerCallSettings.java
@@ -30,20 +30,20 @@ public final class PerCallSettings {
         .build();
 
     try {
-      Response response = client.clone() // Clone to make a customized OkHttp for this request.
-          .setReadTimeout(500, TimeUnit.MILLISECONDS)
-          .newCall(request)
-          .execute();
+      OkHttpClient cloned = client.clone(); // Clone to make a customized OkHttp for this request.
+      cloned.setReadTimeout(500, TimeUnit.MILLISECONDS);
+
+      Response response = cloned.newCall(request).execute();
       System.out.println("Response 1 succeeded: " + response);
     } catch (IOException e) {
       System.out.println("Response 1 failed: " + e);
     }
 
     try {
-      Response response = client.clone() // Clone to make a customized OkHttp for this request.
-          .setReadTimeout(3000, TimeUnit.MILLISECONDS)
-          .newCall(request)
-          .execute();
+      OkHttpClient cloned = client.clone(); // Clone to make a customized OkHttp for this request.
+      cloned.setReadTimeout(3000, TimeUnit.MILLISECONDS);
+
+      Response response = cloned.newCall(request).execute();
       System.out.println("Response 2 succeeded: " + response);
     } catch (IOException e) {
       System.out.println("Response 2 failed: " + e);


### PR DESCRIPTION
I'm still 100% fine with not merging this and just coordinating a Retrofit release to update it for OkHttp v2 support.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] OkHttp (Parent) ................................... SUCCESS [  1.264 s]
[INFO] OkHttp ............................................ SUCCESS [  5.052 s]
[INFO] MockWebServer ..................................... SUCCESS [  7.109 s]
[INFO] OkHttp Apache HttpClient .......................... SUCCESS [  1.461 s]
[INFO] OkHttp URLConnection .............................. SUCCESS [  1.620 s]
[INFO] OkHttp Tests ...................................... SUCCESS [01:10 min]
[INFO] OkCurl ............................................ SUCCESS [  2.763 s]
[INFO] Samples (Parent) .................................. SUCCESS [  0.226 s]
[INFO] Sample: Guide ..................................... SUCCESS [  0.709 s]
[INFO] Sample: Crawler ................................... SUCCESS [  0.613 s]
[INFO] Sample: Simple Client ............................. SUCCESS [  0.689 s]
[INFO] Sample: Static Server ............................. SUCCESS [  1.360 s]
[INFO] Benchmarks ........................................ SUCCESS [  0.648 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:34 min
[INFO] Finished at: 2014-06-09T21:55:28-08:00
[INFO] Final Memory: 39M/201M
[INFO] ------------------------------------------------------------------------
```
