### PR TITLE
Add ability to use InputStream as source of RequestBody

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -16,6 +16,10 @@
 package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.Util;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -23,7 +27,6 @@ import java.net.URI;
 import java.net.URL;
 
 import okio.Buffer;
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -73,6 +76,19 @@ public final class RequestTest {
     RequestBody body = RequestBody.create(contentType, file);
     assertEquals(contentType, body.contentType());
     assertEquals(3, body.contentLength());
+    assertEquals("616263", bodyToHex(body));
+    assertEquals("Retransmit body", "616263", bodyToHex(body));
+  }
+
+  @Test public void inputStream() throws Exception {
+    byte[] bytes = "abc".getBytes(Util.UTF_8);
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
+    MediaType contentType = MediaType.parse("text/plain");
+
+    RequestBody body = RequestBody.create(contentType, inputStream, bytes.length);
+
+    assertEquals(contentType, body.contentType());
+    assertEquals(bytes.length, body.contentLength());
     assertEquals("616263", bodyToHex(body));
     assertEquals("Retransmit body", "616263", bodyToHex(body));
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
@@ -101,9 +101,9 @@ public abstract class RequestBody {
   }
 
   /** Returns a new request body that transmits the content of an {@code InputStream}. */
-  public static RequestBody create(final MediaType contentType, final InputStream is,
-                                   final long length) {
-    if (is == null) throw new NullPointerException("inputStream == null");
+  public static RequestBody create(final MediaType contentType, final InputStream inputStream,
+      final long length) {
+    if (inputStream == null) throw new NullPointerException("inputStream == null");
 
     return new RequestBody() {
       @Override public MediaType contentType() {
@@ -117,10 +117,15 @@ public abstract class RequestBody {
       @Override public void writeTo(BufferedSink sink) throws IOException {
         Source source = null;
         try {
-          source = Okio.source(is);
+          source = Okio.source(inputStream);
           sink.writeAll(source);
         } finally {
-          Util.closeQuietly(source);
+            try {
+                inputStream.reset();
+            } catch (IOException e) {
+                // reset might not be supported. do nothing.
+            }
+            Util.closeQuietly(source);
         }
       }
     };


### PR DESCRIPTION
Currently you can only use static resources when creating a RequestBody. In practice it can be beneficial to provide an InputStream as the RequestBody data source. For example an input stream can be monitored during the upload so that a use can be provided with feedback about the upload progress.
