### PR TITLE
Use MockWebServerRule in more tests.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
@@ -120,7 +120,6 @@ public final class InterceptorTest {
       client.newCall(request).execute();
       fail();
     } catch (IllegalStateException expected) {
-      expected.printStackTrace();
       assertEquals("network interceptor " + interceptor + " must call proceed() exactly once",
           expected.getMessage());
     }

--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/JavaApiConverterTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/JavaApiConverterTest.java
@@ -28,7 +28,7 @@ import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.internal.SslContextBuilder;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -60,6 +60,7 @@ import okio.Buffer;
 import okio.BufferedSource;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -108,14 +109,13 @@ public class JavaApiConverterTest {
     }
   };
 
-  private MockWebServer server;
+  @Rule public MockWebServerRule server = new MockWebServerRule();
 
   private OkHttpClient client;
 
   private HttpURLConnection connection;
 
   @Before public void setUp() throws Exception {
-    server = new MockWebServer();
     client = new OkHttpClient();
   }
 
@@ -123,7 +123,6 @@ public class JavaApiConverterTest {
     if (connection != null) {
       connection.disconnect();
     }
-    server.shutdown();
   }
 
   @Test public void createOkResponse_fromOkHttpUrlConnection() throws Exception {
@@ -682,14 +681,12 @@ public class JavaApiConverterTest {
 
   private URL configureServer(MockResponse mockResponse) throws Exception {
     server.enqueue(mockResponse);
-    server.play();
     return server.getUrl("/");
   }
 
   private URL configureHttpsServer(MockResponse mockResponse) throws Exception {
-    server.useHttps(sslContext.getSocketFactory(), false /* tunnelProxy */);
+    server.get().useHttps(sslContext.getSocketFactory(), false /* tunnelProxy */);
     server.enqueue(mockResponse);
-    server.play();
     return server.getUrl("/");
   }
 

--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/ResponseCacheTest.java
@@ -354,7 +354,6 @@ public final class ResponseCacheTest {
       reader.readLine();
       fail("This implementation silently ignored a truncated HTTP body.");
     } catch (IOException expected) {
-        expected.printStackTrace();
     } finally {
       reader.close();
     }


### PR DESCRIPTION
Also fix a bug in MockWebServer where calls to shutdown()
raced with calls to play() would throw a NullPointerException.

Also improve logging in MockWebServer.
