### PR TITLE
Provide a way to prohibit cleartext traffic from an OkHttpClient.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -123,6 +123,7 @@ public class OkHttpClient implements Cloneable {
   private SocketFactory socketFactory;
   private SSLSocketFactory sslSocketFactory;
   private HostnameVerifier hostnameVerifier;
+  private boolean cleartextConnectionsPermitted = true;
   private Authenticator authenticator;
   private ConnectionPool connectionPool;
   private HostResolver hostResolver;
@@ -149,6 +150,7 @@ public class OkHttpClient implements Cloneable {
     this.socketFactory = okHttpClient.getSocketFactory();
     this.sslSocketFactory = okHttpClient.getSslSocketFactory();
     this.hostnameVerifier = okHttpClient.getHostnameVerifier();
+    this.cleartextConnectionsPermitted = okHttpClient.getCleartextConnectionsPermitted();
     this.authenticator = okHttpClient.getAuthenticator();
     this.connectionPool = okHttpClient.getConnectionPool();
     this.followSslRedirects = okHttpClient.getFollowSslRedirects();
@@ -323,6 +325,18 @@ public class OkHttpClient implements Cloneable {
 
   public final HostnameVerifier getHostnameVerifier() {
     return hostnameVerifier;
+  }
+
+  /**
+   * Sets whether cleartext traffic is permitted.
+   */
+  public final OkHttpClient setCleartextConnectionsPermitted(boolean permitted) {
+    this.cleartextConnectionsPermitted = permitted;
+    return this;
+  }
+
+  public final boolean getCleartextConnectionsPermitted() {
+    return cleartextConnectionsPermitted;
   }
 
   /**

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -209,6 +209,15 @@ public final class HttpEngine {
   public void sendRequest() throws IOException {
     if (cacheStrategy != null) return; // Already sent.
     if (transport != null) throw new IllegalStateException();
+    if ((!userRequest.isHttps()) && (!client.getCleartextConnectionsPermitted())) {
+      // This request is prohibited by HttpClient's settings.
+      // Include the scheme/protocol and host:port in the exception message to help identity
+      // what's responsible for this prohibited request, but do not leak other parts of the URL
+      // because they could contain sensitive information.
+      throw new SecurityException(
+          "Cleartext traffic not permitted: " + userRequest.url().getProtocol()
+              + " to " + hostHeader(userRequest.url()));
+    }
 
     Request request = networkRequest(userRequest);
 


### PR DESCRIPTION
More and more applications are avoiding cleartext HTTP and using HTTPS
for all of their traffic. Such apps will benefit from configuring
their OkHttpClient instances to prohibit cleartext traffic. As a
result, a regression (to using cleartext HTTP) in the app will not
lead to sensitive data being transmitted in cleartext.

Fixes #1058
