### PR TITLE
Request body buffering is not transport-specific.

### DIFF
--- a/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
+++ b/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
@@ -37,7 +37,7 @@ public class MainTest {
     Request request = fromArgs("-X", "PUT", "http://example.com").createRequest();
     assertEquals("PUT", request.method());
     assertEquals("http://example.com", request.urlString());
-    assertNull(request.body());
+    assertEquals(0, request.body().contentLength());
   }
 
   @Test public void dataPost() {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -273,6 +273,62 @@ public final class CallTest {
     postZeroLength();
   }
 
+  @Test public void postBodyRetransmittedAfterAuthorizationFail() throws Exception {
+    postBodyRetransmittedAfterAuthorizationFail("abc");
+  }
+
+  @Test public void postBodyRetransmittedAfterAuthorizationFail_SPDY_3() throws Exception {
+    enableProtocol(Protocol.SPDY_3);
+    postBodyRetransmittedAfterAuthorizationFail("abc");
+  }
+
+  @Test public void postBodyRetransmittedAfterAuthorizationFail_HTTP_2() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+    postBodyRetransmittedAfterAuthorizationFail("abc");
+  }
+
+  /** Don't explode when resending an empty post. https://github.com/square/okhttp/issues/1131 */
+  @Test public void postEmptyBodyRetransmittedAfterAuthorizationFail() throws Exception {
+    postBodyRetransmittedAfterAuthorizationFail("");
+  }
+
+  @Test public void postEmptyBodyRetransmittedAfterAuthorizationFail_SPDY_3() throws Exception {
+    enableProtocol(Protocol.SPDY_3);
+    postBodyRetransmittedAfterAuthorizationFail("");
+  }
+
+  @Test public void postEmptyBodyRetransmittedAfterAuthorizationFail_HTTP_2() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+    postBodyRetransmittedAfterAuthorizationFail("");
+  }
+
+  private void postBodyRetransmittedAfterAuthorizationFail(String body) throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(401));
+    server.enqueue(new MockResponse());
+    server.play();
+
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .method("POST", RequestBody.create(null, body))
+        .build();
+
+    String credential = Credentials.basic("jesse", "secret");
+    client.setAuthenticator(new RecordingOkAuthenticator(credential));
+
+    Response response = client.newCall(request).execute();
+    assertEquals(200, response.code());
+
+    RecordedRequest recordedRequest1 = server.takeRequest();
+    assertEquals("POST", recordedRequest1.getMethod());
+    assertEquals(body, recordedRequest1.getUtf8Body());
+    assertNull(recordedRequest1.getHeader("Authorization"));
+
+    RecordedRequest recordedRequest2 = server.takeRequest();
+    assertEquals("POST", recordedRequest2.getMethod());
+    assertEquals(body, recordedRequest2.getUtf8Body());
+    assertEquals(credential, recordedRequest2.getHeader("Authorization"));
+  }
+
   @Test public void delete() throws Exception {
     server.enqueue(new MockResponse().setBody("abc"));
     server.play();

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -93,7 +93,7 @@ public final class RequestTest {
 
     Request delete = new Request.Builder().url("http://localhost/api").delete().build();
     assertEquals("DELETE", delete.method());
-    assertNull(delete.body());
+    assertEquals(0L, delete.body().contentLength());
 
     Request post = new Request.Builder().url("http://localhost/api").post(body).build();
     assertEquals("POST", post.method());

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpOverSpdyTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpOverSpdyTest.java
@@ -126,14 +126,14 @@ public abstract class HttpOverSpdyTest {
 
   byte[] postBytes = "FGHIJ".getBytes(Util.UTF_8);
 
-  /** An output stream can be written to more than once, so we can't guess content length. */
-  @Test public void noDefaultContentLengthOnPost() throws Exception {
+  @Test public void noDefaultContentLengthOnStreamingPost() throws Exception {
     MockResponse response = new MockResponse().setBody("ABCDE");
     server.enqueue(response);
     server.play();
 
     connection = client.open(server.getUrl("/foo"));
     connection.setDoOutput(true);
+    connection.setChunkedStreamingMode(0);
     connection.getOutputStream().write(postBytes);
     assertContent("ABCDE", connection, Integer.MAX_VALUE);
 

--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -298,14 +298,12 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
         if (method.equals("GET")) {
           // they are requesting a stream to write to. This implies a POST method
           method = "POST";
-        } else if (!HttpMethod.hasRequestBody(method)) {
-          // If the request method is neither POST nor PUT nor PATCH, then you're not writing
+        } else if (!HttpMethod.permitsRequestBody(method)) {
           throw new ProtocolException(method + " does not support writing");
         }
       }
       // If the user set content length to zero, we know there will not be a request body.
-      RetryableSink requestBody = doOutput && fixedContentLength == 0 ? Util.emptySink() : null;
-      httpEngine = newHttpEngine(method, null, requestBody, null);
+      httpEngine = newHttpEngine(method, null, null, null);
     } catch (IOException e) {
       httpEngineFailure = e;
       throw e;
@@ -323,7 +321,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
     }
 
     boolean bufferRequestBody = false;
-    if (HttpMethod.hasRequestBody(method)) {
+    if (HttpMethod.permitsRequestBody(method)) {
       // Specify how the request body is terminated.
       if (fixedContentLength != -1) {
         builder.header("Content-Length", Long.toString(fixedContentLength));

--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/JavaApiConverterTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/JavaApiConverterTest.java
@@ -301,7 +301,6 @@ public class JavaApiConverterTest {
     Request request = JavaApiConverter.createOkRequest(uri, "POST", javaRequestHeaders);
     assertFalse(request.isHttps());
     assertEquals(uri, request.uri());
-    assertNull(request.body());
     Headers okRequestHeaders = request.headers();
     assertEquals(0, okRequestHeaders.size());
     assertEquals("POST", request.method());
@@ -315,7 +314,6 @@ public class JavaApiConverterTest {
     Request request = JavaApiConverter.createOkRequest(uri, "POST", javaRequestHeaders);
     assertTrue(request.isHttps());
     assertEquals(uri, request.uri());
-    assertNull(request.body());
     Headers okRequestHeaders = request.headers();
     assertEquals(1, okRequestHeaders.size());
     assertEquals("Bar", okRequestHeaders.get("Foo"));
@@ -335,7 +333,6 @@ public class JavaApiConverterTest {
     Request request = JavaApiConverter.createOkRequest(uri, "POST", javaRequestHeaders);
     assertTrue(request.isHttps());
     assertEquals(uri, request.uri());
-    assertNull(request.body());
     Headers okRequestHeaders = request.headers();
     assertEquals(1, okRequestHeaders.size());
     assertEquals("Bar", okRequestHeaders.get("Foo"));

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -16,9 +16,7 @@
 package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.NamedRunnable;
-import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HttpEngine;
-import com.squareup.okhttp.internal.http.HttpMethod;
 import com.squareup.okhttp.internal.http.OkHeaders;
 import com.squareup.okhttp.internal.http.RetryableSink;
 import java.io.IOException;
@@ -223,8 +221,6 @@ public class Call {
       }
 
       request = requestBuilder.build();
-    } else if (HttpMethod.hasRequestBody(request.method())) {
-      requestBodyOut = Util.emptySink();
     }
 
     // Create the initial HTTP engine. Retries and redirects need new engine for each attempt.

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -16,6 +16,7 @@
 package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.Platform;
+import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HttpMethod;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -224,8 +225,11 @@ public final class Request {
       if (method == null || method.length() == 0) {
         throw new IllegalArgumentException("method == null || method.length() == 0");
       }
-      if (body != null && !HttpMethod.hasRequestBody(method)) {
+      if (body != null && !HttpMethod.permitsRequestBody(method)) {
         throw new IllegalArgumentException("method " + method + " must not have a request body.");
+      }
+      if (body == null && HttpMethod.permitsRequestBody(method)) {
+        body = RequestBody.create(null, Util.EMPTY_BYTE_ARRAY);
       }
       this.method = method;
       this.body = body;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -16,7 +16,6 @@
 
 package com.squareup.okhttp.internal;
 
-import com.squareup.okhttp.internal.http.RetryableSink;
 import com.squareup.okhttp.internal.spdy.Header;
 import java.io.Closeable;
 import java.io.File;
@@ -242,12 +241,6 @@ public final class Util {
     }
     return result;
   }
-
-  public static RetryableSink emptySink() {
-    return EMPTY_SINK;
-  }
-
-  private static final RetryableSink EMPTY_SINK = new RetryableSink(0);
 
   /**
    * Returns a copy of {@code a} containing only elements also in {@code b}. The returned elements

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpMethod.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpMethod.java
@@ -30,10 +30,14 @@ public final class HttpMethod {
         || method.equals("DELETE");
   }
 
-  public static boolean hasRequestBody(String method) {
+  public static boolean requiresRequestBody(String method) {
     return method.equals("POST")
         || method.equals("PUT")
-        || method.equals("PATCH")
+        || method.equals("PATCH");
+  }
+
+  public static boolean permitsRequestBody(String method) {
+    return requiresRequestBody(method)
         || method.equals("DELETE"); // Permitted as spec is ambiguous.
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RetryableSink.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RetryableSink.java
@@ -19,7 +19,6 @@ package com.squareup.okhttp.internal.http;
 import java.io.IOException;
 import java.net.ProtocolException;
 import okio.Buffer;
-import okio.BufferedSink;
 import okio.Sink;
 import okio.Timeout;
 
@@ -72,8 +71,9 @@ public final class RetryableSink implements Sink {
     return content.size();
   }
 
-  public void writeToSocket(BufferedSink socketOut) throws IOException {
+  public void writeToSocket(Sink socketOut) throws IOException {
     // Clone the content; otherwise we won't have data to retry.
-    socketOut.writeAll(content.clone());
+    Buffer buffer = content.clone();
+    socketOut.write(buffer, buffer.size());
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
@@ -30,23 +30,8 @@ public interface Transport {
    */
   int DISCARD_STREAM_TIMEOUT_MILLIS = 100;
 
-  /**
-   * Returns an output stream where the request body can be written. The
-   * returned stream will of one of two types:
-   * <ul>
-   * <li><strong>Direct.</strong> Bytes are written to the socket and
-   * forgotten. This is most efficient, particularly for large request
-   * bodies. The returned stream may be buffered; the caller must call
-   * {@link #flushRequest} before reading the response.</li>
-   * <li><strong>Buffered.</strong> Bytes are written to an in memory
-   * buffer, and must be explicitly flushed with a call to {@link
-   * #writeRequestBody}. This allows HTTP authorization (401, 407)
-   * responses to be retransmitted transparently.</li>
-   * </ul>
-   */
-  // TODO: don't bother retransmitting the request body? It's quite a corner
-  // case and there's uncertainty whether Firefox or Chrome do this
-  Sink createRequestBody(Request request) throws IOException;
+  /** Returns an output stream where the request body can be streamed. */
+  Sink createRequestBody(Request request, long contentLength) throws IOException;
 
   /** This should update the HTTP engine's sentRequestMillis field. */
   void writeRequestHeaders(Request request) throws IOException;


### PR DESCRIPTION
Previously we were only buffering the request body when the transport
was HTTP. But we should buffer it for both SPDY and HTTP transports.

Closes https://github.com/square/okhttp/issues/1132

Also recover gracefully when retrying an empty POST body. This
is a related bug.

Closes https://github.com/square/okhttp/issues/1131
