### PR TITLE
Refine get-response of Call

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -142,6 +142,7 @@ public class Call {
         }
       } catch (IOException e) {
         if (signalledCallback) throw new RuntimeException(e); // Do not signal the callback twice!
+        request = engine.getRequest(); // sync up the request content
         responseCallback.onFailure(request, e);
       } finally {
         client.getDispatcher().finished(this);
@@ -155,10 +156,12 @@ public class Call {
    */
   private Response getResponse() throws IOException {
     engine = new HttpEngine(client, request, false, null, null, null, null);
-    return engine.tryGetResponse(new HttpEngine.CancelIndicator() {
-        @Override public boolean isCanceled() {
-          return Call.this.canceled;
-        }
+    Response response = engine.tryGetResponse(new HttpEngine.CancelIndicator() {
+      @Override public boolean isCanceled() {
+        return Call.this.canceled;
+      }
     });
+    request = engine.getRequest(); // sync up the request content
+    return response;
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -189,6 +189,13 @@ public final class HttpEngine {
   public HttpEngine(OkHttpClient client, Request request, boolean bufferRequestBody,
       Connection connection, RouteSelector routeSelector, RetryableSink requestBodyOut,
       Response priorResponse) {
+    init(client, request, bufferRequestBody, connection, routeSelector, requestBodyOut,
+        priorResponse);
+  }
+
+  private void init(OkHttpClient client, Request request, boolean bufferRequestBody,
+      Connection connection, RouteSelector routeSelector, RetryableSink requestBodyOut,
+      Response priorResponse) {
     this.client = client;
     this.userRequest = request;
     this.bufferRequestBody = bufferRequestBody;
@@ -208,21 +215,6 @@ public final class HttpEngine {
   private void reset(OkHttpClient client, Request request, boolean bufferRequestBody,
       Connection connection, RouteSelector routeSelector, RetryableSink requestBodyOut,
       Response priorResponse) {
-    this.client = client;
-    this.userRequest = request;
-    this.bufferRequestBody = bufferRequestBody;
-    this.connection = connection;
-    this.routeSelector = routeSelector;
-    this.requestBodyOut = requestBodyOut;
-    this.priorResponse = priorResponse;
-
-    if (connection != null) {
-      Internal.instance.setOwner(connection, this);
-      this.route = connection.getRoute();
-    } else {
-      this.route = null;
-    }
-
     this.transport = null;
     this.sentRequestMillis = -1;
     this.transparentGzip = false;
@@ -236,6 +228,9 @@ public final class HttpEngine {
     this.responseBodyBytes = null;
     this.storeRequest = null;
     this.cacheStrategy = null;
+
+    init(client, request, bufferRequestBody, connection, routeSelector, requestBodyOut,
+        priorResponse);
   }
 
   /**
@@ -319,8 +314,7 @@ public final class HttpEngine {
       }
 
       Connection connection = close();
-      userRequest = followUp;
-      reset(client, userRequest, false, connection, null, null, response);
+      reset(client, followUp, false, connection, null, null, response);
     }
   }
 


### PR DESCRIPTION
Refine get-response of Call : move the tries and recovery steps to HttpEngine.java from Call.java.

---

The original code tries and recovery get response logic might be reused by different kinds of HTTP callers. And from the semantics' point of view, the logic is more likely to be one part of HttpEngine. So I wrapped a tryGetReponse method in HttpEngine and put the tries and recovery logic in it.
