### PR TITLE
Fix tests that fail on some Android devices

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingServerSocketFactory.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingServerSocketFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import javax.net.ServerSocketFactory;
+
+/**
+ * A {@link ServerSocketFactory} that delegates calls. Sockets can be configured after creation by
+ * overriding {@link #configureServerSocket(java.net.ServerSocket)}.
+ */
+public class DelegatingServerSocketFactory extends ServerSocketFactory {
+
+  private final ServerSocketFactory delegate;
+
+  public DelegatingServerSocketFactory(ServerSocketFactory delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ServerSocket createServerSocket() throws IOException {
+    ServerSocket serverSocket = delegate.createServerSocket();
+    configureServerSocket(serverSocket);
+    return serverSocket;
+  }
+
+  @Override
+  public ServerSocket createServerSocket(int port) throws IOException {
+    ServerSocket serverSocket = delegate.createServerSocket(port);
+    configureServerSocket(serverSocket);
+    return serverSocket;
+  }
+
+  @Override
+  public ServerSocket createServerSocket(int port, int backlog) throws IOException {
+    ServerSocket serverSocket = delegate.createServerSocket(port, backlog);
+    configureServerSocket(serverSocket);
+    return serverSocket;
+  }
+
+  @Override
+  public ServerSocket createServerSocket(int port, int backlog, InetAddress ifAddress)
+      throws IOException {
+    ServerSocket serverSocket = delegate.createServerSocket(port, backlog, ifAddress);
+    configureServerSocket(serverSocket);
+    return serverSocket;
+  }
+
+  protected void configureServerSocket(ServerSocket serverSocket) throws IOException {
+    // no-op by default
+  }
+}

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingSocketFactory.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingSocketFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import javax.net.SocketFactory;
+
+/**
+ * A {@link SocketFactory} that delegates calls. Sockets can be configured after creation by
+ * overriding {@link #configureSocket(java.net.Socket)}.
+ */
+public class DelegatingSocketFactory extends SocketFactory {
+
+  private final SocketFactory delegate;
+
+  public DelegatingSocketFactory(SocketFactory delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Socket createSocket() throws IOException {
+    Socket socket = delegate.createSocket();
+    configureSocket(socket);
+    return socket;
+  }
+
+  @Override
+  public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+    Socket socket = delegate.createSocket(host, port);
+    configureSocket(socket);
+    return socket;
+  }
+
+  @Override
+  public Socket createSocket(String host, int port, InetAddress localAddress, int localPort)
+      throws IOException, UnknownHostException {
+    Socket socket = delegate.createSocket(host, port, localAddress, localPort);
+    configureSocket(socket);
+    return socket;
+  }
+
+  @Override
+  public Socket createSocket(InetAddress host, int port) throws IOException {
+    Socket socket = delegate.createSocket(host, port);
+    configureSocket(socket);
+    return socket;
+  }
+
+  @Override
+  public Socket createSocket(InetAddress host, int port, InetAddress localAddress, int localPort)
+      throws IOException {
+    Socket socket = delegate.createSocket(host, port, localAddress, localPort);
+    configureSocket(socket);
+    return socket;
+  }
+
+  protected void configureSocket(Socket socket) throws IOException {
+    // no-op by default
+  }
+}


### PR DESCRIPTION
Some tests fail on some Android devices because they have
larger buffer sizes. Setting the buffer size of sockets used
in tests that rely on blocking behavior ensures consistency.

ThreadInterruptTest#interruptWritingRequestBody
URLConnectionTest#writeTimeouts
