### PR TITLE
Fix for SSL test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <java.version>1.7</java.version>
     <okio.version>1.2.0</okio.version>
     <!-- ALPN library targeted to Java 7 -->
-    <alpn.jdk7.version>7.1.2.v20141202</alpn.jdk7.version>
+    <alpn.jdk7.version>7.1.0.v20141016</alpn.jdk7.version>
     <!-- ALPN library targeted to Java 8 update 25. -->
     <alpn.jdk8.version>8.1.2.v20141202</alpn.jdk8.version>
     <bouncycastle.version>1.50</bouncycastle.version>


### PR DESCRIPTION
@swankjesse thought I'd look into this.  Introduced in 03bb6bef 

The core of the issue is around the use of sun.security.ssl.SSLSessionImpl.setAsResumption(boolean) which is used in ALPN 7.1, but not introduced until Java 8. 

I wasn't seeing this fail in IDEA due to IDEA loading the OOTB 1.7 sun.security.ssl.ClientHandShaker over the jetty jar's ClientHandShaker.  

Ha, but sure enough, the reason the version bump was introduced (CallTest.matchingPinnedCertification) is brought back