### PR TITLE
Null reference to allow multiple shutdown calls.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -342,6 +342,7 @@ public final class MockWebServer {
 
     // Cause acceptConnections() to break out.
     serverSocket.close();
+    serverSocket = null;
 
     // Await shutdown.
     try {


### PR DESCRIPTION
The shutdown command was looking for a null reference in order to early return but nobody was nulling the reference.
