### PR TITLE
Fix ResponseCache handling for Android usecases

### DIFF
--- a/okhttp-android-support/src/main/java/com/squareup/okhttp/AndroidShimResponseCache.java
+++ b/okhttp-android-support/src/main/java/com/squareup/okhttp/AndroidShimResponseCache.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import com.squareup.okhttp.internal.huc.JavaApiConverter;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.CacheRequest;
+import java.net.CacheResponse;
+import java.net.ResponseCache;
+import java.net.URI;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A class provided for use by Android so that it can continue supporting a {@link ResponseCache}
+ * with stats.
+ */
+public class AndroidShimResponseCache extends ResponseCache {
+
+  private final Cache delegate;
+
+  private AndroidShimResponseCache(Cache delegate) {
+    this.delegate = delegate;
+  }
+
+  public static AndroidShimResponseCache create(File directory, long maxSize) throws IOException {
+    Cache cache = new Cache(directory, maxSize);
+    return new AndroidShimResponseCache(cache);
+  }
+
+  public boolean isEquivalent(File directory, long maxSize) {
+    Cache installedCache = getCache();
+    return (installedCache.getDirectory().equals(directory)
+        && installedCache.getMaxSize() == maxSize
+        && !installedCache.isClosed());
+  }
+
+  public Cache getCache() {
+    return delegate;
+  }
+
+  @Override public CacheResponse get(URI uri, String requestMethod,
+      Map<String, List<String>> requestHeaders) throws IOException {
+    Request okRequest = JavaApiConverter.createOkRequest(uri, requestMethod, requestHeaders);
+    Response okResponse = delegate.internalCache.get(okRequest);
+    if (okResponse == null) {
+      return null;
+    }
+    return JavaApiConverter.createJavaCacheResponse(okResponse);
+  }
+
+  @Override public CacheRequest put(URI uri, URLConnection urlConnection) throws IOException {
+    Response okResponse = JavaApiConverter.createOkResponse(uri, urlConnection);
+    com.squareup.okhttp.internal.http.CacheRequest okCacheRequest =
+        delegate.internalCache.put(okResponse);
+    if (okCacheRequest == null) {
+      return null;
+    }
+    return JavaApiConverter.createJavaCacheRequest(okCacheRequest);
+  }
+
+  /**
+   * Returns the number of bytes currently being used to store the values in
+   * this cache. This may be greater than the {@link #maxSize} if a background
+   * deletion is pending.
+   */
+  public long size() throws IOException {
+    return delegate.getSize();
+  }
+
+  /**
+   * Returns the maximum number of bytes that this cache should use to store
+   * its data.
+   */
+  public long maxSize() {
+    return delegate.getMaxSize();
+  }
+
+  /**
+   * Force buffered operations to the filesystem. This ensures that responses
+   * written to the cache will be available the next time the cache is opened,
+   * even if this process is killed.
+   */
+  public void flush() throws IOException {
+    delegate.flush();
+  }
+
+  /**
+   * Returns the number of HTTP requests that required the network to either
+   * supply a response or validate a locally cached response.
+   */
+  public int getNetworkCount() {
+    return delegate.getNetworkCount();
+  }
+
+  /**
+   * Returns the number of HTTP requests whose response was provided by the
+   * cache. This may include conditional {@code GET} requests that were
+   * validated over the network.
+   */
+  public int getHitCount() {
+    return delegate.getHitCount();
+  }
+
+  /**
+   * Returns the total number of HTTP requests that were made. This includes
+   * both client requests and requests that were made on the client's behalf
+   * to handle a redirects and retries.
+   */
+  public int getRequestCount() {
+    return delegate.getRequestCount();
+  }
+
+  /**
+   * Uninstalls the cache and releases any active resources. Stored contents
+   * will remain on the filesystem.
+   */
+  public void close() throws IOException {
+    delegate.close();
+  }
+
+  /**
+   * Uninstalls the cache and deletes all of its stored contents.
+   */
+  public void delete() throws IOException {
+    delegate.delete();
+  }
+
+}

--- a/okhttp-android-support/src/main/java/com/squareup/okhttp/OkCacheContainer.java
+++ b/okhttp-android-support/src/main/java/com/squareup/okhttp/OkCacheContainer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+/**
+ * An interface that allows OkHttp to detect that a {@link java.net.ResponseCache} contains a
+ * {@link Cache}.
+ */
+public interface OkCacheContainer {
+  Cache getCache();
+}

--- a/okhttp-android-support/src/test/java/com/squareup/okhttp/android/HttpResponseCache.java
+++ b/okhttp-android-support/src/test/java/com/squareup/okhttp/android/HttpResponseCache.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.okhttp.android;
+
+import com.squareup.okhttp.Cache;
+import com.squareup.okhttp.AndroidShimResponseCache;
+import com.squareup.okhttp.OkCacheContainer;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.net.CacheRequest;
+import java.net.CacheResponse;
+import java.net.ResponseCache;
+import java.net.URI;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A copy of android.net.http.HttpResponseCache taken from AOSP. Android need to keep this code
+ * working somehow. Dependencies on com.squareup.okhttp are com.android.okhttp on Android.
+ */
+/* <p>This class exists in okhttp-android-support to help keep the API as it always has been on
+ * Android. The public API cannot be changed. This class delegates to
+ * {@link com.squareup.okhttp.AndroidShimResponseCache}, a class that exists in a package that
+ * enables it to interact with non-public OkHttp classes.
+ */
+public final class HttpResponseCache extends ResponseCache implements Closeable, OkCacheContainer {
+
+  private AndroidShimResponseCache shimResponseCache;
+
+  private HttpResponseCache(AndroidShimResponseCache shimResponseCache) {
+    this.shimResponseCache = shimResponseCache;
+  }
+
+  /**
+   * Returns the currently-installed {@code HttpResponseCache}, or null if
+   * there is no cache installed or it is not a {@code HttpResponseCache}.
+   */
+  public static HttpResponseCache getInstalled() {
+    ResponseCache installed = ResponseCache.getDefault();
+    if (installed instanceof HttpResponseCache) {
+      return (HttpResponseCache) installed;
+    }
+    return null;
+  }
+
+  /**
+   * Creates a new HTTP response cache and sets it as the system default cache.
+   *
+   * @param directory the directory to hold cache data.
+   * @param maxSize the maximum size of the cache in bytes.
+   * @return the newly-installed cache
+   * @throws java.io.IOException if {@code directory} cannot be used for this cache.
+   *     Most applications should respond to this exception by logging a
+   *     warning.
+   */
+  public static synchronized HttpResponseCache install(File directory, long maxSize) throws
+      IOException {
+    ResponseCache installed = ResponseCache.getDefault();
+
+    if (installed instanceof HttpResponseCache) {
+      HttpResponseCache installedResponseCache = (HttpResponseCache) installed;
+      // don't close and reopen if an equivalent cache is already installed
+      AndroidShimResponseCache trueResponseCache = installedResponseCache.shimResponseCache;
+      if (trueResponseCache.isEquivalent(directory, maxSize)) {
+        return installedResponseCache;
+      } else {
+        // The HttpResponseCache that owns this object is about to be replaced.
+        trueResponseCache.close();
+      }
+    }
+
+    AndroidShimResponseCache trueResponseCache =
+        AndroidShimResponseCache.create(directory, maxSize);
+    HttpResponseCache newResponseCache = new HttpResponseCache(trueResponseCache);
+    ResponseCache.setDefault(newResponseCache);
+    return newResponseCache;
+  }
+
+  @Override public CacheResponse get(URI uri, String requestMethod,
+      Map<String, List<String>> requestHeaders) throws IOException {
+    return shimResponseCache.get(uri, requestMethod, requestHeaders);
+  }
+
+  @Override public CacheRequest put(URI uri, URLConnection urlConnection) throws IOException {
+    return shimResponseCache.put(uri, urlConnection);
+  }
+
+  /**
+   * Returns the number of bytes currently being used to store the values in
+   * this cache. This may be greater than the {@link #maxSize} if a background
+   * deletion is pending.
+   */
+  public long size() {
+    try {
+      return shimResponseCache.size();
+    } catch (IOException e) {
+      // This can occur if the cache failed to lazily initialize. Return -1 to mean "unknown".
+      return -1;
+    }
+  }
+
+  /**
+   * Returns the maximum number of bytes that this cache should use to store
+   * its data.
+   */
+  public long maxSize() {
+    return shimResponseCache.maxSize();
+  }
+
+  /**
+   * Force buffered operations to the filesystem. This ensures that responses
+   * written to the cache will be available the next time the cache is opened,
+   * even if this process is killed.
+   */
+  public void flush() {
+    try {
+      shimResponseCache.flush();
+    } catch (IOException ignored) {
+    }
+  }
+
+  /**
+   * Returns the number of HTTP requests that required the network to either
+   * supply a response or validate a locally cached response.
+   */
+  public int getNetworkCount() {
+    return shimResponseCache.getNetworkCount();
+  }
+
+  /**
+   * Returns the number of HTTP requests whose response was provided by the
+   * cache. This may include conditional {@code GET} requests that were
+   * validated over the network.
+   */
+  public int getHitCount() {
+    return shimResponseCache.getHitCount();
+  }
+
+  /**
+   * Returns the total number of HTTP requests that were made. This includes
+   * both client requests and requests that were made on the client's behalf
+   * to handle a redirects and retries.
+   */
+  public int getRequestCount() {
+    return shimResponseCache.getRequestCount();
+  }
+
+  /**
+   * Uninstalls the cache and releases any active resources. Stored contents
+   * will remain on the filesystem.
+   */
+  @Override public void close() throws IOException {
+    if (ResponseCache.getDefault() == this) {
+      ResponseCache.setDefault(null);
+    }
+    shimResponseCache.close();
+  }
+
+  /**
+   * Uninstalls the cache and deletes all of its stored contents.
+   */
+  public void delete() throws IOException {
+    if (ResponseCache.getDefault() == this) {
+      ResponseCache.setDefault(null);
+    }
+    shimResponseCache.delete();
+  }
+
+  @Override
+  public Cache getCache() {
+    return shimResponseCache.getCache();
+  }
+
+}

--- a/okhttp-android-support/src/test/java/com/squareup/okhttp/android/HttpResponseCacheTest.java
+++ b/okhttp-android-support/src/test/java/com/squareup/okhttp/android/HttpResponseCacheTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.okhttp.android;
+
+import com.squareup.okhttp.AndroidInternal;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.OkUrlFactory;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.CacheRequest;
+import java.net.CacheResponse;
+import java.net.ResponseCache;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+/**
+ * A port of Android's android.net.http.HttpResponseCacheTest to JUnit4.
+ */
+public final class HttpResponseCacheTest {
+
+  @Rule public TemporaryFolder cacheRule = new TemporaryFolder();
+  @Rule public MockWebServerRule serverRule = new MockWebServerRule();
+
+  private File cacheDir;
+  private MockWebServer server;
+  private OkUrlFactory client;
+
+  @Before public void setUp() throws Exception {
+    server = serverRule.get();
+    cacheDir = cacheRule.getRoot();
+    client = new OkUrlFactory(new OkHttpClient());
+  }
+
+  @After public void tearDown() throws Exception {
+    ResponseCache.setDefault(null);
+  }
+
+  @Test public void install() throws Exception {
+    HttpResponseCache installed = HttpResponseCache.install(cacheDir, 10 * 1024 * 1024);
+    assertNotNull(installed);
+    assertSame(installed, ResponseCache.getDefault());
+    assertSame(installed, HttpResponseCache.getDefault());
+  }
+
+  @Test public void secondEquivalentInstallDoesNothing() throws Exception {
+    HttpResponseCache first = HttpResponseCache.install(cacheDir, 10 * 1024 * 1024);
+    HttpResponseCache another = HttpResponseCache.install(cacheDir, 10 * 1024 * 1024);
+    assertSame(first, another);
+  }
+
+  @Test public void installClosesPreviouslyInstalled() throws Exception {
+    HttpResponseCache first = HttpResponseCache.install(cacheDir, 10 * 1024 * 1024);
+    initializeCache(first);
+
+    HttpResponseCache another = HttpResponseCache.install(cacheDir, 8 * 1024 * 1024);
+    initializeCache(another);
+
+    assertNotSame(first, another);
+    try {
+      first.flush();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void getInstalledWithWrongTypeInstalled() {
+    ResponseCache.setDefault(new ResponseCache() {
+      @Override
+      public CacheResponse get(URI uri, String requestMethod,
+          Map<String, List<String>> requestHeaders) {
+        return null;
+      }
+
+      @Override
+      public CacheRequest put(URI uri, URLConnection connection) {
+        return null;
+      }
+    });
+    assertNull(HttpResponseCache.getInstalled());
+  }
+
+  @Test public void closeCloses() throws Exception {
+    HttpResponseCache cache = HttpResponseCache.install(cacheDir, 10 * 1024 * 1024);
+    initializeCache(cache);
+
+    cache.close();
+    try {
+      cache.flush();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void closeUninstalls() throws Exception {
+    HttpResponseCache cache = HttpResponseCache.install(cacheDir, 10 * 1024 * 1024);
+    cache.close();
+    assertNull(ResponseCache.getDefault());
+  }
+
+  @Test public void deleteUninstalls() throws Exception {
+    HttpResponseCache cache = HttpResponseCache.install(cacheDir, 10 * 1024 * 1024);
+    cache.delete();
+    assertNull(ResponseCache.getDefault());
+  }
+
+  /**
+   * Make sure that statistics tracking are wired all the way through the
+   * wrapper class. http://code.google.com/p/android/issues/detail?id=25418
+   */
+  @Test public void statisticsTracking() throws Exception {
+    HttpResponseCache cache = HttpResponseCache.install(cacheDir, 10 * 1024 * 1024);
+
+    server.enqueue(new MockResponse()
+        .addHeader("Cache-Control: max-age=60")
+        .setBody("A"));
+
+    URLConnection c1 = openUrl(server.getUrl("/"));
+
+    InputStream inputStream = c1.getInputStream();
+    assertEquals('A', inputStream.read());
+    inputStream.close();
+    assertEquals(1, cache.getRequestCount());
+    assertEquals(1, cache.getNetworkCount());
+    assertEquals(0, cache.getHitCount());
+
+    URLConnection c2 = openUrl(server.getUrl("/"));
+    assertEquals('A', c2.getInputStream().read());
+
+    URLConnection c3 = openUrl(server.getUrl("/"));
+    assertEquals('A', c3.getInputStream().read());
+    assertEquals(3, cache.getRequestCount());
+    assertEquals(1, cache.getNetworkCount());
+    assertEquals(2, cache.getHitCount());
+  }
+
+  // This mimics the Android HttpHandler, which is found in the com.squareup.okhttp package.
+  private URLConnection openUrl(URL url) {
+    ResponseCache responseCache = ResponseCache.getDefault();
+    AndroidInternal.setResponseCache(client, responseCache);
+    return client.open(url);
+  }
+
+  private void initializeCache(HttpResponseCache cache) {
+    // Ensure the cache is initialized, otherwise various methods are no-ops.
+    cache.size();
+  }
+}

--- a/okhttp-android-support/src/test/java/com/squareup/okhttp/internal/huc/CacheAdapterTest.java
+++ b/okhttp-android-support/src/test/java/com/squareup/okhttp/internal/huc/CacheAdapterTest.java
@@ -30,6 +30,7 @@ import java.net.ResponseCache;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,8 @@ import javax.net.ssl.SSLSession;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import okio.Buffer;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -130,17 +133,19 @@ public class CacheAdapterTest {
 
   @Test public void put_httpGet() throws Exception {
     final String statusLine = "HTTP/1.1 200 Fantastic";
+    final byte[] response = "ResponseString".getBytes(StandardCharsets.UTF_8);
     final URL serverUrl = configureServer(
         new MockResponse()
             .setStatus(statusLine)
-            .addHeader("A", "c"));
+            .addHeader("A", "c")
+            .setBody(new Buffer().write(response)));
 
     ResponseCache responseCache = new AbstractResponseCache() {
       @Override public CacheRequest put(URI uri, URLConnection connection) throws IOException {
         assertTrue(connection instanceof HttpURLConnection);
         assertFalse(connection instanceof HttpsURLConnection);
 
-        assertEquals(0, connection.getContentLength());
+        assertEquals(response.length, connection.getContentLength());
 
         HttpURLConnection httpUrlConnection = (HttpURLConnection) connection;
         assertEquals("GET", httpUrlConnection.getRequestMethod());


### PR DESCRIPTION
Please see the commit comments for details.

I'd also like to propose a subsequent change to make the purpose of this code more obvious:

We move the following classes into an okhttp/okhttp-android-support sub-build + include it in the standard build (but in the same packages as they are today. The okhttp-android-support code would only be for Android to use, but by keeping it in the okhttp git repository we avoid future pain when Android pull from upstream, plus we reduce the amount of Android-specific junk in okhttp-httpurlconnection.

Move these:
1) AndroidShimResponseCache
2) OkCacheContainer
3) android/HttpResponseCache + Test
4) internal/huc/JavaApiConverter.java + Test
5) internal/huc/CacheAdapter.java

AFAIK, the only thing stopping this is the following method on OkUrlFactory. We could move this code into okhttp-android-support in the appropriate package (e.g. a static method in com.squareup.okhttp.AndroidInternal):

  /** Sets the response cache to be used to read and write cached responses. */
  public OkUrlFactory setResponseCache(ResponseCache responseCache) {
    if (responseCache instanceof OkCacheContainer) {
      // Avoid adding layers of wrappers. Rather than wrap the ResponseCache in yet another layer to
      // make the ResponseCache look like an InternalCache, we can unwrap the Cache instead.
      // This means that Cache stats will be correctly updated.
      OkCacheContainer okCacheContainer = (OkCacheContainer) responseCache;
      client.setCache(okCacheContainer.getCache());
    } else {
      client.setInternalCache(responseCache != null ? new CacheAdapter(responseCache) : null);
    }
    return this;
  }

What do you think?