### PR TITLE
Use urlString for Request.toString()

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -115,7 +115,7 @@ public final class Request {
     return "Request{method="
         + method
         + ", url="
-        + url
+        + urlString
         + ", tag="
         + (tag != this ? tag : null)
         + '}';


### PR DESCRIPTION
Since the `url` field is lazy and can is `null` prior to calling `OkHttpClient.newCall(Request)`
