### PR TITLE
Remove NPN support from OkHttp

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -97,14 +97,15 @@
   </build>
   <profiles>
     <profile>
-      <id>npn-when-jdk7</id>
+      <id>alpn-when-jdk7</id>
       <activation>
         <jdk>1.7</jdk>
       </activation>
       <dependencies>
         <dependency>
-          <groupId>org.mortbay.jetty.npn</groupId>
-          <artifactId>npn-boot</artifactId>
+          <groupId>org.mortbay.jetty.alpn</groupId>
+          <artifactId>alpn-boot</artifactId>
+          <version>${alpn.jdk7.version}</version>
           <scope>provided</scope>
         </dependency>
       </dependencies>
@@ -118,6 +119,7 @@
         <dependency>
           <groupId>org.mortbay.jetty.alpn</groupId>
           <artifactId>alpn-boot</artifactId>
+          <version>${alpn.jdk8.version}</version>
           <scope>provided</scope>
         </dependency>
       </dependencies>

--- a/benchmarks/src/main/java/com/squareup/okhttp/benchmarks/Benchmark.java
+++ b/benchmarks/src/main/java/com/squareup/okhttp/benchmarks/Benchmark.java
@@ -83,7 +83,7 @@ public class Benchmark extends com.google.caliper.Benchmark {
   @Param({ "0", "20" })
   int headerCount;
 
-  /** Which ALPN/NPN protocols are in use. Only useful with TLS. */
+  /** Which ALPN protocols are in use. Only useful with TLS. */
   List<Protocol> protocols = Arrays.asList(Protocol.HTTP_1_1);
 
   public static void main(String[] args) {

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -169,17 +169,7 @@ public final class MockWebServer {
   }
 
   /**
-   * Sets whether NPN is used on incoming HTTPS connections to negotiate a
-   * protocol like HTTP/1.1 or SPDY/3. Call this method to disable NPN and
-   * SPDY.
-   * @deprecated Use {@link #setProtocolNegotiationEnabled}.
-   */
-  public void setNpnEnabled(boolean npnEnabled) {
-    this.protocolNegotiationEnabled = npnEnabled;
-  }
-
-  /**
-   * Sets whether ALPN or NPN is used on incoming HTTPS connections to
+   * Sets whether ALPN is used on incoming HTTPS connections to
    * negotiate a protocol like HTTP/1.1 or HTTP/2. Call this method to disable
    * negotiation and restrict connections to HTTP/1.1.
    */
@@ -188,19 +178,7 @@ public final class MockWebServer {
   }
 
   /**
-   * Indicates the protocols supported by NPN on incoming HTTPS connections.
-   * This list is ignored when npn is disabled.
-   *
-   * @param protocols the protocols to use, in order of preference. The list
-   *     must contain "http/1.1". It must not contain null.
-   * @deprecated Use {@link #setProtocols(java.util.List)}.
-   */
-  public void setNpnProtocols(List<Protocol> protocols) {
-    setProtocols(protocols);
-  }
-
-  /**
-   * Indicates the protocols supported by NPN or ALPN on incoming HTTPS
+   * Indicates the protocols supported by ALPN on incoming HTTPS
    * connections. This list is ignored when
    * {@link #setProtocolNegotiationEnabled negotiation is disabled}.
    *

--- a/okcurl/pom.xml
+++ b/okcurl/pom.xml
@@ -23,10 +23,6 @@
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty.npn</groupId>
-      <artifactId>npn-boot</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>airline</artifactId>
     </dependency>

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ExternalHttp2Example.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ExternalHttp2Example.java
@@ -48,7 +48,7 @@ public final class ExternalHttp2Example {
     int responseCode = connection.getResponseCode();
     System.out.println(responseCode);
     List<String> protocolValues = connection.getHeaderFields().get(SELECTED_PROTOCOL);
-    // If null, probably you didn't add jetty's npn jar to your boot classpath!
+    // If null, probably you didn't add jetty's alpn jar to your boot classpath!
     if (protocolValues != null && !protocolValues.isEmpty()) {
       System.out.println("PROTOCOL " + protocolValues.get(0));
     }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ExternalSpdyExample.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ExternalSpdyExample.java
@@ -48,7 +48,7 @@ public final class ExternalSpdyExample {
     int responseCode = connection.getResponseCode();
     System.out.println(responseCode);
     List<String> protocolValues = connection.getHeaderFields().get(SELECTED_PROTOCOL);
-    // If null, probably you didn't add jetty's npn jar to your boot classpath!
+    // If null, probably you didn't add jetty's alpn jar to your boot classpath!
     if (protocolValues != null && !protocolValues.isEmpty()) {
       System.out.println("PROTOCOL " + protocolValues.get(0));
     }

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -484,8 +484,7 @@ public class OkHttpClient implements Cloneable {
    * successors (h2). The http/1.1 transport will never be dropped.
    *
    * <p>If multiple protocols are specified, <a
-   * href="https://technotes.googlecode.com/git/nextprotoneg.html">NPN</a> or
-   * <a href="http://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg">ALPN</a>
+   * href="http://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg">ALPN</a>
    * will be used to negotiate a transport.
    *
    * <p>{@link Protocol#HTTP_1_0} is not supported in this set. Requests are
@@ -594,9 +593,9 @@ public class OkHttpClient implements Cloneable {
   /**
    * Java and Android programs default to using a single global SSL context,
    * accessible to HTTP clients as {@link SSLSocketFactory#getDefault()}. If we
-   * used the shared SSL context, when OkHttp enables NPN for its SPDY-related
-   * stuff, it would also enable NPN for other usages, which might crash them
-   * because NPN is enabled when it isn't expected to be.
+   * used the shared SSL context, when OkHttp enables ALPN for its SPDY-related
+   * stuff, it would also enable ALPN for other usages, which might crash them
+   * because ALPN is enabled when it isn't expected to be.
    *
    * <p>This code avoids that by defaulting to an OkHttp-created SSL context.
    * The drawback of this approach is that apps that customize the global SSL

--- a/okhttp/src/main/java/com/squareup/okhttp/Protocol.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Protocol.java
@@ -19,8 +19,7 @@ import java.io.IOException;
 
 /**
  * Protocols that OkHttp implements for <a
- * href="http://tools.ietf.org/html/draft-agl-tls-nextprotoneg-04">NPN</a> and
- * <a href="http://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg">ALPN</a>
+ * href="http://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg">ALPN</a>
  * selection.
  *
  * <h3>Protocol vs Scheme</h3>
@@ -91,7 +90,7 @@ public enum Protocol {
   }
 
   /**
-   * Returns the string used to identify this protocol for ALPN and NPN, like
+   * Returns the string used to identify this protocol for ALPN, like
    * "http/1.1", "spdy/3.1" or "h2-15".
    */
   @Override public String toString() {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -40,24 +40,12 @@ import static com.squareup.okhttp.internal.Internal.logger;
  * Access to Platform-specific features necessary for SPDY and advanced TLS.
  * This includes Server Name Indication (SNI) and session tickets.
  *
- * <h3>ALPN and NPN</h3>
- * This class uses TLS extensions ALPN and NPN to negotiate the upgrade from
- * HTTP/1.1 (the default protocol to use with TLS on port 443) to either SPDY
- * or HTTP/2.
+ * <h3>ALPN</h3>
+ * This class uses TLS extension ALPN to negotiate the upgrade from HTTP/1.1
+ * (the default protocol to use with TLS on port 443) to either SPDY or HTTP/2.
  *
- * <p>NPN (Next Protocol Negotiation) was developed for SPDY. It is widely
- * available and we support it on both Android (4.1+) and OpenJDK 7 (via the
- * Jetty Alpn-boot library). NPN is not yet available on OpenJDK 8.
- *
- * <p>ALPN (Application Layer Protocol Negotiation) is the successor to NPN. It
- * has some technical advantages over NPN. ALPN first arrived in Android 4.4,
- * but that release suffers a <a href="http://goo.gl/y5izPP">concurrency bug</a>
- * so we don't use it. ALPN is supported on OpenJDK 7 and 8 (via the Jetty
- * ALPN-boot library).
- *
- * <p>On platforms that support both extensions, OkHttp will use both,
- * preferring ALPN's result. Future versions of OkHttp will drop support for
- * NPN.
+ * <p>ALPN (Application Layer Protocol Negotiation) first arrived in Android 4.4,
+ * ALPN is supported on OpenJDK 7 and 8 (via the Jetty ALPN-boot library).
  */
 public class Platform {
   private static final Platform PLATFORM = findPlatform();
@@ -132,15 +120,9 @@ public class Platform {
       // This isn't an Android runtime.
     }
 
-    try { // to find the Jetty's ALPN or NPN extension for OpenJDK.
+    try { // to find the Jetty's ALPN extension for OpenJDK.
       String negoClassName = "org.eclipse.jetty.alpn.ALPN";
-      Class<?> negoClass;
-      try {
-        negoClass = Class.forName(negoClassName);
-      } catch (ClassNotFoundException ignored) { // ALPN isn't on the classpath.
-        negoClassName = "org.eclipse.jetty.npn.NextProtoNego";
-        negoClass = Class.forName(negoClassName);
-      }
+      Class<?> negoClass = Class.forName(negoClassName);
       Class<?> providerClass = Class.forName(negoClassName + "$Provider");
       Class<?> clientProviderClass = Class.forName(negoClassName + "$ClientProvider");
       Class<?> serverProviderClass = Class.forName(negoClassName + "$ServerProvider");
@@ -148,8 +130,8 @@ public class Platform {
       Method getMethod = negoClass.getMethod("get", SSLSocket.class);
       return new JdkWithJettyBootPlatform(
           putMethod, getMethod, clientProviderClass, serverProviderClass);
-    } catch (ClassNotFoundException ignored) { // NPN isn't on the classpath.
-    } catch (NoSuchMethodException ignored) { // The ALPN or NPN version isn't what we expect.
+    } catch (ClassNotFoundException ignored) {
+    } catch (NoSuchMethodException ignored) { // The ALPN version isn't what we expect.
     }
 
     return new Platform();
@@ -157,7 +139,7 @@ public class Platform {
 
   /**
    * Android 2.3 or better. Version 2.3 supports TLS session tickets and server
-   * name indication (SNI). Versions 4.1 supports NPN.
+   * name indication (SNI). Versions 4.4 supports ALPN.
    */
   private static class Android extends Platform {
 
@@ -173,12 +155,6 @@ public class Platform {
     // setAlpnSelectedProtocol(byte[])
     private static final OptionalMethod<Socket> SET_ALPN_PROTOCOLS =
         new OptionalMethod<Socket>(null, "setAlpnProtocols", byte[].class);
-    // byte[] getNpnSelectedProtocol()
-    private static final OptionalMethod<Socket> GET_NPN_SELECTED_PROTOCOL =
-        new OptionalMethod<Socket>(byte[].class, "getNpnSelectedProtocol");
-    // setNpnSelectedProtocol(byte[])
-    private static final OptionalMethod<Socket> SET_NPN_PROTOCOLS =
-        new OptionalMethod<Socket>(null, "setNpnProtocols", byte[].class);
 
     // Non-null on Android 4.0+.
     private final Method trafficStatsTagSocket;
@@ -210,43 +186,26 @@ public class Platform {
         SET_HOSTNAME.invokeOptionalWithoutCheckedException(sslSocket, hostname);
       }
 
-      // Enable NPN / ALPN.
+      // Enable ALPN.
       boolean alpnSupported = SET_ALPN_PROTOCOLS.isSupported(sslSocket);
-      boolean npnSupported = SET_NPN_PROTOCOLS.isSupported(sslSocket);
-      if (!(alpnSupported || npnSupported)) {
+      if (!alpnSupported) {
         return;
       }
 
       Object[] parameters = { concatLengthPrefixed(protocols) };
-      if (alpnSupported) {
-        SET_ALPN_PROTOCOLS.invokeWithoutCheckedException(sslSocket, parameters);
-      }
-      if (npnSupported) {
-        SET_NPN_PROTOCOLS.invokeWithoutCheckedException(sslSocket, parameters);
-      }
+      SET_ALPN_PROTOCOLS.invokeWithoutCheckedException(sslSocket, parameters);
     }
 
     @Override public String getSelectedProtocol(SSLSocket socket) {
       boolean alpnSupported = GET_ALPN_SELECTED_PROTOCOL.isSupported(socket);
-      boolean npnSupported = GET_NPN_SELECTED_PROTOCOL.isSupported(socket);
-      if (!(alpnSupported || npnSupported)) {
+      if (!alpnSupported) {
         return null;
       }
 
-      // Prefer ALPN's result if it is present.
-      if (alpnSupported) {
-        byte[] alpnResult =
-            (byte[]) GET_ALPN_SELECTED_PROTOCOL.invokeWithoutCheckedException(socket);
-        if (alpnResult != null) {
-          return new String(alpnResult, Util.UTF_8);
-        }
-      }
-      if (npnSupported) {
-        byte[] npnResult =
-            (byte[]) GET_NPN_SELECTED_PROTOCOL.invokeWithoutCheckedException(socket);
-        if (npnResult != null) {
-          return new String(npnResult, Util.UTF_8);
-        }
+      byte[] alpnResult =
+          (byte[]) GET_ALPN_SELECTED_PROTOCOL.invokeWithoutCheckedException(socket);
+      if (alpnResult != null) {
+        return new String(alpnResult, Util.UTF_8);
       }
       return null;
     }
@@ -277,8 +236,7 @@ public class Platform {
   }
 
   /**
-   * OpenJDK 7+ with {@code org.mortbay.jetty.npn/npn-boot} or
-   * {@code org.mortbay.jetty.alpn/alpn-boot} in the boot class path.
+   * OpenJDK 7+ with {@code org.mortbay.jetty.alpn/alpn-boot} in the boot class path.
    */
   private static class JdkWithJettyBootPlatform extends Platform {
     private final Method getMethod;
@@ -299,7 +257,7 @@ public class Platform {
       List<String> names = new ArrayList<>(protocols.size());
       for (int i = 0, size = protocols.size(); i < size; i++) {
         Protocol protocol = protocols.get(i);
-        if (protocol == Protocol.HTTP_1_0) continue; // No HTTP/1.0 for NPN or ALPN.
+        if (protocol == Protocol.HTTP_1_0) continue; // No HTTP/1.0 for ALPN.
         names.add(protocol.toString());
       }
       try {
@@ -318,8 +276,8 @@ public class Platform {
         JettyNegoProvider provider =
             (JettyNegoProvider) Proxy.getInvocationHandler(getMethod.invoke(null, socket));
         if (!provider.unsupported && provider.selected == null) {
-          logger.log(Level.INFO, "NPN/ALPN callback dropped: SPDY and HTTP/2 are disabled. "
-              + "Is npn-boot or alpn-boot on the boot class path?");
+          logger.log(Level.INFO, "ALPN callback dropped: SPDY and HTTP/2 are disabled. "
+              + "Is alpn-boot on the boot class path?");
           return null;
         }
         return provider.unsupported ? null : provider.selected;
@@ -332,15 +290,15 @@ public class Platform {
   }
 
   /**
-   * Handle the methods of NPN or ALPN's ClientProvider and ServerProvider
+   * Handle the methods of ALPN's ClientProvider and ServerProvider
    * without a compile-time dependency on those interfaces.
    */
   private static class JettyNegoProvider implements InvocationHandler {
     /** This peer's supported protocols. */
     private final List<String> protocols;
-    /** Set when remote peer notifies NPN or ALPN is unsupported. */
+    /** Set when remote peer notifies ALPN is unsupported. */
     private boolean unsupported;
-    /** The protocol the client (NPN) or server (ALPN) selected. */
+    /** The protocol the server selected. */
     private String selected;
 
     public JettyNegoProvider(List<String> protocols) {
@@ -354,12 +312,12 @@ public class Platform {
         args = Util.EMPTY_STRING_ARRAY;
       }
       if (methodName.equals("supports") && boolean.class == returnType) {
-        return true; // NPN or ALPN is supported.
+        return true; // ALPN is supported.
       } else if (methodName.equals("unsupported") && void.class == returnType) {
-        this.unsupported = true; // Peer doesn't support NPN or ALPN.
+        this.unsupported = true; // Peer doesn't support ALPN.
         return null;
       } else if (methodName.equals("protocols") && args.length == 0) {
-        return protocols; // Server (NPN) or Client (ALPN) advertises these protocols.
+        return protocols; // Client advertises these protocols.
       } else if ((methodName.equals("selectProtocol") || methodName.equals("select"))
           && String.class == returnType && args.length == 1 && args[0] instanceof List) {
         List<String> peerProtocols = (List) args[0];
@@ -372,7 +330,7 @@ public class Platform {
         return selected = protocols.get(0); // On no intersection, try peer's first protocol.
       } else if ((methodName.equals("protocolSelected") || methodName.equals("selected"))
           && args.length == 1) {
-        this.selected = (String) args[0]; // Client (NPN) or Server (ALPN) selected this protocol.
+        this.selected = (String) args[0]; // Server selected this protocol.
         return null;
       } else {
         return method.invoke(this, args);
@@ -388,7 +346,7 @@ public class Platform {
     Buffer result = new Buffer();
     for (int i = 0, size = protocols.size(); i < size; i++) {
       Protocol protocol = protocols.get(i);
-      if (protocol == Protocol.HTTP_1_0) continue; // No HTTP/1.0 for NPN.
+      if (protocol == Protocol.HTTP_1_0) continue; // No HTTP/1.0 for ALPN.
       result.writeByte(protocol.toString().length());
       result.writeUtf8(protocol.toString());
     }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -172,7 +172,7 @@ public final class SpdyConnection implements Closeable {
     new Thread(readerRunnable).start(); // Not a daemon thread.
   }
 
-  /** The protocol as selected using NPN or ALPN. */
+  /** The protocol as selected using ALPN. */
   public Protocol getProtocol() {
     return protocol;
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Variant.java
@@ -22,7 +22,7 @@ import okio.BufferedSource;
 /** A version and dialect of the framed socket protocol. */
 public interface Variant {
 
-  /** The protocol as selected using NPN or ALPN. */
+  /** The protocol as selected using ALPN. */
   Protocol getProtocol();
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,10 @@
     <!-- Compilation -->
     <java.version>1.7</java.version>
     <okio.version>1.0.1</okio.version>
-    <!-- Targetted to jdk7u60-b13; Oracle jdk7u55-b13. -->
-    <npn.version>1.1.7.v20140316</npn.version>
-    <!-- Targetted to OpenJDK 8 b132 -->
-    <alpn.version>8.0.0.v20140317</alpn.version>
+    <!-- ALPN library targeted to OpenJDK 7 -->
+    <alpn.jdk7.version>7.0.0.v20140317</alpn.jdk7.version>
+    <!-- ALPN library targeted to OpenJDK 8 b132 -->
+    <alpn.jdk8.version>8.0.0.v20140317</alpn.jdk8.version>
     <bouncycastle.version>1.50</bouncycastle.version>
     <gson.version>2.2.3</gson.version>
     <apache.http.version>4.2.2</apache.http.version>
@@ -80,15 +80,15 @@
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.mortbay.jetty.npn</groupId>
-        <artifactId>npn-boot</artifactId>
-        <version>${npn.version}</version>
+       <dependency>
+        <groupId>org.mortbay.jetty.alpn</groupId>
+        <artifactId>alpn-jdk7-boot</artifactId>
+        <version>${alpn.jdk7.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mortbay.jetty.alpn</groupId>
-        <artifactId>alpn-boot</artifactId>
-        <version>${alpn.version}</version>
+        <artifactId>alpn-jdk8-boot</artifactId>
+        <version>${alpn.jdk8.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
@@ -213,41 +213,12 @@
 
   <profiles>
     <profile>
-      <id>npn-when-jdk7</id>
+      <id>alpn-when-jdk7</id>
       <activation>
         <jdk>1.7</jdk>
       </activation>
       <properties>
-        <bootclasspathPrefix>${settings.localRepository}/org/mortbay/jetty/npn/npn-boot/${npn.version}/npn-boot-${npn.version}.jar</bootclasspathPrefix>
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <argLine>-Xbootclasspath/p:${bootclasspathPrefix}</argLine>
-              </configuration>
-              <dependencies>
-                <dependency>
-                  <groupId>org.mortbay.jetty.npn</groupId>
-                  <artifactId>npn-boot</artifactId>
-                  <version>${npn.version}</version>
-                </dependency>
-              </dependencies>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <id>alpn-when-jdk8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <properties>
-        <bootclasspathPrefix>${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar</bootclasspathPrefix>
+        <bootclasspathPrefix>${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.jdk7.version}/alpn-boot-${alpn.jdk7.version}.jar</bootclasspathPrefix>
       </properties>
       <build>
         <pluginManagement>
@@ -262,7 +233,36 @@
                 <dependency>
                   <groupId>org.mortbay.jetty.alpn</groupId>
                   <artifactId>alpn-boot</artifactId>
-                  <version>${alpn.version}</version>
+                  <version>${alpn.jdk7.version}</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>alpn-when-jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <bootclasspathPrefix>${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.jdk8.version}/alpn-boot-${alpn.jdk8.version}.jar</bootclasspathPrefix>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <argLine>-Xbootclasspath/p:${bootclasspathPrefix}</argLine>
+              </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>org.mortbay.jetty.alpn</groupId>
+                  <artifactId>alpn-boot</artifactId>
+                  <version>${alpn.jdk8.version}</version>
                 </dependency>
               </dependencies>
             </plugin>


### PR DESCRIPTION
Work in progress.

I see a new failure from a certificate pinning test but I don't
know why. Help solving this would be appreciated.

I also see failures before & after:
1) A failure from DisconnectTest
(https://github.com/square/okhttp/pull/1197 may fix that).
2) A failure from CallTest.doesNotFollow21Redirects_Async (timeout)

The maven changes should be treated with the contempt they deserve.
I mostly removed things I didn't understand and stroked maven until
it stopped squealing. The benchmarks / okcurl changes are a
particular mystery.

Tried with arbitrary versions of openjdk7 and openjdk8 I had
lying around. Behavior was the same across both (i.e. the same
failures).
