### PR TITLE
Test Expect: 100-continue with OkHttp, not HttpURLConnection.

### DIFF
--- a/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/MockWebServerTest.java
@@ -97,61 +97,6 @@ public final class MockWebServerTest {
     assertEquals(Arrays.asList("Cookies: delicious", "cookie: r=robot"), response.getHeaders());
   }
 
-  /**
-   * Clients who adhere to <a
-   * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html#sec8.2.3">100
-   * Status</a> expect the server to send an interim response with status code
-   * 100 before they send their payload.
-   *
-   * <h4>Note</h4>
-   *
-   * JRE 6 only passes this test if
-   * {@code -Dsun.net.http.allowRestrictedHeaders=true} is set.
-   */
-  @Test public void expect100ContinueWithBody() throws Exception {
-    server.enqueue(new MockResponse());
-
-    URL url = server.getUrl("/");
-    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-    connection.setRequestMethod("PUT");
-    connection.setAllowUserInteraction(false);
-    connection.setRequestProperty("Expect", "100-continue");
-    connection.setDoOutput(true);
-    connection.getOutputStream().write("hello".getBytes());
-    assertEquals(HttpURLConnection.HTTP_OK, connection.getResponseCode());
-
-    assertEquals(server.getRequestCount(), 1);
-    RecordedRequest request = server.takeRequest();
-    assertEquals(request.getRequestLine(), "PUT / HTTP/1.1");
-    assertEquals("5", request.getHeader("Content-Length"));
-    assertEquals(5, request.getBodySize());
-    assertEquals("hello", request.getBody().readUtf8());
-    // below fails on JRE 6 unless -Dsun.net.http.allowRestrictedHeaders=true is set
-    assertEquals("100-continue", request.getHeader("Expect"));
-  }
-
-  @Test public void expect100ContinueWithNoBody() throws Exception {
-    server.enqueue(new MockResponse());
-
-    URL url = server.getUrl("/");
-    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-    connection.setRequestMethod("PUT");
-    connection.setAllowUserInteraction(false);
-    connection.setRequestProperty("Expect", "100-continue");
-    connection.setRequestProperty("Content-Length", "0");
-    connection.setDoOutput(true);
-    connection.setFixedLengthStreamingMode(0);
-    assertEquals(HttpURLConnection.HTTP_OK, connection.getResponseCode());
-
-    assertEquals(server.getRequestCount(), 1);
-    RecordedRequest request = server.takeRequest();
-    assertEquals(request.getRequestLine(), "PUT / HTTP/1.1");
-    assertEquals("0", request.getHeader("Content-Length"));
-    assertEquals(0, request.getBodySize());
-    // below fails on JRE 6 unless -Dsun.net.http.allowRestrictedHeaders=true is set
-    assertEquals("100-continue", request.getHeader("Expect"));
-  }
-
   @Test public void regularResponse() throws Exception {
     server.enqueue(new MockResponse().setBody("hello world"));
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -1617,6 +1617,36 @@ public final class CallTest {
         .assertCode(302);
   }
 
+  @Test public void expect100ContinueNonEmptyRequestBody() throws Exception {
+    server.enqueue(new MockResponse());
+
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .header("Expect", "100-continue")
+        .post(RequestBody.create(MediaType.parse("text/plain"), "abc"))
+        .build();
+
+    executeSynchronously(request)
+        .assertCode(200)
+        .assertSuccessful();
+
+    assertEquals("abc", server.takeRequest().getUtf8Body());
+  }
+
+  @Test public void expect100ContinueEmptyRequestBody() throws Exception {
+    server.enqueue(new MockResponse());
+
+    Request request = new Request.Builder()
+        .url(server.getUrl("/"))
+        .header("Expect", "100-continue")
+        .post(RequestBody.create(MediaType.parse("text/plain"), ""))
+        .build();
+
+    executeSynchronously(request)
+        .assertCode(200)
+        .assertSuccessful();
+  }
+
   private RecordedResponse executeSynchronously(Request request) throws IOException {
     Response response = client.newCall(request).execute();
     return new RecordedResponse(request, response, null, response.body().string(), null);


### PR DESCRIPTION
This test is flaky when relying on the platform's built-in
HttpURLConnectionImpl.

Instead, test it with OkHttp's API and implementation.