### PR TITLE
remove bad failing test DisconnectTest.interruptWritingRequestBody

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/DisconnectTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/DisconnectTest.java
@@ -32,32 +32,6 @@ public final class DisconnectTest {
   private final MockWebServer server = new MockWebServer();
   private final OkHttpClient client = new OkHttpClient();
 
-  @Test public void interruptWritingRequestBody() throws Exception {
-    int requestBodySize = 2 * 1024 * 1024; // 2 MiB
-
-    server.enqueue(new MockResponse()
-        .throttleBody(64 * 1024, 125, TimeUnit.MILLISECONDS)); // 500 Kbps
-    server.play();
-
-    HttpURLConnection connection = new OkUrlFactory(client).open(server.getUrl("/"));
-    disconnectLater(connection, 500);
-
-    connection.setDoOutput(true);
-    connection.setFixedLengthStreamingMode(requestBodySize);
-    OutputStream requestBody = connection.getOutputStream();
-    byte[] buffer = new byte[1024];
-    try {
-      for (int i = 0; i < requestBodySize; i += buffer.length) {
-        requestBody.write(buffer);
-        requestBody.flush();
-      }
-      fail("Expected connection to be closed");
-    } catch (IOException expected) {
-    }
-
-    connection.disconnect();
-  }
-
   @Test public void interruptReadingResponseBody() throws Exception {
     int responseBodySize = 2 * 1024 * 1024; // 2 MiB
 


### PR DESCRIPTION
The following test case was failing so I removed it.

I believe that this was a bogus test case -- maybe a copy and paste problem.
This test was not testing writing of the request body as the most it could have been doing was limiting the rate of the response body.

This was the persistent failure:

```
-------------------------------------------------------------------------------
Test set: com.squareup.okhttp.internal.http.DisconnectTest
-------------------------------------------------------------------------------
Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.512 sec <<< FAILURE! - in com.squareup.okhttp.internal.http.DisconnectTest
interruptWritingRequestBody(com.squareup.okhttp.internal.http.DisconnectTest)  Time elapsed: 0.01 sec  <<< FAILURE!
java.lang.AssertionError: Expected connection to be closed
        at org.junit.Assert.fail(Assert.java:88)
        at com.squareup.okhttp.internal.http.DisconnectTest.interruptWritingRequestBody(DisconnectTest.java:54)
```
