### PR TITLE
Be consistent about host names in RouteSelector.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
@@ -243,7 +243,7 @@ public final class RouteSelector {
     String socketHost;
     int socketPort;
     if (proxy.type() == Proxy.Type.DIRECT) {
-      socketHost = uri.getHost();
+      socketHost = address.getUriHost();
       socketPort = getEffectivePort(uri);
     } else {
       SocketAddress proxyAddress = proxy.address();


### PR DESCRIPTION
Use the host specified by the address, and not URI.getHost().

bug: 18023709
Change-Id: I2c39c2ce89049130dc00047c8de6f214159144c0

Originally https://android-review.googlesource.com/#/c/112027/
Closes https://github.com/square/okhttp/issues/1110
