### PR TITLE
WIP: Connection route selection

### DIFF
--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -25,6 +25,7 @@ import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 import com.squareup.okhttp.Route;
+import com.squareup.okhttp.ConnectionFailureException;
 import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.Platform;
 import com.squareup.okhttp.internal.Util;
@@ -432,6 +433,10 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       }
 
       return true;
+    } catch (ConnectionFailureException e) {
+      // TODO(nfuller): It would be nice to log or expose all exceptions somehow. E.g. >= JDK1.7
+      // with "suppressed" exceptions.
+      throw e.getLastConnectException();
     } catch (IOException e) {
       HttpEngine retryEngine = httpEngine.recover(e);
       if (retryEngine != null) {

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -270,6 +270,10 @@ public class Call {
       try {
         engine.sendRequest();
         engine.readResponse();
+      } catch (ConnectionFailureException e) {
+        // TODO(nfuller): It would be nice to log or expose all exceptions somehow. E.g. >= JDK1.7
+        // with "suppressed" exceptions.
+        throw e.getLastConnectException();
       } catch (IOException e) {
         HttpEngine retryEngine = engine.recover(e, null);
         if (retryEngine != null) {

--- a/okhttp/src/main/java/com/squareup/okhttp/ConnectionFailureException.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ConnectionFailureException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import java.io.IOException;
+import java.util.LinkedList;
+
+/**
+ * An exception thrown to indicate a problem connecting to an address. Multiple attempts may have
+ * been made, none of which were successful.
+ */
+public class ConnectionFailureException extends Exception {
+
+  private final LinkedList<IOException> connectExceptions = new LinkedList<IOException>();
+
+  public ConnectionFailureException(IOException cause) {
+    super(cause);
+    connectExceptions.add(cause);
+  }
+
+  public IOException getLastConnectException() {
+    return connectExceptions.getLast();
+  }
+
+  public void addConnectException(IOException e) {
+    connectExceptions.add(e);
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -116,7 +116,7 @@ public class OkHttpClient implements Cloneable {
       }
 
       @Override public void connectAndSetOwner(OkHttpClient client, Connection connection,
-          HttpEngine owner, Request request) throws IOException {
+          HttpEngine owner, Request request) throws ConnectionFailureException {
         connection.connectAndSetOwner(client, owner, request);
       }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/RouteSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/RouteSelector.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import java.io.IOException;
+
+/**
+ * Selects routes to connect to an origin server.
+ */
+public interface RouteSelector {
+
+  /**
+   * Returns true if there's another route to attempt. Every address has at
+   * least one route.
+   */
+  boolean hasNext();
+
+  /**
+   * Returns the next Route to attempt.
+   *
+   * @throws IOException if the next route could not be determined
+   * @throws java.util.NoSuchElementException if there is no next route
+   */
+  Route next() throws IOException;
+
+  /**
+   * Clients should invoke this method when they encounter a connectivity
+   * failure on a connection returned by this route selector.
+   */
+  void connectFailed(Route failedRoute, IOException failure);
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
@@ -23,6 +23,7 @@ import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.ConnectionFailureException;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.Transport;
 import java.io.IOException;
@@ -67,7 +68,7 @@ public abstract class Internal {
   public abstract void setNetwork(OkHttpClient client, Network network);
 
   public abstract void connectAndSetOwner(OkHttpClient client, Connection connection,
-      HttpEngine owner, Request request) throws IOException;
+      HttpEngine owner, Request request) throws ConnectionFailureException;
 
   // TODO delete the following when web sockets move into the main package.
   public abstract void callEnqueue(Call call, Callback responseCallback, boolean forWebSocket);


### PR DESCRIPTION
Work in progress. This is to get feedback and to show you where I'm heading with this. The ultimate aim is to implement multiple-level fallback, but without creating unnecessary connections when an SSLSocketFactory returns a socket that does not support all the protocols.

In Android I only moved the protocol selection out of RouteSelector / Route. Here, I have kept the RouteSelector, but made Connection responsible for creating the socket connection; it handles the retries.

See https://android-review.googlesource.com/#/c/113411 for the Android change against an older OkHttp

This pull request adds a commit on top of the first refactoring commit I sent out earlier. Please see the commit comment there for more information and potential benefits from the change.

Several files have TODO(nfuller) in the code and I would like feedback on. All OkHttp tests pass.

I expect the next commit would further modify the RouteSelector / Connection interaction. An SSLSocket can be interrogated by the RouteSelectorImpl to work out whether further attempts with other TLS protocols are worth trying. As things stand and plain socket is created, an SSLSocket wrapped around it, and *then* the Connection code would be able to work out there's no point in going further. This way we can avoid making unnecessary connections.