### PR TITLE
Implement message reader.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/ws/RecordingWebSocketListener.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/ws/RecordingWebSocketListener.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.ws;
+
+import com.squareup.okhttp.WebSocketListener;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import okio.Buffer;
+import okio.BufferedSource;
+
+import static com.squareup.okhttp.WebSocket.PayloadType;
+import static org.junit.Assert.assertEquals;
+
+public final class RecordingWebSocketListener implements WebSocketListener {
+  public interface MessageDelegate {
+    void onMessage(BufferedSource payload, PayloadType type) throws IOException;
+  }
+
+  public static class Message {
+    public final Buffer buffer = new Buffer();
+    public final PayloadType type;
+
+    public Message(PayloadType type) {
+      this.type = type;
+    }
+  }
+
+  public static class Close {
+    public final int code;
+    public final String reason;
+
+    public Close(int code, String reason) {
+      this.code = code;
+      this.reason = reason;
+    }
+  }
+
+  private final Deque<Object> events = new ArrayDeque<Object>();
+
+  private MessageDelegate delegate;
+
+  /** Sets a delegate for the next call to {@link #onMessage}. Cleared after invoked. */
+  public void setNextMessageDelegate(MessageDelegate delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public void onMessage(BufferedSource payload, PayloadType type) throws IOException {
+    if (delegate != null) {
+      delegate.onMessage(payload, type);
+      delegate = null;
+    } else {
+      Message message = new Message(type);
+      payload.readAll(message.buffer);
+      payload.close();
+      events.add(message);
+    }
+  }
+
+  @Override public void onClose(int code, String reason) {
+    events.add(new Close(code, reason));
+  }
+
+  @Override public void onFailure(IOException e) {
+    events.add(e);
+  }
+
+  public void assertTextMessage(String payload) throws IOException {
+    Message message = (Message) events.removeFirst();
+    assertEquals(payload, message.buffer.readUtf8());
+  }
+
+  public void assertBinaryMessage(byte[] payload) {
+    Message message = (Message) events.removeFirst();
+    assertEquals(new Buffer().write(payload), message.buffer);
+  }
+}

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/ws/WebSocketReaderTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/ws/WebSocketReaderTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.ws;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.ProtocolException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.ByteString;
+import org.junit.Test;
+
+import static com.squareup.okhttp.WebSocket.PayloadType;
+import static com.squareup.okhttp.internal.ws.RecordingWebSocketListener.MessageDelegate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class WebSocketReaderTest {
+  private final Buffer data = new Buffer();
+  private final RecordingWebSocketListener listener = new RecordingWebSocketListener();
+  private final Random random = new Random(0);
+
+  // Mutually exclusive. Use the one corresponding to the peer whose behavior you wish to test.
+  private final WebSocketReader serverReader = new WebSocketReader(false, data, listener);
+  private final WebSocketReader clientReader = new WebSocketReader(true, data, listener);
+
+  @Test public void controlFramesMustBeFinal() throws IOException {
+    data.write(ByteString.decodeHex("0a00")); // Empty ping.
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (ProtocolException e) {
+      assertEquals("Control frames must be final.", e.getMessage());
+    }
+  }
+
+  @Test public void reservedFlagsAreUnsupported() throws IOException {
+    data.write(ByteString.decodeHex("9a00")); // Empty ping, flag 1 set.
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (ProtocolException e) {
+      assertEquals("Reserved flags are unsupported.", e.getMessage());
+    }
+    data.clear();
+    data.write(ByteString.decodeHex("aa00")); // Empty ping, flag 2 set.
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (ProtocolException e) {
+      assertEquals("Reserved flags are unsupported.", e.getMessage());
+    }
+    data.clear();
+    data.write(ByteString.decodeHex("ca00")); // Empty ping, flag 3 set.
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (ProtocolException e) {
+      assertEquals("Reserved flags are unsupported.", e.getMessage());
+    }
+  }
+
+  @Test public void clientSentFramesMustBeMasked() throws IOException {
+    data.write(ByteString.decodeHex("8100"));
+    try {
+      serverReader.readMessage();
+      fail();
+    } catch (ProtocolException e) {
+      assertEquals("Client-sent frames must be masked. Server sent must not.", e.getMessage());
+    }
+  }
+
+  @Test public void serverSentFramesMustNotBeMasked() throws IOException {
+    data.write(ByteString.decodeHex("8180"));
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (ProtocolException e) {
+      assertEquals("Client-sent frames must be masked. Server sent must not.", e.getMessage());
+    }
+  }
+
+  @Test public void controlFramePayloadMax() throws IOException {
+    data.write(ByteString.decodeHex("8a7e007e"));
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (ProtocolException e) {
+      assertEquals("Control frame must be less than 125B.", e.getMessage());
+    }
+  }
+
+  @Test public void clientSimpleHello() throws IOException {
+    data.write(ByteString.decodeHex("810548656c6c6f")); // Hello
+    clientReader.readMessage();
+    listener.assertTextMessage("Hello");
+  }
+
+  @Test public void serverSimpleHello() throws IOException {
+    data.write(ByteString.decodeHex("818537fa213d7f9f4d5158")); // Hello
+    serverReader.readMessage();
+    listener.assertTextMessage("Hello");
+  }
+
+  @Test public void serverHelloTwoChunks() throws IOException {
+    data.write(ByteString.decodeHex("818537fa213d7f9f4d")); // Hel
+
+    final Buffer sink = new Buffer();
+    listener.setNextMessageDelegate(new MessageDelegate() {
+      @Override public void onMessage(BufferedSource payload, PayloadType type) throws IOException {
+        payload.readFully(sink, 3); // Read "Hel"
+        data.write(ByteString.decodeHex("5158")); // lo
+        payload.readFully(sink, 2); // Read "lo"
+        payload.close();
+      }
+    });
+    serverReader.readMessage();
+
+    assertEquals("Hello", sink.readUtf8());
+  }
+
+  @Test public void clientTwoFrameHello() throws IOException {
+    data.write(ByteString.decodeHex("010348656c")); // Hel
+    data.write(ByteString.decodeHex("80026c6f")); // lo
+    clientReader.readMessage();
+    listener.assertTextMessage("Hello");
+  }
+
+  @Test public void clientTwoFrameHelloWithPongs() throws IOException {
+    data.write(ByteString.decodeHex("010348656c")); // Hel
+    data.write(ByteString.decodeHex("8a00")); // Pong
+    data.write(ByteString.decodeHex("8a00")); // Pong
+    data.write(ByteString.decodeHex("8a00")); // Pong
+    data.write(ByteString.decodeHex("8a00")); // Pong
+    data.write(ByteString.decodeHex("80026c6f")); // lo
+    clientReader.readMessage();
+    listener.assertTextMessage("Hello");
+  }
+
+  @Test public void clientIncompleteMessageBodyThrows() throws IOException {
+    data.write(ByteString.decodeHex("810548656c")); // Length = 5, "Hel"
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (EOFException ignored) {
+    }
+  }
+
+  @Test public void clientIncompleteControlFrameBodyThrows() throws IOException {
+    data.write(ByteString.decodeHex("8a0548656c")); // Length = 5, "Hel"
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (EOFException ignored) {
+    }
+  }
+
+  @Test public void serverIncompleteMessageBodyThrows() throws IOException {
+    data.write(ByteString.decodeHex("818537fa213d7f9f4d")); // Length = 5, "Hel"
+    try {
+      serverReader.readMessage();
+      fail();
+    } catch (EOFException ignored) {
+    }
+  }
+
+  @Test public void serverIncompleteControlFrameBodyThrows() throws IOException {
+    data.write(ByteString.decodeHex("8a8537fa213d7f9f4d")); // Length = 5, "Hel"
+    try {
+      serverReader.readMessage();
+      fail();
+    } catch (EOFException ignored) {
+    }
+  }
+
+  @Test public void clientSimpleBinary() throws IOException {
+    byte[] bytes = binaryData(256);
+    data.write(ByteString.decodeHex("827E0100")).write(bytes);
+    clientReader.readMessage();
+    listener.assertBinaryMessage(bytes);
+  }
+
+  @Test public void clientTwoFrameBinary() throws IOException {
+    byte[] bytes = binaryData(200);
+    data.write(ByteString.decodeHex("0264")).write(bytes, 0, 100);
+    data.write(ByteString.decodeHex("8064")).write(bytes, 100, 100);
+    clientReader.readMessage();
+    listener.assertBinaryMessage(bytes);
+  }
+
+  @Test public void twoFrameNotContinuation() throws IOException {
+    byte[] bytes = binaryData(200);
+    data.write(ByteString.decodeHex("0264")).write(bytes, 0, 100);
+    data.write(ByteString.decodeHex("8264")).write(bytes, 100, 100);
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (ProtocolException e) {
+      assertEquals("Expected continuation opcode. Got: 2", e.getMessage());
+    }
+  }
+
+  @Test public void noCloseErrors() throws IOException {
+    data.write(ByteString.decodeHex("810548656c6c6f")); // Hello
+    listener.setNextMessageDelegate(new MessageDelegate() {
+      @Override public void onMessage(BufferedSource payload, PayloadType type) throws IOException {
+        payload.readAll(new Buffer());
+      }
+    });
+    try {
+      clientReader.readMessage();
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals("Listener failed to call close on message payload.", e.getMessage());
+    }
+  }
+
+  @Test public void closeExhaustsMessage() throws IOException {
+    data.write(ByteString.decodeHex("810548656c6c6f")); // Hello
+    data.write(ByteString.decodeHex("810448657921")); // Hey!
+
+    final Buffer sink = new Buffer();
+    listener.setNextMessageDelegate(new MessageDelegate() {
+      @Override public void onMessage(BufferedSource payload, PayloadType type) throws IOException {
+        payload.read(sink, 3);
+        payload.close();
+      }
+    });
+
+    clientReader.readMessage();
+    assertEquals("Hel", sink.readUtf8());
+
+    clientReader.readMessage();
+    listener.assertTextMessage("Hey!");
+  }
+
+  @Test public void closeExhaustsMessageOverControlFrames() throws IOException {
+    data.write(ByteString.decodeHex("010348656c")); // Hel
+    data.write(ByteString.decodeHex("8a00")); // Pong
+    data.write(ByteString.decodeHex("8a00")); // Pong
+    data.write(ByteString.decodeHex("80026c6f")); // lo
+    data.write(ByteString.decodeHex("810448657921")); // Hey!
+
+    final Buffer sink = new Buffer();
+    listener.setNextMessageDelegate(new MessageDelegate() {
+      @Override public void onMessage(BufferedSource payload, PayloadType type) throws IOException {
+        payload.read(sink, 2);
+        payload.close();
+      }
+    });
+
+    clientReader.readMessage();
+    assertEquals("He", sink.readUtf8());
+
+    clientReader.readMessage();
+    listener.assertTextMessage("Hey!");
+  }
+
+  @Test public void closedMessageSourceThrows() throws IOException {
+    data.write(ByteString.decodeHex("810548656c6c6f")); // Hello
+
+    final AtomicReference<IOException> exception = new AtomicReference<IOException>();
+    listener.setNextMessageDelegate(new MessageDelegate() {
+      @Override public void onMessage(BufferedSource payload, PayloadType type) throws IOException {
+        payload.close();
+        try {
+          payload.readAll(new Buffer());
+          fail();
+        } catch (IOException e) {
+          exception.set(e);
+        }
+      }
+    });
+    clientReader.readMessage();
+
+    assertNotNull(exception.get());
+  }
+
+  private byte[] binaryData(int length) {
+    byte[] junk = new byte[length];
+    random.nextBytes(junk);
+    return junk;
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/WebSocketListener.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/WebSocketListener.java
@@ -26,7 +26,7 @@ public interface WebSocketListener {
    * Called when a server message is received. The {@code type} indicates whether the
    * {@code payload} should be interpreted as UTF-8 text or binary data.
    */
-  void onMessage(BufferedSource payload, PayloadType type);
+  void onMessage(BufferedSource payload, PayloadType type) throws IOException;
 
   /**
    * Called when the server sends a close message. This may have been initiated
@@ -34,7 +34,7 @@ public interface WebSocketListener {
    * the server.
    *
    * @param code The <a href="http://tools.ietf.org/html/rfc6455#section-7.4.1>RFC-compliant</a>
-   * status code or {@code -1} for none.
+   * status code.
    * @param reason Optional reason for close. May be {@code null}.
    */
   void onClose(int code, String reason);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -19,6 +19,7 @@ package com.squareup.okhttp.internal;
 import com.squareup.okhttp.internal.http.RetryableSink;
 import com.squareup.okhttp.internal.spdy.Header;
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -35,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import okio.Buffer;
+import okio.BufferedSource;
 import okio.ByteString;
 import okio.Source;
 
@@ -229,4 +231,13 @@ public final class Util {
   }
 
   private static final RetryableSink EMPTY_SINK = new RetryableSink(0);
+
+  public static void readFully(BufferedSource source, byte[] sink) throws IOException {
+    int read = 0;
+    do {
+      int got = source.read(sink, read, sink.length - read);
+      if (got == -1) throw new EOFException();
+      read += got;
+    } while (read < sink.length);
+  }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/ws/Protocol.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/ws/Protocol.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.ws;
+
+final class Protocol {
+  /*
+  Each frame starts with two bytes of data.
+
+   0 1 2 3 4 5 6 7    0 1 2 3 4 5 6 7
+  +-+-+-+-+-------+  +-+-------------+
+  |F|R|R|R| OP    |  |M| LENGTH      |
+  |I|S|S|S| CODE  |  |A|             |
+  |N|V|V|V|       |  |S|             |
+  | |1|2|3|       |  |K|             |
+  +-+-+-+-+-------+  +-+-------------+
+  */
+
+  /** Byte 0 flag for whether this is the final fragment in a message. */
+  static final int B0_FLAG_FIN = 0x80; // 0b10000000
+  /** Byte 0 reserved flag 1. Must be 0 unless negotiated otherwise. */
+  static final int B0_FLAG_RSV1 = 0x40; // 0b01000000
+  /** Byte 0 reserved flag 2. Must be 0 unless negotiated otherwise. */
+  static final int B0_FLAG_RSV2 = 0x20; // 0b00100000
+  /** Byte 0 reserved flag 3. Must be 0 unless negotiated otherwise. */
+  static final int B0_FLAG_RSV3 = 0x10; // 0b00010000
+  /** Byte 0 mask for the frame opcode. */
+  static final int B0_MASK_OPCODE = 0x0f; // 0b00001111
+  /** Flag in the opcode which indicates a control frame. */
+  static final int OPCODE_FLAG_CONTROL = 0x08; // 0b00001000
+
+  /**
+   * Byte 1 flag for whether the payload data is masked.
+   * <p>
+   * If this flag is set, the next four bytes represent the mask key. These bytes appear after
+   * any additional bytes specified by {@link #B1_MASK_LENGTH}.
+   */
+  static final int B1_FLAG_MASK = 0x80; // 0b10000000
+  /**
+   * Byte 1 mask for the payload length.
+   * <p>
+   * If this value is {@link #PAYLOAD_SHORT}, the next two bytes represent the length.
+   * If this value is {@link #PAYLOAD_LONG}, the next eight bytes represent the length.
+   */
+  static final int B1_MASK_LENGTH = 0x7f; // 0b0111111
+
+  static final int OPCODE_CONTINUATION = 0x0;
+  static final int OPCODE_TEXT = 0x1;
+  static final int OPCODE_BINARY = 0x2;
+
+  static final int OPCODE_CONTROL_CLOSE = 0x8;
+  static final int OPCODE_CONTROL_PING = 0x9;
+  static final int OPCODE_CONTROL_PONG = 0xa;
+
+  /** Value for {@link #B1_MASK_LENGTH} which indicates the next two bytes are the length. */
+  static final int PAYLOAD_SHORT = 126;
+  /** Value for {@link #B1_MASK_LENGTH} which indicates the next eight bytes are the length. */
+  static final int PAYLOAD_LONG = 127;
+  /** Maximum length of a control frame payload. */
+  static final int MAX_CONTROL_PAYLOAD = 125;
+
+  static void toggleMask(byte[] buffer, long byteCount, byte[] key, long frameBytesRead) {
+    int keyLength = key.length;
+    for (int i = 0; i < byteCount; i++, frameBytesRead++) {
+      int keyIndex = (int) (frameBytesRead % keyLength);
+      buffer[i] = (byte) (buffer[i] ^ key[keyIndex]);
+    }
+  }
+
+  private Protocol() {
+    throw new AssertionError("No instances.");
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/ws/WebSocketReader.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/ws/WebSocketReader.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.ws;
+
+import com.squareup.okhttp.WebSocketListener;
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.ProtocolException;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.Okio;
+import okio.Source;
+import okio.Timeout;
+
+import static com.squareup.okhttp.WebSocket.PayloadType;
+import static com.squareup.okhttp.internal.Util.readFully;
+import static com.squareup.okhttp.internal.ws.Protocol.B0_FLAG_FIN;
+import static com.squareup.okhttp.internal.ws.Protocol.B0_FLAG_RSV1;
+import static com.squareup.okhttp.internal.ws.Protocol.B0_FLAG_RSV2;
+import static com.squareup.okhttp.internal.ws.Protocol.B0_FLAG_RSV3;
+import static com.squareup.okhttp.internal.ws.Protocol.B0_MASK_OPCODE;
+import static com.squareup.okhttp.internal.ws.Protocol.B1_FLAG_MASK;
+import static com.squareup.okhttp.internal.ws.Protocol.B1_MASK_LENGTH;
+import static com.squareup.okhttp.internal.ws.Protocol.MAX_CONTROL_PAYLOAD;
+import static com.squareup.okhttp.internal.ws.Protocol.OPCODE_BINARY;
+import static com.squareup.okhttp.internal.ws.Protocol.OPCODE_CONTINUATION;
+import static com.squareup.okhttp.internal.ws.Protocol.OPCODE_CONTROL_CLOSE;
+import static com.squareup.okhttp.internal.ws.Protocol.OPCODE_CONTROL_PING;
+import static com.squareup.okhttp.internal.ws.Protocol.OPCODE_CONTROL_PONG;
+import static com.squareup.okhttp.internal.ws.Protocol.OPCODE_FLAG_CONTROL;
+import static com.squareup.okhttp.internal.ws.Protocol.OPCODE_TEXT;
+import static com.squareup.okhttp.internal.ws.Protocol.PAYLOAD_LONG;
+import static com.squareup.okhttp.internal.ws.Protocol.PAYLOAD_SHORT;
+import static com.squareup.okhttp.internal.ws.Protocol.toggleMask;
+import static java.lang.Integer.toHexString;
+
+public final class WebSocketReader {
+  private final boolean isClient;
+  private final BufferedSource source;
+  private final WebSocketListener listener;
+
+  private final Source framedMessageSource = new FramedMessageSource();
+
+  private boolean closed;
+  private boolean messageClosed;
+
+  // Stateful data about the current frame.
+  private int opcode;
+  private long frameLength;
+  private long frameBytesRead;
+  private boolean isFinalFrame;
+  private boolean isControlFrame;
+  private boolean isMasked;
+
+  private final byte[] maskKey = new byte[4];
+  private final byte[] maskBuffer = new byte[2048];
+
+  public WebSocketReader(boolean isClient, BufferedSource source, WebSocketListener listener) {
+    this.isClient = isClient;
+    this.source = source;
+    this.listener = listener;
+  }
+
+  /**
+   * Reads one message from source consuming any control frames that precede or are interleaved
+   * between frame fragments. This will result in one call to {@link WebSocketListener#onMessage}.
+   */
+  public void readMessage() throws IOException {
+    readUntilNonControlFrame();
+
+    PayloadType type;
+    switch (opcode) {
+      case OPCODE_TEXT:
+        type = PayloadType.TEXT;
+        break;
+      case OPCODE_BINARY:
+        type = PayloadType.BINARY;
+        break;
+      default:
+        throw new IllegalStateException("Unknown opcode: " + toHexString(opcode));
+    }
+
+    messageClosed = false;
+    listener.onMessage(Okio.buffer(framedMessageSource), type);
+    if (!messageClosed) {
+      throw new IllegalStateException("Listener failed to call close on message payload.");
+    }
+  }
+
+  /** Read headers and process any control frames until we reach a non-control frame. */
+  private void readUntilNonControlFrame() throws IOException {
+    while (true) {
+      readHeader();
+      if (!isControlFrame) {
+        break;
+      }
+      readControlFrame();
+    }
+  }
+
+  private void readHeader() throws IOException {
+    if (closed) throw new IllegalStateException("Closed");
+
+    int b0 = source.readByte() & 0xff;
+
+    opcode = b0 & B0_MASK_OPCODE;
+    isFinalFrame = (b0 & B0_FLAG_FIN) != 0;
+    isControlFrame = (b0 & OPCODE_FLAG_CONTROL) != 0;
+
+    // Control frames must be final frames (cannot contain continuations).
+    if (isControlFrame && !isFinalFrame) {
+      throw new ProtocolException("Control frames must be final.");
+    }
+
+    boolean reservedFlag1 = (b0 & B0_FLAG_RSV1) != 0;
+    boolean reservedFlag2 = (b0 & B0_FLAG_RSV2) != 0;
+    boolean reservedFlag3 = (b0 & B0_FLAG_RSV3) != 0;
+    if (reservedFlag1 || reservedFlag2 || reservedFlag3) {
+      // Reserved flags are for extensions which we currently do not support.
+      throw new ProtocolException("Reserved flags are unsupported.");
+    }
+
+    int b1 = source.readByte() & 0xff;
+
+    isMasked = (b1 & B1_FLAG_MASK) != 0;
+    if (isMasked == isClient) {
+      // Masked payloads must be read on the server. Unmasked payloads must be read on the client.
+      throw new ProtocolException("Client-sent frames must be masked. Server sent must not.");
+    }
+
+    // Get frame length, optionally reading from follow-up bytes if indicated by special values.
+    frameLength = b1 & B1_MASK_LENGTH;
+    if (frameLength == PAYLOAD_SHORT) {
+      frameLength = source.readShort();
+    } else if (frameLength == PAYLOAD_LONG) {
+      frameLength = source.readLong();
+    }
+    frameBytesRead = 0;
+
+    if (isControlFrame && frameLength > MAX_CONTROL_PAYLOAD) {
+      throw new ProtocolException("Control frame must be less than " + MAX_CONTROL_PAYLOAD + "B.");
+    }
+
+    if (isMasked) {
+      // Read the masking key as bytes so that they can be used directly for unmasking.
+      readFully(source, maskKey);
+    }
+  }
+
+  private void readControlFrame() throws IOException {
+    Buffer buffer = null;
+    if (frameBytesRead < frameLength) {
+      buffer = new Buffer();
+
+      if (isClient) {
+        while (frameBytesRead < frameLength) {
+          int toRead = (int) Math.min(frameLength - frameBytesRead, maskBuffer.length);
+          int read = source.read(maskBuffer, 0, toRead);
+          if (read == -1) throw new EOFException();
+          toggleMask(maskBuffer, read, maskKey, frameBytesRead);
+          buffer.write(maskBuffer, 0, read);
+          frameBytesRead += read;
+        }
+      } else {
+        source.readFully(buffer, frameLength);
+      }
+    }
+
+    switch (opcode) {
+      case OPCODE_CONTROL_PING:
+        break; // TODO enqueue a pong with the read buffer.
+      case OPCODE_CONTROL_PONG:
+        // Thanks for the pong! Nothing to do here.
+        break;
+      case OPCODE_CONTROL_CLOSE:
+        // TODO if we did not initiate the close, enqueue an ack close on the writer.
+        closed = true;
+        break;
+      default:
+        throw new IllegalStateException("Unknown control opcode: " + toHexString(opcode));
+    }
+  }
+
+  /**
+   * A special source which knows how to read a message body across one or more frames. Control
+   * frames that occur between fragments will be processed. If the message payload is masked this
+   * will unmask as it's being processed.
+   */
+  private final class FramedMessageSource implements Source {
+    @Override public long read(Buffer sink, long byteCount) throws IOException {
+      if (closed) throw new IOException("Closed");
+
+      if (frameBytesRead == frameLength) {
+        if (isFinalFrame) return -1; // We are exhausted and have no continuations.
+
+        readUntilNonControlFrame();
+        if (opcode != OPCODE_CONTINUATION) {
+          throw new ProtocolException("Expected continuation opcode. Got: " + toHexString(opcode));
+        }
+      }
+
+      long toRead = Math.min(byteCount, frameLength - frameBytesRead);
+
+      long read;
+      if (isMasked) {
+        toRead = Math.min(toRead, maskBuffer.length);
+        read = source.read(maskBuffer, 0, (int) toRead);
+        if (read == -1) throw new EOFException();
+        toggleMask(maskBuffer, read, maskKey, frameBytesRead);
+        sink.write(maskBuffer, 0, (int) read);
+      } else {
+        read = source.read(sink, toRead);
+        if (read == -1) throw new EOFException();
+      }
+
+      frameBytesRead += read;
+      return read;
+    }
+
+    @Override public Timeout timeout() {
+      return source.timeout();
+    }
+
+    @Override public void close() throws IOException {
+      if (messageClosed) return;
+      messageClosed = true;
+      if (closed) return;
+
+      // Exhaust the remainder of the message, if any.
+      source.skip(frameLength - frameBytesRead);
+      while (!isFinalFrame) {
+        readUntilNonControlFrame();
+        source.skip(frameLength);
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <!-- Compilation -->
     <java.version>1.6</java.version>
-    <okio.version>1.0.0</okio.version>
+    <okio.version>1.0.1-SNAPSHOT</okio.version>
     <!-- Targetted to jdk7u60-b13; Oracle jdk7u55-b13. -->
     <npn.version>1.1.7.v20140316</npn.version>
     <!-- Targetted to OpenJDK 8 b132 -->


### PR DESCRIPTION
Currently the reader skips control frames.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] OkHttp (Parent) ................................... SUCCESS [  1.723 s]
[INFO] OkHttp ............................................ SUCCESS [ 14.493 s]
[INFO] MockWebServer ..................................... SUCCESS [ 11.644 s]
[INFO] OkHttp Apache HttpClient .......................... SUCCESS [  1.590 s]
[INFO] OkHttp URLConnection .............................. SUCCESS [  2.402 s]
[INFO] OkHttp Tests ...................................... SUCCESS [01:07 min]
[INFO] OkCurl ............................................ SUCCESS [  2.838 s]
[INFO] Samples (Parent) .................................. SUCCESS [  0.218 s]
[INFO] Sample: Guide ..................................... SUCCESS [  0.753 s]
[INFO] Sample: Crawler ................................... SUCCESS [  0.584 s]
[INFO] Sample: Simple Client ............................. SUCCESS [  0.589 s]
[INFO] Sample: Static Server ............................. SUCCESS [  1.290 s]
[INFO] Benchmarks ........................................ SUCCESS [  0.644 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:46 min
[INFO] Finished at: 2014-06-13T01:31:36-08:00
[INFO] Final Memory: 39M/193M
[INFO] ------------------------------------------------------------------------
```
