### PR TITLE
OkHttp now needs to explicitly close the response InputStream before it ...

### DIFF
--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/UrlConnectionCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/UrlConnectionCacheTest.java
@@ -1832,4 +1832,32 @@ public final class UrlConnectionCacheTest {
     sink.close();
     return result;
   }
+
+  @Test
+  public void cachedEntryDoesNotNeedClose() throws Exception {
+    server.enqueue(new MockResponse()
+        .addHeader("Cache-Control: max-age=60")
+        .setBody("A"));
+
+    URLConnection c1 = client.open(server.getUrl("/"));
+    InputStream inputStream = c1.getInputStream();
+    assertEquals('A', inputStream.read());
+
+    // TODO: This wasn't required before. It is now
+    // inputStream.close();
+
+    assertEquals(1, cache.getRequestCount());
+    assertEquals(1, cache.getNetworkCount());
+    assertEquals(0, cache.getHitCount());
+
+    URLConnection c2 = client.open(server.getUrl("/"));
+    assertEquals('A', c2.getInputStream().read());
+
+    URLConnection c3 = client.open(server.getUrl("/"));
+    assertEquals('A', c3.getInputStream().read());
+    assertEquals(3, cache.getRequestCount());
+    assertEquals(1, cache.getNetworkCount());
+    assertEquals(2, cache.getHitCount());
+  }
+
 }


### PR DESCRIPTION
...will be cached

I think this is a regression introduced by commit
e74e3f3bf744ef7f4d8ee724a7cf2347e486cfab

Can it go back the way it was?

[Do not submit as is - right now the test hangs due to the change in behavior]