### PR TITLE
Use one logger for all logging.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -48,7 +48,6 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Logger;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLProtocolException;
@@ -62,6 +61,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static com.squareup.okhttp.internal.Internal.logger;
 import static java.lang.Thread.UncaughtExceptionHandler;
 import static java.net.CookiePolicy.ACCEPT_ORIGINAL_SERVER;
 import static org.junit.Assert.assertEquals;
@@ -87,7 +87,7 @@ public final class CallTest {
     File cacheDir = new File(tmp, "HttpCache-" + UUID.randomUUID());
     cache = new Cache(cacheDir, Integer.MAX_VALUE);
     defaultUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
-    Logger.getLogger(OkHttpClient.class.getName()).addHandler(logHandler);
+    logger.addHandler(logHandler);
   }
 
   @After public void tearDown() throws Exception {
@@ -95,7 +95,7 @@ public final class CallTest {
     server2.shutdown();
     cache.delete();
     Thread.setDefaultUncaughtExceptionHandler(defaultUncaughtExceptionHandler);
-    Logger.getLogger(OkHttpClient.class.getName()).removeHandler(logHandler);
+    logger.removeHandler(logHandler);
   }
 
   @Test public void get() throws Exception {

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -26,10 +26,10 @@ import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import okio.BufferedSink;
 import okio.BufferedSource;
 
+import static com.squareup.okhttp.internal.Internal.logger;
 import static com.squareup.okhttp.internal.http.HttpEngine.MAX_REDIRECTS;
 
 /**
@@ -169,8 +169,7 @@ public class Call {
       } catch (IOException e) {
         if (signalledCallback) {
           // Do not signal the callback twice!
-          Logger.getLogger(OkHttpClient.class.getName())
-              .log(Level.INFO, "Callback failure for " + toLoggableString(), e);
+          logger.log(Level.INFO, "Callback failure for " + toLoggableString(), e);
         } else {
           responseCallback.onFailure(request, e);
         }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
@@ -24,6 +24,7 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.Transport;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 /**
  * Escalate internal APIs in {@code com.squareup.okhttp} so they can be used
@@ -31,6 +32,7 @@ import java.io.IOException;
  * interface is in {@link com.squareup.okhttp.OkHttpClient}.
  */
 public abstract class Internal {
+  public static final Logger logger = Logger.getLogger(OkHttpClient.class.getName());
   public static Internal instance;
 
   public abstract Transport newTransport(Connection connection, HttpEngine httpEngine)

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -16,7 +16,6 @@
  */
 package com.squareup.okhttp.internal;
 
-import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
@@ -32,9 +31,10 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.net.ssl.SSLSocket;
 import okio.Buffer;
+
+import static com.squareup.okhttp.internal.Internal.logger;
 
 /**
  * Access to Platform-specific features necessary for SPDY and advanced TLS.
@@ -328,9 +328,8 @@ public class Platform {
         JettyNegoProvider provider =
             (JettyNegoProvider) Proxy.getInvocationHandler(getMethod.invoke(null, socket));
         if (!provider.unsupported && provider.selected == null) {
-          Logger.getLogger(OkHttpClient.class.getName()).log(Level.INFO,
-              "NPN/ALPN callback dropped: SPDY and HTTP/2 are disabled. "
-                  + "Is npn-boot or alpn-boot on the boot class path?");
+          logger.log(Level.INFO, "NPN/ALPN callback dropped: SPDY and HTTP/2 are disabled. "
+              + "Is npn-boot or alpn-boot on the boot class path?");
           return null;
         }
         return provider.unsupported ? null : provider.selected;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft14.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft14.java
@@ -18,7 +18,6 @@ package com.squareup.okhttp.internal.spdy;
 import com.squareup.okhttp.Protocol;
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Logger;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
@@ -26,6 +25,7 @@ import okio.ByteString;
 import okio.Source;
 import okio.Timeout;
 
+import static com.squareup.okhttp.internal.Internal.logger;
 import static com.squareup.okhttp.internal.spdy.Http20Draft14.FrameLogger.formatHeader;
 import static java.lang.String.format;
 import static java.util.logging.Level.FINE;
@@ -40,8 +40,6 @@ import static okio.ByteString.EMPTY;
  * <p>http://tools.ietf.org/html/draft-ietf-httpbis-http2-14
  */
 public final class Http20Draft14 implements Variant {
-  private static final Logger logger = Logger.getLogger(Http20Draft14.class.getName());
-
   @Override public Protocol getProtocol() {
     return Protocol.HTTP_2;
   }


### PR DESCRIPTION
There was a concurrency problem in CallTest where multiple calls to
Logger.getLogger() didn't return the same instance, leading to failures
in the test.
