### PR TITLE
Fix isClosed() when a cache has not been initialized

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/DiskLruCacheTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/DiskLruCacheTest.java
@@ -1081,6 +1081,16 @@ public final class DiskLruCacheTest {
     assertFalse(iterator.hasNext());
   }
 
+  @Test public void isClosed_uninitializedCache() throws Exception {
+    // Create an uninitialized cache.
+    cache = new DiskLruCache(cacheDir, appVersion, 2, Integer.MAX_VALUE, executor);
+    toClose.add(cache);
+
+    assertFalse(cache.isClosed());
+    cache.close();
+    assertTrue(cache.isClosed());
+  }
+
   private void assertJournalEquals(String... expectedBodyLines) throws Exception {
     List<String> expectedLines = new ArrayList<>();
     expectedLines.add(MAGIC);


### PR DESCRIPTION
isClosed() now means "has close() been called", after
commit ea565b2e30e15cd52ddfc2ddc6db4ea8f1c3de88
it meant "has not been initialized or close() has been
called".

Introduced explicit closed state. Minor tweak to use
initialized state to determine whether cleanup will
do anything. Added a test.