### PR TITLE
Log uncaught IOExceptions instead of rethrowing them.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/TestLogHandler.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/TestLogHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+/**
+ * A log handler that records which log messages were published so that a calling test can make
+ * assertions about them.
+ */
+public final class TestLogHandler extends Handler {
+  private final List<String> logs = new ArrayList<>();
+
+  @Override public synchronized void publish(LogRecord logRecord) {
+    logs.add(logRecord.getLevel() + ": " + logRecord.getMessage());
+    notifyAll();
+  }
+
+  @Override public void flush() {
+  }
+
+  @Override public void close() throws SecurityException {
+  }
+
+  public synchronized String take() throws InterruptedException {
+    while (logs.isEmpty()) {
+      wait();
+    }
+    return logs.remove(0);
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -16,6 +16,7 @@
  */
 package com.squareup.okhttp.internal;
 
+import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
@@ -327,8 +328,8 @@ public class Platform {
         JettyNegoProvider provider =
             (JettyNegoProvider) Proxy.getInvocationHandler(getMethod.invoke(null, socket));
         if (!provider.unsupported && provider.selected == null) {
-          Logger logger = Logger.getLogger("com.squareup.okhttp.OkHttpClient");
-          logger.log(Level.INFO, "NPN/ALPN callback dropped: SPDY and HTTP/2 are disabled. "
+          Logger.getLogger(OkHttpClient.class.getName()).log(Level.INFO,
+              "NPN/ALPN callback dropped: SPDY and HTTP/2 are disabled. "
                   + "Is npn-boot or alpn-boot on the boot class path?");
           return null;
         }


### PR DESCRIPTION
The application layer can handle these with a try/catch block in their
onResponse method if desired.

This prevents a crash for applications that haven't deliberately configured
their uncaught exception handlers.

Closes https://github.com/square/okhttp/issues/1049
