### PR TITLE
Permit GETs to have Content-Length: 0.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -524,7 +524,7 @@ public final class MockWebServer {
     List<Integer> chunkSizes = new ArrayList<>();
     MockResponse throttlePolicy = dispatcher.peek();
     if (contentLength != -1) {
-      hasBody = true;
+      hasBody = contentLength > 0;
       throttledTransfer(throttlePolicy, in, requestBody, contentLength);
     } else if (chunked) {
       hasBody = true;


### PR DESCRIPTION
It's ridiculous, but Apache HTTP client wants it.
Closes https://github.com/square/okhttp/issues/990
