### PR TITLE
Use the socket factory for direct connections as well.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -49,6 +49,7 @@ import java.net.InetAddress;
 import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.ProxySelector;
+import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URL;
@@ -69,6 +70,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
+import javax.net.SocketFactory;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
@@ -712,6 +714,48 @@ public final class URLConnectionTest {
     server.play();
 
     assertContent("abc", client.open(server.getUrl("/")));
+  }
+
+  public void testConnectViaSocketFactory(boolean useHttps) throws IOException {
+    SocketFactory uselessSocketFactory = new SocketFactory() {
+      public Socket createSocket() { throw new IllegalArgumentException("useless"); }
+      public Socket createSocket(InetAddress host, int port) { return null; }
+      public Socket createSocket(InetAddress address, int port, InetAddress localAddress,
+          int localPort) { return null; }
+      public Socket createSocket(String host, int port) { return null; }
+      public Socket createSocket(String host, int port, InetAddress localHost, int localPort) {
+        return null;
+      }
+    };
+
+    if (useHttps) {
+      server.useHttps(sslContext.getSocketFactory(), false);
+      client.client().setSslSocketFactory(sslContext.getSocketFactory());
+      client.client().setHostnameVerifier(new RecordingHostnameVerifier());
+    }
+
+    server.enqueue(new MockResponse().setStatus("HTTP/1.1 200 OK"));
+    server.play();
+
+    client.client().setSocketFactory(uselessSocketFactory);
+    connection = client.open(server.getUrl("/"));
+    try {
+      connection.getResponseCode();
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+
+    client.client().setSocketFactory(SocketFactory.getDefault());
+    connection = client.open(server.getUrl("/"));
+    assertEquals(200, connection.getResponseCode());
+  }
+
+  @Test public void connectHttpViaSocketFactory() throws Exception {
+    testConnectViaSocketFactory(false);
+  }
+
+  @Test public void connectHttpsViaSocketFactory() throws Exception {
+    testConnectViaSocketFactory(true);
   }
 
   @Test public void contentDisagreesWithChunkedHeader() throws IOException {

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -140,10 +140,10 @@ public final class Connection {
       throws IOException {
     if (connected) throw new IllegalStateException("already connected");
 
-    if (route.proxy.type() != Proxy.Type.HTTP) {
-      socket = new Socket(route.proxy);
-    } else {
+    if (route.proxy.type() == Proxy.Type.DIRECT || route.proxy.type() == Proxy.Type.HTTP) {
       socket = route.address.socketFactory.createSocket();
+    } else {
+      socket = new Socket(route.proxy);
     }
 
     socket.setSoTimeout(readTimeout);


### PR DESCRIPTION
Currently, the passed-in socket factory is only used for
connections to HTTP proxies. I think this was not the intent of
the original socket factory change, because the commit message
said that the "socket factory will be used for all non-proxy
connections and HTTP proxy connections".  So use it for DIRECT
connections as well.

Also add a test to check that a socket factory is used if
specified.
