### PR TITLE
Fix a bug where the cacheResponse's request method was wrong.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -752,6 +752,7 @@ public final class CallTest {
     cacheHit.cacheResponse()
         .assertCode(200)
         .assertHeader("ETag", "v1")
+        .assertRequestMethod("GET")
         .assertRequestUrl(cacheStoreRequest.url())
         .assertRequestHeader("Accept-Language")
         .assertRequestHeader("Accept-Charset", "UTF-8");

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RecordedResponse.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RecordedResponse.java
@@ -46,6 +46,11 @@ public class RecordedResponse {
     return this;
   }
 
+  public RecordedResponse assertRequestMethod(String method) {
+    assertEquals(method, request.method());
+    return this;
+  }
+
   public RecordedResponse assertRequestHeader(String name, String... values) {
     assertEquals(Arrays.asList(values), request.headers(name));
     return this;

--- a/okhttp/src/main/java/com/squareup/okhttp/Cache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Cache.java
@@ -563,7 +563,7 @@ public final class Cache {
       String contentLength = responseHeaders.get("Content-Length");
       Request cacheRequest = new Request.Builder()
           .url(url)
-          .method(message, null)
+          .method(requestMethod, null)
           .headers(varyHeaders)
           .build();
       return new Response.Builder()


### PR DESCRIPTION
We were returning the message (like 'OK') rather than the method
(like 'GET'). Ugh.
