### PR TITLE
Permit all ResponseBody methods to throw IOException.

### DIFF
--- a/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
+++ b/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
@@ -33,14 +33,14 @@ public class MainTest {
     assertNull(request.body());
   }
 
-  @Test public void put() {
+  @Test public void put() throws IOException {
     Request request = fromArgs("-X", "PUT", "http://example.com").createRequest();
     assertEquals("PUT", request.method());
     assertEquals("http://example.com", request.urlString());
     assertEquals(0, request.body().contentLength());
   }
 
-  @Test public void dataPost() {
+  @Test public void dataPost() throws IOException {
     Request request = fromArgs("-d", "foo", "http://example.com").createRequest();
     RequestBody body = request.body();
     assertEquals("POST", request.method());
@@ -49,7 +49,7 @@ public class MainTest {
     assertEquals("foo", bodyAsString(body));
   }
 
-  @Test public void dataPut() {
+  @Test public void dataPut() throws IOException {
     Request request = fromArgs("-d", "foo", "-X", "PUT", "http://example.com").createRequest();
     RequestBody body = request.body();
     assertEquals("PUT", request.method());
@@ -58,7 +58,7 @@ public class MainTest {
     assertEquals("foo", bodyAsString(body));
   }
 
-  @Test public void contentTypeHeader() {
+  @Test public void contentTypeHeader() throws IOException {
     Request request = fromArgs("-d", "foo", "-H", "Content-Type: application/json",
         "http://example.com").createRequest();
     RequestBody body = request.body();

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -79,7 +79,7 @@ public final class RequestTest {
   }
 
   /** Common verbs used for apis such as GitHub, AWS, and Google Cloud. */
-  @Test public void crudVerbs() {
+  @Test public void crudVerbs() throws IOException {
     MediaType contentType = MediaType.parse("application/json");
     RequestBody body = RequestBody.create(contentType, "{}");
 

--- a/okhttp/src/main/java/com/squareup/okhttp/MultipartBuilder.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/MultipartBuilder.java
@@ -110,12 +110,12 @@ public final class MultipartBuilder {
   }
 
   /** Add a part to the body. */
-  public MultipartBuilder addPart(RequestBody body) {
+  public MultipartBuilder addPart(RequestBody body) throws IOException {
     return addPart(null, body);
   }
 
   /** Add a part to the body. */
-  public MultipartBuilder addPart(Headers headers, RequestBody body) {
+  public MultipartBuilder addPart(Headers headers, RequestBody body) throws IOException {
     if (body == null) {
       throw new NullPointerException("body == null");
     }
@@ -175,12 +175,13 @@ public final class MultipartBuilder {
   }
 
   /** Add a form data part to the body. */
-  public MultipartBuilder addFormDataPart(String name, String value) {
+  public MultipartBuilder addFormDataPart(String name, String value) throws IOException {
     return addFormDataPart(name, null, RequestBody.create(null, value));
   }
 
   /** Add a form data part to the body. */
-  public MultipartBuilder addFormDataPart(String name, String filename, RequestBody value) {
+  public MultipartBuilder addFormDataPart(String name, String filename, RequestBody value)
+      throws IOException {
     if (name == null) {
       throw new NullPointerException("name == null");
     }
@@ -196,7 +197,8 @@ public final class MultipartBuilder {
   }
 
   /** Creates a part "heading" from the boundary and any real or generated headers. */
-  private Buffer createPartHeading(Headers headers, RequestBody body, boolean isFirst) {
+  private Buffer createPartHeading(Headers headers, RequestBody body, boolean isFirst)
+      throws IOException {
     Buffer sink = new Buffer();
 
     if (!isFirst) {

--- a/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
@@ -25,13 +25,13 @@ import okio.Source;
 
 public abstract class RequestBody {
   /** Returns the Content-Type header for this body. */
-  public abstract MediaType contentType();
+  public abstract MediaType contentType() throws IOException;
 
   /**
    * Returns the number of bytes that will be written to {@code out} in a call
    * to {@link #writeTo}, or -1 if that count is unknown.
    */
-  public long contentLength() {
+  public long contentLength() throws IOException {
     return -1;
   }
 


### PR DESCRIPTION
This is a binary-compatible change, but source-incompatible. I think it's
unlikely to cause real world problems though, since most application code
will be implementing these methods, not calling them.

And if they are calling them, it's likely they're also reading the body,
which already throws an IOException.

Closes https://github.com/square/okhttp/issues/1141
