### PR TITLE
Use ResponseBody to model the response body everywhere.

### DIFF
--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -126,8 +126,9 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
   @Override public final InputStream getErrorStream() {
     try {
       HttpEngine response = getResponse();
-      if (response.hasResponseBody() && response.getResponse().code() >= HTTP_BAD_REQUEST) {
-        return response.getResponseBodyBytes();
+      if (HttpEngine.hasBody(response.getResponse())
+          && response.getResponse().code() >= HTTP_BAD_REQUEST) {
+        return response.getResponse().body().byteStream();
       }
       return null;
     } catch (IOException e) {
@@ -228,11 +229,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       throw new FileNotFoundException(url.toString());
     }
 
-    InputStream result = response.getResponseBodyBytes();
-    if (result == null) {
-      throw new ProtocolException("No response body exists; responseCode=" + getResponseCode());
-    }
-    return result;
+    return response.getResponse().body().byteStream();
   }
 
   @Override public final OutputStream getOutputStream() throws IOException {
@@ -349,8 +346,8 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       engineClient = client.clone().setCache(null);
     }
 
-    return new HttpEngine(engineClient, request, bufferRequestBody, connection, null, requestBody,
-        priorResponse);
+    return new HttpEngine(engineClient, request, bufferRequestBody, true, connection, null,
+        requestBody, priorResponse);
   }
 
   private String defaultUserAgent() {
@@ -426,7 +423,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
           ? httpEngine.getConnection().getHandshake()
           : null;
       if (readResponse) {
-        httpEngine.readResponse(false);
+        httpEngine.readResponse(false, null);
       }
 
       return true;

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -33,7 +33,6 @@ import java.net.URL;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLSocket;
-
 import okio.Source;
 
 import static com.squareup.okhttp.internal.Util.getDefaultPort;
@@ -406,12 +405,12 @@ public final class Connection {
       // The response body from a CONNECT should be empty, but if it is not then we should consume
       // it before proceeding.
       long contentLength = OkHeaders.contentLength(response);
-      if (contentLength != -1) {
-        Source body = tunnelConnection.newFixedLengthSource(contentLength);
-        Util.skipAll(body, Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
-      } else {
-        tunnelConnection.emptyResponseBody();
+      if (contentLength == -1L) {
+        contentLength = 0L;
       }
+      Source body = tunnelConnection.newFixedLengthSource(contentLength);
+      Util.skipAll(body, Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
+      body.close();
 
       switch (response.code()) {
         case HTTP_OK:

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RealResponseBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RealResponseBody.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.ResponseBody;
+import okio.BufferedSource;
+
+public final class RealResponseBody extends ResponseBody {
+  private final Headers headers;
+  private final BufferedSource source;
+
+  public RealResponseBody(Headers headers, BufferedSource source) {
+    this.headers = headers;
+    this.source = source;
+  }
+
+  @Override public MediaType contentType() {
+    String contentType = headers.get("Content-Type");
+    return contentType != null ? MediaType.parse(contentType) : null;
+  }
+
+  @Override public long contentLength() {
+    return OkHeaders.contentLength(headers);
+  }
+
+  @Override public BufferedSource source() {
+    return source;
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -20,6 +20,7 @@ import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.spdy.ErrorCode;
 import com.squareup.okhttp.internal.spdy.Header;
@@ -34,8 +35,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import okio.ByteString;
+import okio.Okio;
 import okio.Sink;
-import okio.Source;
 
 import static com.squareup.okhttp.internal.spdy.Header.RESPONSE_STATUS;
 import static com.squareup.okhttp.internal.spdy.Header.TARGET_AUTHORITY;
@@ -95,7 +96,7 @@ public final class SpdyTransport implements Transport {
     requestBody.writeToSocket(stream.getSink());
   }
 
-  @Override public void flushRequest() throws IOException {
+  @Override public void finishRequest() throws IOException {
     stream.getSink().close();
   }
 
@@ -204,12 +205,8 @@ public final class SpdyTransport implements Transport {
         .headers(headersBuilder.build());
   }
 
-  @Override public void emptyTransferStream() {
-    // Do nothing.
-  }
-
-  @Override public Source getTransferStream() throws IOException {
-    return stream.getSource();
+  @Override public ResponseBody openResponseBody(Response response) throws IOException {
+    return new RealResponseBody(response.headers(), Okio.buffer(stream.getSource()));
   }
 
   @Override public void releaseConnectionOnIdle() {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Transport.java
@@ -18,9 +18,9 @@ package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
 import java.io.IOException;
 import okio.Sink;
-import okio.Source;
 
 public interface Transport {
   /**
@@ -42,16 +42,14 @@ public interface Transport {
    */
   void writeRequestBody(RetryableSink requestBody) throws IOException;
 
-  /** Flush the request body to the underlying socket. */
-  void flushRequest() throws IOException;
+  /** Flush the request to the underlying socket. */
+  void finishRequest() throws IOException;
 
-  /** Read response headers and update the cookie manager. */
+  /** Read and return response headers. */
   Response.Builder readResponseHeaders() throws IOException;
 
-  /** Notify the transport that no response body will be read. */
-  void emptyTransferStream() throws IOException;
-
-  Source getTransferStream() throws IOException;
+  /** Returns a stream that reads the response body. */
+  ResponseBody openResponseBody(Response response) throws IOException;
 
   /**
    * Configures the response body to pool or close the socket connection when


### PR DESCRIPTION
This makes cache writing and gzip layering work a bit nicer
because there are fewer fields in HttpEngine to track the
various competing streams.
