### PR TITLE
ConnectionSpec: Allow custom specifications

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionSpecTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionSpecTest.java
@@ -166,6 +166,16 @@ public final class ConnectionSpecTest {
     assertEquals(expectedCipherSet, expectedCipherSet);
   }
 
+  @Test
+  public void tls_stringCiphersAndVersions() throws Exception {
+    // Supporting arbitrary input strings allows users to enable suites and versions that are not
+    // yet known to the library, but are supported by the platform.
+    ConnectionSpec tlsSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+        .cipherSuites("MAGIC-CIPHER")
+        .tlsVersions("TLS9k")
+        .build();
+  }
+
   private static Set<String> createSet(String... values) {
     return new LinkedHashSet<String>(Arrays.asList(values));
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/ConnectionSpec.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ConnectionSpec.java
@@ -238,12 +238,20 @@ public final class ConnectionSpec {
       for (int i = 0; i < cipherSuites.length; i++) {
         strings[i] = cipherSuites[i].javaName;
       }
-
-      return cipherSuites(strings);
+      this.cipherSuites = strings;
+      return this;
     }
 
-    Builder cipherSuites(String[] cipherSuites) {
-      this.cipherSuites = cipherSuites; // No defensive copy.
+    public Builder cipherSuites(String... cipherSuites) {
+      if (!tls) throw new IllegalStateException("no cipher suites for cleartext connections");
+
+      if (cipherSuites == null) {
+        this.cipherSuites = null;
+      } else {
+        // This makes a defensive copy!
+        this.cipherSuites = cipherSuites.clone();
+      }
+
       return this;
     }
 
@@ -255,12 +263,20 @@ public final class ConnectionSpec {
       for (int i = 0; i < tlsVersions.length; i++) {
         strings[i] = tlsVersions[i].javaName;
       }
-
-      return tlsVersions(strings);
+      this.tlsVersions = strings;
+      return this;
     }
 
-    Builder tlsVersions(String... tlsVersions) {
-      this.tlsVersions = tlsVersions; // No defensive copy.
+    public Builder tlsVersions(String... tlsVersions) {
+      if (!tls) throw new IllegalStateException("no TLS versions for cleartext connections");
+
+      if (tlsVersions == null) {
+        this.tlsVersions = null;
+      } else {
+        // This makes a defensive copy!
+        this.tlsVersions = tlsVersions.clone();
+      }
+
       return this;
     }
 


### PR DESCRIPTION
I would like to be able to create ConnectionSpec's, like so:

``` java
ConnectionSpec mySpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
    .cipherSuites( ... strings or enums ... ).build();
```

 * Users can use the String... API to set CiperSuites and TLS versions, enabling forward-compatibility. You may wish to encourage users to continue to use the enums, but we already have a use case where the enum is insufficient.

Thank you in advance for your review, and thank you for the library!