### PR TITLE
Modify bad CONNECT handling

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -843,39 +843,33 @@ public final class URLConnectionTest {
     assertEquals(Arrays.asList("verify android.com"), hostnameVerifier.calls);
   }
 
-  /** Tolerate bad https proxy response when using a cache. http://b/6754912 */
+  /** Tolerate bad https proxy response when using HttpResponseCache. Android bug 6754912. */
   @Test public void connectViaHttpProxyToHttpsUsingBadProxyAndHttpResponseCache() throws Exception {
     initResponseCache();
 
     server.useHttps(sslContext.getSocketFactory(), true);
-    MockResponse response = new MockResponse() // Key to reproducing b/6754912
+    // The inclusion of a body in the response to a CONNECT is key to reproducing b/6754912.
+    MockResponse badProxyResponse = new MockResponse()
         .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
         .setBody("bogus proxy connect response content");
+    server.enqueue(badProxyResponse);
+    server.enqueue(new MockResponse().setBody("response"));
+    server.play();
 
     // Configure a single IP address for the host and a single configuration, so we only need one
     // failure to fail permanently.
     Internal.instance.setNetwork(client.client(), new SingleInetAddressNetwork());
+    client.client().setSslSocketFactory(sslContext.getSocketFactory());
     client.client().setConnectionSpecs(Util.immutableList(ConnectionSpec.MODERN_TLS));
-    server.enqueue(response);
-    server.play();
+    client.client().setHostnameVerifier(new RecordingHostnameVerifier());
     client.client().setProxy(server.toProxyAddress());
 
     URL url = new URL("https://android.com/foo");
-    client.client().setSslSocketFactory(sslContext.getSocketFactory());
     connection = client.open(url);
-
-    try {
-      connection.getResponseCode();
-      fail();
-    } catch (IOException expected) {
-      // Thrown when the connect causes SSLSocket.startHandshake() to throw
-      // when it sees the "bogus proxy connect response content"
-      // instead of a ServerHello handshake message.
-    }
+    assertContent("response", connection);
 
     RecordedRequest connect = server.takeRequest();
-    assertEquals("Connect line failure on proxy", "CONNECT android.com:443 HTTP/1.1",
-        connect.getRequestLine());
+    assertEquals("CONNECT android.com:443 HTTP/1.1", connect.getRequestLine());
     assertContains(connect.getHeaders(), "Host: android.com");
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -17,6 +17,7 @@
 package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.Platform;
+import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HttpConnection;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.HttpTransport;
@@ -29,6 +30,8 @@ import java.net.Proxy;
 import java.net.Socket;
 import java.net.URL;
 import javax.net.ssl.SSLSocket;
+
+import okio.Source;
 
 import static com.squareup.okhttp.internal.Util.getDefaultPort;
 import static com.squareup.okhttp.internal.Util.getEffectivePort;
@@ -393,12 +396,22 @@ public final class Connection {
       tunnelConnection.writeRequest(request.headers(), requestLine);
       tunnelConnection.flush();
       Response response = tunnelConnection.readResponse().request(request).build();
-      tunnelConnection.emptyResponseBody();
+      // The response body from a CONNECT should be empty, but if it is not then we should consume
+      // it before proceeding.
+      long contentLength = OkHeaders.contentLength(response);
+      if (contentLength != -1) {
+        Source body = tunnelConnection.newFixedLengthSource(null, contentLength);
+        Util.skipAll(body, Integer.MAX_VALUE);
+      } else {
+        tunnelConnection.emptyResponseBody();
+      }
 
       switch (response.code()) {
         case HTTP_OK:
           // Assume the server won't send a TLS ServerHello until we send a TLS ClientHello. If that
           // happens, then we will have buffered bytes that are needed by the SSLSocket!
+          // This check is imperfect: it doesn't tell us whether a handshake will succeed, just that
+          // it will almost certainly fail because the proxy has sent unexpected data.
           if (tunnelConnection.bufferSize() > 0) {
             throw new IOException("TLS tunnel buffered too many bytes!");
           }


### PR DESCRIPTION
Changing the way that OkHttp handles CONNECT responses
from proxies.

Before the change:
If a proxy returns a body and some of the body bytes have
already been buffered then an IOException is thrown.
If the body bytes have not been buffered then the handshake will
fail due to the presence of bytes where the Server HELLO is
expected, typically with some kind of SSLHandshakeException.

After the change:
The body bytes are consumed to ensure consistent behavior. The
handshake will then take place.

History:
This is an unusual case that would occasionally cause failures
on Android when a ResponseCache was installed. Android introduced
a patch to prevent CONNECT responses being cached. Since then,
OkHttp has changed the code and probably fixed the issue via
other means. The Android test remained and would sometimes
experience one exception, sometimes another, depending on the
state of the buffer.

If the presence of a body is a possibility it would be nice
to deal with it consistently and deterministically.

The motivation for this change is to make
URLConnectionTest#connectViaHttpProxyToHttpsUsingBadProxyAndHttpResponseCache
behave consistently and in a way that doesn't involve connection
fallback.

The only risk with this change is if a proxy is incorrectly
reporting the content length: this might lead to blocking on
the body read/skip (as OkHttp would probably do elsewhere if a
server mis-reports a content-length). This change may make
connections to "bad" proxies slightly more reliable.
