### PR TITLE
Avoid a reverse DNS-lookup for a numeric proxy address

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
@@ -401,6 +401,24 @@ public final class RouteSelectorTest {
     assertEquals(regularRoutes.size(), routesWithFailedRoute.size());
   }
 
+  @Test public void getHostString() throws Exception {
+    // Name proxy specification.
+    InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("host", 1234);
+    assertEquals("host", RouteSelector.getHostString(socketAddress));
+    socketAddress = InetSocketAddress.createUnresolved("127.0.0.1", 1234);
+    assertEquals("127.0.0.1", RouteSelector.getHostString(socketAddress));
+
+    // InetAddress proxy specification.
+    socketAddress = new InetSocketAddress(InetAddress.getByName("localhost"), 1234);
+    assertEquals("127.0.0.1", RouteSelector.getHostString(socketAddress));
+    socketAddress = new InetSocketAddress(
+        InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }), 1234);
+    assertEquals("127.0.0.1", RouteSelector.getHostString(socketAddress));
+    socketAddress = new InetSocketAddress(
+        InetAddress.getByAddress("foobar", new byte[] { 127, 0, 0, 1 }), 1234);
+    assertEquals("127.0.0.1", RouteSelector.getHostString(socketAddress));
+  }
+
   private void assertConnection(Connection connection, Address address, Proxy proxy,
       InetAddress socketAddress, int socketPort, ConnectionSpec connectionSpec) {
     assertEquals(address, connection.getRoute().getAddress());

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
@@ -251,7 +251,7 @@ public final class RouteSelector {
             "Proxy.address() is not an " + "InetSocketAddress: " + proxyAddress.getClass());
       }
       InetSocketAddress proxySocketAddress = (InetSocketAddress) proxyAddress;
-      socketHost = proxySocketAddress.getHostName();
+      socketHost = getHostString(proxySocketAddress);
       socketPort = proxySocketAddress.getPort();
     }
 
@@ -260,6 +260,24 @@ public final class RouteSelector {
       inetSocketAddresses.add(new InetSocketAddress(inetAddress, socketPort));
     }
     nextInetSocketAddressIndex = 0;
+  }
+
+  /**
+   * Obtain a "host" from an {@link InetSocketAddress}. This returns a string containing either an
+   * actual host name or a numeric IP address.
+   */
+  // Visible for testing
+  static String getHostString(InetSocketAddress socketAddress) {
+    InetAddress address = socketAddress.getAddress();
+    if (address == null) {
+      // The InetSocketAddress was specified with a string (either a numeric IP or a host name). If
+      // it is a name, all IPs for that name should be tried. If it is an IP address, only that IP
+      // address should be tried.
+      return socketAddress.getHostName();
+    }
+    // The InetSocketAddress has a specific address: we should only try that address. Therefore we
+    // return the address and ignore any host name that may be available.
+    return address.getHostAddress();
   }
 
   /** Returns true if there's another socket address to try. */


### PR DESCRIPTION
When the proxy was specified as an IP address the RouteSelector would force
a reverse-lookup. This introduced extra latency when the DNS is being slow or
missing. It also then turned the name back into a set of IPs, which could
result in the original IP address not being given priority and
connection attempts being made to IPs besides the one specified by the
original Proxy specifier.

This change distinguishes between whether the proxy InetSocketAddress is
specified with a string, or with an InetAddress. This is referred to as
"unresolved" and "resolved" respectively. If an InetAddress is present
we assume we should use that single address to communicate with the
proxy.

This relies on the InetSocketAddress being created "unresolved": if the
InetSocketAddress is created from a hostname but created "resolved",
the InetAddress is filled in and OkHttp will interpret that as an
instruction to just communicate with just that one IP.
