### PR TITLE
Add trailing CRLF to multipart.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/MultipartBuilderTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/MultipartBuilderTest.java
@@ -34,7 +34,7 @@ public final class MultipartBuilderTest {
         + "Content-Length: 13\r\n"
         + "\r\n"
         + "Hello, World!\r\n"
-        + "--123--";
+        + "--123--\r\n";
 
     RequestBody requestBody = new MultipartBuilder("123")
         .addPart(RequestBody.create(null, "Hello, World!"))
@@ -61,7 +61,7 @@ public final class MultipartBuilderTest {
         + "Content-Length: 3\r\n"
         + "\r\n"
         + "Fox\r\n"
-        + "--123--";
+        + "--123--\r\n";
 
     RequestBody requestBody = new MultipartBuilder("123")
         .addPart(RequestBody.create(null, "Quick"))
@@ -101,7 +101,8 @@ public final class MultipartBuilderTest {
         + "\r\n"
         + "... contents of file2.gif ...\r\n"
         + "--BbC04y--\r\n"
-        + "--AaB03x--";
+        + "\r\n"
+        + "--AaB03x--\r\n";
 
     RequestBody requestBody = new MultipartBuilder("AaB03x")
         .type(MultipartBuilder.FORM)
@@ -152,7 +153,7 @@ public final class MultipartBuilderTest {
         + "Content-Length: 5\r\n"
         + "\r\n"
         + "Alpha\r\n"
-        + "--AaB03x--";
+        + "--AaB03x--\r\n";
 
     RequestBody requestBody = new MultipartBuilder("AaB03x")
         .type(MultipartBuilder.FORM)

--- a/okhttp/src/main/java/com/squareup/okhttp/MultipartBuilder.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/MultipartBuilder.java
@@ -229,9 +229,8 @@ public final class MultipartBuilder {
       sink.write(boundary);
       if (last) {
         sink.writeUtf8("--");
-      } else {
-        sink.writeUtf8("\r\n");
       }
+      sink.writeUtf8("\r\n");
     }
 
     private void writePart(BufferedSink sink, Headers headers, RequestBody body)


### PR DESCRIPTION
Port of square/retrofit#552. Quote from @JakeWharton:

> .NET's MVC 4 fails to parse multipart uploads which lack a trailing CRLF. This is safe to add to all multipart requests since it is after the final boundary which is considered part of the epilogue and is ignored (per RFC1341 section 7.2.1).
