### PR TITLE
Move frame length constraint to where it is used.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2ConnectionTest.java
@@ -222,13 +222,13 @@ public final class Http2ConnectionTest {
     peer.sendFrame().synReply(false, 3, headerEntries("a", "android"));
     for (int i = 0; i < 3; i++) {
       // Send frames of summing to size 50, which is windowUpdateThreshold.
-      peer.sendFrame().data(false, 3, data(24));
-      peer.sendFrame().data(false, 3, data(25));
-      peer.sendFrame().data(false, 3, data(1));
+      peer.sendFrame().data(false, 3, data(24), 24);
+      peer.sendFrame().data(false, 3, data(25), 25);
+      peer.sendFrame().data(false, 3, data(1), 1);
       peer.acceptFrame(); // connection WINDOW UPDATE
       peer.acceptFrame(); // stream WINDOW UPDATE
     }
-    peer.sendFrame().data(true, 3, data(0));
+    peer.sendFrame().data(true, 3, data(0), 0);
     peer.play();
 
     // Play it back.
@@ -268,7 +268,7 @@ public final class Http2ConnectionTest {
     // Write the mocking script.
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().synReply(false, 3, headerEntries("a", "android"));
-    peer.sendFrame().data(true, 3, data(0));
+    peer.sendFrame().data(true, 3, data(0), 0);
     peer.play();
 
     // Play it back.
@@ -308,7 +308,7 @@ public final class Http2ConnectionTest {
   @Test public void maxFrameSizeHonored() throws Exception {
     peer.setVariantAndClient(HTTP_2, false);
 
-    byte[] buff = new byte[HTTP_2.maxFrameSize() + 1];
+    byte[] buff = new byte[peer.maxOutboundDataLength() + 1];
     Arrays.fill(buff, (byte) '*');
 
     // write the mocking script
@@ -329,7 +329,7 @@ public final class Http2ConnectionTest {
     MockSpdyPeer.InFrame synStream = peer.takeFrame();
     assertEquals(TYPE_HEADERS, synStream.type);
     MockSpdyPeer.InFrame data = peer.takeFrame();
-    assertEquals(HTTP_2.maxFrameSize(), data.data.length);
+    assertEquals(peer.maxOutboundDataLength(), data.data.length);
     data = peer.takeFrame();
     assertEquals(1, data.data.length);
   }
@@ -351,7 +351,7 @@ public final class Http2ConnectionTest {
         new Header(Header.RESPONSE_STATUS, "200")
     );
     peer.sendFrame().synReply(true, 2, expectedResponseHeaders);
-    peer.sendFrame().data(true, 3, data(0));
+    peer.sendFrame().data(true, 3, data(0), 0);
     peer.play();
 
     RecordingPushObserver observer = new RecordingPushObserver();

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -63,6 +63,11 @@ public final class MockSpdyPeer implements Closeable {
     frameCount++;
   }
 
+  /** Maximum length of an outbound data frame. */
+  public int maxOutboundDataLength() {
+    return frameWriter.maxDataLength();
+  }
+
   /** Count of frames sent or received. */
   public int frameCount() {
     return frameCount;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/FrameWriter.java
@@ -54,15 +54,18 @@ public interface FrameWriter extends Closeable {
   void headers(int streamId, List<Header> headerBlock) throws IOException;
   void rstStream(int streamId, ErrorCode errorCode) throws IOException;
 
+  /** The maximum size of bytes that may be sent in a single call to {@link #data}. */
+  int maxDataLength();
+
   /**
-   * {@code data.length} may be longer than the max length of the variant's data frame.
+   * {@code source.length} may be longer than the max length of the variant's data frame.
    * Implementations must send multiple frames as necessary.
    *
    * @param source the buffer to draw bytes from. May be null if byteCount is 0.
+   * @param byteCount must be between 0 and the minimum of {code source.length}
+   * and {@link #maxDataLength}.
    */
   void data(boolean outFinished, int streamId, Buffer source, int byteCount) throws IOException;
-
-  void data(boolean outFinished, int streamId, Buffer source) throws IOException;
 
   /** Write okhttp's settings to the peer. */
   void settings(Settings okHttpSettings) throws IOException;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft13.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft13.java
@@ -15,18 +15,17 @@
  */
 package com.squareup.okhttp.internal.spdy;
 
+import com.squareup.okhttp.Protocol;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
-
-import com.squareup.okhttp.Protocol;
-
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.ByteString;
 import okio.Source;
 import okio.Timeout;
+
 import static com.squareup.okhttp.internal.spdy.Http20Draft13.FrameLogger.formatHeader;
 import static java.lang.String.format;
 import static java.util.logging.Level.FINE;
@@ -79,10 +78,6 @@ public final class Http20Draft13 implements Variant {
 
   @Override public FrameWriter newWriter(BufferedSink sink, boolean client) {
     return new Writer(sink, client);
-  }
-
-  @Override public int maxFrameSize() {
-    return MAX_FRAME_SIZE;
   }
 
   static final class Reader implements FrameReader {
@@ -461,9 +456,8 @@ public final class Http20Draft13 implements Variant {
       sink.flush();
     }
 
-    @Override public synchronized void data(boolean outFinished, int streamId, Buffer source)
-        throws IOException {
-      data(outFinished, streamId, source, (int) source.size());
+    @Override public int maxDataLength() {
+      return MAX_FRAME_SIZE;
     }
 
     @Override public synchronized void data(boolean outFinished, int streamId, Buffer source,

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Spdy3.java
@@ -103,10 +103,6 @@ public final class Spdy3 implements Variant {
     return new Writer(sink, client);
   }
 
-  @Override public int maxFrameSize() {
-    return 16383;
-  }
-
   /** Read spdy/3 frames. */
   static final class Reader implements FrameReader {
     private final BufferedSource source;
@@ -386,9 +382,8 @@ public final class Spdy3 implements Variant {
       sink.flush();
     }
 
-    @Override public synchronized void data(boolean outFinished, int streamId, Buffer source)
-        throws IOException {
-      data(outFinished, streamId, source, (int) source.size());
+    @Override public int maxDataLength() {
+      return 16383;
     }
 
     @Override public synchronized void data(boolean outFinished, int streamId, Buffer source,

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
@@ -34,6 +34,4 @@ public interface Variant {
    * @param client true if this is the HTTP client's writer, writing frames to a server.
    */
   FrameWriter newWriter(BufferedSink sink, boolean client);
-
-  int maxFrameSize();
 }


### PR DESCRIPTION
Starting in [http/2 draft 14](https://tools.ietf.org/html/draft-ietf-httpbis-http2-14), the max data length constraint is variable. This exposed a small problem in our SPDY implementation, where we assume that the frame length for reads is the same as writes.

In preparation for #1046, this moves the frame length constraint we expose to the writer, which is the context in which it is used.

This also removes an internal method to write a buffer as a data frame by inspecting its length. Since this method was only used in tests, I removed it.
