### PR TITLE
Fixes the do not follow redirects bug

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -1345,6 +1345,25 @@ public final class CallTest {
     assertNull(recordedRequest.getHeader("User-Agent"));
   }
 
+  @Test
+  public void setFollowRedirectsFalse() throws Exception {
+    server.enqueue(new MockResponse()
+        .setResponseCode(302)
+        .addHeader("Location: /b")
+        .setBody("A"));
+    server.enqueue(new MockResponse()
+        .setBody("B"));
+    server.play();
+
+    client.setFollowRedirects(false);
+    RecordedResponse recordedResponse = executeSynchronously(
+        new Request.Builder().url(server.getUrl("/a")).build());
+
+    recordedResponse
+        .assertBody("A")
+        .assertCode(302);
+  }
+
   private RecordedResponse executeSynchronously(Request request) throws IOException {
     Response response = client.newCall(request).execute();
     return new RecordedResponse(request, response, response.body().string(), null);

--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -268,6 +268,11 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     client.setConnectTimeout(timeoutMillis, TimeUnit.MILLISECONDS);
   }
 
+  @Override
+  public void setInstanceFollowRedirects(boolean followRedirects) {
+    client.setFollowRedirects(followRedirects);
+  }
+
   @Override public int getConnectTimeout() {
     return client.getConnectTimeout();
   }

--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/OkUrlFactoryTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/OkUrlFactoryTest.java
@@ -125,6 +125,21 @@ public class OkUrlFactoryTest {
     assertResponseHeader(connection2, "NONE");
   }
 
+  @Test
+  public void setInstanceFollowRedirectsFalse() throws Exception {
+    server.enqueue(new MockResponse()
+        .setResponseCode(302)
+        .addHeader("Location: /b")
+        .setBody("A"));
+    server.enqueue(new MockResponse()
+        .setBody("B"));
+
+    HttpURLConnection connection = factory.open(server.getUrl("/a"));
+    connection.setInstanceFollowRedirects(false);
+    assertResponseBody(connection, "A");
+    assertResponseCode(connection, 302);
+  }
+
   private void assertResponseBody(HttpURLConnection connection, String expected) throws Exception {
     String actual = buffer(source(connection.getInputStream())).readString(US_ASCII);
     assertEquals(expected, actual);
@@ -132,6 +147,10 @@ public class OkUrlFactoryTest {
 
   private void assertResponseHeader(HttpURLConnection connection, String expected) {
     assertEquals(expected, connection.getHeaderField("OkHttp-Response-Source"));
+  }
+
+  private void assertResponseCode(HttpURLConnection connection, int expected) throws IOException {
+    assertEquals(expected, connection.getResponseCode());
   }
 
   private static String formatDate(long delta, TimeUnit timeUnit) {

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -147,6 +147,7 @@ public final class OkHttpClient implements Cloneable {
   private Authenticator authenticator;
   private ConnectionPool connectionPool;
   private boolean followSslRedirects = true;
+  private boolean followRedirects = true;
   private int connectTimeout;
   private int readTimeout;
   private int writeTimeout;
@@ -368,6 +369,20 @@ public final class OkHttpClient implements Cloneable {
 
   public boolean getFollowSslRedirects() {
     return followSslRedirects;
+  }
+
+  /**
+   * Configure this client to follow redirects.
+   *
+   * <p>If unset, redirects will not be followed. This is the equivalent as the
+   * built-in {@code HttpURLConnection}'s default.
+   */
+  public void setFollowRedirects(boolean followRedirects) {
+    this.followRedirects = followRedirects;
+  }
+
+  public boolean getFollowRedirects() {
+    return followRedirects;
   }
 
   RouteDatabase getRoutesDatabase() {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -852,6 +852,9 @@ public final class HttpEngine {
       case HTTP_MOVED_PERM:
       case HTTP_MOVED_TEMP:
       case HTTP_SEE_OTHER:
+        // Does the client allow redirects?
+        if (!client.getFollowRedirects()) return null;
+
         String location = userResponse.header("Location");
         if (location == null) return null;
         URL url = new URL(userRequest.url(), location);


### PR DESCRIPTION
The HttpEngine would not obey the set state because there was no
correlation between the HttpURLConnection.setInstanceFollowRedirects
method and the OkHttpClient.

Fixed the missing link by adding a new setFollowRedirects method to the
OkHttpClient class.  Bridged the gap for the HttpURLConnection.setInstanceFollowRedirects
by forwarding that state into the OkHttpClient.

Now the HttpEngine will always obey the OkHttpClient redirect state when
attempting the followUp phase.

Added necessary test to both OkUrlFactoryTest and CallTest.

https://github.com/square/okhttp/issues/943
