### PR TITLE
Trivial optimization for comparing ConnectionSpecs

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/ConnectionSpec.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ConnectionSpec.java
@@ -176,6 +176,7 @@ public final class ConnectionSpec {
 
   @Override public boolean equals(Object other) {
     if (!(other instanceof ConnectionSpec)) return false;
+    if (other == this) return true;
 
     ConnectionSpec that = (ConnectionSpec) other;
     if (this.tls != that.tls) return false;


### PR DESCRIPTION
ConnectionSpec instances will usually originate from
final statics, particularly ConnectionSpec.CLEARTEXT. This seems
like a no-brainer to avoid array comparisons.