### PR TITLE
Prevent MockSpdyPeer interfering with Android tests

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -122,7 +122,7 @@ public final class MockSpdyPeer implements Closeable {
           readAndWriteFrames();
         } catch (IOException e) {
           Util.closeQuietly(MockSpdyPeer.this);
-          throw new RuntimeException(e);
+          e.printStackTrace();
         }
       }
     });


### PR DESCRIPTION
On Android we run the OkHttp tests as an instrumented test case.
The default UncaughtExceptionHandler on Android will quit the
app, causing the current test to fail.

MockSpdyPeer creates a thread that fails for various reasons
that are not related to / required for the actual test. Often the
exception is thrown during a subsequent test.

This change logs the exception but prevents it from
propagating out of the top of the call stack. This decreases
overall flakiness.
