### PR TITLE
Modify the way MockWebServer selects a host IP to bind to

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -285,7 +285,7 @@ public final class MockWebServer {
   public void start(int port) throws IOException {
     if (executor != null) throw new IllegalStateException("start() already called");
     executor = Executors.newCachedThreadPool(Util.threadFactory("MockWebServer", false));
-    inetAddress = InetAddress.getByName(null);
+    inetAddress = InetAddress.getByName("localhost");
     serverSocket = serverSocketFactory.createServerSocket();
     serverSocket.setReuseAddress(port != 0); // Reuse the port if the port number was specified.
     serverSocket.bind(new InetSocketAddress(inetAddress, port), 50);


### PR DESCRIPTION
On Android getByName(null) returns the first of
[IPv6 loopback, IPv4 loopback], binding the server to ::1.
The IPv6 loopback address returns "localhost". "localhost"
does not resolve to the IPv6 address.

Instead: explicitly select "localhost" ensuring
MockWebServer binds to an IP that can be looked up by name
and should also be a loopback address.

Suggested fix for https://github.com/square/okhttp/issues/1069