### PR TITLE
Source-incompatible: RequestBody.contentLength() throws IOException

### DIFF
--- a/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
+++ b/okcurl/src/test/java/com/squareup/okhttp/curl/MainTest.java
@@ -33,7 +33,7 @@ public class MainTest {
     assertNull(request.body());
   }
 
-  @Test public void put() {
+  @Test public void put() throws IOException {
     Request request = fromArgs("-X", "PUT", "http://example.com").createRequest();
     assertEquals("PUT", request.method());
     assertEquals("http://example.com", request.urlString());

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
@@ -378,7 +378,7 @@ public final class InterceptorTest {
         return original.contentType();
       }
 
-      @Override public long contentLength() {
+      @Override public long contentLength() throws IOException {
         return original.contentLength();
       }
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/MultipartBuilderTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/MultipartBuilderTest.java
@@ -46,8 +46,7 @@ public final class MultipartBuilderTest {
 
     Buffer buffer = new Buffer();
     requestBody.writeTo(buffer);
-    assertEquals(53, requestBody.contentLength());
-    assertEquals(buffer.size(), requestBody.contentLength());
+    assertEquals(-1L, requestBody.contentLength());
     assertEquals(expected, buffer.readUtf8());
   }
 
@@ -77,8 +76,7 @@ public final class MultipartBuilderTest {
 
     Buffer buffer = new Buffer();
     requestBody.writeTo(buffer);
-    assertEquals(112, requestBody.contentLength());
-    assertEquals(buffer.size(), requestBody.contentLength());
+    assertEquals(-1L, requestBody.contentLength());
     assertEquals(expected, buffer.readUtf8());
   }
 
@@ -92,7 +90,6 @@ public final class MultipartBuilderTest {
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"files\"\r\n"
         + "Content-Type: multipart/mixed; boundary=BbC04y\r\n"
-        + "Content-Length: 337\r\n"
         + "\r\n"
         + "--BbC04y\r\n"
         + "Content-Disposition: file; filename=\"file1.txt\"\r\n"
@@ -134,8 +131,7 @@ public final class MultipartBuilderTest {
 
     Buffer buffer = new Buffer();
     requestBody.writeTo(buffer);
-    assertEquals(568, requestBody.contentLength());
-    assertEquals(buffer.size(), requestBody.contentLength());
+    assertEquals(-1L, requestBody.contentLength());
     assertEquals(expected, buffer.readUtf8());
   }
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -79,7 +79,7 @@ public final class RequestTest {
   }
 
   /** Common verbs used for apis such as GitHub, AWS, and Google Cloud. */
-  @Test public void crudVerbs() {
+  @Test public void crudVerbs() throws IOException {
     MediaType contentType = MediaType.parse("application/json");
     RequestBody body = RequestBody.create(contentType, "{}");
 

--- a/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
@@ -31,7 +31,7 @@ public abstract class RequestBody {
    * Returns the number of bytes that will be written to {@code out} in a call
    * to {@link #writeTo}, or -1 if that count is unknown.
    */
-  public long contentLength() {
+  public long contentLength() throws IOException {
     return -1;
   }
 


### PR DESCRIPTION
This is a binary-compatible change, but code that currently calls
RequestBody.contentLength() doesn't necessarily catch or declare
IOException, and will need to with this change.

MultipartBuilder is most impacted by this change; previously the
length was computed eagerly; now it's not computed at all.
Applications that require the previous behavior should fully
buffer the request bodies and use that to compute the length.

Closes https://github.com/square/okhttp/issues/1141
