### PR TITLE
Respect the max idle connections limit.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -317,14 +317,6 @@ public final class Connection {
   }
 
   /**
-   * Returns true if this connection has been idle for longer than
-   * {@code keepAliveDurationNs}.
-   */
-  boolean isExpired(long keepAliveDurationNs) {
-    return getIdleStartTimeNs() < System.nanoTime() - keepAliveDurationNs;
-  }
-
-  /**
    * Returns the time in ns when this connection became idle. Undefined if
    * this connection is not idle.
    */


### PR DESCRIPTION
The structure here is a bit ugly. But it permits a single 'synchronized'
block, which makes the method easier to reason about.

Closes https://github.com/square/okhttp/issues/1239
