### PR TITLE
Fixed "connection refused" error on Android devices due to server listener bound to IPv6 address instead IPv4

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -285,7 +285,7 @@ public final class MockWebServer {
   public void start(int port) throws IOException {
     if (executor != null) throw new IllegalStateException("start() already called");
     executor = Executors.newCachedThreadPool(Util.threadFactory("MockWebServer", false));
-    inetAddress = InetAddress.getByName(null);
+    inetAddress = InetAddress.getLocalHost(); // Get IPv4 local host
     serverSocket = serverSocketFactory.createServerSocket();
     serverSocket.setReuseAddress(port != 0); // Reuse the port if the port number was specified.
     serverSocket.bind(new InetSocketAddress(inetAddress, port), 50);


### PR DESCRIPTION
Probably it's needed to bind both to IPv4 and IPv6 addresses but I still don't see any IPv6 usage around