### PR TITLE
More context when the hostname is not verified.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/CertificatePinner.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/CertificatePinner.java
@@ -134,8 +134,8 @@ public final class CertificatePinner {
         .append("\n  Peer certificate chain:");
     for (Certificate c : peerCertificates) {
       X509Certificate x509Certificate = (X509Certificate) c;
-      message.append("\n    sha1/").append(sha1(x509Certificate).base64()).append(": ")
-          .append(x509Certificate.getSubjectDN().getName());
+      message.append("\n    ").append(pin(x509Certificate))
+          .append(": ").append(x509Certificate.getSubjectDN().getName());
     }
     message.append("\n  Pinned certificates for ").append(hostname).append(":");
     for (ByteString pin : pins) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/tls/OkHostnameVerifier.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/tls/OkHostnameVerifier.java
@@ -114,7 +114,14 @@ public final class OkHostnameVerifier implements HostnameVerifier {
     return false;
   }
 
-  private List<String> getSubjectAltNames(X509Certificate certificate, int type) {
+  public static List<String> allSubjectAltNames(X509Certificate certificate) {
+    List<String> result = new ArrayList<>();
+    result.addAll(getSubjectAltNames(certificate, ALT_IPA_NAME));
+    result.addAll(getSubjectAltNames(certificate, ALT_DNS_NAME));
+    return result;
+  }
+
+  private static List<String> getSubjectAltNames(X509Certificate certificate, int type) {
     List<String> result = new ArrayList<>();
     try {
       Collection<?> subjectAltNames = certificate.getSubjectAlternativeNames();

--- a/samples/guide/src/main/java/com/squareup/okhttp/recipes/SynchronousGet.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/recipes/SynchronousGet.java
@@ -26,7 +26,7 @@ public final class SynchronousGet {
 
   public void run() throws Exception {
     Request request = new Request.Builder()
-        .url("http://publicobject.com/helloworld.txt")
+        .url("https://publicobject.com/helloworld.txt")
         .build();
 
     Response response = client.newCall(request).execute();


### PR DESCRIPTION
```
Exception in thread "main" java.io.IOException: Hostname square.com not verified:
    certificate: sha1/FBzx5Wrwa9EpylnPrsKjpBQu1RE=
    DN: CN=square.com, OU=Information Security, O=Square Inc., STREET=1455 Market Street, L=San Francisco, ST=California, OID.2.5.4.17=94103, C=US, SERIALNUMBER=4699855, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US
    subjectAltNames: [square.com, www.square.com, cash.square.com, blog.square.com]
      at com.squareup.okhttp.Connection.upgradeToTls(Connection.java:242)
      at com.squareup.okhttp.Connection.connect(Connection.java:155)
      at com.squareup.okhttp.Connection.connectAndSetOwner(Connection.java:171)
      at com.squareup.okhttp.OkHttpClient$1.connectAndSetOwner(OkHttpClient.java:119)
```

Closes https://github.com/square/okhttp/issues/1163
