### PR TITLE
Add helper class with commonly used MediaType constants

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/MediaTypeTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/MediaTypeTest.java
@@ -156,6 +156,15 @@ public class MediaTypeTest {
     assertEquals("text/plain;", mediaType.toString());
   }
 
+  @Test public void testValidTypes() throws Exception {
+    assertEquals(MediaType.parse("application/x-www-form-urlencoded"), MediaType.APPLICATION_FORM_URLENCODED);
+    assertEquals(MediaType.parse("application/octet-stream"), MediaType.APPLICATION_OCTET_STREAM);
+    assertEquals(MediaType.parse("multipart/form-data"), MediaType.MULTIPART_FORM_DATA);
+    assertEquals(MediaType.parse("application/json; charset=utf-8"), MediaType.APPLICATION_JSON);
+    assertEquals(MediaType.parse("application/xml; charset=utf-8"), MediaType.APPLICATION_XML);
+    assertEquals(MediaType.parse("text/plain; charset=utf-8"), MediaType.TEXT_PLAIN);
+  }
+
   private void assertMediaType(String string) {
     MediaType mediaType = MediaType.parse(string);
     assertEquals(string, mediaType.toString());

--- a/okhttp/src/main/java/com/squareup/okhttp/MediaType.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/MediaType.java
@@ -31,6 +31,38 @@ public final class MediaType {
   private static final Pattern PARAMETER = Pattern.compile(
       ";\\s*(?:" + TOKEN + "=(?:" + TOKEN + "|" + QUOTED + "))?");
 
+  /**
+   * A {@link MediaType} constant representing the "application/xml; charset=utf-8" media type.
+   */
+  public static final MediaType APPLICATION_XML =
+                  new MediaType("application/xml; charset=utf-8", "application", "xml", "utf-8");
+  /**
+   * A {@link MediaType} constant representing the "application/json; charset=utf-8" media type.
+   */
+  public static final MediaType APPLICATION_JSON =
+                  new MediaType("application/json; charset=utf-8", "application", "json", "utf-8");
+  /**
+   * A {@link MediaType} constant representing the "application/x-www-form-urlencoded" media type.
+   */
+  public static final MediaType APPLICATION_FORM_URLENCODED =
+                  new MediaType("application/x-www-form-urlencoded",
+                                "application", "x-www-form-urlencoded", null);
+  /**
+   * A {@link MediaType} constant representing the "multipart/form-data" media type.
+   */
+  public static final MediaType MULTIPART_FORM_DATA =
+                  new MediaType("multipart/form-data", "multipart", "form-data", null);
+  /**
+   * A {@link MediaType} constant representing the "application/octet-stream" media type.
+   */
+  public static final MediaType APPLICATION_OCTET_STREAM =
+                  new MediaType("application/octet-stream", "application", "octet-stream", null);
+  /**
+   * A {@link MediaType} constant representing the "text/plain; charset=utf-8" media type.
+   */
+  public static final MediaType TEXT_PLAIN =
+                  new MediaType("text/plain; charset=utf-8", "text", "plain", "utf-8");
+
   private final String mediaType;
   private final String type;
   private final String subtype;


### PR DESCRIPTION
This change set adds the helper class `MediaTypes` defining commonly used media types.

The class has been inspired by [`MediaType`](http://docs.oracle.com/javaee/7/api/javax/ws/rs/core/MediaType.html) from JAX-RS and is intended to save users from typing or having to define commonly used media types by themselves again and again.

The selection of media types in `MediaTypes` is rather arbitrary but should be sensible.