### PR TITLE
Use native Okio copy for retrying.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RetryableSink.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RetryableSink.java
@@ -72,8 +72,9 @@ public final class RetryableSink implements Sink {
   }
 
   public void writeToSocket(Sink socketOut) throws IOException {
-    // Clone the content; otherwise we won't have data to retry.
-    Buffer buffer = content.clone();
+    // Copy the content; otherwise we won't have data to retry.
+    Buffer buffer = new Buffer();
+    content.copyTo(buffer, 0, content.size());
     socketOut.write(buffer, buffer.size());
   }
 }


### PR DESCRIPTION
For your consideration and review, because this has a slight behavioral problem...

This method is called from two places in two different ways:
 * `SpdyTransport.writeRequestBody` calls it with an instance of `SpdyDataSink`. This class is a `Sink` implementation which adds framing around a SPDY `FrameWriter` who ultimately delegates to a `BufferedSink` around the `Socket`.
 * `HttpConnection.writeRequestBody` on the other hand passes a `BufferedSink` which is directly wrapped around the `Socket`.

The distinction of the former being a `Sink` and the latter being a `BufferedSink` means that `Okio.buffer` is going to behave differently. When we ultimately call `.emit()` to ensure we're not leaking segments, one writes directly to a `Socket` whereas the other hands off to another `Buffer` and lets emission to the socket happen at the discretion of that sink.

So, are we fine with that behavior? Do we revert Okio's behavior?