### PR TITLE
HTTP/2 initial window size is 65535 not 65536

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2ConnectionTest.java
@@ -112,7 +112,10 @@ public final class Http2ConnectionTest {
 
     SpdyConnection connection = connection(peer, HTTP_2);
 
-    // verify the peer received the ACK
+    // Default is 64KiB - 1.
+    assertEquals(65535, connection.peerSettings.getInitialWindowSize(-1));
+
+    // Verify the peer received the ACK.
     MockSpdyPeer.InFrame ackFrame = peer.takeFrame();
     assertEquals(TYPE_SETTINGS, ackFrame.type);
     assertEquals(0, ackFrame.streamId);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -158,6 +158,8 @@ public final class SpdyConnection implements Closeable {
           0L, TimeUnit.MILLISECONDS,
           new LinkedBlockingQueue<Runnable>(),
           Util.threadFactory(String.format("OkHttp %s Push Observer", hostName), true));
+      // 1 less than SPDY http://tools.ietf.org/html/draft-ietf-httpbis-http2-13#section-6.9.2
+      peerSettings.set(Settings.INITIAL_WINDOW_SIZE, 0, 65535);
     } else if (protocol == Protocol.SPDY_3) {
       variant = new Spdy3();
       pushExecutor = null;


### PR DESCRIPTION
Bug discovered by @jpinner in #929
