### PR TITLE
Remove ALPN jars from dependencies block.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,16 +80,6 @@
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
       </dependency>
-       <dependency>
-        <groupId>org.mortbay.jetty.alpn</groupId>
-        <artifactId>alpn-jdk7-boot</artifactId>
-        <version>${alpn.jdk7.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mortbay.jetty.alpn</groupId>
-        <artifactId>alpn-jdk8-boot</artifactId>
-        <version>${alpn.jdk8.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>


### PR DESCRIPTION
These aren't needed since the full dependency is declared directly on the plugin below.