### PR TITLE
Extend the keep-alive time for the SPDY push executor.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -85,7 +85,7 @@ public final class Connection {
       "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",        // 0x00,0x33  Android 2.3
       "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",        // 0x00,0x32  Android 2.3
       "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",        // 0x00,0x39  Android 2.3
-      "TLS_RSA_WITH_AES_128_GCM_SHA256",         // 0x00,0x9C
+      "TLS_RSA_WITH_AES_128_GCM_SHA256",         // 0x00,0x9C  Android L
       "TLS_RSA_WITH_AES_128_CBC_SHA",            // 0x00,0x2F  Android 2.3
       "TLS_RSA_WITH_AES_256_CBC_SHA",            // 0x00,0x35  Android 2.3
       "SSL_RSA_WITH_3DES_EDE_CBC_SHA",           // 0x00,0x0A  Android 2.3  (Deprecated in L)

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -153,8 +153,7 @@ public final class SpdyConnection implements Closeable {
     if (protocol == Protocol.HTTP_2) {
       variant = new Http20Draft14();
       // Like newSingleThreadExecutor, except lazy creates the thread.
-      pushExecutor = new ThreadPoolExecutor(0, 1,
-          0L, TimeUnit.MILLISECONDS,
+      pushExecutor = new ThreadPoolExecutor(0, 1, 60, TimeUnit.SECONDS,
           new LinkedBlockingQueue<Runnable>(),
           Util.threadFactory(String.format("OkHttp %s Push Observer", hostName), true));
       // 1 less than SPDY http://tools.ietf.org/html/draft-ietf-httpbis-http2-14#section-6.9.2


### PR DESCRIPTION
Closes https://github.com/square/okhttp/issues/1034
