### PR TITLE
Network interceptors.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
@@ -19,12 +19,15 @@ import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.ForwardingSink;
 import okio.ForwardingSource;
+import okio.GzipSink;
 import okio.Okio;
 import okio.Sink;
 import okio.Source;
@@ -32,7 +35,10 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 public final class InterceptorTest {
   @Rule public MockWebServerRule server = new MockWebServerRule();
@@ -40,11 +46,11 @@ public final class InterceptorTest {
   private OkHttpClient client = new OkHttpClient();
   private RecordingCallback callback = new RecordingCallback();
 
-  @Test public void shortCircuitResponseBeforeConnection() throws Exception {
+  @Test public void applicationInterceptorsCanShortCircuitResponses() throws Exception {
     server.get().shutdown(); // Accept no connections.
 
     Request request = new Request.Builder()
-        .url("https://localhost:0/")
+        .url("https://localhost:1/")
         .build();
 
     final Response interceptorResponse = new Response.Builder()
@@ -65,10 +71,154 @@ public final class InterceptorTest {
     assertSame(interceptorResponse, response);
   }
 
-  @Test public void rewriteRequestToServer() throws Exception {
+  @Test public void networkInterceptorsCannotShortCircuitResponses() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    Interceptor interceptor = new Interceptor() {
+      @Override public Response intercept(Chain chain) throws IOException {
+        return new Response.Builder()
+            .request(chain.request())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("Intercepted!")
+            .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "abc"))
+            .build();
+      }
+    };
+    client.networkInterceptors().add(interceptor);
+
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .build();
+
+    try {
+      client.newCall(request).execute();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("network interceptor " + interceptor + " must call proceed() exactly once",
+          expected.getMessage());
+    }
+  }
+
+  @Test public void networkInterceptorsCannotCallProceedMultipleTimes() throws Exception {
+    server.enqueue(new MockResponse());
     server.enqueue(new MockResponse());
 
-    client.interceptors().add(new Interceptor() {
+    Interceptor interceptor = new Interceptor() {
+      @Override public Response intercept(Chain chain) throws IOException {
+        chain.proceed(chain.request());
+        return chain.proceed(chain.request());
+      }
+    };
+    client.networkInterceptors().add(interceptor);
+
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .build();
+
+    try {
+      client.newCall(request).execute();
+      fail();
+    } catch (IllegalStateException expected) {
+      expected.printStackTrace();
+      assertEquals("network interceptor " + interceptor + " must call proceed() exactly once",
+          expected.getMessage());
+    }
+  }
+
+  @Test public void networkInterceptorsCannotChangeServerAddress() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    Interceptor interceptor = new Interceptor() {
+      @Override public Response intercept(Chain chain) throws IOException {
+        Address address = chain.connection().getRoute().getAddress();
+        String sameHost = address.getUriHost();
+        int differentPort = address.getUriPort() + 1;
+        return chain.proceed(chain.request().newBuilder()
+            .url(new URL("http://" + sameHost + ":" + differentPort + "/"))
+            .build());
+      }
+    };
+    client.networkInterceptors().add(interceptor);
+
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .build();
+
+    try {
+      client.newCall(request).execute();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("network interceptor " + interceptor + " must retain the same host and port",
+          expected.getMessage());
+    }
+  }
+
+  @Test public void networkInterceptorsHaveConnectionAccess() throws Exception {
+    server.enqueue(new MockResponse());
+
+    client.networkInterceptors().add(new Interceptor() {
+      @Override public Response intercept(Chain chain) throws IOException {
+        Connection connection = chain.connection();
+        assertNotNull(connection);
+        return chain.proceed(chain.request());
+      }
+    });
+
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .build();
+    client.newCall(request).execute();
+  }
+
+  @Test public void networkInterceptorsObserveNetworkHeaders() throws Exception {
+    server.enqueue(new MockResponse()
+        .setBody(gzip("abcabcabc"))
+        .addHeader("Content-Encoding: gzip"));
+
+    client.networkInterceptors().add(new Interceptor() {
+      @Override public Response intercept(Chain chain) throws IOException {
+        // The network request has everything: User-Agent, Host, Accept-Encoding.
+        Request networkRequest = chain.request();
+        assertNotNull(networkRequest.header("User-Agent"));
+        assertEquals(server.get().getHostName() + ":" + server.get().getPort(),
+            networkRequest.header("Host"));
+        assertNotNull(networkRequest.header("Accept-Encoding"));
+
+        // The network response also has everything, including the raw gzipped content.
+        Response networkResponse = chain.proceed(networkRequest);
+        assertEquals("gzip", networkResponse.header("Content-Encoding"));
+        return networkResponse;
+      }
+    });
+
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .build();
+
+    // No extra headers in the application's request.
+    assertNull(request.header("User-Agent"));
+    assertNull(request.header("Host"));
+    assertNull(request.header("Accept-Encoding"));
+
+    // No extra headers in the application's response.
+    Response response = client.newCall(request).execute();
+    assertNull(request.header("Content-Encoding"));
+    assertEquals("abcabcabc", response.body().string());
+  }
+
+  @Test public void applicationInterceptorsRewriteRequestToServer() throws Exception {
+    rewriteRequestToServer(client.interceptors());
+  }
+
+  @Test public void networkInterceptorsRewriteRequestToServer() throws Exception {
+    rewriteRequestToServer(client.networkInterceptors());
+  }
+
+  private void rewriteRequestToServer(List<Interceptor> interceptors) throws Exception {
+    server.enqueue(new MockResponse());
+
+    interceptors.add(new Interceptor() {
       @Override public Response intercept(Chain chain) throws IOException {
         Request originalRequest = chain.request();
         return chain.proceed(originalRequest.newBuilder()
@@ -93,12 +243,20 @@ public final class InterceptorTest {
     assertEquals("POST", recordedRequest.getMethod());
   }
 
-  @Test public void rewriteResponseFromServer() throws Exception {
+  @Test public void applicationInterceptorsRewriteResponseFromServer() throws Exception {
+    rewriteResponseFromServer(client.interceptors());
+  }
+
+  @Test public void networkInterceptorsRewriteResponseFromServer() throws Exception {
+    rewriteResponseFromServer(client.networkInterceptors());
+  }
+
+  private void rewriteResponseFromServer(List<Interceptor> interceptors) throws Exception {
     server.enqueue(new MockResponse()
         .addHeader("Original-Header: foo")
         .setBody("abc"));
 
-    client.interceptors().add(new Interceptor() {
+    interceptors.add(new Interceptor() {
       @Override public Response intercept(Chain chain) throws IOException {
         Response originalResponse = chain.proceed(chain.request());
         return originalResponse.newBuilder()
@@ -118,10 +276,18 @@ public final class InterceptorTest {
     assertEquals("foo", response.header("Original-Header"));
   }
 
-  @Test public void multipleInterceptors() throws Exception {
+  @Test public void multipleApplicationInterceptors() throws Exception {
+    multipleInterceptors(client.interceptors());
+  }
+
+  @Test public void multipleNetworkInterceptors() throws Exception {
+    multipleInterceptors(client.networkInterceptors());
+  }
+
+  private void multipleInterceptors(List<Interceptor> interceptors) throws Exception {
     server.enqueue(new MockResponse());
 
-    client.interceptors().add(new Interceptor() {
+    interceptors.add(new Interceptor() {
       @Override public Response intercept(Chain chain) throws IOException {
         Request originalRequest = chain.request();
         Response originalResponse = chain.proceed(originalRequest.newBuilder()
@@ -132,7 +298,7 @@ public final class InterceptorTest {
             .build();
       }
     });
-    client.interceptors().add(new Interceptor() {
+    interceptors.add(new Interceptor() {
       @Override public Response intercept(Chain chain) throws IOException {
         Request originalRequest = chain.request();
         Response originalResponse = chain.proceed(originalRequest.newBuilder()
@@ -157,37 +323,37 @@ public final class InterceptorTest {
         recordedRequest.getHeaders("Request-Interceptor"));
   }
 
-  @Test public void asyncInterceptors() throws Exception {
-    server.get().shutdown(); // Accept no connections.
+  @Test public void asyncApplicationInterceptors() throws Exception {
+    asyncInterceptors(client.interceptors());
+  }
 
-    Request request = new Request.Builder()
-        .url("https://localhost:0/")
-        .build();
+  @Test public void asyncNetworkInterceptors() throws Exception {
+    asyncInterceptors(client.networkInterceptors());
+  }
 
-    final Response interceptorResponse = new Response.Builder()
-        .request(request)
-        .protocol(Protocol.HTTP_1_1)
-        .code(200)
-        .message("Intercepted!")
-        .header("OkHttp-Intercepted", "yep")
-        .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "abc"))
-        .build();
+  private void asyncInterceptors(List<Interceptor> interceptors) throws Exception {
+    server.enqueue(new MockResponse());
 
-    client.interceptors().add(new Interceptor() {
+    interceptors.add(new Interceptor() {
       @Override public Response intercept(Chain chain) throws IOException {
-        return interceptorResponse;
+        Response originalResponse = chain.proceed(chain.request());
+        return originalResponse.newBuilder()
+            .addHeader("OkHttp-Intercepted", "yep")
+            .build();
       }
     });
 
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .build();
     client.newCall(request).enqueue(callback);
 
     callback.await(request.url())
         .assertCode(200)
-        .assertBody("abc")
         .assertHeader("OkHttp-Intercepted", "yep");
   }
 
-  @Test public void multipleRequestsToServer() throws Exception {
+  @Test public void applicationInterceptorsCanMakeMultipleRequestsToServer() throws Exception {
     server.enqueue(new MockResponse().setBody("a"));
     server.enqueue(new MockResponse().setBody("b"));
 
@@ -210,6 +376,10 @@ public final class InterceptorTest {
     return new RequestBody() {
       @Override public MediaType contentType() {
         return original.contentType();
+      }
+
+      @Override public long contentLength() {
+        return original.contentLength();
       }
 
       @Override public void writeTo(BufferedSink sink) throws IOException {
@@ -243,5 +413,13 @@ public final class InterceptorTest {
         return count;
       }
     };
+  }
+
+  private Buffer gzip(String data) throws IOException {
+    Buffer result = new Buffer();
+    BufferedSink sink = Okio.buffer(new GzipSink(result));
+    sink.writeUtf8(data);
+    sink.close();
+    return result;
   }
 }

--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -346,7 +346,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       engineClient = client.clone().setCache(null);
     }
 
-    return new HttpEngine(engineClient, request, bufferRequestBody, true, connection, null,
+    return new HttpEngine(engineClient, request, bufferRequestBody, true, false, connection, null,
         requestBody, priorResponse);
   }
 
@@ -423,7 +423,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
           ? httpEngine.getConnection().getHandshake()
           : null;
       if (readResponse) {
-        httpEngine.readResponse(false, null);
+        httpEngine.readResponse();
       }
 
       return true;

--- a/okhttp/src/main/java/com/squareup/okhttp/Interceptor.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Interceptor.java
@@ -28,5 +28,6 @@ public interface Interceptor {
   interface Chain {
     Request request();
     Response proceed(Request request) throws IOException;
+    Connection connection();
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -161,6 +161,7 @@ public class OkHttpClient implements Cloneable {
   private List<Protocol> protocols;
   private List<ConnectionSpec> connectionSpecs;
   private final List<Interceptor> interceptors = new ArrayList<>();
+  private final List<Interceptor> networkInterceptors = new ArrayList<>();
   private ProxySelector proxySelector;
   private CookieHandler cookieHandler;
 
@@ -193,6 +194,7 @@ public class OkHttpClient implements Cloneable {
     this.protocols = okHttpClient.protocols;
     this.connectionSpecs = okHttpClient.connectionSpecs;
     this.interceptors.addAll(okHttpClient.interceptors);
+    this.networkInterceptors.addAll(okHttpClient.networkInterceptors);
     this.proxySelector = okHttpClient.proxySelector;
     this.cookieHandler = okHttpClient.cookieHandler;
     this.cache = okHttpClient.cache;
@@ -531,6 +533,15 @@ public class OkHttpClient implements Cloneable {
    */
   public List<Interceptor> interceptors() {
     return interceptors;
+  }
+
+  /**
+   * Returns a modifiable list of interceptors that observe a single network request and response.
+   * These interceptors must call {@link Interceptor.Chain#proceed} exactly once: it is an error for
+   * a network interceptor to short-circuit or repeat a network request.
+   */
+  public List<Interceptor> networkInterceptors() {
+    return networkInterceptors;
   }
 
   /**


### PR DESCRIPTION
These exist between the OkHttp features (gzip, response cache, retry, route
planning, etc.) and the network server. They can be used to rewrite the response
headers and body from what the server actually returned to what the client wants.

For example, the interceptor could inject a missing 'Cache-Control' header to make
caching work better.
