### PR TITLE
Fix two problems with the window size.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2ConnectionTest.java
@@ -211,17 +211,17 @@ public final class Http2ConnectionTest {
   @Test public void readSendsWindowUpdateHttp2() throws Exception {
     peer.setVariantAndClient(HTTP_2, false);
 
-    int windowUpdateThreshold = DEFAULT_INITIAL_WINDOW_SIZE / 2;
+    int windowSize = 100;
+    int windowUpdateThreshold = 50;
 
     // Write the mocking script.
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().synReply(false, 3, headerEntries("a", "android"));
     for (int i = 0; i < 3; i++) {
-      // Send frames summing to windowUpdateThreshold.
-      for (int sent = 0, count; sent < windowUpdateThreshold; sent += count) {
-        count = Math.min(HTTP_2.maxFrameSize(), windowUpdateThreshold - sent);
-        peer.sendFrame().data(false, 3, data(count));
-      }
+      // Send frames of summing to size 50, which is windowUpdateThreshold.
+      peer.sendFrame().data(false, 3, data(24));
+      peer.sendFrame().data(false, 3, data(25));
+      peer.sendFrame().data(false, 3, data(1));
       peer.acceptFrame(); // connection WINDOW UPDATE
       peer.acceptFrame(); // stream WINDOW UPDATE
     }
@@ -230,15 +230,15 @@ public final class Http2ConnectionTest {
 
     // Play it back.
     SpdyConnection connection = connection(peer, HTTP_2);
+    connection.okHttpSettings.set(Settings.INITIAL_WINDOW_SIZE, 0, windowSize);
     SpdyStream stream = connection.newStream(headerEntries("b", "banana"), false, true);
     assertEquals(0, stream.unacknowledgedBytesRead);
     assertEquals(headerEntries("a", "android"), stream.getResponseHeaders());
     Source in = stream.getSource();
     Buffer buffer = new Buffer();
-    while (in.read(buffer, 1024) != -1) {
-      if (buffer.size() == 3 * windowUpdateThreshold) break;
-    }
+    buffer.writeAll(in);
     assertEquals(-1, in.read(buffer, 1));
+    assertEquals(150, buffer.size());
 
     MockSpdyPeer.InFrame synStream = peer.takeFrame();
     assertEquals(TYPE_HEADERS, synStream.type);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyStream.java
@@ -350,7 +350,7 @@ public final class SpdyStream {
         // Flow control: notify the peer that we're ready for more data!
         unacknowledgedBytesRead += read;
         if (unacknowledgedBytesRead
-            >= connection.peerSettings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE) / 2) {
+            >= connection.okHttpSettings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE) / 2) {
           connection.writeWindowUpdateLater(id, unacknowledgedBytesRead);
           unacknowledgedBytesRead = 0;
         }
@@ -360,7 +360,7 @@ public final class SpdyStream {
       synchronized (connection) { // Multiple application threads may hit this section.
         connection.unacknowledgedBytesRead += read;
         if (connection.unacknowledgedBytesRead
-            >= connection.peerSettings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE) / 2) {
+            >= connection.okHttpSettings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE) / 2) {
           connection.writeWindowUpdateLater(0, connection.unacknowledgedBytesRead);
           connection.unacknowledgedBytesRead = 0;
         }


### PR DESCRIPTION
Each peer has a window size. The peer's window size controls how much
data we can send the peer, and our window size controls how much data
the peer can send us. We had these reversed in SpdyStream, so if the
peer specified a non-default window size we wouldn't send the required
WINDOW_UPDATE events when we needed to.

The connection has its own window size. But unlike the stream window
sizes, this needs to be manually adjusted with a windowUpdate frame
when the connection is opened.

Closes https://github.com/square/okhttp/issues/933
