### PR TITLE
Bugfix - Optional DELETE RequestBody via Request.Builder

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -209,6 +209,10 @@ public final class Request {
       return method("POST", body);
     }
 
+    public Builder delete(RequestBody body) {
+      return method("DELETE", body);
+    }
+
     public Builder delete() {
       return method("DELETE", null);
     }


### PR DESCRIPTION
In #610, support was added for `DELETE` requests to allow a `RequestBody`. Although this currently works internally, there's no way to load the request body through the convenience methods that `Request.Builder` exposes (like `Request.Builder.delete()`).

This PR introduces the ability to provide a `RequestBody` when building a `delete` request

Example usage:

```java
public void run() throws Exception {
  Request request = new Request.Builder()
      .url("https://someApiEndpoint")
      .delete(RequestBody.create(MEDIA_TYPE_JSON, postBody))
      .build();
  //..
}
```

----
Currently, one has to call `method`:
```java
public void run() throws Exception {
  Request request = new Request.Builder()
      .url("https://someApiEndpoint")
      .method("DELETE", RequestBody.create(MEDIA_TYPE_JSON, postBody))
      .build();
  //..
}
```

---
In  [HttpMethod.java](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpMethod.java#L32-L35), `permitsRequestBody` allows `DELETE` to pass through with a request body (via #610 and https://github.com/square/okhttp/pull/1143)