### PR TITLE
mockwebserver: bind specifically to a loopback interface

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/internal/SslContextBuilder.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/internal/SslContextBuilder.java
@@ -68,7 +68,7 @@ public final class SslContextBuilder {
   public static synchronized SSLContext localhost() {
     if (localhost == null) {
       try {
-        localhost = new SslContextBuilder(InetAddress.getLocalHost().getHostName()).build();
+        localhost = new SslContextBuilder(InetAddress.getByName(null).getHostName()).build();
       } catch (GeneralSecurityException e) {
         throw new RuntimeException(e);
       } catch (UnknownHostException e) {

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -290,7 +290,7 @@ public final class MockWebServer {
   public void play(int port) throws IOException {
     if (executor != null) throw new IllegalStateException("play() already called");
     executor = Executors.newCachedThreadPool(Util.threadFactory("MockWebServer", false));
-    inetAddress = InetAddress.getLocalHost();
+    inetAddress = InetAddress.getByName(null);
     serverSocket = serverSocketFactory.createServerSocket(port, 50, inetAddress);
     serverSocket.setReuseAddress(true);
 


### PR DESCRIPTION
The changes in this pull request:
1) bind specifically to a loopback interface, and
2) update animal sniffer to java 7 to allow the use of the 1.7 api "getLoopbackAddress" - http://docs.oracle.com/javase/8/docs/api/java/net/InetAddress.html#getLoopbackAddress--

First, it looks like the Java 7 updates for commit cdd71f1bbd32f20d63d7100787b91c327d1b5b0c simply overlooked the animal sniffer update.

Second, about the loopback interface binding, I was writing/running some unit tests on a Ubuntu machine.

Since I was unit testing, I expected everything to be on the machine's loopback interface, which is typically known as "localhost".

I wrote a test where the client tried to connect to the mock server on "localhost", and it failed to connect.
I didn't realize that my machine name and "localhost" were mapped to two different loopback addresses at the time. /etc/hosts contained:
127.0.0.1 localhost
127.0.1.1 foo

The first thing I did was make a temp change to /etc/hosts to make "foo" resolve to the same address as "localhost": 127.0.0.1 localhost foo.
That worked.

But, that isn't a great solution because if the machine name is normally mapped to an address on a non-loopback interface, then the mock server will wind up listening on an interface to which remote hosts can possibly connect.

I don't see a need for that. So, these changes use a newer 1.7 Java API that particularly gets a loopback address instead of using an interface associated with whatever the machine name maps to.

More info about the /etc/hosts config for Debian-based systems:
http://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
