### PR TITLE
Change the cache to have non-shared semantics.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CacheTest.java
@@ -1216,40 +1216,8 @@ public final class CacheTest {
     assertEquals("", response.body().string());
   }
 
-  @Test public void authorizationRequestHeaderPreventsCaching() throws Exception {
+  @Test public void authorizationRequestFullyCached() throws Exception {
     server.enqueue(new MockResponse()
-        .addHeader("Last-Modified: " + formatDate(-2, TimeUnit.MINUTES))
-        .addHeader("Cache-Control: max-age=60")
-        .setBody("A"));
-    server.enqueue(new MockResponse()
-        .setBody("B"));
-
-    URL url = server.getUrl("/");
-    Request request = new Request.Builder()
-        .url(url)
-        .header("Authorization", "password")
-        .build();
-    Response response = client.newCall(request).execute();
-    assertEquals("A", response.body().string());
-    assertEquals("B", get(url).body().string());
-  }
-
-  @Test public void authorizationResponseCachedWithSMaxAge() throws Exception {
-    assertAuthorizationRequestFullyCached(
-        new MockResponse().addHeader("Cache-Control: s-maxage=60"));
-  }
-
-  @Test public void authorizationResponseCachedWithPublic() throws Exception {
-    assertAuthorizationRequestFullyCached(new MockResponse().addHeader("Cache-Control: public"));
-  }
-
-  @Test public void authorizationResponseCachedWithMustRevalidate() throws Exception {
-    assertAuthorizationRequestFullyCached(
-        new MockResponse().addHeader("Cache-Control: must-revalidate"));
-  }
-
-  public void assertAuthorizationRequestFullyCached(MockResponse mockResponse) throws Exception {
-    server.enqueue(mockResponse
         .addHeader("Cache-Control: max-age=60")
         .setBody("A"));
     server.enqueue(new MockResponse()

--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/UrlConnectionCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/UrlConnectionCacheTest.java
@@ -1098,36 +1098,8 @@ public final class UrlConnectionCacheTest {
     assertEquals("", readAscii(connection));
   }
 
-  @Test public void authorizationRequestHeaderPreventsCaching() throws Exception {
-    server.enqueue(
-        new MockResponse().addHeader("Last-Modified: " + formatDate(-2, TimeUnit.MINUTES))
-            .addHeader("Cache-Control: max-age=60")
-            .setBody("A"));
-    server.enqueue(new MockResponse().setBody("B"));
-
-    URL url = server.getUrl("/");
-    URLConnection connection = client.open(url);
-    connection.addRequestProperty("Authorization", "password");
-    assertEquals("A", readAscii(connection));
-    assertEquals("B", readAscii(client.open(url)));
-  }
-
-  @Test public void authorizationResponseCachedWithSMaxAge() throws Exception {
-    assertAuthorizationRequestFullyCached(
-        new MockResponse().addHeader("Cache-Control: s-maxage=60"));
-  }
-
-  @Test public void authorizationResponseCachedWithPublic() throws Exception {
-    assertAuthorizationRequestFullyCached(new MockResponse().addHeader("Cache-Control: public"));
-  }
-
-  @Test public void authorizationResponseCachedWithMustRevalidate() throws Exception {
-    assertAuthorizationRequestFullyCached(
-        new MockResponse().addHeader("Cache-Control: must-revalidate"));
-  }
-
-  public void assertAuthorizationRequestFullyCached(MockResponse response) throws Exception {
-    server.enqueue(response.addHeader("Cache-Control: max-age=60").setBody("A"));
+  @Test public void authorizationRequestFullyCached() throws Exception {
+    server.enqueue(new MockResponse().addHeader("Cache-Control: max-age=60").setBody("A"));
     server.enqueue(new MockResponse().setBody("B"));
 
     URL url = server.getUrl("/");

--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
@@ -917,36 +917,8 @@ public final class ResponseCacheTest {
     assertEquals("", readAscii(connection));
   }
 
-  @Test public void authorizationRequestHeaderPreventsCaching() throws Exception {
-    server.enqueue(
-        new MockResponse().addHeader("Last-Modified: " + formatDate(-2, TimeUnit.MINUTES))
-            .addHeader("Cache-Control: max-age=60")
-            .setBody("A"));
-    server.enqueue(new MockResponse().setBody("B"));
-
-    URL url = server.getUrl("/");
-    URLConnection connection = openConnection(url);
-    connection.addRequestProperty("Authorization", "password");
-    assertEquals("A", readAscii(connection));
-    assertEquals("B", readAscii(openConnection(url)));
-  }
-
-  @Test public void authorizationResponseCachedWithSMaxAge() throws Exception {
-    assertAuthorizationRequestFullyCached(
-        new MockResponse().addHeader("Cache-Control: s-maxage=60"));
-  }
-
-  @Test public void authorizationResponseCachedWithPublic() throws Exception {
-    assertAuthorizationRequestFullyCached(new MockResponse().addHeader("Cache-Control: public"));
-  }
-
-  @Test public void authorizationResponseCachedWithMustRevalidate() throws Exception {
-    assertAuthorizationRequestFullyCached(
-        new MockResponse().addHeader("Cache-Control: must-revalidate"));
-  }
-
-  public void assertAuthorizationRequestFullyCached(MockResponse response) throws Exception {
-    server.enqueue(response.addHeader("Cache-Control: max-age=60").setBody("A"));
+  @Test public void authorizationRequestFullyCached() throws Exception {
+    server.enqueue(new MockResponse().addHeader("Cache-Control: max-age=60").setBody("A"));
     server.enqueue(new MockResponse().setBody("B"));
 
     URL url = server.getUrl("/");

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
@@ -50,17 +50,8 @@ public final class CacheStrategy {
       return false;
     }
 
-    // Responses to authorized requests aren't cacheable unless they include
-    // a 'public', 'must-revalidate' or 's-maxage' directive.
-    CacheControl responseCaching = response.cacheControl();
-    if (request.header("Authorization") != null
-        && !responseCaching.isPublic()
-        && !responseCaching.mustRevalidate()
-        && responseCaching.sMaxAgeSeconds() == -1) {
-      return false;
-    }
-
     // A 'no-store' directive on request or response prevents the response from being cached.
+    CacheControl responseCaching = response.cacheControl();
     CacheControl requestCaching = request.cacheControl();
     if (responseCaching.noStore() || requestCaching.noStore()) {
       return false;


### PR DESCRIPTION
This means we'll cache responses that use an 'Authorization' header. This
means OkHttp's cache shouldn't be used on middleboxes that sit between
user agents and the origin server; in practice this is never a use case
for OkHttp.

Fixes https://github.com/square/okhttp/issues/1035
