### PR TITLE
Normalize caching size in loop-local variable.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/internal/spdy/SpdyServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/internal/spdy/SpdyServer.java
@@ -80,7 +80,7 @@ public final class SpdyServer implements IncomingStreamHandler {
   @Override public void receive(final SpdyStream stream) throws IOException {
     List<Header> requestHeaders = stream.getRequestHeaders();
     String path = null;
-    for (int i = 0; i < requestHeaders.size(); i++) {
+    for (int i = 0, size = requestHeaders.size(); i < size; i++) {
       if (requestHeaders.get(i).name.equals(Header.TARGET_PATH)) {
         path = requestHeaders.get(i).value.utf8();
         break;

--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -145,7 +145,7 @@ public class Main extends HelpOption implements Runnable {
       if (showHeaders) {
         System.out.println(StatusLine.get(response));
         Headers headers = response.headers();
-        for (int i = 0, count = headers.size(); i < count; i++) {
+        for (int i = 0, size = headers.size(); i < size; i++) {
           System.out.println(headers.name(i) + ": " + headers.value(i));
         }
         System.out.println();

--- a/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
+++ b/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
@@ -84,7 +84,7 @@ public final class OkApacheClient implements HttpClient {
     httpResponse.setEntity(entity);
 
     Headers headers = response.headers();
-    for (int i = 0; i < headers.size(); i++) {
+    for (int i = 0, size = headers.size(); i < size; i++) {
       String name = headers.name(i);
       String value = headers.value(i);
       httpResponse.addHeader(name, value);

--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -318,7 +318,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
         .url(getURL())
         .method(method, null /* No body; that's passed separately. */);
     Headers headers = requestHeaders.build();
-    for (int i = 0; i < headers.size(); i++) {
+    for (int i = 0, size = headers.size(); i < size; i++) {
       builder.addHeader(headers.name(i), headers.value(i));
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Cache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Cache.java
@@ -483,7 +483,7 @@ public final class Cache {
       sink.writeByte('\n');
       sink.writeUtf8(Integer.toString(varyHeaders.size()));
       sink.writeByte('\n');
-      for (int i = 0; i < varyHeaders.size(); i++) {
+      for (int i = 0, size = varyHeaders.size(); i < size; i++) {
         sink.writeUtf8(varyHeaders.name(i));
         sink.writeUtf8(": ");
         sink.writeUtf8(varyHeaders.value(i));
@@ -494,7 +494,7 @@ public final class Cache {
       sink.writeByte('\n');
       sink.writeUtf8(Integer.toString(responseHeaders.size()));
       sink.writeByte('\n');
-      for (int i = 0; i < responseHeaders.size(); i++) {
+      for (int i = 0, size = responseHeaders.size(); i < size; i++) {
         sink.writeUtf8(responseHeaders.name(i));
         sink.writeUtf8(": ");
         sink.writeUtf8(responseHeaders.value(i));

--- a/okhttp/src/main/java/com/squareup/okhttp/CacheControl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/CacheControl.java
@@ -150,7 +150,7 @@ public final class CacheControl {
     boolean onlyIfCached = false;
     boolean noTransform = false;
 
-    for (int i = 0; i < headers.size(); i++) {
+    for (int i = 0, size = headers.size(); i < size; i++) {
       if (!headers.name(i).equalsIgnoreCase("Cache-Control")
           && !headers.name(i).equalsIgnoreCase("Pragma")) {
         continue;

--- a/okhttp/src/main/java/com/squareup/okhttp/Headers.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Headers.java
@@ -96,7 +96,7 @@ public final class Headers {
   /** Returns an immutable case-insensitive set of header names. */
   public Set<String> names() {
     TreeSet<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-    for (int i = 0; i < size(); i++) {
+    for (int i = 0, size = size(); i < size; i++) {
       result.add(name(i));
     }
     return Collections.unmodifiableSet(result);
@@ -105,7 +105,7 @@ public final class Headers {
   /** Returns an immutable list of the header values for {@code name}. */
   public List<String> values(String name) {
     List<String> result = null;
-    for (int i = 0; i < size(); i++) {
+    for (int i = 0, size = size(); i < size; i++) {
       if (name.equalsIgnoreCase(name(i))) {
         if (result == null) result = new ArrayList<>(2);
         result.add(value(i));
@@ -124,7 +124,7 @@ public final class Headers {
 
   @Override public String toString() {
     StringBuilder result = new StringBuilder();
-    for (int i = 0; i < size(); i++) {
+    for (int i = 0, size = size(); i < size; i++) {
       result.append(name(i)).append(": ").append(value(i)).append("\n");
     }
     return result.toString();

--- a/okhttp/src/main/java/com/squareup/okhttp/MultipartBuilder.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/MultipartBuilder.java
@@ -207,7 +207,7 @@ public final class MultipartBuilder {
     sink.write(CRLF);
 
     if (headers != null) {
-      for (int i = 0; i < headers.size(); i++) {
+      for (int i = 0, size = headers.size(); i < size; i++) {
         sink.writeUtf8(headers.name(i))
             .write(COLONSPACE)
             .writeUtf8(headers.value(i))

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/CacheStrategy.java
@@ -1,6 +1,7 @@
 package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.CacheControl;
+import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 import java.util.Date;
@@ -103,9 +104,10 @@ public final class CacheStrategy {
       this.cacheResponse = cacheResponse;
 
       if (cacheResponse != null) {
-        for (int i = 0; i < cacheResponse.headers().size(); i++) {
-          String fieldName = cacheResponse.headers().name(i);
-          String value = cacheResponse.headers().value(i);
+        Headers headers = cacheResponse.headers();
+        for (int i = 0, size = headers.size(); i < size; i++) {
+          String fieldName = headers.name(i);
+          String value = headers.value(i);
           if ("Date".equalsIgnoreCase(fieldName)) {
             servedDate = HttpDate.parse(value);
             servedDateString = value;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
@@ -167,7 +167,7 @@ public final class HttpConnection {
   public void writeRequest(Headers headers, String requestLine) throws IOException {
     if (state != STATE_IDLE) throw new IllegalStateException("state: " + state);
     sink.writeUtf8(requestLine).writeUtf8("\r\n");
-    for (int i = 0; i < headers.size(); i ++) {
+    for (int i = 0, size = headers.size(); i < size; i ++) {
       sink.writeUtf8(headers.name(i))
           .writeUtf8(": ")
           .writeUtf8(headers.value(i))

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -880,7 +880,7 @@ public final class HttpEngine {
   private static Headers combine(Headers cachedHeaders, Headers networkHeaders) throws IOException {
     Headers.Builder result = new Headers.Builder();
 
-    for (int i = 0; i < cachedHeaders.size(); i++) {
+    for (int i = 0, size = cachedHeaders.size(); i < size; i++) {
       String fieldName = cachedHeaders.name(i);
       String value = cachedHeaders.value(i);
       if ("Warning".equalsIgnoreCase(fieldName) && value.startsWith("1")) {
@@ -891,7 +891,7 @@ public final class HttpEngine {
       }
     }
 
-    for (int i = 0; i < networkHeaders.size(); i++) {
+    for (int i = 0, size = networkHeaders.size(); i < size; i++) {
       String fieldName = networkHeaders.name(i);
       if ("Content-Length".equalsIgnoreCase(fieldName)) {
         continue; // Ignore content-length headers of validating responses.

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkHeaders.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/OkHeaders.java
@@ -87,7 +87,7 @@ public final class OkHeaders {
    */
   public static Map<String, List<String>> toMultimap(Headers headers, String valueForNullKey) {
     Map<String, List<String>> result = new TreeMap<>(FIELD_NAME_COMPARATOR);
-    for (int i = 0; i < headers.size(); i++) {
+    for (int i = 0, size = headers.size(); i < size; i++) {
       String fieldName = headers.name(i);
       String value = headers.value(i);
 
@@ -122,7 +122,7 @@ public final class OkHeaders {
   private static String buildCookieHeader(List<String> cookies) {
     if (cookies.size() == 1) return cookies.get(0);
     StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < cookies.size(); i++) {
+    for (int i = 0, size = cookies.size(); i < size; i++) {
       if (i > 0) sb.append("; ");
       sb.append(cookies.get(i));
     }
@@ -152,7 +152,7 @@ public final class OkHeaders {
   private static Set<String> varyFields(Response response) {
     Set<String> result = Collections.emptySet();
     Headers headers = response.headers();
-    for (int i = 0; i < headers.size(); i++) {
+    for (int i = 0, size = headers.size(); i < size; i++) {
       if (!"Vary".equalsIgnoreCase(headers.name(i))) continue;
 
       String value = headers.value(i);
@@ -180,7 +180,7 @@ public final class OkHeaders {
     Headers requestHeaders = response.networkResponse().request().headers();
 
     Headers.Builder result = new Headers.Builder();
-    for (int i = 0; i < requestHeaders.size(); i++) {
+    for (int i = 0, size = requestHeaders.size(); i < size; i++) {
       String fieldName = requestHeaders.name(i);
       if (varyFields.contains(fieldName)) {
         result.add(fieldName, requestHeaders.value(i));
@@ -215,11 +215,11 @@ public final class OkHeaders {
     // realm       = "realm" "=" realm-value
     // realm-value = quoted-string
     List<Challenge> result = new ArrayList<>();
-    for (int h = 0; h < responseHeaders.size(); h++) {
-      if (!challengeHeader.equalsIgnoreCase(responseHeaders.name(h))) {
+    for (int i = 0, size = responseHeaders.size(); i < size; i++) {
+      if (!challengeHeader.equalsIgnoreCase(responseHeaders.name(i))) {
         continue;
       }
-      String value = responseHeaders.value(h);
+      String value = responseHeaders.value(i);
       int pos = 0;
       while (pos < value.length()) {
         int tokenStart = pos;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SpdyTransport.java
@@ -127,7 +127,7 @@ public final class SpdyTransport implements Transport {
     result.add(new Header(TARGET_SCHEME, request.url().getProtocol()));
 
     Set<ByteString> names = new LinkedHashSet<ByteString>();
-    for (int i = 0; i < headers.size(); i++) {
+    for (int i = 0, size = headers.size(); i < size; i++) {
       // header names must be lowercase.
       ByteString name = ByteString.encodeUtf8(headers.name(i).toLowerCase(Locale.US));
       String value = headers.value(i);
@@ -175,7 +175,7 @@ public final class SpdyTransport implements Transport {
 
     Headers.Builder headersBuilder = new Headers.Builder();
     headersBuilder.set(OkHeaders.SELECTED_PROTOCOL, protocol.toString());
-    for (int i = 0; i < headerBlock.size(); i++) {
+    for (int i = 0, size = headerBlock.size(); i < size; i++) {
       ByteString name = headerBlock.get(i).name;
       String values = headerBlock.get(i).value.utf8();
       for (int start = 0; start < values.length(); ) {

--- a/samples/guide/src/main/java/com/squareup/okhttp/recipes/AsynchronousGet.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/recipes/AsynchronousGet.java
@@ -39,7 +39,7 @@ public final class AsynchronousGet {
         if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);
 
         Headers responseHeaders = response.headers();
-        for (int i = 0; i < responseHeaders.size(); i++) {
+        for (int i = 0, size = responseHeaders.size(); i < size; i++) {
           System.out.println(responseHeaders.name(i) + ": " + responseHeaders.value(i));
         }
 


### PR DESCRIPTION
This was present in a bunch of loops, but not all and not consistently. After fixing two, I figured that I would normalize them all under the umbrella of uniformity and being lazy (only lookup up the value once if it never changes).
