### PR TITLE
Fix a bug where we weren't storing rewritten request headers.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CacheTest.java
@@ -920,6 +920,19 @@ public final class CacheTest {
     assertEquals("DEFDEFDEF", readAscii(client.open(server.getUrl("/"))));
   }
 
+  /** https://github.com/square/okhttp/issues/947 */
+  @Test public void gzipAndVaryOnAcceptEncoding() throws Exception {
+    server.enqueue(new MockResponse()
+        .setBody(gzip("ABCABCABC"))
+        .addHeader("Content-Encoding: gzip")
+        .addHeader("Vary: Accept-Encoding")
+        .addHeader("Cache-Control: max-age=60"));
+    server.enqueue(new MockResponse().setBody("FAIL"));
+
+    assertEquals("ABCABCABC", readAscii(client.open(server.getUrl("/"))));
+    assertEquals("ABCABCABC", readAscii(client.open(server.getUrl("/"))));
+  }
+
   @Test public void conditionalCacheHitIsNotDoublePooled() throws Exception {
     server.enqueue(new MockResponse().addHeader("ETag: v1").setBody("A"));
     server.enqueue(new MockResponse()

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkHeaders.java
@@ -174,8 +174,12 @@ public final class OkHeaders {
     Set<String> varyFields = varyFields(response);
     if (varyFields.isEmpty()) return new Headers.Builder().build();
 
+    // Use the request headers sent over the network, since that's what the
+    // response varies on. Otherwise OkHttp-supplied headers like
+    // "Accept-Encoding: gzip" may be lost.
+    Headers requestHeaders = response.networkResponse().request().headers();
+
     Headers.Builder result = new Headers.Builder();
-    Headers requestHeaders = response.request().headers();
     for (int i = 0; i < requestHeaders.size(); i++) {
       String fieldName = requestHeaders.name(i);
       if (varyFields.contains(fieldName)) {


### PR DESCRIPTION
Closes https://github.com/square/okhttp/issues/947
