### PR TITLE
Allow callers to pass in a custom host resolver implementation.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/HostResolver.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HostResolver.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.okhttp.internal;
+package com.squareup.okhttp;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -22,8 +22,8 @@ import java.net.UnknownHostException;
  * Domain name service. Prefer this over {@link InetAddress#getAllByName} to
  * make code more testable.
  */
-public interface Dns {
-  Dns DEFAULT = new Dns() {
+public interface HostResolver {
+  HostResolver DEFAULT = new HostResolver() {
     @Override public InetAddress[] getAllByName(String host) throws UnknownHostException {
       if (host == null) throw new UnknownHostException("host == null");
       return InetAddress.getAllByName(host);

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -125,6 +125,7 @@ public class OkHttpClient implements Cloneable {
   private HostnameVerifier hostnameVerifier;
   private Authenticator authenticator;
   private ConnectionPool connectionPool;
+  private HostResolver hostResolver;
   private boolean followSslRedirects = true;
   private boolean followRedirects = true;
   private int connectTimeout;
@@ -445,6 +446,19 @@ public class OkHttpClient implements Cloneable {
     return protocols;
   }
 
+  /*
+   * Sets the {@code HostResolver} that will be used by this client to resolve
+   * hostnames to IP addresses.
+   */
+  public OkHttpClient setHostResolver(HostResolver hostResolver) {
+    this.hostResolver = hostResolver;
+    return this;
+  }
+
+  public HostResolver getHostResolver() {
+    return hostResolver;
+  }
+
   /**
    * Prepares the {@code request} to be executed at some point in the future.
    */
@@ -490,6 +504,9 @@ public class OkHttpClient implements Cloneable {
     }
     if (result.protocols == null) {
       result.protocols = Util.immutableList(Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1);
+    }
+    if (result.hostResolver == null) {
+      result.hostResolver = HostResolver.DEFAULT;
     }
     return result;
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -26,7 +26,6 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.Route;
-import com.squareup.okhttp.internal.Dns;
 import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.InternalCache;
 import com.squareup.okhttp.internal.Util;
@@ -288,7 +287,7 @@ public final class HttpEngine {
     if (connection != null) throw new IllegalStateException();
 
     if (routeSelector == null) {
-      routeSelector = RouteSelector.get(request, client, Dns.DEFAULT);
+      routeSelector = RouteSelector.get(request, client);
     }
 
     connection = routeSelector.next(this);


### PR DESCRIPTION
An HTTP client interacts with the network in two main ways: DNS
lookups and connections to HTTP servers. OkHttp already abstracts
the latter by allowing callers to pass in custom SocketFactory
objects, but does not yet abstract the former.

This change takes the existing internal Dns interface, which is
currently used for testing, and turns it into a publicly
accessible HostResolver interface. This allows callers to
completely abstract all network interaction points.

Examples of what this can be used for:
1. Use alternative DNS implementations with different
   performance / caching / ordering / parallelization / ...
   characteristics than standard InetAddress.getAllByName.
2. Resolve hosts using different DNS servers than the system
   resolvers, or even non-DNS protocols (e.g., MDNS or even
   NetBIOS/WINS) that are not supported by the system resolver.
3. Do DNS lookups on specific networks, similarly to what
   android_getaddrinfofornet does.

Change-Id: I6e488acd938067e4c078c6ffe4d5eddb5f3951de
