### PR TITLE
OkHttpClient.cancel(tag) doesn't cancel in-flight synchronous requests.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -1172,6 +1172,33 @@ public final class CallTest {
     assertEquals(1, server.getRequestCount());
   }
 
+  @Test public void cancelInFlightBeforeResponseReadThrowsIOE() throws Exception {
+    server.setDispatcher(new Dispatcher() {
+      @Override public MockResponse dispatch(RecordedRequest request) {
+        client.cancel("request");
+        return new MockResponse().setBody("A");
+      }
+    });
+    server.play();
+
+    Request request = new Request.Builder().url(server.getUrl("/a")).tag("request").build();
+    try {
+      client.newCall(request).execute();
+      fail();
+    } catch (IOException e) {
+    }
+  }
+
+  @Test public void cancelInFlightBeforeResponseReadThrowsIOE_HTTP_2() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+    cancelInFlightBeforeResponseReadThrowsIOE();
+  }
+
+  @Test public void cancelInFlightBeforeResponseReadThrowsIOE_SPDY_3() throws Exception {
+    enableProtocol(Protocol.SPDY_3);
+    cancelInFlightBeforeResponseReadThrowsIOE();
+  }
+
   /**
    * This test puts a request in front of one that is to be canceled, so that it is canceled before
    * I/O takes place.

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -77,10 +77,20 @@ public class Call {
       if (executed) throw new IllegalStateException("Already Executed");
       executed = true;
     }
-    Response result = getResponse();
-    engine.releaseConnection(); // Transfer ownership of the body to the caller.
-    if (result == null) throw new IOException("Canceled");
-    return result;
+    try {
+      client.getDispatcher().executed(this);
+      Response result = getResponse();
+      System.out.println("releasing");
+      engine.releaseConnection(); // Transfer ownership of the body to the caller.
+      if (result == null) throw new IOException("Canceled");
+      return result;
+    } finally {
+      client.getDispatcher().finished(this);
+    }
+  }
+
+  Object tag() {
+    return request.tag();
   }
 
   /**

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -467,8 +467,8 @@ public class OkHttpClient implements Cloneable {
   }
 
   /**
-   * Cancels all scheduled tasks tagged with {@code tag}. Requests that are already
-   * complete cannot be canceled.
+   * Cancels all scheduled or in-flight calls tagged with {@code tag}. Requests
+   * that are already complete cannot be canceled.
    */
   public OkHttpClient cancel(Object tag) {
     getDispatcher().cancel(tag);


### PR DESCRIPTION
Fixes gap where synchronous requests weren't canceled.
