### PR TITLE
Move cache writing out of the transport.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CacheTest.java
@@ -660,9 +660,11 @@ public final class CacheTest {
         .method(requestMethod, requestBodyOrNull(requestMethod))
         .build();
     Response response1 = client.newCall(request).execute();
+    response1.body().close();
     assertEquals("1", response1.header("X-Response-ID"));
 
     Response response2 = get(url);
+    response2.body().close();
     if (expectCached) {
       assertEquals("1", response2.header("X-Response-ID"));
     } else {

--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/UrlConnectionCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/UrlConnectionCacheTest.java
@@ -629,9 +629,11 @@ public final class UrlConnectionCacheTest {
     HttpURLConnection request1 = client.open(url);
     request1.setRequestMethod(requestMethod);
     addRequestBodyIfNecessary(requestMethod, request1);
+    request1.getInputStream().close();
     assertEquals("1", request1.getHeaderField("X-Response-ID"));
 
     URLConnection request2 = client.open(url);
+    request2.getInputStream().close();
     if (expectCached) {
       assertEquals("1", request2.getHeaderField("X-Response-ID"));
     } else {

--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
@@ -556,9 +556,11 @@ public final class ResponseCacheTest {
     HttpURLConnection request1 = openConnection(url);
     request1.setRequestMethod(requestMethod);
     addRequestBodyIfNecessary(requestMethod, request1);
+    request1.getInputStream().close();
     assertEquals("1", request1.getHeaderField("X-Response-ID"));
 
     URLConnection request2 = openConnection(url);
+    request2.getInputStream().close();
     if (expectCached) {
       assertEquals("1", request2.getHeaderField("X-Response-ID"));
     } else {

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -169,7 +169,7 @@ public class Call {
           // Do not signal the callback twice!
           logger.log(Level.INFO, "Callback failure for " + toLoggableString(), e);
         } else {
-          responseCallback.onFailure(originalRequest, e);
+          responseCallback.onFailure(engine.getRequest(), e);
         }
       } finally {
         client.getDispatcher().finished(this);

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -31,6 +31,7 @@ import java.net.Proxy;
 import java.net.Socket;
 import java.net.URL;
 import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocket;
 
 import okio.Source;
@@ -406,8 +407,8 @@ public final class Connection {
       // it before proceeding.
       long contentLength = OkHeaders.contentLength(response);
       if (contentLength != -1) {
-        Source body = tunnelConnection.newFixedLengthSource(null, contentLength);
-        Util.skipAll(body, Integer.MAX_VALUE);
+        Source body = tunnelConnection.newFixedLengthSource(contentLength);
+        Util.skipAll(body, Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
       } else {
         tunnelConnection.emptyResponseBody();
       }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -108,24 +108,24 @@ public final class HttpTransport implements Transport {
     httpConnection.emptyResponseBody();
   }
 
-  @Override public Source getTransferStream(CacheRequest cacheRequest) throws IOException {
+  @Override public Source getTransferStream() throws IOException {
     if (!httpEngine.hasResponseBody()) {
-      return httpConnection.newFixedLengthSource(cacheRequest, 0);
+      return httpConnection.newFixedLengthSource(0);
     }
 
     if ("chunked".equalsIgnoreCase(httpEngine.getResponse().header("Transfer-Encoding"))) {
-      return httpConnection.newChunkedSource(cacheRequest, httpEngine);
+      return httpConnection.newChunkedSource(httpEngine);
     }
 
     long contentLength = OkHeaders.contentLength(httpEngine.getResponse());
     if (contentLength != -1) {
-      return httpConnection.newFixedLengthSource(cacheRequest, contentLength);
+      return httpConnection.newFixedLengthSource(contentLength);
     }
 
     // Wrap the input stream from the connection (rather than just returning
     // "socketIn" directly here), so that we can control its use after the
     // reference escapes.
-    return httpConnection.newUnknownLengthSource(cacheRequest);
+    return httpConnection.newUnknownLengthSource();
   }
 
   @Override public void disconnect(HttpEngine engine) throws IOException {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -33,13 +33,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import okio.Buffer;
-import okio.BufferedSink;
 import okio.ByteString;
-import okio.Okio;
 import okio.Sink;
 import okio.Source;
-import okio.Timeout;
 
 import static com.squareup.okhttp.internal.spdy.Header.RESPONSE_STATUS;
 import static com.squareup.okhttp.internal.spdy.Header.TARGET_AUTHORITY;
@@ -212,8 +208,8 @@ public final class SpdyTransport implements Transport {
     // Do nothing.
   }
 
-  @Override public Source getTransferStream(CacheRequest cacheRequest) throws IOException {
-    return new SpdySource(stream, cacheRequest);
+  @Override public Source getTransferStream() throws IOException {
+    return stream.getSource();
   }
 
   @Override public void releaseConnectionOnIdle() {
@@ -235,88 +231,6 @@ public final class SpdyTransport implements Transport {
       return HTTP_2_PROHIBITED_HEADERS.contains(name);
     } else {
       throw new AssertionError(protocol);
-    }
-  }
-
-  /** An HTTP message body terminated by the end of the underlying stream. */
-  private static class SpdySource implements Source {
-    private final SpdyStream stream;
-    private final Source source;
-    private final CacheRequest cacheRequest;
-    private final BufferedSink cacheBody;
-
-    private boolean inputExhausted;
-    private boolean closed;
-
-    SpdySource(SpdyStream stream, CacheRequest cacheRequest) throws IOException {
-      this.stream = stream;
-      this.source = stream.getSource();
-
-      // Some apps return a null body; for compatibility we treat that like a null cache request.
-      Sink cacheBody = cacheRequest != null ? cacheRequest.body() : null;
-      if (cacheBody == null) {
-        cacheRequest = null;
-      }
-
-      this.cacheBody = cacheBody != null ? Okio.buffer(cacheBody) : null;
-      this.cacheRequest = cacheRequest;
-    }
-
-    @Override public long read(Buffer buffer, long byteCount)
-        throws IOException {
-      if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
-      if (closed) throw new IllegalStateException("closed");
-      if (inputExhausted) return -1;
-
-      long read = source.read(buffer, byteCount);
-      if (read == -1) {
-        inputExhausted = true;
-        if (cacheRequest != null) {
-          cacheBody.close();
-        }
-        return -1;
-      }
-
-      if (cacheBody != null) {
-        buffer.copyTo(cacheBody.buffer(), buffer.size() - read, read);
-        cacheBody.emitCompleteSegments();
-      }
-
-      return read;
-    }
-
-    @Override public Timeout timeout() {
-      return source.timeout();
-    }
-
-    @Override public void close() throws IOException {
-      if (closed) return;
-
-      if (!inputExhausted && cacheBody != null) {
-        discardStream(); // Could make inputExhausted true!
-      }
-
-      closed = true;
-
-      if (!inputExhausted) {
-        stream.closeLater(ErrorCode.CANCEL);
-        if (cacheRequest != null) {
-          cacheRequest.abort();
-        }
-      }
-    }
-
-    private boolean discardStream() {
-      long oldTimeoutNanos = stream.readTimeout().timeoutNanos();
-      stream.readTimeout().timeout(DISCARD_STREAM_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-      try {
-        Util.skipAll(this, DISCARD_STREAM_TIMEOUT_MILLIS);
-        return true;
-      } catch (IOException e) {
-        return false;
-      } finally {
-        stream.readTimeout().timeout(oldTimeoutNanos, TimeUnit.NANOSECONDS);
-      }
     }
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
@@ -51,8 +51,7 @@ public interface Transport {
   /** Notify the transport that no response body will be read. */
   void emptyTransferStream() throws IOException;
 
-  // TODO: make this the content stream?
-  Source getTransferStream(CacheRequest cacheRequest) throws IOException;
+  Source getTransferStream() throws IOException;
 
   /**
    * Configures the response body to pool or close the socket connection when


### PR DESCRIPTION
This is necessary to unblock network interceptors, where the interceptor
may elect to rewrite the response body. If we've already cached the
original response body, we're too late.
