### PR TITLE
Fix formatting / parsing for Android

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpDateTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpDateTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class HttpDateTest {
+
+  private TimeZone originalDefault;
+
+  @Before
+  public void setUp() throws Exception {
+    originalDefault = TimeZone.getDefault();
+    // The default timezone should affect none of these tests: HTTP specified GMT, so we set it to
+    // something else.
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TimeZone.setDefault(originalDefault);
+  }
+
+  @Test public void parseStandardFormats() throws Exception {
+    // RFC 822, updated by RFC 1123 with GMT.
+    assertEquals(0L, HttpDate.parse("Thu, 01 Jan 1970 00:00:00 GMT").getTime());
+    assertEquals(1402057830000L, HttpDate.parse("Fri, 06 Jun 2014 12:30:30 GMT").getTime());
+
+    // RFC 850, obsoleted by RFC 1036 with GMT.
+    assertEquals(0L, HttpDate.parse("Thursday, 01-Jan-70 00:00:00 GMT").getTime());
+    assertEquals(1402057830000L, HttpDate.parse("Friday, 06-Jun-14 12:30:30 GMT").getTime());
+
+    // ANSI C's asctime(): should use GMT, not platform default.
+    assertEquals(0L, HttpDate.parse("Thu Jan 1 00:00:00 1970").getTime());
+    assertEquals(1402057830000L, HttpDate.parse("Fri Jun 6 12:30:30 2014").getTime());
+  }
+
+  @Test public void format() throws Exception {
+    assertEquals("Thu, 01 Jan 1970 00:00:00 GMT", HttpDate.format(new Date(0)));
+    assertEquals("Fri, 06 Jun 2014 12:30:30 GMT", HttpDate.format(new Date(1402057830000L)));
+  }
+
+  @Test public void parseNonStandardStrings() throws Exception {
+    // RFC 822, updated by RFC 1123 with any TZ
+    assertEquals(3600000L, HttpDate.parse("Thu, 01 Jan 1970 00:00:00 GMT-01:00").getTime());
+    assertEquals(28800000L, HttpDate.parse("Thu, 01 Jan 1970 00:00:00 PST").getTime());
+    // Ignore trailing junk
+    assertEquals(0L, HttpDate.parse("Thu, 01 Jan 1970 00:00:00 GMT JUNK").getTime());
+    // Missing timezones treated as bad.
+    assertNull(HttpDate.parse("Thu, 01 Jan 1970 00:00:00"));
+    // Missing seconds treated as bad.
+    assertNull(HttpDate.parse("Thu, 01 Jan 1970 00:00 GMT"));
+    // Extra spaces treated as bad.
+    assertNull(HttpDate.parse("Thu,  01 Jan 1970 00:00 GMT"));
+    // Missing leading zero treated as bad.
+    assertNull(HttpDate.parse("Thu, 1 Jan 1970 00:00 GMT"));
+
+    // RFC 850, obsoleted by RFC 1036 with any TZ.
+    assertEquals(3600000L, HttpDate.parse("Thursday, 01-Jan-1970 00:00:00 GMT-01:00").getTime());
+    assertEquals(28800000L, HttpDate.parse("Thursday, 01-Jan-1970 00:00:00 PST").getTime());
+    // Ignore trailing junk
+    assertEquals(28800000L, HttpDate.parse("Thursday, 01-Jan-1970 00:00:00 PST JUNK").getTime());
+
+    // ANSI C's asctime() format
+    // This format ignores the timezone entirely even if it is present and uses GMT.
+    assertEquals(1402057830000L, HttpDate.parse("Fri Jun 6 12:30:30 2014 PST").getTime());
+    // Ignore trailing junk.
+    assertEquals(1402057830000L, HttpDate.parse("Fri Jun 6 12:30:30 2014 JUNK").getTime());
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpDate.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpDate.java
@@ -17,7 +17,7 @@
 package com.squareup.okhttp.internal.http;
 
 import java.text.DateFormat;
-import java.text.ParseException;
+import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -28,6 +28,8 @@ import java.util.TimeZone;
  */
 public final class HttpDate {
 
+  private static final TimeZone GMT = TimeZone.getTimeZone("GMT");
+
   /**
    * Most websites serve cookies in the blessed format. Eagerly create the parser to ensure such
    * cookies are on the fast path.
@@ -35,16 +37,21 @@ public final class HttpDate {
   private static final ThreadLocal<DateFormat> STANDARD_DATE_FORMAT =
       new ThreadLocal<DateFormat>() {
         @Override protected DateFormat initialValue() {
-          DateFormat rfc1123 = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
-          rfc1123.setTimeZone(TimeZone.getTimeZone("GMT"));
+          // RFC 2616 specified: RFC 822, updated by RFC 1123 format with fixed GMT.
+          DateFormat rfc1123 = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US);
+          rfc1123.setLenient(false);
+          rfc1123.setTimeZone(GMT);
           return rfc1123;
         }
       };
 
   /** If we fail to parse a date in a non-standard format, try each of these formats in sequence. */
   private static final String[] BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS = new String[] {
-      "EEEE, dd-MMM-yy HH:mm:ss zzz", // RFC 1036
-      "EEE MMM d HH:mm:ss yyyy", // ANSI C asctime()
+      // HTTP formats required by RFC2616 but with any timezone.
+      "EEE, dd MMM yyyy HH:mm:ss zzz", // RFC 822, updated by RFC 1123 with any TZ
+      "EEEE, dd-MMM-yy HH:mm:ss zzz", // RFC 850, obsoleted by RFC 1036 with any TZ.
+      "EEE MMM d HH:mm:ss yyyy", // ANSI C's asctime() format
+       // Alternative formats.
       "EEE, dd-MMM-yyyy HH:mm:ss z",
       "EEE, dd-MMM-yyyy HH-mm-ss z",
       "EEE, dd MMM yy HH:mm:ss z",
@@ -66,20 +73,36 @@ public final class HttpDate {
 
   /** Returns the date for {@code value}. Returns null if the value couldn't be parsed. */
   public static Date parse(String value) {
-    try {
-      return STANDARD_DATE_FORMAT.get().parse(value);
-    } catch (ParseException ignored) {
+    if (value.length() == 0) {
+      return null;
+    }
+
+    ParsePosition position = new ParsePosition(0);
+    Date result = STANDARD_DATE_FORMAT.get().parse(value, position);
+    if (position.getIndex() == value.length()) {
+      // STANDARD_DATE_FORMAT must match exactly; all text must be consumed, e.g. no ignored
+      // non-standard trailing "+01:00". Those cases are covered below.
+      return result;
     }
     synchronized (BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS) {
       for (int i = 0, count = BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS.length; i < count; i++) {
         DateFormat format = BROWSER_COMPATIBLE_DATE_FORMATS[i];
         if (format == null) {
           format = new SimpleDateFormat(BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS[i], Locale.US);
+          // Set the timezone to use when interpreting formats that don't have a timezone. GMT is
+          // specified by RFC 2616.
+          format.setTimeZone(GMT);
           BROWSER_COMPATIBLE_DATE_FORMATS[i] = format;
         }
-        try {
-          return format.parse(value);
-        } catch (ParseException ignored) {
+        position.setIndex(0);
+        result = format.parse(value, position);
+        if (position.getIndex() != 0) {
+          // Something was parsed. It's possible the entire string was not consumed but we ignore
+          // that. If any of the BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS ended in "'GMT'" we'd have
+          // to also check that position.getIndex() == value.length() otherwise parsing might have
+          // terminated early, ignoring things like "+01:00". Leaving this as != 0 means that any
+          // trailing junk is ignored.
+          return result;
         }
       }
     }


### PR DESCRIPTION
Ensuring that this Android bug is fixed for the next Android release:
https://code.google.com/p/android/issues/detail?id=66135

On Android the SimpleDateFormat for "zzz" returns GMT+00:00.
This is regrettable but awkward to change as it is existing
behavior.
https://code.google.com/p/android/issues/detail?id=66136

This change also fixes a bug where the default timezone
is used for parsing non-standard date/times.

This change also fixes a bug where the timezone from one parse
could leak into another.
