### PR TITLE
Fix a major bug where threads weren't being created.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Dispatcher.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Dispatcher.java
@@ -22,7 +22,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -59,7 +59,7 @@ public final class Dispatcher {
   public synchronized ExecutorService getExecutorService() {
     if (executorService == null) {
       executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
-          new LinkedBlockingQueue<Runnable>(), Util.threadFactory("OkHttp Dispatcher", false));
+          new SynchronousQueue<Runnable>(), Util.threadFactory("OkHttp Dispatcher", false));
     }
     return executorService;
   }


### PR DESCRIPTION
The LinkedBlockingQueue and core pool size of 0 do not interact well.
This prevents more threads from being created, harming overall
concurrency for async requests.