### PR TITLE
provide a friendlier API for multipart forms.

### DIFF
--- a/samples/guide/src/main/java/com/squareup/okhttp/recipes/PostMultipart.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/recipes/PostMultipart.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.okhttp.recipes;
 
-import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.MultipartBuilder;
 import com.squareup.okhttp.OkHttpClient;
@@ -40,11 +39,8 @@ public final class PostMultipart {
     // Use the imgur image upload API as documented at https://api.imgur.com/endpoints/image
     RequestBody requestBody = new MultipartBuilder()
         .type(MultipartBuilder.FORM)
-        .addPart(
-            Headers.of("Content-Disposition", "form-data; name=\"title\""),
-            RequestBody.create(null, "Square Logo"))
-        .addPart(
-            Headers.of("Content-Disposition", "form-data; name=\"image\""),
+        .addFormDataPart("title", "Square Logo")
+        .addFormDataPart("image", null,
             RequestBody.create(MEDIA_TYPE_PNG, new File("website/static/logo-square.png")))
         .build();
 


### PR DESCRIPTION
The super-generic `MultipartBuilder` API is pretty nice, but probably the most common case is building multipart forms. This patch provides a couple of convenience methods preventing the caller from having to write `Content-Disposition: form-data` all the time.

Open questions:
- should the `addFormPart(String name, String value)` overload provided a default content-type, presumably `text/plain; charset=utf-8`? [RFC 2388](http://www.ietf.org/rfc/rfc2388.txt) implies that the answer is yes.
- should we bother to do the quoted-string encoding if the caller includes "special characters" in the field name or filename parameter?

Also note that I can't get the tests to pass even before my changes; a quick review seems to indicate that I didn't make anything _more_ broken with these changes, but apologies if I'm wrong here.
