### PR TITLE
Source-incompatible: ResponseBody methods throw IOException

### DIFF
--- a/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
+++ b/okhttp-apache/src/main/java/com/squareup/okhttp/apache/OkApacheClient.java
@@ -74,7 +74,7 @@ public final class OkApacheClient implements HttpClient {
     return builder.build();
   }
 
-  private static HttpResponse transformResponse(Response response) {
+  private static HttpResponse transformResponse(Response response) throws IOException {
     int code = response.code();
     String message = response.message();
     BasicHttpResponse httpResponse = new BasicHttpResponse(HTTP_1_1, code, message);

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
@@ -398,7 +398,7 @@ public final class InterceptorTest {
     };
   }
 
-  static ResponseBody uppercase(ResponseBody original) {
+  static ResponseBody uppercase(ResponseBody original) throws IOException {
     return ResponseBody.create(original.contentType(), original.contentLength(),
         Okio.buffer(uppercase(original.source())));
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/ResponseBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ResponseBody.java
@@ -37,13 +37,13 @@ public abstract class ResponseBody implements Closeable {
    * Returns the number of bytes in that will returned by {@link #bytes}, or
    * {@link #byteStream}, or -1 if unknown.
    */
-  public abstract long contentLength();
+  public abstract long contentLength() throws IOException;
 
-  public final InputStream byteStream() {
+  public final InputStream byteStream() throws IOException {
     return source().inputStream();
   }
 
-  public abstract BufferedSource source();
+  public abstract BufferedSource source() throws IOException;
 
   public final byte[] bytes() throws IOException {
     long contentLength = contentLength();
@@ -69,7 +69,7 @@ public abstract class ResponseBody implements Closeable {
    * of the Content-Type header. If that header is either absent or lacks a
    * charset, this will attempt to decode the response body as UTF-8.
    */
-  public final Reader charStream() {
+  public final Reader charStream() throws IOException {
     Reader r = reader;
     return r != null ? r : (reader = new InputStreamReader(byteStream(), charset()));
   }


### PR DESCRIPTION
This is a binary-compatible change, but code that currently calls
ResponseBody [contentLength()|byteStream()|source()|charStream()]
that doesn't necessarily catch or declare IOException will need
to with this change.

These methods could be performing I/O (opening streams, etc.).
Throwing IOException seems reasonable in this case.

contentType() and charset() have not been changed.