### PR TITLE
okcurl truncates values of headers with timestamp values

### DIFF
--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -218,7 +218,7 @@ public class Main extends HelpOption implements Runnable {
 
     if (headers != null) {
       for (String header : headers) {
-        String[] parts = header.split(":", -1);
+        String[] parts = header.split(":", 2);
         request.header(parts[0], parts[1]);
       }
     }

--- a/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
+++ b/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
@@ -84,6 +84,12 @@ public class MainTest {
     assertNull(request.body());
   }
 
+  @Test public void headerSplitWithDate() {
+    Request request = fromArgs("-H", "If-Modified-Since: Mon, 18 Aug 2014 15:16:06 GMT",
+        "http://example.com").createRequest();
+    assertEquals("Mon, 18 Aug 2014 15:16:06 GMT", request.header("If-Modified-Since"));
+  }
+
   private static String bodyAsString(RequestBody body) {
     try {
       Buffer buffer = new Buffer();


### PR DESCRIPTION
Fixes an issue where the full timestamp is not sent to server.

Example
./target/okcurl-2.0.1-SNAPSHOT-jar-with-dependencies.jar --header 'If-Modified-Since: Thu, 04 Oct 2013 09:28:58 GMT' -i example.com

would submit: [If-Modified-Since] => Thu, 04 Oct 2013 09
