### PR TITLE
(Hopefully) fix a flake in Spdy3ConnectionTest on Android

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -44,10 +44,10 @@ public final class MockSpdyPeer implements Closeable {
   private FrameWriter frameWriter = variant.newWriter(bytesOut, client);
   private final List<OutFrame> outFrames = new ArrayList<>();
   private final BlockingQueue<InFrame> inFrames = new LinkedBlockingQueue<>();
-  private int port;
   private final ExecutorService executor = Executors.newSingleThreadExecutor(
       Util.threadFactory("MockSpdyPeer", false));
-  private ServerSocket serverSocket;
+  private volatile ServerSocket serverSocket;
+  private volatile int port;
   private Socket socket;
 
   public void setVariantAndClient(Variant variant, boolean client) {


### PR DESCRIPTION
In some cases serverSocket is found to be null in
readAndWriteFrames().

The suspicion is that it's because of a lack of synchronization
between the thread setting the field, and the thread (started in
play()) reading it. serverSocket / port have been made
volatile to ensure the field state is flushed / read and not
cached. No flakes seen in several runs since the change.