### PR TITLE
Clean up HostResolver.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
@@ -19,7 +19,7 @@ import com.squareup.okhttp.Address;
 import com.squareup.okhttp.Authenticator;
 import com.squareup.okhttp.Connection;
 import com.squareup.okhttp.ConnectionPool;
-import com.squareup.okhttp.HostResolver;
+import com.squareup.okhttp.internal.Network;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
@@ -89,8 +89,9 @@ public final class RouteSelectorTest {
         .setSslSocketFactory(sslSocketFactory)
         .setHostnameVerifier(hostnameVerifier)
         .setProtocols(protocols)
-        .setConnectionPool(ConnectionPool.getDefault())
-        .setHostResolver(dns);
+        .setConnectionPool(ConnectionPool.getDefault());
+    Internal.instance.setNetwork(client, dns);
+
     routeDatabase = Internal.instance.routeDatabase(client);
 
     httpRequest = new Request.Builder()
@@ -421,11 +422,11 @@ public final class RouteSelectorTest {
     }
   }
 
-  private static class FakeDns implements HostResolver {
+  private static class FakeDns implements Network {
     List<String> requestedHosts = new ArrayList<>();
     InetAddress[] inetAddresses;
 
-    @Override public InetAddress[] getAllByName(String host) throws UnknownHostException {
+    @Override public InetAddress[] resolveInetAddresses(String host) throws UnknownHostException {
       requestedHosts.add(host);
       if (inetAddresses == null) throw new UnknownHostException();
       return inetAddresses;

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -17,6 +17,7 @@ package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.InternalCache;
+import com.squareup.okhttp.internal.Network;
 import com.squareup.okhttp.internal.RouteDatabase;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.AuthenticatorAdapter;
@@ -99,6 +100,14 @@ public class OkHttpClient implements Cloneable {
         return client.routeDatabase();
       }
 
+      @Override public Network network(OkHttpClient client) {
+        return client.network;
+      }
+
+      @Override public void setNetwork(OkHttpClient client, Network network) {
+        client.network = network;
+      }
+
       @Override public void connectAndSetOwner(OkHttpClient client, Connection connection,
           HttpEngine owner, Request request) throws IOException {
         connection.connectAndSetOwner(client, owner, request);
@@ -125,7 +134,7 @@ public class OkHttpClient implements Cloneable {
   private HostnameVerifier hostnameVerifier;
   private Authenticator authenticator;
   private ConnectionPool connectionPool;
-  private HostResolver hostResolver;
+  private Network network;
   private boolean followSslRedirects = true;
   private boolean followRedirects = true;
   private int connectTimeout;
@@ -446,19 +455,6 @@ public class OkHttpClient implements Cloneable {
     return protocols;
   }
 
-  /*
-   * Sets the {@code HostResolver} that will be used by this client to resolve
-   * hostnames to IP addresses.
-   */
-  public OkHttpClient setHostResolver(HostResolver hostResolver) {
-    this.hostResolver = hostResolver;
-    return this;
-  }
-
-  public HostResolver getHostResolver() {
-    return hostResolver;
-  }
-
   /**
    * Prepares the {@code request} to be executed at some point in the future.
    */
@@ -505,8 +501,8 @@ public class OkHttpClient implements Cloneable {
     if (result.protocols == null) {
       result.protocols = Util.immutableList(Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1);
     }
-    if (result.hostResolver == null) {
-      result.hostResolver = HostResolver.DEFAULT;
+    if (result.network == null) {
+      result.network = Network.DEFAULT;
     }
     return result;
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
@@ -58,6 +58,10 @@ public abstract class Internal {
 
   public abstract RouteDatabase routeDatabase(OkHttpClient client);
 
+  public abstract Network network(OkHttpClient client);
+
+  public abstract void setNetwork(OkHttpClient client, Network network);
+
   public abstract void connectAndSetOwner(OkHttpClient client, Connection connection,
       HttpEngine owner, Request request) throws IOException;
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Network.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Network.java
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.okhttp;
+package com.squareup.okhttp.internal;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 /**
- * Domain name service. Prefer this over {@link InetAddress#getAllByName} to
- * make code more testable.
+ * Services specific to the host device's network interface. Prefer this over {@link
+ * InetAddress#getAllByName} to make code more testable.
  */
-public interface HostResolver {
-  HostResolver DEFAULT = new HostResolver() {
-    @Override public InetAddress[] getAllByName(String host) throws UnknownHostException {
+public interface Network {
+  Network DEFAULT = new Network() {
+    @Override public InetAddress[] resolveInetAddresses(String host) throws UnknownHostException {
       if (host == null) throw new UnknownHostException("host == null");
       return InetAddress.getAllByName(host);
     }
   };
 
-  InetAddress[] getAllByName(String host) throws UnknownHostException;
+  InetAddress[] resolveInetAddresses(String host) throws UnknownHostException;
 }


### PR DESCRIPTION
Hide the interface and rename it to Network. We may make this a public
interface later, particularly in order to track more capable network
APIs in Android L. For now, we want a hidden interface with a general
purpose name.

Closes https://github.com/square/okhttp/issues/1062
