### PR TITLE
Move connection configuration to ConnectionConfiguration.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -1347,7 +1347,8 @@ public final class CallTest {
     call.enqueue(callback);
     assertEquals("/a", server.takeRequest().getPath());
 
-    callback.await(requestA.url()).assertFailure("Canceled");
+    callback.await(requestA.url()).assertFailure(
+        "Canceled", "stream was reset: CANCEL", "Broken pipe");
   }
 
   @Test public void canceledBeforeResponseReadSignalsOnFailure_HTTP_2() throws Exception {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
@@ -18,15 +18,12 @@ package com.squareup.okhttp;
 import com.squareup.okhttp.internal.RecordingHostnameVerifier;
 import com.squareup.okhttp.internal.SslContextBuilder;
 import com.squareup.okhttp.internal.Util;
-import com.squareup.okhttp.internal.http.AuthenticatorAdapter;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Arrays;
-import java.util.List;
-import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
 import org.junit.After;
 import org.junit.Before;
@@ -67,34 +64,32 @@ public final class ConnectionPoolTest {
   }
 
   private void setUp(int poolSize) throws Exception {
-    SocketFactory socketFactory = SocketFactory.getDefault();
-
     spdyServer = new MockWebServer();
     httpServer = new MockWebServer();
     spdyServer.useHttps(sslContext.getSocketFactory(), false);
 
-    List<ConnectionConfiguration> connectionConfigurations = Util.immutableList(
-        ConnectionConfiguration.MODERN_TLS, ConnectionConfiguration.CLEARTEXT);
-
     httpServer.play();
-    httpAddress = new Address(httpServer.getHostName(), httpServer.getPort(), socketFactory, null,
-        null, null, AuthenticatorAdapter.INSTANCE, null,
-        Util.immutableList(Protocol.SPDY_3, Protocol.HTTP_1_1), connectionConfigurations);
+    httpAddress = new Address(httpServer.getHostName(), httpServer.getPort(), null,
+        Util.immutableList(ConnectionConfiguration.CLEARTEXT));
     httpSocketAddress = new InetSocketAddress(InetAddress.getByName(httpServer.getHostName()),
         httpServer.getPort());
 
+    ConnectionConfiguration connectionConfiguration
+        = new ConnectionConfiguration.Builder(ConnectionConfiguration.MODERN_TLS)
+        .sslSocketFactory(sslContext.getSocketFactory())
+        .hostnameVerifier(new RecordingHostnameVerifier())
+        .build();
+
     spdyServer.play();
-    spdyAddress = new Address(spdyServer.getHostName(), spdyServer.getPort(), socketFactory,
-        sslContext.getSocketFactory(), new RecordingHostnameVerifier(), CertificatePinner.DEFAULT,
-        AuthenticatorAdapter.INSTANCE, null,
-        Util.immutableList(Protocol.SPDY_3, Protocol.HTTP_1_1), connectionConfigurations);
+    spdyAddress = new Address(spdyServer.getHostName(), spdyServer.getPort(), null,
+        Util.immutableList(connectionConfiguration));
     spdySocketAddress = new InetSocketAddress(InetAddress.getByName(spdyServer.getHostName()),
         spdyServer.getPort());
 
     Route httpRoute = new Route(httpAddress, Proxy.NO_PROXY, httpSocketAddress,
         ConnectionConfiguration.CLEARTEXT);
     Route spdyRoute = new Route(spdyAddress, Proxy.NO_PROXY, spdySocketAddress,
-        ConnectionConfiguration.MODERN_TLS);
+        connectionConfiguration);
     pool = new ConnectionPool(poolSize, KEEP_ALIVE_DURATION_MS);
     httpA = new Connection(pool, httpRoute);
     httpA.connect(200, 200, 200, null);

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
@@ -65,8 +65,10 @@ public final class OkHttpClientTest {
     assertEquals(0, client.getWriteTimeout());
     assertTrue(client.getFollowSslRedirects());
     assertNull(client.getProxy());
+
+    ConnectionConfiguration connectionConfiguration = client.getConnectionConfigurations().get(0);
     assertEquals(Arrays.asList(Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1),
-        client.getProtocols());
+        connectionConfiguration.protocols());
   }
 
   /**
@@ -89,10 +91,11 @@ public final class OkHttpClientTest {
 
     assertSame(proxySelector, client.getProxySelector());
     assertSame(cookieManager, client.getCookieHandler());
-    assertSame(AuthenticatorAdapter.INSTANCE, client.getAuthenticator());
-    assertSame(socketFactory, client.getSocketFactory());
-    assertSame(hostnameVerifier, client.getHostnameVerifier());
-    assertSame(certificatePinner, client.getCertificatePinner());
+    ConnectionConfiguration connectionConfiguration = client.getConnectionConfigurations().get(0);
+    assertSame(AuthenticatorAdapter.INSTANCE, connectionConfiguration.authenticator());
+    assertSame(socketFactory, connectionConfiguration.socketFactory());
+    assertSame(hostnameVerifier, connectionConfiguration.hostnameVerifier());
+    assertSame(certificatePinner, connectionConfiguration.certificatePinner());
   }
 
   /** There is no default cache. */
@@ -129,7 +132,7 @@ public final class OkHttpClientTest {
     assertNotNull(a.routeDatabase());
     assertNotNull(a.getDispatcher());
     assertNotNull(a.getConnectionPool());
-    assertNotNull(a.getSslSocketFactory());
+    assertNotNull(a.getConnectionConfigurations().get(0).sslSocketFactory());
 
     // Multiple clients share the instances.
     OkHttpClient b = client.clone().copyWithDefaults();
@@ -137,6 +140,8 @@ public final class OkHttpClientTest {
     assertSame(a.getDispatcher(), b.getDispatcher());
     assertSame(a.getConnectionPool(), b.getConnectionPool());
     assertSame(a.getSslSocketFactory(), b.getSslSocketFactory());
+    assertSame(a.getConnectionConfigurations().get(0).sslSocketFactory(),
+        b.getConnectionConfigurations().get(0).sslSocketFactory());
   }
 
   /** We don't want to run user code inside of HttpEngine, etc. */

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RecordedResponse.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RecordedResponse.java
@@ -136,8 +136,9 @@ public class RecordedResponse {
     return new RecordedResponse(cacheResponse.request(), cacheResponse, null, null);
   }
 
-  public void assertFailure(String message) {
+  public void assertFailure(String... possibleMessages) {
     assertNotNull(failure);
-    assertEquals(message, failure.getMessage());
+    assertTrue(failure.getMessage(),
+        Arrays.asList(possibleMessages).contains(failure.getMessage()));
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/Address.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Address.java
@@ -18,9 +18,6 @@ package com.squareup.okhttp;
 import com.squareup.okhttp.internal.Util;
 import java.net.Proxy;
 import java.util.List;
-import javax.net.SocketFactory;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSocketFactory;
 
 import static com.squareup.okhttp.internal.Util.equal;
 
@@ -38,31 +35,22 @@ public final class Address {
   final Proxy proxy;
   final String uriHost;
   final int uriPort;
-  final SocketFactory socketFactory;
-  final SSLSocketFactory sslSocketFactory;
-  final HostnameVerifier hostnameVerifier;
-  final CertificatePinner certificatePinner;
-  final Authenticator authenticator;
-  final List<Protocol> protocols;
   final List<ConnectionConfiguration> connectionConfigurations;
 
-  public Address(String uriHost, int uriPort, SocketFactory socketFactory,
-      SSLSocketFactory sslSocketFactory, HostnameVerifier hostnameVerifier,
-      CertificatePinner certificatePinner, Authenticator authenticator, Proxy proxy,
-      List<Protocol> protocols, List<ConnectionConfiguration> connectionConfigurations) {
-    if (uriHost == null) throw new NullPointerException("uriHost == null");
-    if (uriPort <= 0) throw new IllegalArgumentException("uriPort <= 0: " + uriPort);
-    if (authenticator == null) throw new IllegalArgumentException("authenticator == null");
-    if (protocols == null) throw new IllegalArgumentException("protocols == null");
+  public Address(String uriHost, int uriPort, Proxy proxy,
+      List<ConnectionConfiguration> connectionConfigurations) {
+    if (uriHost == null) {
+      throw new NullPointerException("uriHost == null");
+    }
+    if (uriPort <= 0) {
+      throw new IllegalArgumentException("uriPort <= 0: " + uriPort);
+    }
+    if (connectionConfigurations.isEmpty()) {
+      throw new IllegalArgumentException("connectionConfigurations.isEmpty()");
+    }
     this.proxy = proxy;
     this.uriHost = uriHost;
     this.uriPort = uriPort;
-    this.socketFactory = socketFactory;
-    this.sslSocketFactory = sslSocketFactory;
-    this.hostnameVerifier = hostnameVerifier;
-    this.certificatePinner = certificatePinner;
-    this.authenticator = authenticator;
-    this.protocols = Util.immutableList(protocols);
     this.connectionConfigurations = Util.immutableList(connectionConfigurations);
   }
 
@@ -77,42 +65,6 @@ public final class Address {
    */
   public int getUriPort() {
     return uriPort;
-  }
-
-  /** Returns the socket factory for new connections. */
-  public SocketFactory getSocketFactory() {
-    return socketFactory;
-  }
-
-  /**
-   * Returns the SSL socket factory, or null if this is not an HTTPS
-   * address.
-   */
-  public SSLSocketFactory getSslSocketFactory() {
-    return sslSocketFactory;
-  }
-
-  /**
-   * Returns the hostname verifier, or null if this is not an HTTPS
-   * address.
-   */
-  public HostnameVerifier getHostnameVerifier() {
-    return hostnameVerifier;
-  }
-
-  /**
-   * Returns the client's authenticator. This method never returns null.
-   */
-  public Authenticator getAuthenticator() {
-    return authenticator;
-  }
-
-  /**
-   * Returns the protocols the client supports. This method always returns a
-   * non-null list that contains minimally {@link Protocol#HTTP_1_1}.
-   */
-  public List<Protocol> getProtocols() {
-    return protocols;
   }
 
   public List<ConnectionConfiguration> getConnectionConfigurations() {
@@ -133,11 +85,7 @@ public final class Address {
       return equal(this.proxy, that.proxy)
           && this.uriHost.equals(that.uriHost)
           && this.uriPort == that.uriPort
-          && equal(this.sslSocketFactory, that.sslSocketFactory)
-          && equal(this.hostnameVerifier, that.hostnameVerifier)
-          && equal(this.certificatePinner, that.certificatePinner)
-          && equal(this.authenticator, that.authenticator)
-          && equal(this.protocols, that.protocols);
+          && this.connectionConfigurations.equals(that.connectionConfigurations);
     }
     return false;
   }
@@ -146,12 +94,8 @@ public final class Address {
     int result = 17;
     result = 31 * result + uriHost.hashCode();
     result = 31 * result + uriPort;
-    result = 31 * result + (sslSocketFactory != null ? sslSocketFactory.hashCode() : 0);
-    result = 31 * result + (hostnameVerifier != null ? hostnameVerifier.hashCode() : 0);
-    result = 31 * result + (certificatePinner != null ? certificatePinner.hashCode() : 0);
-    result = 31 * result + authenticator.hashCode();
     result = 31 * result + (proxy != null ? proxy.hashCode() : 0);
-    result = 31 * result + protocols.hashCode();
+    result = 31 * result + connectionConfigurations.hashCode();
     return result;
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/ConnectionConfiguration.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ConnectionConfiguration.java
@@ -17,9 +17,18 @@ package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.Platform;
 import com.squareup.okhttp.internal.Util;
+import com.squareup.okhttp.internal.http.AuthenticatorAdapter;
+import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
+import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.List;
+import javax.net.SocketFactory;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import static com.squareup.okhttp.internal.Util.equal;
 
 /**
  * Configuration for the socket connection that HTTP traffic travels through.
@@ -27,53 +36,64 @@ import javax.net.ssl.SSLSocket;
  * when negotiating a secure connection.
  */
 public final class ConnectionConfiguration {
-  /**
-   * This is a subset of the cipher suites supported in Chrome 37, current as of 2014-10-5. All of
-   * these suites are available on Android L; earlier releases support a subset of these suites.
-   * https://github.com/square/okhttp/issues/330
-   */
-  private static final String[] CIPHER_SUITES = new String[] {
-      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", // 0xC0,0x2B  Android L
-      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",   // 0xC0,0x2F  Android L
-      "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",     // 0x00,0x9E  Android L
-      "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",    // 0xC0,0x0A  Android 4.0
-      "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",    // 0xC0,0x09  Android 4.0
-      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",      // 0xC0,0x13  Android 4.0
-      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",      // 0xC0,0x14  Android 4.0
-      "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",        // 0xC0,0x07  Android 4.0
-      "TLS_ECDHE_RSA_WITH_RC4_128_SHA",          // 0xC0,0x11  Android 4.0
-      "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",        // 0x00,0x33  Android 2.3
-      "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",        // 0x00,0x32  Android 2.3
-      "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",        // 0x00,0x39  Android 2.3
-      "TLS_RSA_WITH_AES_128_GCM_SHA256",         // 0x00,0x9C  Android L
-      "TLS_RSA_WITH_AES_128_CBC_SHA",            // 0x00,0x2F  Android 2.3
-      "TLS_RSA_WITH_AES_256_CBC_SHA",            // 0x00,0x35  Android 2.3
-      "SSL_RSA_WITH_3DES_EDE_CBC_SHA",           // 0x00,0x0A  Android 2.3  (Deprecated in L)
-      "SSL_RSA_WITH_RC4_128_SHA",                // 0x00,0x05  Android 2.3
-      "SSL_RSA_WITH_RC4_128_MD5"                 // 0x00,0x04  Android 2.3  (Deprecated in L)
-  };
+  private static final List<Protocol> DEFAULT_PROTOCOLS = Util.immutableList(
+      Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1);
 
   private static final String TLS_1_2 = "TLSv1.2"; // 2008.
   private static final String TLS_1_1 = "TLSv1.1"; // 2006.
   private static final String TLS_1_0 = "TLSv1";   // 1999.
   private static final String SSL_3_0 = "SSLv3";   // 1996.
 
+  /** Lazily-initialized. */
+  private static SSLSocketFactory defaultSslSocketFactory;
+
   /** A modern TLS configuration with extensions like SNI and ALPN available. */
-  public static final ConnectionConfiguration MODERN_TLS = new ConnectionConfiguration(
-      true, CIPHER_SUITES, new String[] { TLS_1_2, TLS_1_1, TLS_1_0, SSL_3_0 }, true);
+  public static final ConnectionConfiguration MODERN_TLS = new Builder(true)
+      .cipherSuites(
+          // This is a subset of the cipher suites supported in Chrome 37, current as of 2014-10-5.
+          // All of these suites are available on Android L; earlier releases support a subset of
+          // these suites. https://github.com/square/okhttp/issues/330
+          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", // 0xC0,0x2B  Android L
+          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",   // 0xC0,0x2F  Android L
+          "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",     // 0x00,0x9E  Android L
+          "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",    // 0xC0,0x0A  Android 4.0
+          "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",    // 0xC0,0x09  Android 4.0
+          "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",      // 0xC0,0x13  Android 4.0
+          "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",      // 0xC0,0x14  Android 4.0
+          "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",        // 0xC0,0x07  Android 4.0
+          "TLS_ECDHE_RSA_WITH_RC4_128_SHA",          // 0xC0,0x11  Android 4.0
+          "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",        // 0x00,0x33  Android 2.3
+          "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",        // 0x00,0x32  Android 2.3
+          "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",        // 0x00,0x39  Android 2.3
+          "TLS_RSA_WITH_AES_128_GCM_SHA256",         // 0x00,0x9C  Android L
+          "TLS_RSA_WITH_AES_128_CBC_SHA",            // 0x00,0x2F  Android 2.3
+          "TLS_RSA_WITH_AES_256_CBC_SHA",            // 0x00,0x35  Android 2.3
+          "SSL_RSA_WITH_3DES_EDE_CBC_SHA",           // 0x00,0x0A  Android 2.3  (Deprecated in L)
+          "SSL_RSA_WITH_RC4_128_SHA",                // 0x00,0x05  Android 2.3
+          "SSL_RSA_WITH_RC4_128_MD5"                 // 0x00,0x04  Android 2.3  (Deprecated in L)
+      )
+      .tlsVersions(TLS_1_2, TLS_1_1, TLS_1_0, SSL_3_0)
+      .supportsTlsExtensions(true)
+      .build();
 
   /** A backwards-compatible fallback configuration for interop with obsolete servers. */
-  public static final ConnectionConfiguration COMPATIBLE_TLS = new ConnectionConfiguration(
-      true, CIPHER_SUITES, new String[] { SSL_3_0 }, true);
+  public static final ConnectionConfiguration COMPATIBLE_TLS = new Builder(MODERN_TLS)
+      .tlsVersions(SSL_3_0)
+      .build();
 
   /** Unencrypted, unauthenticated connections for {@code http:} URLs. */
-  public static final ConnectionConfiguration CLEARTEXT = new ConnectionConfiguration(
-      false, new String[0], new String[0], false);
+  public static final ConnectionConfiguration CLEARTEXT = new Builder(false).build();
 
-  private final boolean tls;
+  final SocketFactory socketFactory;
+  final Authenticator authenticator;
+  final boolean tls;
   private final String[] cipherSuites;
   private final String[] tlsVersions;
-  private final boolean supportsTlsExtensions;
+  final boolean supportsTlsExtensions;
+  final SSLSocketFactory sslSocketFactory;
+  final HostnameVerifier hostnameVerifier;
+  final CertificatePinner certificatePinner;
+  final List<Protocol> protocols;
 
   /**
    * Caches the subset of this configuration that's supported by the host
@@ -82,19 +102,53 @@ public final class ConnectionConfiguration {
    */
   private ConnectionConfiguration supportedConfiguration;
 
-  private ConnectionConfiguration(boolean tls, String[] cipherSuites, String[] tlsVersions,
-      boolean supportsTlsExtensions) {
-    this.tls = tls;
-    this.cipherSuites = cipherSuites;
-    this.tlsVersions = tlsVersions;
-    this.supportsTlsExtensions = supportsTlsExtensions;
+  private ConnectionConfiguration(Builder builder) {
+    this.tls = builder.tls;
+    this.cipherSuites = builder.cipherSuites;
+    this.tlsVersions = builder.tlsVersions;
+    this.supportsTlsExtensions = builder.supportsTlsExtensions;
+    this.socketFactory = builder.socketFactory == null
+        ? SocketFactory.getDefault()
+        : builder.socketFactory;
+    this.authenticator = builder.authenticator == null
+        ? AuthenticatorAdapter.INSTANCE
+        : builder.authenticator;
+    this.sslSocketFactory = builder.tls && builder.sslSocketFactory == null
+        ? getDefaultSSLSocketFactory()
+        : builder.sslSocketFactory;
+    this.hostnameVerifier = builder.tls && builder.hostnameVerifier == null
+        ? OkHostnameVerifier.INSTANCE
+        : builder.hostnameVerifier;
+    this.certificatePinner = builder.tls && builder.certificatePinner == null
+        ? CertificatePinner.DEFAULT
+        : builder.certificatePinner;
+    this.protocols = builder.tls && builder.protocols == null
+        ? DEFAULT_PROTOCOLS
+        : builder.protocols;
+  }
 
-    if (tls && (cipherSuites.length == 0 || tlsVersions.length == 0)) {
-      throw new IllegalArgumentException("Unexpected configuration: " + this);
-    }
-    if (!tls && (cipherSuites.length != 0 || tlsVersions.length != 0 || supportsTlsExtensions)) {
-      throw new IllegalArgumentException("Unexpected configuration: " + this);
-    }
+  public Authenticator authenticator() {
+    return authenticator;
+  }
+
+  public SocketFactory socketFactory() {
+    return socketFactory;
+  }
+
+  public SSLSocketFactory sslSocketFactory() {
+    return sslSocketFactory;
+  }
+
+  public HostnameVerifier hostnameVerifier() {
+    return hostnameVerifier;
+  }
+
+  public CertificatePinner certificatePinner() {
+    return certificatePinner;
+  }
+
+  public List<Protocol> protocols() {
+    return protocols;
   }
 
   public boolean isTls() {
@@ -126,7 +180,7 @@ public final class ConnectionConfiguration {
 
     Platform platform = Platform.get();
     if (configurationToApply.supportsTlsExtensions) {
-      platform.configureTlsExtensions(sslSocket, route.address.uriHost, route.address.protocols);
+      platform.configureTlsExtensions(sslSocket, route.address.uriHost, protocols);
     }
   }
 
@@ -139,17 +193,174 @@ public final class ConnectionConfiguration {
         Arrays.asList(sslSocket.getSupportedCipherSuites()));
     List<String> supportedTlsVersions = Util.intersect(Arrays.asList(tlsVersions),
         Arrays.asList(sslSocket.getSupportedProtocols()));
-    return new ConnectionConfiguration(tls,
-        supportedCipherSuites.toArray(new String[supportedCipherSuites.size()]),
-        supportedTlsVersions.toArray(new String[supportedTlsVersions.size()]),
-        supportsTlsExtensions);
+    return new Builder(this)
+        .cipherSuites(supportedCipherSuites.toArray(new String[supportedCipherSuites.size()]))
+        .tlsVersions(supportedTlsVersions.toArray(new String[supportedTlsVersions.size()]))
+        .build();
+  }
+
+  @Override public boolean equals(Object other) {
+    if (!(other instanceof ConnectionConfiguration)) return false;
+
+    ConnectionConfiguration that = (ConnectionConfiguration) other;
+    if (!equal(this.socketFactory, that.socketFactory)) return false;
+    if (!equal(this.authenticator, that.authenticator)) return false;
+    if (this.tls != that.tls) return false;
+
+    if (tls) {
+      if (!Arrays.equals(this.cipherSuites, that.cipherSuites)) return false;
+      if (!Arrays.equals(this.tlsVersions, that.tlsVersions)) return false;
+      if (this.supportsTlsExtensions != that.supportsTlsExtensions) return false;
+      if (!equal(this.sslSocketFactory, that.sslSocketFactory)) return false;
+      if (!equal(this.hostnameVerifier, that.hostnameVerifier)) return false;
+      if (!equal(this.certificatePinner, that.certificatePinner)) return false;
+      if (!equal(this.protocols, that.protocols)) return false;
+    }
+
+    return true;
+  }
+
+  @Override public int hashCode() {
+    int result = 17;
+    result = 31 * result + socketFactory.hashCode();
+    result = 31 * result + authenticator.hashCode();
+    if (tls) {
+      result = 31 * result + Arrays.hashCode(cipherSuites);
+      result = 31 * result + Arrays.hashCode(tlsVersions);
+      result = 31 * result + (supportsTlsExtensions ? 0 : 1);
+      result = 31 * result + sslSocketFactory.hashCode();
+      result = 31 * result + hostnameVerifier.hashCode();
+      result = 31 * result + certificatePinner.hashCode();
+      result = 31 * result + protocols.hashCode();
+    }
+    return result;
   }
 
   @Override public String toString() {
-    return "ConnectionConfiguration(tls=" + tls
-        + ", cipherSuites=" + Arrays.toString(cipherSuites)
-        + ", tlsVersions=" + Arrays.toString(tlsVersions)
-        + ", supportsTlsExtensions=" + supportsTlsExtensions
-        + ")";
+    StringBuilder result = new StringBuilder()
+        .append("ConnectionConfiguration(socketFactory=").append(socketFactory)
+        .append(", authenticator=").append(authenticator);
+    if (tls) {
+      result.append(", cipherSuites=").append(Arrays.toString(cipherSuites))
+          .append(", tlsVersions=").append(Arrays.toString(tlsVersions))
+          .append(", supportsTlsExtensions=").append(supportsTlsExtensions)
+          .append(", sslSocketFactory=").append(sslSocketFactory)
+          .append(", hostnameVerifier=").append(hostnameVerifier)
+          .append(", certificatePinner=").append(certificatePinner)
+          .append(", protocols=").append(protocols);
+    }
+    return result.append(")").toString();
+  }
+
+  public static final class Builder {
+    private SocketFactory socketFactory;
+    private Authenticator authenticator;
+    private boolean tls;
+    private String[] cipherSuites;
+    private String[] tlsVersions;
+    private boolean supportsTlsExtensions;
+    private SSLSocketFactory sslSocketFactory;
+    private HostnameVerifier hostnameVerifier;
+    private CertificatePinner certificatePinner;
+    private List<Protocol> protocols;
+
+    private Builder(boolean tls) {
+      this.tls = tls;
+    }
+
+    public Builder(ConnectionConfiguration connectionConfiguration) {
+      this.socketFactory = connectionConfiguration.socketFactory;
+      this.authenticator = connectionConfiguration.authenticator;
+      this.tls = connectionConfiguration.tls;
+      this.cipherSuites = connectionConfiguration.cipherSuites;
+      this.tlsVersions = connectionConfiguration.tlsVersions;
+      this.supportsTlsExtensions = connectionConfiguration.supportsTlsExtensions;
+      this.sslSocketFactory = connectionConfiguration.sslSocketFactory;
+      this.hostnameVerifier = connectionConfiguration.hostnameVerifier;
+      this.certificatePinner = connectionConfiguration.certificatePinner;
+      this.protocols = connectionConfiguration.protocols;
+    }
+
+    public Builder socketFactory(SocketFactory socketFactory) {
+      this.socketFactory = socketFactory;
+      return this;
+    }
+
+    public Builder authenticator(Authenticator authenticator) {
+      if (authenticator == null) throw new IllegalArgumentException("authenticator == null");
+      this.authenticator = authenticator;
+      return this;
+    }
+
+    public Builder cipherSuites(String... cipherSuites) {
+      if (!tls) throw new IllegalStateException("no cipher suites for cleartext connections");
+      this.cipherSuites = cipherSuites.clone(); // Defensive copy.
+      return this;
+    }
+
+    public Builder tlsVersions(String... tlsVersions) {
+      if (!tls) throw new IllegalStateException("no TLS versions for cleartext connections");
+      this.tlsVersions = tlsVersions.clone(); // Defensive copy.
+      return this;
+    }
+
+    public Builder supportsTlsExtensions(boolean supportsTlsExtensions) {
+      if (!tls) throw new IllegalStateException("no TLS extensions for cleartext connections");
+      this.supportsTlsExtensions = supportsTlsExtensions;
+      return this;
+    }
+
+    public Builder sslSocketFactory(SSLSocketFactory sslSocketFactory) {
+      if (!tls) throw new IllegalStateException("no SSL sockets for cleartext connections");
+      this.sslSocketFactory = sslSocketFactory;
+      return this;
+    }
+
+    public Builder hostnameVerifier(HostnameVerifier hostnameVerifier) {
+      if (!tls) throw new IllegalStateException("no hostname verifier for cleartext connections");
+      this.hostnameVerifier = hostnameVerifier;
+      return this;
+    }
+
+    public Builder certificatePinner(CertificatePinner certificatePinner) {
+      if (!tls) throw new IllegalStateException("no certificate pinner for cleartext connections");
+      this.certificatePinner = certificatePinner;
+      return this;
+    }
+
+    public Builder protocols(List<Protocol> protocols) {
+      if (!tls) throw new IllegalStateException("no protocols for cleartext connections");
+      if (protocols == null) throw new IllegalArgumentException("protocols == null");
+      this.protocols = Util.immutableList(protocols);
+      return this;
+    }
+
+    public ConnectionConfiguration build() {
+      return new ConnectionConfiguration(this);
+    }
+  }
+
+  /**
+   * Java and Android programs default to using a single global SSL context,
+   * accessible to HTTP clients as {@link SSLSocketFactory#getDefault()}. If we
+   * used the shared SSL context, when OkHttp enables NPN for its SPDY-related
+   * stuff, it would also enable NPN for other usages, which might crash them
+   * because NPN is enabled when it isn't expected to be.
+   *
+   * <p>This code avoids that by defaulting to an OkHttp-created SSL context.
+   * The drawback of this approach is that apps that customize the global SSL
+   * context will lose these customizations.
+   */
+  private static synchronized SSLSocketFactory getDefaultSSLSocketFactory() {
+    if (defaultSslSocketFactory == null) {
+      try {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, null, null);
+        defaultSslSocketFactory = sslContext.getSocketFactory();
+      } catch (GeneralSecurityException e) {
+        throw new AssertionError(); // The system has no TLS. Just give up.
+      }
+    }
+    return defaultSslSocketFactory;
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/Route.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Route.java
@@ -87,7 +87,7 @@ public final class Route {
    * href="http://www.ietf.org/rfc/rfc2817.txt">RFC 2817, Section 5.2</a>.
    */
   public boolean requiresTunnel() {
-    return address.sslSocketFactory != null && proxy.type() == Proxy.Type.HTTP;
+    return connectionConfiguration.isTls() && proxy.type() == Proxy.Type.HTTP;
   }
 
   @Override public boolean equals(Object obj) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -780,7 +780,8 @@ public final class HttpEngine {
         }
         // fall-through
       case HTTP_UNAUTHORIZED:
-        return OkHeaders.processAuthHeader(client.getAuthenticator(), userResponse, selectedProxy);
+        return OkHeaders.processAuthHeader(route.getConnectionConfiguration().authenticator(),
+            userResponse, selectedProxy);
 
       case HTTP_PERM_REDIRECT:
       case HTTP_TEMP_REDIRECT:


### PR DESCRIPTION
The setters are left behind in OkHttpClient for backwards-compatibility. But
the new best way to configure this stuff is with a ConnectionConfiguration.

That class still needs a nice new name, and perhaps tighter configuration
for string-enums (cipher suites and TLS versions).
