### PR TITLE
Don't close the SPDY peer too early.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Spdy3ConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Spdy3ConnectionTest.java
@@ -1109,7 +1109,8 @@ public final class Spdy3ConnectionTest {
     // write the mocking script
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().synReply(false, 1, headerEntries("a", "android"));
-    peer.sendTruncatedFrame(8 + 100).data(false, 1, data(1024), 1024);
+    peer.sendFrame().data(false, 1, data(1024), 1024);
+    peer.truncateLastFrame(8 + 100);
     peer.play();
 
     // play it back


### PR DESCRIPTION
This was occasionally causing tests to fail because the test was
observing the connection close.
