### PR TITLE
Lazily initialize the cache.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/DiskLruCacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/DiskLruCacheTest.java
@@ -72,7 +72,9 @@ public final class DiskLruCacheTest {
 
   private void createNewCacheWithSize(int maxSize) throws IOException {
     cache = new DiskLruCache(cacheDir, appVersion, 2, maxSize, executor);
-    cache.initialize();
+    synchronized (cache) {
+      cache.initialize();
+    }
     toClose.add(cache);
   }
 
@@ -643,7 +645,7 @@ public final class DiskLruCacheTest {
 
   @Test public void constructorDoesNotAllowZeroCacheSize() throws Exception {
     try {
-      DiskLruCache.open(cacheDir, appVersion, 2, 0);
+      DiskLruCache.create(cacheDir, appVersion, 2, 0);
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -651,7 +653,7 @@ public final class DiskLruCacheTest {
 
   @Test public void constructorDoesNotAllowZeroValuesPerEntry() throws Exception {
     try {
-      DiskLruCache.open(cacheDir, appVersion, 0, 10);
+      DiskLruCache.create(cacheDir, appVersion, 0, 10);
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -772,7 +774,7 @@ public final class DiskLruCacheTest {
   @Test public void openCreatesDirectoryIfNecessary() throws Exception {
     cache.close();
     File dir = tempDir.newFolder("testOpenCreatesDirectoryIfNecessary");
-    cache = DiskLruCache.open(dir, appVersion, 2, Integer.MAX_VALUE);
+    cache = DiskLruCache.create(dir, appVersion, 2, Integer.MAX_VALUE);
     set("a", "a", "a");
     assertTrue(new File(dir, "a.0").exists());
     assertTrue(new File(dir, "a.1").exists());

--- a/okhttp/src/main/java/com/squareup/okhttp/Cache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Cache.java
@@ -138,8 +138,8 @@ public final class Cache {
   private int hitCount;
   private int requestCount;
 
-  public Cache(File directory, long maxSize) throws IOException {
-    cache = DiskLruCache.open(directory, VERSION, ENTRY_COUNT, maxSize);
+  public Cache(File directory, long maxSize) {
+    cache = DiskLruCache.create(directory, VERSION, ENTRY_COUNT, maxSize);
   }
 
   private static String urlToKey(Request request) {
@@ -269,7 +269,7 @@ public final class Cache {
    * <p>The iterator supports {@linkplain Iterator#remove}. Removing a URL from the iterator evicts
    * the corresponding response from the cache. Use this to evict selected responses.
    */
-  public Iterator<String> urls() {
+  public Iterator<String> urls() throws IOException {
     return new Iterator<String>() {
       final Iterator<DiskLruCache.Snapshot> delegate = cache.snapshots();
 
@@ -320,7 +320,7 @@ public final class Cache {
     return writeSuccessCount;
   }
 
-  public long getSize() {
+  public long getSize() throws IOException {
     return cache.size();
   }
 


### PR DESCRIPTION
For Android this defers a non-zero amount of I/O when applications are initializing. Since this is both happening on app startup and on the main thread it has a large chance of non-trivially impacting startup even though the work is relatively small.