### PR TITLE
Resurrect http/2 frame logging,

### DIFF
--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -266,7 +266,7 @@ public class Main extends HelpOption implements Runnable {
   }
 
   private static void enableHttp2FrameLogging() {
-    Logger logger = Logger.getLogger(Http20Draft15.class.getName());
+    Logger logger = Logger.getLogger(Http20Draft15.class.getName() + "$FrameLogger");
     logger.setLevel(Level.FINE);
     ConsoleHandler handler = new ConsoleHandler();
     handler.setLevel(Level.FINE);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft15.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Http20Draft15.java
@@ -18,6 +18,7 @@ package com.squareup.okhttp.internal.spdy;
 import com.squareup.okhttp.Protocol;
 import java.io.IOException;
 import java.util.List;
+import java.util.logging.Logger;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
@@ -25,7 +26,6 @@ import okio.ByteString;
 import okio.Source;
 import okio.Timeout;
 
-import static com.squareup.okhttp.internal.Internal.logger;
 import static com.squareup.okhttp.internal.spdy.Http20Draft15.FrameLogger.formatHeader;
 import static java.lang.String.format;
 import static java.util.logging.Level.FINE;
@@ -40,6 +40,8 @@ import static okio.ByteString.EMPTY;
  * <p>http://tools.ietf.org/html/draft-ietf-httpbis-http2-15
  */
 public final class Http20Draft15 implements Variant {
+  private static final Logger logger = Logger.getLogger(FrameLogger.class.getName());
+
   @Override public Protocol getProtocol() {
     return Protocol.HTTP_2;
   }


### PR DESCRIPTION
per chat here https://github.com/square/okhttp/commit/40c2e6aec09d139a4e96b45856020a5b324b01ef#commitcomment-8786586

Note I retained use of the name `logger` as `frameLogger` would make a bunch of lines wrap.
