### PR TITLE
Fix transparent gzip for basic auth.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RecordedResponse.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RecordedResponse.java
@@ -81,7 +81,7 @@ public class RecordedResponse {
    * response for the original request.
    */
   public RecordedResponse redirectedBy() {
-    Response redirectedBy = response.redirectedBy();
+    Response redirectedBy = response.priorResponse();
     assertNotNull(redirectedBy);
     assertNull(redirectedBy.body());
     return new RecordedResponse(redirectedBy.request(), redirectedBy, null, null);

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/RecordingOkAuthenticator.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/RecordingOkAuthenticator.java
@@ -23,28 +23,43 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class RecordingOkAuthenticator implements OkAuthenticator {
-  public final List<String> calls = new ArrayList<String>();
+  public final List<URL> urls = new ArrayList<URL>();
+  public final List<List<Challenge>> challengesList = new ArrayList<List<Challenge>>();
+  public final List<Proxy> proxies = new ArrayList<Proxy>();
   public final Credential credential;
 
   public RecordingOkAuthenticator(Credential credential) {
     this.credential = credential;
   }
 
+  public URL onlyUrl() {
+    if (urls.size() != 1) throw new IllegalStateException();
+    return urls.get(0);
+  }
+
+  public List<Challenge> onlyChallenge() {
+    if (challengesList.size() != 1) throw new IllegalStateException();
+    return challengesList.get(0);
+  }
+
+  public Proxy onlyProxy() {
+    if (proxies.size() != 1) throw new IllegalStateException();
+    return proxies.get(0);
+  }
+
   @Override public Credential authenticate(Proxy proxy, URL url, List<Challenge> challenges)
       throws IOException {
-    calls.add("authenticate"
-        + " proxy=" + proxy.type()
-        + " url=" + url
-        + " challenges=" + challenges);
+    urls.add(url);
+    challengesList.add(challenges);
+    proxies.add(proxy);
     return credential;
   }
 
   @Override public Credential authenticateProxy(Proxy proxy, URL url, List<Challenge> challenges)
       throws IOException {
-    calls.add("authenticateProxy"
-        + " proxy=" + proxy.type()
-        + " url=" + url
-        + " challenges=" + challenges);
+    urls.add(url);
+    challengesList.add(challenges);
+    proxies.add(proxy);
     return credential;
   }
 }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -18,6 +18,7 @@ package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.ConnectionPool;
 import com.squareup.okhttp.HttpResponseCache;
+import com.squareup.okhttp.OkAuthenticator.Challenge;
 import com.squareup.okhttp.OkAuthenticator.Credential;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.OkUrlFactory;
@@ -1644,6 +1645,39 @@ public final class URLConnectionTest {
     }
   }
 
+  /** https://code.google.com/p/android/issues/detail?id=74026 */
+  @Test public void authenticateWithGetAndTransparentGzip() throws Exception {
+    MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
+        .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
+        .setBody("Please authenticate.");
+    // fail auth three times...
+    server.enqueue(pleaseAuthenticate);
+    server.enqueue(pleaseAuthenticate);
+    server.enqueue(pleaseAuthenticate);
+    // ...then succeed the fourth time
+    MockResponse successfulResponse = new MockResponse()
+        .addHeader("Content-Encoding", "gzip")
+        .setBody(gzip("Successful auth!".getBytes("UTF-8")));
+    server.enqueue(successfulResponse);
+    server.play();
+
+    Authenticator.setDefault(new RecordingAuthenticator());
+    connection = client.open(server.getUrl("/"));
+    assertEquals("Successful auth!", readAscii(connection.getInputStream(), Integer.MAX_VALUE));
+
+    // no authorization header for the first request...
+    RecordedRequest request = server.takeRequest();
+    assertContainsNoneMatching(request.getHeaders(), "Authorization: Basic .*");
+
+    // ...but the three requests that follow requests include an authorization header
+    for (int i = 0; i < 3; i++) {
+      request = server.takeRequest();
+      assertEquals("GET / HTTP/1.1", request.getRequestLine());
+      assertContains(request.getHeaders(),
+          "Authorization: Basic " + RecordingAuthenticator.BASE_64_CREDENTIALS);
+    }
+  }
+ 
   /** https://github.com/square/okhttp/issues/342 */
   @Test public void authenticateRealmUppercase() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(401)
@@ -2661,11 +2695,10 @@ public final class URLConnectionTest {
     assertContains(server.takeRequest().getHeaders(),
         "Authorization: " + credential.getHeaderValue());
 
-    assertEquals(1, authenticator.calls.size());
-    String call = authenticator.calls.get(0);
-    assertTrue(call, call.contains("proxy=DIRECT"));
-    assertTrue(call, call.contains("url=" + server.getUrl("/private")));
-    assertTrue(call, call.contains("challenges=[Basic realm=\"protected area\"]"));
+    assertEquals(Proxy.NO_PROXY, authenticator.onlyProxy());
+    URL url = authenticator.onlyUrl();
+    assertEquals("/private", url.getPath());
+    assertEquals(Arrays.asList(new Challenge("Basic", "protected area")), authenticator.onlyChallenge());
   }
 
   @Test public void npnSetsProtocolHeader_SPDY_3() throws Exception {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
@@ -44,14 +44,18 @@ public final class CacheStrategy {
     }
   }
 
-  public final Request request;
-  public final Response response;
+  /** The request to send on the network, or null if this call doesn't use the network. */
+  public final Request networkRequest;
+
+  /** The cached response to return or validate; or null if this call doesn't use a cache. */
+  public final Response cacheResponse;
+
   public final ResponseSource source;
 
   private CacheStrategy(
-      Request request, Response response, ResponseSource source) {
-    this.request = request;
-    this.response = response;
+      Request networkRequest, Response cacheResponse, ResponseSource source) {
+    this.networkRequest = networkRequest;
+    this.cacheResponse = cacheResponse;
     this.source = source;
   }
 
@@ -165,12 +169,12 @@ public final class CacheStrategy {
       if (candidate.source != ResponseSource.CACHE && request.cacheControl().onlyIfCached()) {
         // We're forbidden from using the network, but the cache is insufficient.
         Response noneResponse = new Response.Builder()
-            .request(candidate.request)
+            .request(candidate.networkRequest)
             .statusLine(GATEWAY_TIMEOUT_STATUS_LINE)
             .setResponseSource(ResponseSource.NONE)
             .body(EMPTY_BODY)
             .build();
-        return new CacheStrategy(candidate.request, noneResponse, ResponseSource.NONE);
+        return new CacheStrategy(null, noneResponse, ResponseSource.NONE);
       }
 
       return candidate;
@@ -180,19 +184,19 @@ public final class CacheStrategy {
     private CacheStrategy getCandidate() {
       // No cached response.
       if (cacheResponse == null) {
-        return new CacheStrategy(request, cacheResponse, ResponseSource.NETWORK);
+        return new CacheStrategy(request, null, ResponseSource.NETWORK);
       }
 
       // Drop the cached response if it's missing a required handshake.
       if (request.isHttps() && cacheResponse.handshake() == null) {
-        return new CacheStrategy(request, cacheResponse, ResponseSource.NETWORK);
+        return new CacheStrategy(request, null, ResponseSource.NETWORK);
       }
 
       // If this response shouldn't have been stored, it should never be used
       // as a response source. This check should be redundant as long as the
       // persistence store is well-behaved and the rules are constant.
       if (!isCacheable(cacheResponse, request)) {
-        return new CacheStrategy(request, cacheResponse, ResponseSource.NETWORK);
+        return new CacheStrategy(request, null, ResponseSource.NETWORK);
       }
 
       CacheControl requestCaching = request.cacheControl();
@@ -228,7 +232,7 @@ public final class CacheStrategy {
         if (ageMillis > oneDayMillis && isFreshnessLifetimeHeuristic()) {
           builder.addHeader("Warning", "113 HttpURLConnection \"Heuristic expiration\"");
         }
-        return new CacheStrategy(request, builder.build(), ResponseSource.CACHE);
+        return new CacheStrategy(null, builder.build(), ResponseSource.CACHE);
       }
 
       Request.Builder conditionalRequestBuilder = request.newBuilder();
@@ -244,10 +248,9 @@ public final class CacheStrategy {
       }
 
       Request conditionalRequest = conditionalRequestBuilder.build();
-      ResponseSource responseSource = hasConditions(conditionalRequest)
-          ? ResponseSource.CONDITIONAL_CACHE
-          : ResponseSource.NETWORK;
-      return new CacheStrategy(conditionalRequest, cacheResponse, responseSource);
+      return hasConditions(conditionalRequest)
+          ? new CacheStrategy(conditionalRequest, cacheResponse, ResponseSource.CONDITIONAL_CACHE)
+          : new CacheStrategy(conditionalRequest, null, ResponseSource.NETWORK);
     }
 
     /**

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpURLConnectionImpl.java
@@ -273,7 +273,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
           throw new ProtocolException(method + " does not support writing");
         }
       }
-      httpEngine = newHttpEngine(method, null, null);
+      httpEngine = newHttpEngine(method, null, null, null);
     } catch (IOException e) {
       httpEngineFailure = e;
       throw e;
@@ -281,7 +281,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   }
 
   private HttpEngine newHttpEngine(String method, Connection connection,
-      RetryableSink requestBody) {
+      RetryableSink requestBody, Response priorResponse) {
     Request.Builder builder = new Request.Builder()
         .url(getURL())
         .method(method, null /* No body; that's passed separately. */);
@@ -309,7 +309,8 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       engineClient = client.clone().setOkResponseCache(null);
     }
 
-    return new HttpEngine(engineClient, request, bufferRequestBody, connection, null, requestBody);
+    return new HttpEngine(engineClient, request, bufferRequestBody, connection, null, requestBody,
+        priorResponse);
   }
 
   /**
@@ -328,6 +329,8 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       if (!execute(true)) {
         continue;
       }
+
+      Response response = httpEngine.getResponse();
 
       Retry retry = processResponseHeaders();
       if (retry == Retry.NONE) {
@@ -361,7 +364,8 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       }
 
       Connection connection = httpEngine.close();
-      httpEngine = newHttpEngine(retryMethod, connection, (RetryableSink) requestBody);
+      httpEngine = newHttpEngine(retryMethod, connection, (RetryableSink) requestBody,
+          response);
     }
   }
 


### PR DESCRIPTION
Externally reported Android bug:
https://code.google.com/p/android/issues/detail?id=74026

This change involves backporting this commit from 2.0 to 1.6:
https://github.com/square/okhttp/commit/9abfde9e5ad7c67ddad907c55bfb2378bc65082c

There have been many changes between 1.6 and that commit that touch
related code. Details of those changes are below.

A test has been added to demonstrate the fix.

Changes that are related and had to be accomodated:

https://github.com/square/okhttp/commit/da484932625ab15681e469c1680b6371b8f67080
- Change: Replace TunnelRequest with a regular Request
- Impact: HttpEngine: getTunnelConfig() replaced.
- Action: Not applied. Worked around.

https://github.com/square/okhttp/commit/ee2ed56c9ad4563f5713ff0f572a5454af16901d
- Change: Track redirectedBy in HttpEngine.
- Impact: Addition of a new parameter (redirectedBy) to HttpEngine.
- Action: Partially applied - added the parameter to HttpEngine / HttpUrlConnectionImpl
  but not Call (does not exist in 1.6). Some test changes backported, some excluded.

https://github.com/square/okhttp/commit/d30c48a1943f165cbd18a33b629b15434079a15a
- Change: Rename of redirectedBy to priorResponse
- Impact: Response, HttpEngine, HttpURLConnectionImpl
- Action: Applied.

https://github.com/square/okhttp/commit/520d9fc2bc6b251a998b58794070f8bebee9d682
- Change: Support common http verbs including zero length POST, DELETE.
- Impact: HttpEngine: Introduction of Util.emptySink() check in hasRequestBody()
- Action: Not applied. Ignored additional check.

https://github.com/square/okhttp/commit/8e9d8f6fbf4a505417ead296b2c2a1bb15e6ba5c
- Change: Change the signature of OkResponseCache.maybeRemove
- Impact: Changed HttpResponseCache.maybeRemove() to remove() and pulled condition
  code into caller.
- Action: Not applied. Worked around.

https://github.com/square/okhttp/commit/9546527a1c34400a0020f50fe58ffd1f109800ab
- Change: Removed httpMinorVersion().
- Impact: HttpEngine: connection.setHttpMinorVersion(networkResponse.httpMinorVersion())
  -> connection.setProtocol(response.protocol());
- Action: Not applied. Left as is.

https://github.com/square/okhttp/commit/1044d9eea21d8be54c195fff75ca0a7b9bba79b3
- Change: Introduction of Internal class methods.
- Impact: HttpEngine: connection.setProtocol(response.protocol())
  -> Internal.instance.setProtocol(connection, response.protocol())
- Action: Not applied. Left as is.

https://github.com/square/okhttp/commit/825b31dc5ca5be249b165e8c6ae90340f3c678d1
- Change: Basic support for OAuth in OkAuthenticator
- Impact: URLConnectionTest
- Action: Not applied. Left as is.
