### PR TITLE
Bump to 2.1.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Download [the latest JAR][3] or grab via Maven:
 <dependency>
   <groupId>com.squareup.okhttp</groupId>
   <artifactId>okhttp</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.squareup.okhttp:okhttp:2.0.0'
+compile 'com.squareup.okhttp:okhttp:2.1.0'
 ```
 
 
@@ -34,13 +34,13 @@ Download [the latest JAR][4] or grab via Maven:
 <dependency>
   <groupId>com.squareup.okhttp</groupId>
   <artifactId>mockwebserver</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <scope>test</scope>
 </dependency>
 ```
 or Gradle:
 ```groovy
-testCompile 'com.squareup.okhttp:mockwebserver:2.0.0'
+testCompile 'com.squareup.okhttp:mockwebserver:2.1.0'
 ```
 
 


### PR DESCRIPTION
I've bumped to `2.1.0` in README.
