### PR TITLE
Avoid hardcoding the custom header prefix

### DIFF
--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/OkUrlFactoryTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/OkUrlFactoryTest.java
@@ -1,5 +1,6 @@
 package com.squareup.okhttp;
 
+import com.squareup.okhttp.internal.Platform;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
@@ -146,7 +147,8 @@ public class OkUrlFactoryTest {
   }
 
   private void assertResponseHeader(HttpURLConnection connection, String expected) {
-    assertEquals(expected, connection.getHeaderField("OkHttp-Response-Source"));
+    final String headerFieldPrefix = Platform.get().getPrefix();
+    assertEquals(expected, connection.getHeaderField(headerFieldPrefix + "-Response-Source"));
   }
 
   private void assertResponseCode(HttpURLConnection connection, int expected) throws IOException {


### PR DESCRIPTION
The test is failing under Android CTS tests. Android uses an "X-Android"
prefix.

This fix is benign and ensures the tests pass in all cases.
