### PR TITLE
Revise how TLS connections are negotiated.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/internal/spdy/SpdyServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/internal/spdy/SpdyServer.java
@@ -67,7 +67,7 @@ public final class SpdyServer implements IncomingStreamHandler {
         (SSLSocket) sslSocketFactory.createSocket(socket, socket.getInetAddress().getHostAddress(),
             socket.getPort(), true);
     sslSocket.setUseClientMode(false);
-    Platform.get().setProtocols(sslSocket, spdyProtocols);
+    Platform.get().configureTlsExtensions(sslSocket, null, spdyProtocols);
     sslSocket.startHandshake();
     String protocolString = Platform.get().getSelectedProtocol(sslSocket);
     protocol = protocolString != null ? Protocol.get(protocolString) : null;

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -369,7 +369,7 @@ public final class MockWebServer {
           openClientSockets.put(socket, true);
 
           if (protocolNegotiationEnabled) {
-            Platform.get().setProtocols(sslSocket, protocols);
+            Platform.get().configureTlsExtensions(sslSocket, null, protocols);
           }
 
           sslSocket.startHandshake();

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
@@ -31,7 +31,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.squareup.okhttp.internal.http.RouteSelector.TLS_V1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -88,8 +87,10 @@ public final class ConnectionPoolTest {
     spdySocketAddress = new InetSocketAddress(InetAddress.getByName(spdyServer.getHostName()),
         spdyServer.getPort());
 
-    Route httpRoute = new Route(httpAddress, Proxy.NO_PROXY, httpSocketAddress, TLS_V1);
-    Route spdyRoute = new Route(spdyAddress, Proxy.NO_PROXY, spdySocketAddress, TLS_V1);
+    Route httpRoute = new Route(httpAddress, Proxy.NO_PROXY, httpSocketAddress,
+        TlsConfiguration.PREFERRED);
+    Route spdyRoute = new Route(spdyAddress, Proxy.NO_PROXY, spdySocketAddress,
+        TlsConfiguration.PREFERRED);
     pool = new ConnectionPool(poolSize, KEEP_ALIVE_DURATION_MS);
     httpA = new Connection(pool, httpRoute);
     httpA.connect(200, 200, 200, null);
@@ -134,8 +135,8 @@ public final class ConnectionPoolTest {
     Connection connection = pool.get(httpAddress);
     assertNull(connection);
 
-    connection = new Connection(
-        pool, new Route(httpAddress, Proxy.NO_PROXY, httpSocketAddress, TLS_V1));
+    connection = new Connection(pool, new Route(httpAddress, Proxy.NO_PROXY, httpSocketAddress,
+        TlsConfiguration.PREFERRED));
     connection.connect(200, 200, 200, null);
     connection.setOwner(owner);
     assertEquals(0, pool.getConnectionCount());

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
@@ -17,12 +17,12 @@ package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.Address;
 import com.squareup.okhttp.Authenticator;
-import com.squareup.okhttp.CertificatePinner;
 import com.squareup.okhttp.Connection;
 import com.squareup.okhttp.ConnectionPool;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.TlsConfiguration;
 import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.Network;
 import com.squareup.okhttp.internal.RouteDatabase;
@@ -45,8 +45,6 @@ import javax.net.ssl.SSLSocketFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.squareup.okhttp.internal.http.RouteSelector.SSL_V3;
-import static com.squareup.okhttp.internal.http.RouteSelector.TLS_V1;
 import static java.net.Proxy.NO_PROXY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -110,7 +108,7 @@ public final class RouteSelectorTest {
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, SSL_V3);
+        uriPort, TlsConfiguration.FALLBACK);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
@@ -131,7 +129,7 @@ public final class RouteSelectorTest {
     routeDatabase.failed(connection.getRoute());
     routeSelector = RouteSelector.get(httpRequest, client);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, SSL_V3);
+        uriPort, TlsConfiguration.FALLBACK);
     assertFalse(routeSelector.hasNext());
     try {
       routeSelector.nextUnconnected();
@@ -149,9 +147,9 @@ public final class RouteSelectorTest {
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
     assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
-        proxyAPort, SSL_V3);
+        proxyAPort, TlsConfiguration.FALLBACK);
     assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[1],
-        proxyAPort, SSL_V3);
+        proxyAPort, TlsConfiguration.FALLBACK);
 
     assertFalse(routeSelector.hasNext());
     dns.assertRequests(proxyAHost);
@@ -167,9 +165,9 @@ public final class RouteSelectorTest {
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, SSL_V3);
+        uriPort, TlsConfiguration.FALLBACK);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[1],
-        uriPort, SSL_V3);
+        uriPort, TlsConfiguration.FALLBACK);
 
     assertFalse(routeSelector.hasNext());
     dns.assertRequests(uriHost);
@@ -186,7 +184,7 @@ public final class RouteSelectorTest {
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, SSL_V3);
+        uriPort, TlsConfiguration.FALLBACK);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
@@ -199,9 +197,9 @@ public final class RouteSelectorTest {
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, SSL_V3);
+        uriPort, TlsConfiguration.FALLBACK);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[1],
-        uriPort, SSL_V3);
+        uriPort, TlsConfiguration.FALLBACK);
 
     assertFalse(routeSelector.hasNext());
     dns.assertRequests(uriHost);
@@ -220,23 +218,23 @@ public final class RouteSelectorTest {
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
     assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0], proxyAPort,
-        SSL_V3);
+        TlsConfiguration.FALLBACK);
     assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[1], proxyAPort,
-        SSL_V3);
+        TlsConfiguration.FALLBACK);
     dns.assertRequests(proxyAHost);
 
     // Next try the IP address of the second proxy.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(254, 1);
     assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[0], proxyBPort,
-        SSL_V3);
+        TlsConfiguration.FALLBACK);
     dns.assertRequests(proxyBHost);
 
     // Finally try the only IP address of the origin server.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(253, 1);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0], uriPort,
-        SSL_V3);
+        TlsConfiguration.FALLBACK);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
@@ -253,7 +251,7 @@ public final class RouteSelectorTest {
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0], uriPort,
-        SSL_V3);
+        TlsConfiguration.FALLBACK);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
@@ -270,8 +268,8 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0], proxyAPort,
-        SSL_V3);
+    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
+        proxyAPort, TlsConfiguration.FALLBACK);
     dns.assertRequests(proxyAHost);
 
     assertTrue(routeSelector.hasNext());
@@ -285,14 +283,14 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0], proxyAPort,
-        SSL_V3);
+    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
+        proxyAPort, TlsConfiguration.FALLBACK);
     dns.assertRequests(proxyAHost);
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(254, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0], uriPort,
-        SSL_V3);
+    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
+        uriPort, TlsConfiguration.FALLBACK);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
@@ -306,7 +304,7 @@ public final class RouteSelectorTest {
     dns.inetAddresses = makeFakeAddresses(255, 1);
     Connection connection = routeSelector.nextUnconnected();
     routeSelector.connectFailed(connection, new IOException("Non SSL exception"));
-    assertTrue(routeDatabase.failedRoutesCount() == 2);
+    assertEquals(RouteSelector.TLS_CONFIGURATIONS.size(), routeDatabase.failedRoutesCount());
     assertFalse(routeSelector.hasNext());
   }
 
@@ -331,38 +329,38 @@ public final class RouteSelectorTest {
     // Proxy A
     dns.inetAddresses = makeFakeAddresses(255, 2);
     assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
-        proxyAPort, TLS_V1);
+        proxyAPort, TlsConfiguration.PREFERRED);
     dns.assertRequests(proxyAHost);
     assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
-        proxyAPort, SSL_V3);
+        proxyAPort, TlsConfiguration.FALLBACK);
     assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[1],
-        proxyAPort, TLS_V1);
+        proxyAPort, TlsConfiguration.PREFERRED);
     assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[1],
-        proxyAPort, SSL_V3);
+        proxyAPort, TlsConfiguration.FALLBACK);
 
     // Proxy B
     dns.inetAddresses = makeFakeAddresses(254, 2);
     assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[0],
-        proxyBPort, TLS_V1);
+        proxyBPort, TlsConfiguration.PREFERRED);
     dns.assertRequests(proxyBHost);
     assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[0],
-        proxyBPort, SSL_V3);
+        proxyBPort, TlsConfiguration.FALLBACK);
     assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[1],
-        proxyBPort, TLS_V1);
+        proxyBPort, TlsConfiguration.PREFERRED);
     assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[1],
-        proxyBPort, SSL_V3);
+        proxyBPort, TlsConfiguration.FALLBACK);
 
     // Origin
     dns.inetAddresses = makeFakeAddresses(253, 2);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, TLS_V1);
+        uriPort, TlsConfiguration.PREFERRED);
     dns.assertRequests(uriHost);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, SSL_V3);
+        uriPort, TlsConfiguration.FALLBACK);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[1],
-        uriPort, TLS_V1);
+        uriPort, TlsConfiguration.PREFERRED);
     assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[1],
-        uriPort, SSL_V3);
+        uriPort, TlsConfiguration.FALLBACK);
 
     assertFalse(routeSelector.hasNext());
   }
@@ -397,12 +395,12 @@ public final class RouteSelectorTest {
   }
 
   private void assertConnection(Connection connection, Address address, Proxy proxy,
-      InetAddress socketAddress, int socketPort, String tlsVersion) {
+      InetAddress socketAddress, int socketPort, TlsConfiguration tlsConfiguration) {
     assertEquals(address, connection.getRoute().getAddress());
     assertEquals(proxy, connection.getRoute().getProxy());
     assertEquals(socketAddress, connection.getRoute().getSocketAddress().getAddress());
     assertEquals(socketPort, connection.getRoute().getSocketAddress().getPort());
-    assertEquals(tlsVersion, connection.getRoute().getTlsVersion());
+    assertEquals(tlsConfiguration, connection.getRoute().getTlsConfiguration());
   }
 
   /** Returns an address that's without an SSL socket factory or hostname verifier. */

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -17,7 +17,6 @@
 package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.Platform;
-import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HttpConnection;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.HttpTransport;
@@ -29,14 +28,10 @@ import java.io.IOException;
 import java.net.Proxy;
 import java.net.Socket;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLSocket;
 
 import static com.squareup.okhttp.internal.Util.getDefaultPort;
 import static com.squareup.okhttp.internal.Util.getEffectivePort;
-import static com.squareup.okhttp.internal.Util.immutableList;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
 
@@ -67,39 +62,6 @@ import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
  * should the attempt fail.
  */
 public final class Connection {
-  /**
-   * This is a subset of the cipher suites supported in Chrome 37, current as of 2014-10-5. All of
-   * these suites are available on Android L; earlier releases support a subset of these suites.
-   * https://github.com/square/okhttp/issues/330
-   */
-  private static final List<String> CIPHER_SUITES = immutableList(
-      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", // 0xC0,0x2B  Android L
-      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",   // 0xC0,0x2F  Android L
-      "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",     // 0x00,0x9E  Android L
-      "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",    // 0xC0,0x0A  Android 4.0
-      "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",    // 0xC0,0x09  Android 4.0
-      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",      // 0xC0,0x13  Android 4.0
-      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",      // 0xC0,0x14  Android 4.0
-      "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",        // 0xC0,0x07  Android 4.0
-      "TLS_ECDHE_RSA_WITH_RC4_128_SHA",          // 0xC0,0x11  Android 4.0
-      "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",        // 0x00,0x33  Android 2.3
-      "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",        // 0x00,0x32  Android 2.3
-      "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",        // 0x00,0x39  Android 2.3
-      "TLS_RSA_WITH_AES_128_GCM_SHA256",         // 0x00,0x9C  Android L
-      "TLS_RSA_WITH_AES_128_CBC_SHA",            // 0x00,0x2F  Android 2.3
-      "TLS_RSA_WITH_AES_256_CBC_SHA",            // 0x00,0x35  Android 2.3
-      "SSL_RSA_WITH_3DES_EDE_CBC_SHA",           // 0x00,0x0A  Android 2.3  (Deprecated in L)
-      "SSL_RSA_WITH_RC4_128_SHA",                // 0x00,0x05  Android 2.3
-      "SSL_RSA_WITH_RC4_128_MD5"                 // 0x00,0x04  Android 2.3  (Deprecated in L)
-  );
-
-  /**
-   * Cache of the intersection between {@link #CIPHER_SUITES} and the platform's supported suites.
-   * It's possible that the platform hosts multiple implementations of {@link SSLSocket}, in which
-   * case this cache will be incorrect.
-   */
-  private static final AtomicReference<String[]> SELECTED_CIPHER_SUITES = new AtomicReference<>();
-
   private final ConnectionPool pool;
   private final Route route;
 
@@ -265,13 +227,9 @@ public final class Connection {
     socket = route.address.sslSocketFactory
         .createSocket(socket, route.address.uriHost, route.address.uriPort, true /* autoClose */);
     SSLSocket sslSocket = (SSLSocket) socket;
-    sslSocket.setEnabledCipherSuites(cipherSuites(sslSocket));
-    platform.configureTls(sslSocket, route.address.uriHost, route.tlsVersion);
 
-    boolean useNpn = route.supportsNpn();
-    if (useNpn) {
-      platform.setProtocols(sslSocket, route.address.protocols);
-    }
+    // Configure the socket's ciphers, TLS versions, and extensions.
+    route.tlsConfiguration.apply(sslSocket, route);
 
     // Force handshake. This can throw!
     sslSocket.startHandshake();
@@ -288,7 +246,8 @@ public final class Connection {
     handshake = Handshake.get(sslSocket.getSession());
 
     String maybeProtocol;
-    if (useNpn && (maybeProtocol = platform.getSelectedProtocol(sslSocket)) != null) {
+    if (route.tlsConfiguration.supportsTlsExtensions()
+        && (maybeProtocol = platform.getSelectedProtocol(sslSocket)) != null) {
       protocol = Protocol.get(maybeProtocol); // Throws IOE on unknown.
     }
 
@@ -300,17 +259,6 @@ public final class Connection {
     } else {
       httpConnection = new HttpConnection(pool, this, socket);
     }
-  }
-
-  private String[] cipherSuites(SSLSocket sslSocket) {
-    String[] result = SELECTED_CIPHER_SUITES.get();
-    if (result == null) {
-      List<String> intersection = Util.intersect(CIPHER_SUITES,
-          Arrays.asList(sslSocket.getSupportedCipherSuites()));
-      result = intersection.toArray(new String[intersection.size()]);
-      SELECTED_CIPHER_SUITES.set(result);
-    }
-    return result;
   }
 
   /** Returns true if {@link #connect} has been attempted on this connection. */

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -148,25 +148,26 @@ public class OkHttpClient implements Cloneable {
   }
 
   private OkHttpClient(OkHttpClient okHttpClient) {
-    this.routeDatabase = okHttpClient.routeDatabase();
-    this.dispatcher = okHttpClient.getDispatcher();
-    this.proxy = okHttpClient.getProxy();
-    this.protocols = okHttpClient.getProtocols();
-    this.proxySelector = okHttpClient.getProxySelector();
-    this.cookieHandler = okHttpClient.getCookieHandler();
-    this.cache = okHttpClient.getCache();
+    this.routeDatabase = okHttpClient.routeDatabase;
+    this.dispatcher = okHttpClient.dispatcher;
+    this.proxy = okHttpClient.proxy;
+    this.protocols = okHttpClient.protocols;
+    this.proxySelector = okHttpClient.proxySelector;
+    this.cookieHandler = okHttpClient.cookieHandler;
+    this.cache = okHttpClient.cache;
     this.internalCache = cache != null ? cache.internalCache : okHttpClient.internalCache;
-    this.socketFactory = okHttpClient.getSocketFactory();
-    this.sslSocketFactory = okHttpClient.getSslSocketFactory();
-    this.hostnameVerifier = okHttpClient.getHostnameVerifier();
-    this.certificatePinner = okHttpClient.getCertificatePinner();
-    this.authenticator = okHttpClient.getAuthenticator();
-    this.connectionPool = okHttpClient.getConnectionPool();
-    this.followSslRedirects = okHttpClient.getFollowSslRedirects();
-    this.followRedirects = okHttpClient.getFollowRedirects();
-    this.connectTimeout = okHttpClient.getConnectTimeout();
-    this.readTimeout = okHttpClient.getReadTimeout();
-    this.writeTimeout = okHttpClient.getWriteTimeout();
+    this.socketFactory = okHttpClient.socketFactory;
+    this.sslSocketFactory = okHttpClient.sslSocketFactory;
+    this.hostnameVerifier = okHttpClient.hostnameVerifier;
+    this.certificatePinner = okHttpClient.certificatePinner;
+    this.authenticator = okHttpClient.authenticator;
+    this.connectionPool = okHttpClient.connectionPool;
+    this.network = okHttpClient.network;
+    this.followSslRedirects = okHttpClient.followSslRedirects;
+    this.followRedirects = okHttpClient.followRedirects;
+    this.connectTimeout = okHttpClient.connectTimeout;
+    this.readTimeout = okHttpClient.readTimeout;
+    this.writeTimeout = okHttpClient.writeTimeout;
   }
 
   /**

--- a/okhttp/src/main/java/com/squareup/okhttp/TlsConfiguration.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/TlsConfiguration.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import com.squareup.okhttp.internal.Platform;
+import com.squareup.okhttp.internal.Util;
+import java.util.Arrays;
+import java.util.List;
+import javax.net.ssl.SSLSocket;
+
+/**
+ * The TLS version and ciphers used to negotiate a secure connection. */
+public final class TlsConfiguration {
+  /**
+   * This is a subset of the cipher suites supported in Chrome 37, current as of 2014-10-5. All of
+   * these suites are available on Android L; earlier releases support a subset of these suites.
+   * https://github.com/square/okhttp/issues/330
+   */
+  private static final String[] CIPHER_SUITES = new String[] {
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", // 0xC0,0x2B  Android L
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",   // 0xC0,0x2F  Android L
+      "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",     // 0x00,0x9E  Android L
+      "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",    // 0xC0,0x0A  Android 4.0
+      "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",    // 0xC0,0x09  Android 4.0
+      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",      // 0xC0,0x13  Android 4.0
+      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",      // 0xC0,0x14  Android 4.0
+      "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",        // 0xC0,0x07  Android 4.0
+      "TLS_ECDHE_RSA_WITH_RC4_128_SHA",          // 0xC0,0x11  Android 4.0
+      "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",        // 0x00,0x33  Android 2.3
+      "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",        // 0x00,0x32  Android 2.3
+      "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",        // 0x00,0x39  Android 2.3
+      "TLS_RSA_WITH_AES_128_GCM_SHA256",         // 0x00,0x9C  Android L
+      "TLS_RSA_WITH_AES_128_CBC_SHA",            // 0x00,0x2F  Android 2.3
+      "TLS_RSA_WITH_AES_256_CBC_SHA",            // 0x00,0x35  Android 2.3
+      "SSL_RSA_WITH_3DES_EDE_CBC_SHA",           // 0x00,0x0A  Android 2.3  (Deprecated in L)
+      "SSL_RSA_WITH_RC4_128_SHA",                // 0x00,0x05  Android 2.3
+      "SSL_RSA_WITH_RC4_128_MD5"                 // 0x00,0x04  Android 2.3  (Deprecated in L)
+  };
+
+  private static final String TLS_1_2 = "TLSv1.2"; // 2008.
+  private static final String TLS_1_1 = "TLSv1.1"; // 2006.
+  private static final String TLS_1_0 = "TLSv1";   // 1999.
+  private static final String SSL_3_0 = "SSLv3";   // 1996.
+
+  /** A modern TLS configuration with extensions like SNI and ALPN available. */
+  public static final TlsConfiguration PREFERRED = new TlsConfiguration(
+      CIPHER_SUITES, new String[] { TLS_1_2, TLS_1_1, TLS_1_0, SSL_3_0 }, true);
+
+  /** A backwards-compatible fallback configuration for interop with obsolete servers. */
+  public static final TlsConfiguration FALLBACK = new TlsConfiguration(
+      CIPHER_SUITES, new String[] { SSL_3_0 }, true);
+
+  private final String[] cipherSuites;
+  private final String[] tlsVersions;
+  private final boolean supportsTlsExtensions;
+
+  /**
+   * Caches the subset of this TLS configuration that's supported by the platform. It's possible
+   * that the platform hosts multiple implementations of {@link SSLSocket}, in which case this cache
+   * will be incorrect.
+   */
+  private TlsConfiguration supportedConfiguration;
+
+  private TlsConfiguration(String[] cipherSuites, String[] tlsVersions,
+      boolean supportsTlsExtensions) {
+    this.cipherSuites = cipherSuites;
+    this.tlsVersions = tlsVersions;
+    this.supportsTlsExtensions = supportsTlsExtensions;
+  }
+
+  public List<String> cipherSuites() {
+    return Util.immutableList(cipherSuites);
+  }
+
+  public List<String> tlsVersions() {
+    return Util.immutableList(tlsVersions);
+  }
+
+  public boolean supportsTlsExtensions() {
+    return supportsTlsExtensions;
+  }
+
+  /** Applies this configuration to {@code sslSocket} for {@code route}. */
+  public void apply(SSLSocket sslSocket, Route route) {
+    TlsConfiguration configurationToApply = supportedConfiguration;
+    if (configurationToApply == null) {
+      configurationToApply = supportedConfiguration(sslSocket);
+      supportedConfiguration = configurationToApply;
+    }
+
+    sslSocket.setEnabledProtocols(configurationToApply.tlsVersions);
+    sslSocket.setEnabledCipherSuites(configurationToApply.cipherSuites);
+
+    Platform platform = Platform.get();
+    if (configurationToApply.supportsTlsExtensions) {
+      platform.configureTlsExtensions(sslSocket, route.address.uriHost, route.address.protocols);
+    }
+  }
+
+  /**
+   * Returns a copy of this that omits cipher suites and TLS versions not
+   * supported by {@code sslSocket}.
+   */
+  private TlsConfiguration supportedConfiguration(SSLSocket sslSocket) {
+    List<String> supportedCipherSuites = Util.intersect(Arrays.asList(cipherSuites),
+        Arrays.asList(sslSocket.getSupportedCipherSuites()));
+    List<String> supportedTlsVersions = Util.intersect(Arrays.asList(tlsVersions),
+        Arrays.asList(sslSocket.getSupportedProtocols()));
+    return new TlsConfiguration(
+        supportedCipherSuites.toArray(new String[supportedCipherSuites.size()]),
+        supportedTlsVersions.toArray(new String[supportedTlsVersions.size()]),
+        supportsTlsExtensions);
+  }
+}


### PR DESCRIPTION
Now we explicitly enable TLSv1.2, TLSv1.1 and TLSv1.0 where they are supported.
We continue to perform only one fallback, to SSLv3.

In a follow-up we can make TLS configurations user-accessible, and allow the
application to limit which versions are used.
