### PR TITLE
Refactoring: Make RouteSelector independent of Connection

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
@@ -17,12 +17,12 @@ package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.Address;
 import com.squareup.okhttp.Authenticator;
-import com.squareup.okhttp.Connection;
-import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.ConnectionPool;
+import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Route;
 import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.Network;
 import com.squareup.okhttp.internal.RouteDatabase;
@@ -110,17 +110,17 @@ public final class RouteSelectorTest {
 
   @Test public void singleRoute() throws Exception {
     Address address = httpAddress();
-    RouteSelector routeSelector = RouteSelector.get(httpRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpRequest, client);
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
         uriPort, ConnectionSpec.CLEARTEXT);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
     try {
-      routeSelector.nextUnconnected();
+      routeSelector.next();
       fail();
     } catch (NoSuchElementException expected) {
     }
@@ -128,18 +128,18 @@ public final class RouteSelectorTest {
 
   @Test public void singleRouteReturnsFailedRoute() throws Exception {
     Address address = httpAddress();
-    RouteSelector routeSelector = RouteSelector.get(httpRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpRequest, client);
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    Connection connection = routeSelector.nextUnconnected();
-    routeDatabase.failed(connection.getRoute());
-    routeSelector = RouteSelector.get(httpRequest, client);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
+    Route route = routeSelector.next();
+    routeDatabase.failed(route);
+    routeSelector = RouteSelector.get(address, httpRequest, client);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
         uriPort, ConnectionSpec.CLEARTEXT);
     assertFalse(routeSelector.hasNext());
     try {
-      routeSelector.nextUnconnected();
+      routeSelector.next();
       fail();
     } catch (NoSuchElementException expected) {
     }
@@ -149,13 +149,13 @@ public final class RouteSelectorTest {
     Address address = new Address(uriHost, uriPort, socketFactory, null, null, null, authenticator,
         proxyA, protocols, connectionSpecs, proxySelector);
     client.setProxy(proxyA);
-    RouteSelector routeSelector = RouteSelector.get(httpRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpRequest, client);
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
         proxyAPort, ConnectionSpec.CLEARTEXT);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[1],
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1],
         proxyAPort, ConnectionSpec.CLEARTEXT);
 
     assertFalse(routeSelector.hasNext());
@@ -167,13 +167,13 @@ public final class RouteSelectorTest {
     Address address = new Address(uriHost, uriPort, socketFactory, null, null, null, authenticator,
         NO_PROXY, protocols, connectionSpecs, proxySelector);
     client.setProxy(NO_PROXY);
-    RouteSelector routeSelector = RouteSelector.get(httpRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpRequest, client);
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
         uriPort, ConnectionSpec.CLEARTEXT);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[1],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1],
         uriPort, ConnectionSpec.CLEARTEXT);
 
     assertFalse(routeSelector.hasNext());
@@ -185,12 +185,12 @@ public final class RouteSelectorTest {
     Address address = httpAddress();
 
     proxySelector.proxies = null;
-    RouteSelector routeSelector = RouteSelector.get(httpRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpRequest, client);
     proxySelector.assertRequests(httpRequest.uri());
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
         uriPort, ConnectionSpec.CLEARTEXT);
     dns.assertRequests(uriHost);
 
@@ -199,13 +199,13 @@ public final class RouteSelectorTest {
 
   @Test public void proxySelectorReturnsNoProxies() throws Exception {
     Address address = httpAddress();
-    RouteSelector routeSelector = RouteSelector.get(httpRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpRequest, client);
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
         uriPort, ConnectionSpec.CLEARTEXT);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[1],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1],
         uriPort, ConnectionSpec.CLEARTEXT);
 
     assertFalse(routeSelector.hasNext());
@@ -218,29 +218,30 @@ public final class RouteSelectorTest {
 
     proxySelector.proxies.add(proxyA);
     proxySelector.proxies.add(proxyB);
-    RouteSelector routeSelector = RouteSelector.get(httpRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpRequest, client);
     proxySelector.assertRequests(httpRequest.uri());
 
     // First try the IP addresses of the first proxy, in sequence.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0], proxyAPort,
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0], proxyAPort,
         ConnectionSpec.CLEARTEXT);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[1], proxyAPort,
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1], proxyAPort,
         ConnectionSpec.CLEARTEXT);
     dns.assertRequests(proxyAHost);
 
     // Next try the IP address of the second proxy.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(254, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[0], proxyBPort,
+    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[0],
+        proxyBPort,
         ConnectionSpec.CLEARTEXT);
     dns.assertRequests(proxyBHost);
 
     // Finally try the only IP address of the origin server.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(253, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0], uriPort,
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort,
         ConnectionSpec.CLEARTEXT);
     dns.assertRequests(uriHost);
 
@@ -251,13 +252,13 @@ public final class RouteSelectorTest {
     Address address = httpAddress();
 
     proxySelector.proxies.add(NO_PROXY);
-    RouteSelector routeSelector = RouteSelector.get(httpRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpRequest, client);
     proxySelector.assertRequests(httpRequest.uri());
 
     // Only the origin server will be attempted.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0], uriPort,
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort,
         ConnectionSpec.CLEARTEXT);
     dns.assertRequests(uriHost);
 
@@ -270,19 +271,19 @@ public final class RouteSelectorTest {
     proxySelector.proxies.add(proxyA);
     proxySelector.proxies.add(proxyB);
     proxySelector.proxies.add(proxyA);
-    RouteSelector routeSelector = RouteSelector.get(httpRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpRequest, client);
     proxySelector.assertRequests(httpRequest.uri());
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
         proxyAPort, ConnectionSpec.CLEARTEXT);
     dns.assertRequests(proxyAHost);
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = null;
     try {
-      routeSelector.nextUnconnected();
+      routeSelector.next();
       fail();
     } catch (UnknownHostException expected) {
     }
@@ -290,13 +291,13 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
         proxyAPort, ConnectionSpec.CLEARTEXT);
     dns.assertRequests(proxyAHost);
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(254, 1);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
         uriPort, ConnectionSpec.CLEARTEXT);
     dns.assertRequests(uriHost);
 
@@ -305,99 +306,101 @@ public final class RouteSelectorTest {
 
   // https://github.com/square/okhttp/issues/442
   @Test public void nonSslErrorAddsAllTlsModesToFailedRoute() throws Exception {
+    Address address = httpsAddress();
     client.setProxy(Proxy.NO_PROXY);
-    RouteSelector routeSelector = RouteSelector.get(httpsRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpsRequest, client);
 
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    Connection connection = routeSelector.nextUnconnected();
-    routeSelector.connectFailed(connection, new IOException("Non SSL exception"));
+    Route route = routeSelector.next();
+    routeSelector.connectFailed(route, new IOException("Non SSL exception"));
     assertEquals(2, routeDatabase.failedRoutesCount());
     assertFalse(routeSelector.hasNext());
   }
 
   @Test public void sslErrorAddsOnlyFailedConfigurationToFailedRoute() throws Exception {
+    Address address = httpsAddress();
     client.setProxy(Proxy.NO_PROXY);
-    RouteSelector routeSelector = RouteSelector.get(httpsRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpsRequest, client);
 
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    Connection connection = routeSelector.nextUnconnected();
-    routeSelector.connectFailed(connection, new SSLHandshakeException("SSL exception"));
+    Route route = routeSelector.next();
+    routeSelector.connectFailed(route, new SSLHandshakeException("SSL exception"));
     assertTrue(routeDatabase.failedRoutesCount() == 1);
     assertTrue(routeSelector.hasNext());
   }
 
   @Test public void multipleProxiesMultipleInetAddressesMultipleConfigurations() throws Exception {
-    Address address = new Address(uriHost, uriPort, socketFactory, sslSocketFactory,
-        hostnameVerifier, null, authenticator, null, protocols, connectionSpecs, proxySelector);
+    Address address = httpsAddress();
     proxySelector.proxies.add(proxyA);
     proxySelector.proxies.add(proxyB);
-    RouteSelector routeSelector = RouteSelector.get(httpsRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpsRequest, client);
 
     // Proxy A
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
         proxyAPort, ConnectionSpec.MODERN_TLS);
     dns.assertRequests(proxyAHost);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
         proxyAPort, ConnectionSpec.COMPATIBLE_TLS);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[1],
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1],
         proxyAPort, ConnectionSpec.MODERN_TLS);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyA, dns.inetAddresses[1],
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1],
         proxyAPort, ConnectionSpec.COMPATIBLE_TLS);
 
     // Proxy B
     dns.inetAddresses = makeFakeAddresses(254, 2);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[0],
         proxyBPort, ConnectionSpec.MODERN_TLS);
     dns.assertRequests(proxyBHost);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[0],
         proxyBPort, ConnectionSpec.COMPATIBLE_TLS);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[1],
+    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[1],
         proxyBPort, ConnectionSpec.MODERN_TLS);
-    assertConnection(routeSelector.nextUnconnected(), address, proxyB, dns.inetAddresses[1],
+    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[1],
         proxyBPort, ConnectionSpec.COMPATIBLE_TLS);
 
     // Origin
     dns.inetAddresses = makeFakeAddresses(253, 2);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
         uriPort, ConnectionSpec.MODERN_TLS);
     dns.assertRequests(uriHost);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[0],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
         uriPort, ConnectionSpec.COMPATIBLE_TLS);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[1],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1],
         uriPort, ConnectionSpec.MODERN_TLS);
-    assertConnection(routeSelector.nextUnconnected(), address, NO_PROXY, dns.inetAddresses[1],
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1],
         uriPort, ConnectionSpec.COMPATIBLE_TLS);
 
     assertFalse(routeSelector.hasNext());
   }
 
   @Test public void failedRoutesAreLast() throws Exception {
+    Address address = httpsAddress();
     client.setProxy(Proxy.NO_PROXY);
-    RouteSelector routeSelector = RouteSelector.get(httpsRequest, client);
+    RouteSelector routeSelector = RouteSelector.get(address, httpsRequest, client);
 
     dns.inetAddresses = makeFakeAddresses(255, 1);
 
     // Extract the regular sequence of routes from selector.
-    List<Connection> regularRoutes = new ArrayList<>();
+    List<Route> regularRoutes = new ArrayList<>();
     while (routeSelector.hasNext()) {
-      regularRoutes.add(routeSelector.nextUnconnected());
+      regularRoutes.add(routeSelector.next());
     }
 
     // Check that we do indeed have more than one route.
     assertTrue(regularRoutes.size() > 1);
     // Add first regular route as failed.
-    routeDatabase.failed(regularRoutes.get(0).getRoute());
+    routeDatabase.failed(regularRoutes.get(0));
     // Reset selector
-    routeSelector = RouteSelector.get(httpsRequest, client);
+    routeSelector = RouteSelector.get(address, httpsRequest, client);
 
-    List<Connection> routesWithFailedRoute = new ArrayList<>();
+    List<Route> routesWithFailedRoute = new ArrayList<>();
     while (routeSelector.hasNext()) {
-      routesWithFailedRoute.add(routeSelector.nextUnconnected());
+      routesWithFailedRoute.add(routeSelector.next());
     }
 
-    assertEquals(regularRoutes.get(0).getRoute(),
-        routesWithFailedRoute.get(routesWithFailedRoute.size() - 1).getRoute());
+    assertEquals(regularRoutes.get(0),
+        routesWithFailedRoute.get(routesWithFailedRoute.size() - 1));
     assertEquals(regularRoutes.size(), routesWithFailedRoute.size());
   }
 
@@ -419,19 +422,24 @@ public final class RouteSelectorTest {
     assertEquals("127.0.0.1", RouteSelector.getHostString(socketAddress));
   }
 
-  private void assertConnection(Connection connection, Address address, Proxy proxy,
+  private void assertRoute(Route route, Address address, Proxy proxy,
       InetAddress socketAddress, int socketPort, ConnectionSpec connectionSpec) {
-    assertEquals(address, connection.getRoute().getAddress());
-    assertEquals(proxy, connection.getRoute().getProxy());
-    assertEquals(socketAddress, connection.getRoute().getSocketAddress().getAddress());
-    assertEquals(socketPort, connection.getRoute().getSocketAddress().getPort());
-    assertEquals(connectionSpec, connection.getRoute().getConnectionSpec());
+    assertEquals(address, route.getAddress());
+    assertEquals(proxy, route.getProxy());
+    assertEquals(socketAddress, route.getSocketAddress().getAddress());
+    assertEquals(socketPort, route.getSocketAddress().getPort());
+    assertEquals(connectionSpec, route.getConnectionSpec());
   }
 
   /** Returns an address that's without an SSL socket factory or hostname verifier. */
   private Address httpAddress() {
     return new Address(uriHost, uriPort, socketFactory, null, null, null, authenticator, null,
         protocols, connectionSpecs, proxySelector);
+  }
+
+  private Address httpsAddress() {
+    return new Address(uriHost, uriPort, socketFactory, sslSocketFactory,
+        hostnameVerifier, null, authenticator, null, protocols, connectionSpecs, proxySelector);
   }
 
   private static InetAddress[] makeFakeAddresses(int prefix, int count) {


### PR DESCRIPTION
Ultimate goal: to improve the TLS fallback behavior so that
socket connections will not be created if the necessary
TLS protocols will not be supported.

To achieve this RouteSelector will be moved into Connection
and so that it can be passed the Socket or protocol information
during the route selection process.

This is a small first step: Make RouteSelector independent
of Connection so that it can later be moved inside of
Connection. It puts the RouteSelector interface in terms
of Routes, which seems logical.