### PR TITLE
Move TLS retries / fallback into Connection.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -38,7 +38,6 @@ import java.net.UnknownServiceException;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
@@ -681,6 +680,7 @@ public final class CallTest {
     }
   }
 
+  // https://github.com/square/okhttp/issues/442
   @Test public void timeoutsNotRetried() throws Exception {
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.NO_RESPONSE));
@@ -851,7 +851,7 @@ public final class CallTest {
       client.newCall(request).execute();
       fail();
     } catch (UnknownServiceException expected) {
-      assertTrue(expected.getMessage().contains("no connection specs"));
+      assertTrue(expected.getMessage().contains("CLEARTEXT communication not supported"));
     }
   }
 
@@ -1697,21 +1697,6 @@ public final class CallTest {
     sink.writeUtf8(data);
     sink.close();
     return result;
-  }
-
-  private void assertContains(Collection<String> collection, String element) {
-    for (String c : collection) {
-      if (c != null && c.equalsIgnoreCase(element)) return;
-    }
-    fail("No " + element + " in " + collection);
-  }
-
-  private void assertContainsNoneMatching(List<String> headers, String pattern) {
-    for (String header : headers) {
-      if (header.matches(pattern)) {
-        fail("Header " + header + " matches " + pattern);
-      }
-    }
   }
 
   private static class RecordingSSLSocketFactory extends DelegatingSSLSocketFactory {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionSpecTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionSpecTest.java
@@ -15,13 +15,8 @@
  */
 package com.squareup.okhttp;
 
-import com.squareup.okhttp.internal.http.AuthenticatorAdapter;
-
 import org.junit.Test;
 
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.net.ProxySelector;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -34,14 +29,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public final class ConnectionSpecTest {
-
-  private static final Proxy PROXY = Proxy.NO_PROXY;
-  private static final InetSocketAddress INET_SOCKET_ADDRESS =
-      InetSocketAddress.createUnresolved("host", 443);
-  private static final Address HTTPS_ADDRESS = new Address(
-      INET_SOCKET_ADDRESS.getHostString(), INET_SOCKET_ADDRESS.getPort(), null, null, null, null,
-      AuthenticatorAdapter.INSTANCE, PROXY, Arrays.asList(Protocol.HTTP_1_1),
-      Arrays.asList(ConnectionSpec.MODERN_TLS), ProxySelector.getDefault());
 
   @Test
   public void cleartextBuilder() throws Exception {
@@ -89,9 +76,8 @@ public final class ConnectionSpecTest {
         TlsVersion.TLS_1_1.javaName,
     });
 
-    Route route = new Route(HTTPS_ADDRESS, PROXY, INET_SOCKET_ADDRESS, tlsSpec,
-        false /* shouldSendTlsFallbackIndicator */);
-    tlsSpec.apply(socket, route);
+    assertTrue(tlsSpec.isCompatible(socket));
+    tlsSpec.apply(socket, false /* isFallback */);
 
     assertEquals(createSet(TlsVersion.TLS_1_2.javaName), createSet(socket.getEnabledProtocols()));
 
@@ -119,9 +105,8 @@ public final class ConnectionSpecTest {
         TlsVersion.TLS_1_1.javaName,
     });
 
-    Route route = new Route(HTTPS_ADDRESS, PROXY, INET_SOCKET_ADDRESS, tlsSpec,
-        true /* shouldSendTlsFallbackIndicator */);
-    tlsSpec.apply(socket, route);
+    assertTrue(tlsSpec.isCompatible(socket));
+    tlsSpec.apply(socket, true /* isFallback */);
 
     assertEquals(createSet(TlsVersion.TLS_1_2.javaName), createSet(socket.getEnabledProtocols()));
 
@@ -153,9 +138,8 @@ public final class ConnectionSpecTest {
         TlsVersion.TLS_1_1.javaName,
     });
 
-    Route route = new Route(HTTPS_ADDRESS, PROXY, INET_SOCKET_ADDRESS, tlsSpec,
-        true /* shouldSendTlsFallbackIndicator */);
-    tlsSpec.apply(socket, route);
+    assertTrue(tlsSpec.isCompatible(socket));
+    tlsSpec.apply(socket, true /* isFallback */);
 
     assertEquals(createSet(TlsVersion.TLS_1_2.javaName), createSet(socket.getEnabledProtocols()));
 
@@ -174,6 +158,52 @@ public final class ConnectionSpecTest {
         .cipherSuites("MAGIC-CIPHER")
         .tlsVersions("TLS9k")
         .build();
+  }
+
+  public void tls_missingRequiredCipher() throws Exception {
+    ConnectionSpec tlsSpec = new ConnectionSpec.Builder(true)
+        .cipherSuites(CipherSuite.TLS_RSA_WITH_RC4_128_MD5)
+        .tlsVersions(TlsVersion.TLS_1_2)
+        .supportsTlsExtensions(false)
+        .build();
+
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+    socket.setEnabledProtocols(new String[] {
+        TlsVersion.TLS_1_2.javaName,
+        TlsVersion.TLS_1_1.javaName,
+    });
+
+    socket.setEnabledCipherSuites(new String[] {
+        CipherSuite.TLS_RSA_WITH_RC4_128_SHA.javaName,
+        CipherSuite.TLS_RSA_WITH_RC4_128_MD5.javaName,
+    });
+    assertTrue(tlsSpec.isCompatible(socket));
+
+    socket.setEnabledCipherSuites(new String[] {
+        CipherSuite.TLS_RSA_WITH_RC4_128_SHA.javaName,
+    });
+    assertFalse(tlsSpec.isCompatible(socket));
+  }
+
+  @Test
+  public void tls_missingTlsVersion() throws Exception {
+    ConnectionSpec tlsSpec = new ConnectionSpec.Builder(true)
+        .cipherSuites(CipherSuite.TLS_RSA_WITH_RC4_128_MD5)
+        .tlsVersions(TlsVersion.TLS_1_2)
+        .supportsTlsExtensions(false)
+        .build();
+
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+    socket.setEnabledCipherSuites(new String[] {
+        CipherSuite.TLS_RSA_WITH_RC4_128_MD5.javaName,
+    });
+
+    socket.setEnabledProtocols(
+        new String[] { TlsVersion.TLS_1_2.javaName, TlsVersion.TLS_1_1.javaName });
+    assertTrue(tlsSpec.isCompatible(socket));
+
+    socket.setEnabledProtocols(new String[] { TlsVersion.TLS_1_1.javaName });
+    assertFalse(tlsSpec.isCompatible(socket));
   }
 
   private static Set<String> createSet(String... values) {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/ConnectionSpecSelectorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/ConnectionSpecSelectorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal;
+
+import com.squareup.okhttp.ConnectionSpec;
+import com.squareup.okhttp.TlsVersion;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocket;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConnectionSpecSelectorTest {
+
+  static {
+    Internal.initializeInstanceForTests();
+  }
+
+  private static final SSLContext sslContext = SslContextBuilder.localhost();
+
+  public static final SSLHandshakeException RETRYABLE_EXCEPTION = new SSLHandshakeException(
+      "Simulated handshake exception");
+
+  @Test
+  public void nonRetryableIOException() throws Exception {
+    ConnectionSpecSelector connectionSpecSelector =
+        createConnectionSpecSelector(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS);
+    SSLSocket socket = createSocketWithEnabledProtocols(TlsVersion.TLS_1_1, TlsVersion.TLS_1_0);
+    connectionSpecSelector.configureSecureSocket(socket);
+
+    boolean retry = connectionSpecSelector.connectionFailed(
+        new IOException("Non-handshake exception"));
+    assertFalse(retry);
+    socket.close();
+  }
+
+  @Test
+  public void nonRetryableSSLHandshakeException() throws Exception {
+    ConnectionSpecSelector connectionSpecSelector =
+        createConnectionSpecSelector(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS);
+    SSLSocket socket = createSocketWithEnabledProtocols(TlsVersion.TLS_1_1, TlsVersion.TLS_1_0);
+    connectionSpecSelector.configureSecureSocket(socket);
+
+    SSLHandshakeException trustIssueException =
+        new SSLHandshakeException("Certificate handshake exception");
+    trustIssueException.initCause(new CertificateException());
+    boolean retry = connectionSpecSelector.connectionFailed(trustIssueException);
+    assertFalse(retry);
+    socket.close();
+  }
+
+  @Test
+  public void retryableSSLHandshakeException() throws Exception {
+    ConnectionSpecSelector connectionSpecSelector =
+        createConnectionSpecSelector(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS);
+    SSLSocket socket = createSocketWithEnabledProtocols(TlsVersion.TLS_1_1, TlsVersion.TLS_1_0);
+    connectionSpecSelector.configureSecureSocket(socket);
+
+    boolean retry = connectionSpecSelector.connectionFailed(RETRYABLE_EXCEPTION);
+    assertTrue(retry);
+    socket.close();
+  }
+
+  @Test
+  public void someFallbacksSupported() throws Exception {
+    ConnectionSpec sslV3 =
+        new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .tlsVersions(TlsVersion.SSL_3_0)
+            .build();
+
+    ConnectionSpecSelector connectionSpecSelector = createConnectionSpecSelector(
+        ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS, sslV3);
+
+    TlsVersion[] enabledSocketTlsVersions = { TlsVersion.TLS_1_1, TlsVersion.TLS_1_0 };
+    SSLSocket socket = createSocketWithEnabledProtocols(enabledSocketTlsVersions);
+
+    // MODERN_TLS is used here.
+    connectionSpecSelector.configureSecureSocket(socket);
+    assertEnabledProtocols(socket, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0);
+
+    boolean retry = connectionSpecSelector.connectionFailed(RETRYABLE_EXCEPTION);
+    assertTrue(retry);
+    socket.close();
+
+    // COMPATIBLE_TLS is used here.
+    socket = createSocketWithEnabledProtocols(enabledSocketTlsVersions);
+    connectionSpecSelector.configureSecureSocket(socket);
+    assertEnabledProtocols(socket, TlsVersion.TLS_1_0);
+
+    retry = connectionSpecSelector.connectionFailed(RETRYABLE_EXCEPTION);
+    assertFalse(retry);
+    socket.close();
+
+    // sslV3 is not used because SSLv3 is not enabled on the socket.
+  }
+
+  private static ConnectionSpecSelector createConnectionSpecSelector(
+      ConnectionSpec... connectionSpecs) {
+    return new ConnectionSpecSelector(Arrays.asList(connectionSpecs));
+  }
+
+  private SSLSocket createSocketWithEnabledProtocols(TlsVersion... tlsVersions) throws IOException {
+    SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
+    socket.setEnabledProtocols(javaNames(tlsVersions));
+    return socket;
+  }
+
+  private static void assertEnabledProtocols(SSLSocket socket, TlsVersion... required) {
+    Set<String> actual = new LinkedHashSet<>(Arrays.asList(socket.getEnabledProtocols()));
+    Set<String> expected = new LinkedHashSet<>(Arrays.asList(javaNames(required)));
+    assertEquals(expected, actual);
+  }
+
+  private static String[] javaNames(TlsVersion... tlsVersions) {
+    String[] protocols = new String[tlsVersions.length];
+    for (int i = 0; i < tlsVersions.length; i++) {
+      protocols[i] = tlsVersions[i].javaName();
+    }
+    return protocols;
+  }
+}

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteSelectorTest.java
@@ -28,7 +28,6 @@ import com.squareup.okhttp.internal.Network;
 import com.squareup.okhttp.internal.RouteDatabase;
 import com.squareup.okhttp.internal.SslContextBuilder;
 import com.squareup.okhttp.internal.Util;
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -41,7 +40,6 @@ import javax.net.SocketFactory;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocketFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -114,8 +112,7 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
@@ -135,8 +132,7 @@ public final class RouteSelectorTest {
     Route route = routeSelector.next();
     routeDatabase.failed(route);
     routeSelector = RouteSelector.get(address, httpRequest, client);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort);
     assertFalse(routeSelector.hasNext());
     try {
       routeSelector.next();
@@ -153,10 +149,8 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
-        proxyAPort, ConnectionSpec.CLEARTEXT);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1],
-        proxyAPort, ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0], proxyAPort);
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1], proxyAPort);
 
     assertFalse(routeSelector.hasNext());
     dns.assertRequests(proxyAHost);
@@ -171,10 +165,8 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, ConnectionSpec.CLEARTEXT);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1],
-        uriPort, ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1], uriPort);
 
     assertFalse(routeSelector.hasNext());
     dns.assertRequests(uriHost);
@@ -190,8 +182,7 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
@@ -203,10 +194,8 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, ConnectionSpec.CLEARTEXT);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1],
-        uriPort, ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1], uriPort);
 
     assertFalse(routeSelector.hasNext());
     dns.assertRequests(uriHost);
@@ -224,25 +213,20 @@ public final class RouteSelectorTest {
     // First try the IP addresses of the first proxy, in sequence.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0], proxyAPort,
-        ConnectionSpec.CLEARTEXT);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1], proxyAPort,
-        ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0], proxyAPort);
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1], proxyAPort);
     dns.assertRequests(proxyAHost);
 
     // Next try the IP address of the second proxy.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(254, 1);
-    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[0],
-        proxyBPort,
-        ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[0], proxyBPort);
     dns.assertRequests(proxyBHost);
 
     // Finally try the only IP address of the origin server.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(253, 1);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort,
-        ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
@@ -258,8 +242,7 @@ public final class RouteSelectorTest {
     // Only the origin server will be attempted.
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort,
-        ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
@@ -276,8 +259,7 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
-        proxyAPort, ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0], proxyAPort);
     dns.assertRequests(proxyAHost);
 
     assertTrue(routeSelector.hasNext());
@@ -291,42 +273,15 @@ public final class RouteSelectorTest {
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(255, 1);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
-        proxyAPort, ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0], proxyAPort);
     dns.assertRequests(proxyAHost);
 
     assertTrue(routeSelector.hasNext());
     dns.inetAddresses = makeFakeAddresses(254, 1);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, ConnectionSpec.CLEARTEXT);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort);
     dns.assertRequests(uriHost);
 
     assertFalse(routeSelector.hasNext());
-  }
-
-  // https://github.com/square/okhttp/issues/442
-  @Test public void nonSslErrorAddsAllTlsModesToFailedRoute() throws Exception {
-    Address address = httpsAddress();
-    client.setProxy(Proxy.NO_PROXY);
-    RouteSelector routeSelector = RouteSelector.get(address, httpsRequest, client);
-
-    dns.inetAddresses = makeFakeAddresses(255, 1);
-    Route route = routeSelector.next();
-    routeSelector.connectFailed(route, new IOException("Non SSL exception"));
-    assertEquals(2, routeDatabase.failedRoutesCount());
-    assertFalse(routeSelector.hasNext());
-  }
-
-  @Test public void sslErrorAddsOnlyFailedConfigurationToFailedRoute() throws Exception {
-    Address address = httpsAddress();
-    client.setProxy(Proxy.NO_PROXY);
-    RouteSelector routeSelector = RouteSelector.get(address, httpsRequest, client);
-
-    dns.inetAddresses = makeFakeAddresses(255, 1);
-    Route route = routeSelector.next();
-    routeSelector.connectFailed(route, new SSLHandshakeException("SSL exception"));
-    assertTrue(routeDatabase.failedRoutesCount() == 1);
-    assertTrue(routeSelector.hasNext());
   }
 
   @Test public void multipleProxiesMultipleInetAddressesMultipleConfigurations() throws Exception {
@@ -337,39 +292,21 @@ public final class RouteSelectorTest {
 
     // Proxy A
     dns.inetAddresses = makeFakeAddresses(255, 2);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
-        proxyAPort, ConnectionSpec.MODERN_TLS);
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0], proxyAPort);
     dns.assertRequests(proxyAHost);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[0],
-        proxyAPort, ConnectionSpec.COMPATIBLE_TLS);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1],
-        proxyAPort, ConnectionSpec.MODERN_TLS);
-    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1],
-        proxyAPort, ConnectionSpec.COMPATIBLE_TLS);
+    assertRoute(routeSelector.next(), address, proxyA, dns.inetAddresses[1], proxyAPort);
 
     // Proxy B
     dns.inetAddresses = makeFakeAddresses(254, 2);
-    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[0],
-        proxyBPort, ConnectionSpec.MODERN_TLS);
+    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[0], proxyBPort);
     dns.assertRequests(proxyBHost);
-    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[0],
-        proxyBPort, ConnectionSpec.COMPATIBLE_TLS);
-    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[1],
-        proxyBPort, ConnectionSpec.MODERN_TLS);
-    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[1],
-        proxyBPort, ConnectionSpec.COMPATIBLE_TLS);
+    assertRoute(routeSelector.next(), address, proxyB, dns.inetAddresses[1], proxyBPort);
 
     // Origin
     dns.inetAddresses = makeFakeAddresses(253, 2);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, ConnectionSpec.MODERN_TLS);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0], uriPort);
     dns.assertRequests(uriHost);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[0],
-        uriPort, ConnectionSpec.COMPATIBLE_TLS);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1],
-        uriPort, ConnectionSpec.MODERN_TLS);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1],
-        uriPort, ConnectionSpec.COMPATIBLE_TLS);
+    assertRoute(routeSelector.next(), address, NO_PROXY, dns.inetAddresses[1], uriPort);
 
     assertFalse(routeSelector.hasNext());
   }
@@ -379,7 +316,8 @@ public final class RouteSelectorTest {
     client.setProxy(Proxy.NO_PROXY);
     RouteSelector routeSelector = RouteSelector.get(address, httpsRequest, client);
 
-    dns.inetAddresses = makeFakeAddresses(255, 1);
+    final int numberOfAddresses = 2;
+    dns.inetAddresses = makeFakeAddresses(255, numberOfAddresses);
 
     // Extract the regular sequence of routes from selector.
     List<Route> regularRoutes = new ArrayList<>();
@@ -388,7 +326,7 @@ public final class RouteSelectorTest {
     }
 
     // Check that we do indeed have more than one route.
-    assertTrue(regularRoutes.size() > 1);
+    assertEquals(numberOfAddresses, regularRoutes.size());
     // Add first regular route as failed.
     routeDatabase.failed(regularRoutes.get(0));
     // Reset selector
@@ -422,13 +360,12 @@ public final class RouteSelectorTest {
     assertEquals("127.0.0.1", RouteSelector.getHostString(socketAddress));
   }
 
-  private void assertRoute(Route route, Address address, Proxy proxy,
-      InetAddress socketAddress, int socketPort, ConnectionSpec connectionSpec) {
+  private void assertRoute(Route route, Address address, Proxy proxy, InetAddress socketAddress,
+      int socketPort) {
     assertEquals(address, route.getAddress());
     assertEquals(proxy, route.getProxy());
     assertEquals(socketAddress, route.getSocketAddress().getAddress());
     assertEquals(socketPort, route.getSocketAddress().getPort());
-    assertEquals(connectionSpec, route.getConnectionSpec());
   }
 
   /** Returns an address that's without an SSL socket factory or hostname verifier. */

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -613,6 +613,7 @@ public final class URLConnectionTest {
 
     RecordedRequest request = server.takeRequest();
     assertEquals("GET /foo HTTP/1.1", request.getRequestLine());
+    assertEquals(TlsVersion.TLS_1_0, request.getTlsVersion());
   }
 
   /**

--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -27,11 +27,13 @@ import com.squareup.okhttp.Response;
 import com.squareup.okhttp.Route;
 import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.Platform;
+import com.squareup.okhttp.internal.http.RouteException;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HttpDate;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.HttpMethod;
 import com.squareup.okhttp.internal.http.OkHeaders;
+import com.squareup.okhttp.internal.http.RequestException;
 import com.squareup.okhttp.internal.http.RetryableSink;
 import com.squareup.okhttp.internal.http.StatusLine;
 import java.io.FileNotFoundException;
@@ -432,7 +434,25 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       }
 
       return true;
+    } catch (RequestException e) {
+      // An attempt to interpret a request failed.
+      IOException toThrow = e.getCause();
+      httpEngineFailure = toThrow;
+      throw toThrow;
+    } catch (RouteException e) {
+      // The attempt to connect via a route failed. The request will not have been sent.
+      HttpEngine retryEngine = httpEngine.recover(e);
+      if (retryEngine != null) {
+        httpEngine = retryEngine;
+        return false;
+      }
+
+      // Give up; recovery is not possible.
+      IOException toThrow = e.getLastConnectException();
+      httpEngineFailure = toThrow;
+      throw toThrow;
     } catch (IOException e) {
+      // An attempt to communicate with a server failed. The request may have been sent.
       HttpEngine retryEngine = httpEngine.recover(e);
       if (retryEngine != null) {
         httpEngine = retryEngine;

--- a/okhttp/src/main/java/com/squareup/okhttp/Address.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Address.java
@@ -139,6 +139,13 @@ public final class Address {
     return proxySelector;
   }
 
+  /**
+   * Returns this address's certificate pinner. Only used for secure connections.
+   */
+  public CertificatePinner getCertificatePinner() {
+    return certificatePinner;
+  }
+
   @Override public boolean equals(Object other) {
     if (other instanceof Address) {
       Address that = (Address) other;

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -16,7 +16,9 @@
 package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.NamedRunnable;
+import com.squareup.okhttp.internal.http.RouteException;
 import com.squareup.okhttp.internal.http.HttpEngine;
+import com.squareup.okhttp.internal.http.RequestException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
@@ -270,7 +272,20 @@ public class Call {
       try {
         engine.sendRequest();
         engine.readResponse();
+      } catch (RequestException e) {
+        // The attempt to interpret the request failed. Give up.
+        throw e.getCause();
+      } catch (RouteException e) {
+        // The attempt to connect via a route failed. The request will not have been sent.
+        HttpEngine retryEngine = engine.recover(e);
+        if (retryEngine != null) {
+          engine = retryEngine;
+          continue;
+        }
+        // Give up; recovery is not possible.
+        throw e.getLastConnectException();
       } catch (IOException e) {
+        // An attempt to communicate with a server failed. The request may have been sent.
         HttpEngine retryEngine = engine.recover(e, null);
         if (retryEngine != null) {
           engine = retryEngine;

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -16,30 +16,18 @@
  */
 package com.squareup.okhttp;
 
-import com.squareup.okhttp.internal.Platform;
-import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.HttpConnection;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.HttpTransport;
-import com.squareup.okhttp.internal.http.OkHeaders;
+import com.squareup.okhttp.internal.http.RouteException;
+import com.squareup.okhttp.internal.http.SocketConnector;
 import com.squareup.okhttp.internal.http.SpdyTransport;
 import com.squareup.okhttp.internal.http.Transport;
 import com.squareup.okhttp.internal.spdy.SpdyConnection;
-import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
 import java.io.IOException;
-import java.net.Proxy;
 import java.net.Socket;
-import java.net.URL;
-import java.security.cert.X509Certificate;
-import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSocket;
-import okio.Source;
-
-import static com.squareup.okhttp.internal.Util.getDefaultPort;
-import static com.squareup.okhttp.internal.Util.getEffectivePort;
-import static java.net.HttpURLConnection.HTTP_OK;
-import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
+import java.net.UnknownServiceException;
+import java.util.List;
 
 /**
  * The sockets and streams of an HTTP, HTTPS, or HTTPS+SPDY connection. May be
@@ -142,23 +130,42 @@ public final class Connection {
     socket.close();
   }
 
-  void connect(int connectTimeout, int readTimeout, int writeTimeout, Request tunnelRequest)
-      throws IOException {
+  void connect(int connectTimeout, int readTimeout, int writeTimeout, Request request,
+      List<ConnectionSpec> connectionSpecs, boolean connectionRetryEnabled) throws RouteException {
     if (connected) throw new IllegalStateException("already connected");
 
-    if (route.proxy.type() == Proxy.Type.DIRECT || route.proxy.type() == Proxy.Type.HTTP) {
-      socket = route.address.socketFactory.createSocket();
+    SocketConnector socketConnector = new SocketConnector(this, pool);
+    SocketConnector.ConnectedSocket connectedSocket;
+    if (route.address.getSslSocketFactory() != null) {
+      // https:// communication
+      connectedSocket = socketConnector.connectTls(connectTimeout, readTimeout, writeTimeout,
+          request, route, connectionSpecs, connectionRetryEnabled);
     } else {
-      socket = new Socket(route.proxy);
+      // http:// communication.
+      if (!connectionSpecs.contains(ConnectionSpec.CLEARTEXT)) {
+        throw new RouteException(
+            new UnknownServiceException(
+                "CLEARTEXT communication not supported: " + connectionSpecs));
+      }
+      connectedSocket = socketConnector.connectCleartext(connectTimeout, readTimeout, route);
     }
 
-    socket.setSoTimeout(readTimeout);
-    Platform.get().connectSocket(socket, route.inetSocketAddress, connectTimeout);
+    socket = connectedSocket.socket;
+    handshake = connectedSocket.handshake;
+    protocol = connectedSocket.alpnProtocol == null
+        ? Protocol.HTTP_1_1 : connectedSocket.alpnProtocol;
 
-    if (route.address.sslSocketFactory != null) {
-      upgradeToTls(tunnelRequest, readTimeout, writeTimeout);
-    } else {
-      httpConnection = new HttpConnection(pool, this, socket);
+    try {
+      if (protocol == Protocol.SPDY_3 || protocol == Protocol.HTTP_2) {
+        socket.setSoTimeout(0); // SPDY timeouts are set per-stream.
+        spdyConnection = new SpdyConnection.Builder(route.address.uriHost, true, socket)
+            .protocol(protocol).build();
+        spdyConnection.sendConnectionPreface();
+      } else {
+        httpConnection = new HttpConnection(pool, this, socket);
+      }
+    } catch (IOException e) {
+      throw new RouteException(e);
     }
     connected = true;
   }
@@ -167,13 +174,14 @@ public final class Connection {
    * Connects this connection if it isn't already. This creates tunnels, shares
    * the connection with the connection pool, and configures timeouts.
    */
-  void connectAndSetOwner(OkHttpClient client, Object owner, Request request) throws IOException {
+  void connectAndSetOwner(OkHttpClient client, Object owner, Request request)
+      throws RouteException {
     setOwner(owner);
 
     if (!isConnected()) {
-      Request tunnelRequest = tunnelRequest(request);
-      connect(client.getConnectTimeout(), client.getReadTimeout(),
-          client.getWriteTimeout(), tunnelRequest);
+      List<ConnectionSpec> connectionSpecs = route.address.getConnectionSpecs();
+      connect(client.getConnectTimeout(), client.getReadTimeout(), client.getWriteTimeout(),
+          request, connectionSpecs, client.getRetryOnConnectionFailure());
       if (isSpdy()) {
         client.getConnectionPool().share(this);
       }
@@ -181,97 +189,6 @@ public final class Connection {
     }
 
     setTimeouts(client.getReadTimeout(), client.getWriteTimeout());
-  }
-
-  /**
-   * Returns a request that creates a TLS tunnel via an HTTP proxy, or null if
-   * no tunnel is necessary. Everything in the tunnel request is sent
-   * unencrypted to the proxy server, so tunnels include only the minimum set of
-   * headers. This avoids sending potentially sensitive data like HTTP cookies
-   * to the proxy unencrypted.
-   */
-  private Request tunnelRequest(Request request) throws IOException {
-    if (!route.requiresTunnel()) return null;
-
-    String host = request.url().getHost();
-    int port = getEffectivePort(request.url());
-    String authority = (port == getDefaultPort("https")) ? host : (host + ":" + port);
-    Request.Builder result = new Request.Builder()
-        .url(new URL("https", host, port, "/"))
-        .header("Host", authority)
-        .header("Proxy-Connection", "Keep-Alive"); // For HTTP/1.0 proxies like Squid.
-
-    // Copy over the User-Agent header if it exists.
-    String userAgent = request.header("User-Agent");
-    if (userAgent != null) {
-      result.header("User-Agent", userAgent);
-    }
-
-    // Copy over the Proxy-Authorization header if it exists.
-    String proxyAuthorization = request.header("Proxy-Authorization");
-    if (proxyAuthorization != null) {
-      result.header("Proxy-Authorization", proxyAuthorization);
-    }
-
-    return result.build();
-  }
-
-  /**
-   * Create an {@code SSLSocket} and perform the TLS handshake and certificate
-   * validation.
-   */
-  private void upgradeToTls(Request tunnelRequest, int readTimeout, int writeTimeout)
-      throws IOException {
-    Platform platform = Platform.get();
-
-    // Make an SSL Tunnel on the first message pair of each SSL + proxy connection.
-    if (tunnelRequest != null) {
-      makeTunnel(tunnelRequest, readTimeout, writeTimeout);
-    }
-
-    // Create the wrapper over connected socket.
-    socket = route.address.sslSocketFactory
-        .createSocket(socket, route.address.uriHost, route.address.uriPort, true /* autoClose */);
-    SSLSocket sslSocket = (SSLSocket) socket;
-
-    // Configure the socket's ciphers, TLS versions, and extensions.
-    route.connectionSpec.apply(sslSocket, route);
-
-    try {
-      // Force handshake. This can throw!
-      sslSocket.startHandshake();
-
-      String maybeProtocol;
-      if (route.connectionSpec.supportsTlsExtensions()
-          && (maybeProtocol = platform.getSelectedProtocol(sslSocket)) != null) {
-        protocol = Protocol.get(maybeProtocol); // Throws IOE on unknown.
-      }
-    } finally {
-      platform.afterHandshake(sslSocket);
-    }
-
-    handshake = Handshake.get(sslSocket.getSession());
-
-    // Verify that the socket's certificates are acceptable for the target host.
-    if (!route.address.hostnameVerifier.verify(route.address.uriHost, sslSocket.getSession())) {
-      X509Certificate cert = (X509Certificate) sslSocket.getSession().getPeerCertificates()[0];
-      throw new SSLPeerUnverifiedException("Hostname " + route.address.uriHost + " not verified:"
-          + "\n    certificate: " + CertificatePinner.pin(cert)
-          + "\n    DN: " + cert.getSubjectDN().getName()
-          + "\n    subjectAltNames: " + OkHostnameVerifier.allSubjectAltNames(cert));
-    }
-
-    // Check that the certificate pinner is satisfied by the certificates presented.
-    route.address.certificatePinner.check(route.address.uriHost, handshake.peerCertificates());
-
-    if (protocol == Protocol.SPDY_3 || protocol == Protocol.HTTP_2) {
-      sslSocket.setSoTimeout(0); // SPDY timeouts are set per-stream.
-      spdyConnection = new SpdyConnection.Builder(route.address.getUriHost(), true, socket)
-          .protocol(protocol).build();
-      spdyConnection.sendConnectionPreface();
-    } else {
-      httpConnection = new HttpConnection(pool, this, socket);
-    }
   }
 
   /** Returns true if {@link #connect} has been attempted on this connection. */
@@ -361,12 +278,17 @@ public final class Connection {
     this.protocol = protocol;
   }
 
-  void setTimeouts(int readTimeoutMillis, int writeTimeoutMillis) throws IOException {
+  void setTimeouts(int readTimeoutMillis, int writeTimeoutMillis)
+      throws RouteException {
     if (!connected) throw new IllegalStateException("setTimeouts - not connected");
 
     // Don't set timeouts on shared SPDY connections.
     if (httpConnection != null) {
-      socket.setSoTimeout(readTimeoutMillis);
+      try {
+        socket.setSoTimeout(readTimeoutMillis);
+      } catch (IOException e) {
+        throw new RouteException(e);
+      }
       httpConnection.setTimeouts(readTimeoutMillis, writeTimeoutMillis);
     }
   }
@@ -381,55 +303,6 @@ public final class Connection {
    */
   int recycleCount() {
     return recycleCount;
-  }
-
-  /**
-   * To make an HTTPS connection over an HTTP proxy, send an unencrypted
-   * CONNECT request to create the proxy connection. This may need to be
-   * retried if the proxy requires authorization.
-   */
-  private void makeTunnel(Request request, int readTimeout, int writeTimeout)
-      throws IOException {
-    HttpConnection tunnelConnection = new HttpConnection(pool, this, socket);
-    tunnelConnection.setTimeouts(readTimeout, writeTimeout);
-    URL url = request.url();
-    String requestLine = "CONNECT " + url.getHost() + ":" + url.getPort() + " HTTP/1.1";
-    while (true) {
-      tunnelConnection.writeRequest(request.headers(), requestLine);
-      tunnelConnection.flush();
-      Response response = tunnelConnection.readResponse().request(request).build();
-      // The response body from a CONNECT should be empty, but if it is not then we should consume
-      // it before proceeding.
-      long contentLength = OkHeaders.contentLength(response);
-      if (contentLength == -1L) {
-        contentLength = 0L;
-      }
-      Source body = tunnelConnection.newFixedLengthSource(contentLength);
-      Util.skipAll(body, Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
-      body.close();
-
-      switch (response.code()) {
-        case HTTP_OK:
-          // Assume the server won't send a TLS ServerHello until we send a TLS ClientHello. If that
-          // happens, then we will have buffered bytes that are needed by the SSLSocket!
-          // This check is imperfect: it doesn't tell us whether a handshake will succeed, just that
-          // it will almost certainly fail because the proxy has sent unexpected data.
-          if (tunnelConnection.bufferSize() > 0) {
-            throw new IOException("TLS tunnel buffered too many bytes!");
-          }
-          return;
-
-        case HTTP_PROXY_AUTH:
-          request = OkHeaders.processAuthHeader(
-              route.address.authenticator, response, route.proxy);
-          if (request != null) continue;
-          throw new IOException("Failed to authenticate with proxy");
-
-        default:
-          throw new IOException(
-              "Unexpected response code for CONNECT: " + response.code());
-      }
-    }
   }
 
   @Override public String toString() {

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -22,6 +22,7 @@ import com.squareup.okhttp.internal.RouteDatabase;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.AuthenticatorAdapter;
 import com.squareup.okhttp.internal.http.HttpEngine;
+import com.squareup.okhttp.internal.http.RouteException;
 import com.squareup.okhttp.internal.http.Transport;
 import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
 import java.io.IOException;
@@ -36,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import javax.net.SocketFactory;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
@@ -116,7 +118,7 @@ public class OkHttpClient implements Cloneable {
       }
 
       @Override public void connectAndSetOwner(OkHttpClient client, Connection connection,
-          HttpEngine owner, Request request) throws IOException {
+          HttpEngine owner, Request request) throws RouteException {
         connection.connectAndSetOwner(client, owner, request);
       }
 
@@ -135,6 +137,11 @@ public class OkHttpClient implements Cloneable {
 
       @Override public void connectionSetOwner(Connection connection, Object owner) {
         connection.setOwner(owner);
+      }
+
+      @Override
+      public void apply(ConnectionSpec tlsConfiguration, SSLSocket sslSocket, boolean isFallback) {
+        tlsConfiguration.apply(sslSocket, isFallback);
       }
     };
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/Route.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Route.java
@@ -28,8 +28,6 @@ import java.net.Proxy;
  *   <li><strong>IP address:</strong> whether connecting directly to an origin
  *       server or a proxy, opening a socket requires an IP address. The DNS
  *       server may return multiple IP addresses to attempt.
- *   <li><strong>TLS configuration:</strong> which cipher suites and TLS
- *       versions to attempt with the HTTPS connection.
  * </ul>
  * Each route is a specific selection of these options.
  */
@@ -37,17 +35,8 @@ public final class Route {
   final Address address;
   final Proxy proxy;
   final InetSocketAddress inetSocketAddress;
-  final ConnectionSpec connectionSpec;
-  final boolean shouldSendTlsFallbackIndicator;
 
-  public Route(Address address, Proxy proxy, InetSocketAddress inetSocketAddress,
-      ConnectionSpec connectionSpec) {
-    this(address, proxy, inetSocketAddress, connectionSpec,
-        false /* shouldSendTlsFallbackIndicator */);
-  }
-
-  public Route(Address address, Proxy proxy, InetSocketAddress inetSocketAddress,
-      ConnectionSpec connectionSpec, boolean shouldSendTlsFallbackIndicator) {
+  public Route(Address address, Proxy proxy, InetSocketAddress inetSocketAddress) {
     if (address == null) {
       throw new NullPointerException("address == null");
     }
@@ -57,14 +46,9 @@ public final class Route {
     if (inetSocketAddress == null) {
       throw new NullPointerException("inetSocketAddress == null");
     }
-    if (connectionSpec == null) {
-      throw new NullPointerException("connectionConfiguration == null");
-    }
     this.address = address;
     this.proxy = proxy;
     this.inetSocketAddress = inetSocketAddress;
-    this.connectionSpec = connectionSpec;
-    this.shouldSendTlsFallbackIndicator = shouldSendTlsFallbackIndicator;
   }
 
   public Address getAddress() {
@@ -86,14 +70,6 @@ public final class Route {
     return inetSocketAddress;
   }
 
-  public ConnectionSpec getConnectionSpec() {
-    return connectionSpec;
-  }
-
-  public boolean getShouldSendTlsFallbackIndicator() {
-    return shouldSendTlsFallbackIndicator;
-  }
-
   /**
    * Returns true if this route tunnels HTTPS through an HTTP proxy. See <a
    * href="http://www.ietf.org/rfc/rfc2817.txt">RFC 2817, Section 5.2</a>.
@@ -107,9 +83,7 @@ public final class Route {
       Route other = (Route) obj;
       return address.equals(other.address)
           && proxy.equals(other.proxy)
-          && inetSocketAddress.equals(other.inetSocketAddress)
-          && connectionSpec.equals(other.connectionSpec)
-          && shouldSendTlsFallbackIndicator == other.shouldSendTlsFallbackIndicator;
+          && inetSocketAddress.equals(other.inetSocketAddress);
     }
     return false;
   }
@@ -119,8 +93,6 @@ public final class Route {
     result = 31 * result + address.hashCode();
     result = 31 * result + proxy.hashCode();
     result = 31 * result + inetSocketAddress.hashCode();
-    result = 31 * result + connectionSpec.hashCode();
-    result = 31 * result + (shouldSendTlsFallbackIndicator ? 1 : 0);
     return result;
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/TlsVersion.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/TlsVersion.java
@@ -43,4 +43,8 @@ public enum TlsVersion {
     }
     throw new IllegalArgumentException("Unexpected TLS version: " + javaName);
   }
+
+  public String javaName() {
+    return javaName;
+  }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/ConnectionSpecSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/ConnectionSpecSelector.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.okhttp.internal;
+
+import com.squareup.okhttp.ConnectionSpec;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.ProtocolException;
+import java.net.UnknownServiceException;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.List;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLProtocolException;
+import javax.net.ssl.SSLSocket;
+
+/**
+ * Handles the connection spec fallback strategy: When a secure socket connection fails
+ * due to a handshake / protocol problem the connection may be retried with different protocols.
+ * Instances are stateful and should be created and used for a single connection attempt.
+ */
+public final class ConnectionSpecSelector {
+
+  private final List<ConnectionSpec> connectionSpecs;
+  private int nextModeIndex;
+  private boolean isFallbackPossible;
+  private boolean isFallback;
+
+  public ConnectionSpecSelector(List<ConnectionSpec> connectionSpecs) {
+    this.nextModeIndex = 0;
+    this.connectionSpecs = connectionSpecs;
+  }
+
+  /**
+   * Configures the supplied {@link SSLSocket} to connect to the specified host using an appropriate
+   * {@link ConnectionSpec}. Returns the chosen {@link ConnectionSpec}, never {@code null}.
+   *
+   * @throws IOException if the socket does not support any of the TLS modes available
+   */
+  public ConnectionSpec configureSecureSocket(SSLSocket sslSocket) throws IOException {
+    ConnectionSpec tlsConfiguration = null;
+    for (int i = nextModeIndex, size = connectionSpecs.size(); i < size; i++) {
+      ConnectionSpec connectionSpec = connectionSpecs.get(i);
+      if (connectionSpec.isCompatible(sslSocket)) {
+        tlsConfiguration = connectionSpec;
+        nextModeIndex = i + 1;
+        break;
+      }
+    }
+
+    if (tlsConfiguration == null) {
+      // This may be the first time a connection has been attempted and the socket does not support
+      // any the required protocols, or it may be a retry (but this socket supports fewer
+      // protocols than was suggested by a prior socket).
+      throw new UnknownServiceException(
+          "Unable to find acceptable protocols. isFallback=" + isFallback
+              + ", modes=" + connectionSpecs
+              + ", supported protocols=" + Arrays.toString(sslSocket.getEnabledProtocols()));
+    }
+
+    isFallbackPossible = isFallbackPossible(sslSocket);
+
+    Internal.instance.apply(tlsConfiguration, sslSocket, isFallback);
+
+    return tlsConfiguration;
+  }
+
+  /**
+   * Reports a failure to complete a connection. Determines the next {@link ConnectionSpec} to
+   * try, if any.
+   *
+   * @return {@code true} if the connection should be retried using
+   *     {@link #configureSecureSocket(SSLSocket)} or {@code false} if not
+   */
+  public boolean connectionFailed(IOException e) {
+    // Any future attempt to connect using this strategy will be a fallback attempt.
+    isFallback = true;
+
+    // TODO(nfuller): This is the same logic as in HttpEngine.
+    // If there was a protocol problem, don't recover.
+    if (e instanceof ProtocolException) {
+      return false;
+    }
+
+    // If there was an interruption or timeout, don't recover.
+    if (e instanceof InterruptedIOException) {
+      return false;
+    }
+
+    // Look for known client-side or negotiation errors that are unlikely to be fixed by trying
+    // again with a different connection spec.
+    if (e instanceof SSLHandshakeException) {
+      // If the problem was a CertificateException from the X509TrustManager,
+      // do not retry.
+      if (e.getCause() instanceof CertificateException) {
+        return false;
+      }
+    }
+    if (e instanceof SSLPeerUnverifiedException) {
+      // e.g. a certificate pinning error.
+      return false;
+    }
+    // TODO(nfuller): End of common code.
+
+
+    // On Android, SSLProtocolExceptions can be caused by TLS_FALLBACK_SCSV failures, which means we
+    // retry those when we probably should not.
+    return ((e instanceof SSLHandshakeException || e instanceof SSLProtocolException))
+        && isFallbackPossible;
+  }
+
+  /**
+   * Returns {@code true} if any later {@link ConnectionSpec} in the fallback strategy looks
+   * possible based on the supplied {@link SSLSocket}. It assumes that a future socket will have the
+   * same capabilities as the supplied socket.
+   */
+  private boolean isFallbackPossible(SSLSocket socket) {
+    for (int i = nextModeIndex; i < connectionSpecs.size(); i++) {
+      if (connectionSpecs.get(i).isCompatible(socket)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
@@ -19,14 +19,17 @@ import com.squareup.okhttp.Call;
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.Connection;
 import com.squareup.okhttp.ConnectionPool;
+import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.internal.http.HttpEngine;
+import com.squareup.okhttp.internal.http.RouteException;
 import com.squareup.okhttp.internal.http.Transport;
 import java.io.IOException;
 import java.util.logging.Logger;
+import javax.net.ssl.SSLSocket;
 
 /**
  * Escalate internal APIs in {@code com.squareup.okhttp} so they can be used
@@ -35,6 +38,12 @@ import java.util.logging.Logger;
  */
 public abstract class Internal {
   public static final Logger logger = Logger.getLogger(OkHttpClient.class.getName());
+
+  public static void initializeInstanceForTests() {
+    // Needed in tests to ensure that the instance is actually pointing to something.
+    new OkHttpClient();
+  }
+
   public static Internal instance;
 
   public abstract Transport newTransport(Connection connection, HttpEngine httpEngine)
@@ -67,7 +76,10 @@ public abstract class Internal {
   public abstract void setNetwork(OkHttpClient client, Network network);
 
   public abstract void connectAndSetOwner(OkHttpClient client, Connection connection,
-      HttpEngine owner, Request request) throws IOException;
+      HttpEngine owner, Request request) throws RouteException;
+
+  public abstract void apply(ConnectionSpec tlsConfiguration, SSLSocket sslSocket,
+      boolean isFallback);
 
   // TODO delete the following when web sockets move into the main package.
   public abstract void callEnqueue(Call call, Callback responseCallback, boolean forWebSocket);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/RouteDatabase.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/RouteDatabase.java
@@ -22,9 +22,8 @@ import java.util.Set;
 /**
  * A blacklist of failed routes to avoid when creating a new connection to a
  * target address. This is used so that OkHttp can learn from its mistakes: if
- * there was a failure attempting to connect to a specific IP address, proxy
- * server or TLS mode, that failure is remembered and alternate routes are
- * preferred.
+ * there was a failure attempting to connect to a specific IP address or proxy
+ * server, that failure is remembered and alternate routes are preferred.
  */
 public final class RouteDatabase {
   private final Set<Route> failedRoutes = new LinkedHashSet<>();

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -210,8 +210,15 @@ public final class HttpEngine {
    * Figures out what the response source will be, and opens a socket to that
    * source if necessary. Prepares the request headers and gets ready to start
    * writing the request body if it exists.
+   *
+   * @throws RequestException if there was a problem with request setup. Unrecoverable.
+   * @throws RouteException if the was a problem during connection via a specific route. Sometimes
+   *     recoverable. See {@link #recover(RouteException)}.
+   * @throws IOException if there was a problem while making a request. Sometimes recoverable. See
+   *     {@link #recover(IOException)}.
+   *
    */
-  public void sendRequest() throws IOException {
+  public void sendRequest() throws RequestException, RouteException, IOException {
     if (cacheStrategy != null) return; // Already sent.
     if (transport != null) throw new IllegalStateException();
 
@@ -308,12 +315,16 @@ public final class HttpEngine {
   }
 
   /** Connect to the origin server either directly or via a proxy. */
-  private void connect() throws IOException {
+  private void connect() throws RequestException, RouteException {
     if (connection != null) throw new IllegalStateException();
 
     if (routeSelector == null) {
       address = createAddress(client, networkRequest);
-      routeSelector = RouteSelector.get(address, networkRequest, client);
+      try {
+        routeSelector = RouteSelector.get(address, networkRequest, client);
+      } catch (IOException e) {
+        throw new RequestException(e);
+      }
     }
 
     connection = nextConnection();
@@ -325,13 +336,13 @@ public final class HttpEngine {
    *
    * @throws java.util.NoSuchElementException if there are no more routes to attempt.
    */
-  private Connection nextConnection() throws IOException {
+  private Connection nextConnection() throws RouteException {
     Connection connection = createNextConnection();
     Internal.instance.connectAndSetOwner(client, connection, this, networkRequest);
     return connection;
   }
 
-  private Connection createNextConnection() throws IOException {
+  private Connection createNextConnection() throws RouteException {
     ConnectionPool pool = client.getConnectionPool();
 
     // Always prefer pooled connections over new connections.
@@ -339,10 +350,15 @@ public final class HttpEngine {
       if (networkRequest.method().equals("GET") || Internal.instance.isReadable(pooled)) {
         return pooled;
       }
-      pooled.getSocket().close();
+      closeQuietly(pooled.getSocket());
     }
-    Route route = routeSelector.next();
-    return new Connection(pool, route);
+
+    try {
+      Route route = routeSelector.next();
+      return new Connection(pool, route);
+    } catch (IOException e) {
+      throw new RouteException(e);
+    }
   }
 
   /**
@@ -393,8 +409,75 @@ public final class HttpEngine {
   }
 
   /**
-   * Report and attempt to recover from {@code e}. Returns a new HTTP engine
-   * that should be used for the retry if {@code e} is recoverable, or null if
+   * Attempt to recover from failure to connect via a route. Returns a new HTTP engine
+   * that should be used for the retry if there are other routes to try, or null if
+   * there are no more routes to try.
+   */
+  public HttpEngine recover(RouteException e) {
+    if (routeSelector != null && connection != null) {
+      connectFailed(routeSelector, e.getLastConnectException());
+    }
+
+    if (routeSelector == null && connection == null // No connection.
+        || routeSelector != null && !routeSelector.hasNext() // No more routes to attempt.
+        || !isRecoverable(e)) {
+      return null;
+    }
+
+    Connection connection = close();
+
+    // For failure recovery, use the same route selector with a new connection.
+    return new HttpEngine(client, userRequest, bufferRequestBody, callerWritesRequestBody,
+        forWebSocket, connection, routeSelector, (RetryableSink) requestBodyOut, priorResponse);
+  }
+
+  private boolean isRecoverable(RouteException e) {
+    // If the application has opted-out of recovery, don't recover.
+    if (!client.getRetryOnConnectionFailure()) {
+      return false;
+    }
+
+    // Problems with a route may mean the connection can be retried with a new route, or may
+    // indicate a client-side or server-side issue that should not be retried. To tell, we must look
+    // at the cause.
+
+    IOException ioe = e.getLastConnectException();
+
+    // TODO(nfuller): This is the same logic as in ConnectionSpecSelector
+    // If there was a protocol problem, don't recover.
+    if (ioe instanceof ProtocolException) {
+      return false;
+    }
+
+    // If there was an interruption or timeout, don't recover.
+    if (ioe instanceof InterruptedIOException) {
+      return false;
+    }
+
+    // Look for known client-side or negotiation errors that are unlikely to be fixed by trying
+    // again with a different route.
+    if (ioe instanceof SSLHandshakeException) {
+      // If the problem was a CertificateException from the X509TrustManager,
+      // do not retry.
+      if (ioe.getCause() instanceof CertificateException) {
+        return false;
+      }
+    }
+    if (ioe instanceof SSLPeerUnverifiedException) {
+      // e.g. a certificate pinning error.
+      return false;
+    }
+    // TODO(nfuller): End of common code.
+
+    // An example of one we might want to retry with a different route is a problem connecting to a
+    // proxy and would manifest as a standard IOException. Unless it is one we know we should not
+    // retry, we return true and try a new route.
+    return true;
+  }
+
+  /**
+   * Report and attempt to recover from a failure to communicate with a server. Returns a new
+   * HTTP engine that should be used for the retry if {@code e} is recoverable, or null if
    * the failure is permanent. Requests with a body can only be recovered if the
    * body is buffered.
    */
@@ -432,13 +515,6 @@ public final class HttpEngine {
   private boolean isRecoverable(IOException e) {
     // If the application has opted-out of recovery, don't recover.
     if (!client.getRetryOnConnectionFailure()) {
-      return false;
-    }
-
-    // If the problem was a CertificateException from the X509TrustManager,
-    // do not retry, we didn't have an abrupt server-initiated exception.
-    if (e instanceof SSLPeerUnverifiedException
-        || (e instanceof SSLHandshakeException && e.getCause() instanceof CertificateException)) {
       return false;
     }
 
@@ -1050,10 +1126,10 @@ public final class HttpEngine {
   }
 
   private static Address createAddress(OkHttpClient client, Request request)
-      throws UnknownHostException {
+      throws RequestException {
     String uriHost = request.url().getHost();
     if (uriHost == null || uriHost.length() == 0) {
-      throw new UnknownHostException(request.url().toString());
+      throw new RequestException(new UnknownHostException(request.url().toString()));
     }
 
     SSLSocketFactory sslSocketFactory = null;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RequestException.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RequestException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import java.io.IOException;
+
+/**
+ * Indicates a problem with interpreting a request. It may indicate there was a problem with the
+ * request itself, or the environment being used to interpret the request (network failure, etc.).
+ */
+public final class RequestException extends Exception {
+
+  public RequestException(IOException cause) {
+    super(cause);
+  }
+
+  @Override
+  public IOException getCause() {
+    return (IOException) super.getCause();
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteException.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An exception thrown to indicate a problem connecting via a single Route. Multiple attempts may
+ * have been made with alternative protocols, none of which were successful.
+ */
+public final class RouteException extends Exception {
+
+  private final List<IOException> connectExceptions = new ArrayList<IOException>();
+
+  public RouteException(IOException cause) {
+    super(cause);
+    connectExceptions.add(cause);
+  }
+
+  public IOException getLastConnectException() {
+    return connectExceptions.get(connectExceptions.size() - 1);
+  }
+
+  public void addConnectException(IOException e) {
+    connectExceptions.add(e);
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
@@ -16,7 +16,6 @@
 package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.Address;
-import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Route;
@@ -30,13 +29,10 @@ import java.net.Proxy;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.URI;
-import java.net.UnknownServiceException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLProtocolException;
 
 import static com.squareup.okhttp.internal.Util.getEffectivePort;
 
@@ -51,12 +47,10 @@ public final class RouteSelector {
   private final Network network;
   private final OkHttpClient client;
   private final RouteDatabase routeDatabase;
-  private final Request request;
 
   /* The most recently attempted route. */
   private Proxy lastProxy;
   private InetSocketAddress lastInetSocketAddress;
-  private ConnectionSpec lastSpec;
 
   /* State for negotiating the next proxy to use. */
   private List<Proxy> proxies = Collections.emptyList();
@@ -66,27 +60,22 @@ public final class RouteSelector {
   private List<InetSocketAddress> inetSocketAddresses = Collections.emptyList();
   private int nextInetSocketAddressIndex;
 
-  /* Specs to attempt with the connection. */
-  private List<ConnectionSpec> connectionSpecs = Collections.emptyList();
-  private int nextSpecIndex;
-
   /* State for negotiating failed routes */
   private final List<Route> postponedRoutes = new ArrayList<>();
 
-  private RouteSelector(Address address, URI uri, OkHttpClient client, Request request) {
+  private RouteSelector(Address address, URI uri, OkHttpClient client) {
     this.address = address;
     this.uri = uri;
     this.client = client;
     this.routeDatabase = Internal.instance.routeDatabase(client);
     this.network = Internal.instance.network(client);
-    this.request = request;
 
     resetNextProxy(uri, address.getProxy());
   }
 
   public static RouteSelector get(Address address, Request request, OkHttpClient client)
       throws IOException {
-    return new RouteSelector(address, request.uri(), client, request);
+    return new RouteSelector(address, request.uri(), client);
   }
 
   /**
@@ -94,31 +83,25 @@ public final class RouteSelector {
    * least one route.
    */
   public boolean hasNext() {
-    return hasNextConnectionSpec()
-        || hasNextInetSocketAddress()
+    return hasNextInetSocketAddress()
         || hasNextProxy()
         || hasNextPostponed();
   }
 
   public Route next() throws IOException {
     // Compute the next route to attempt.
-    if (!hasNextConnectionSpec()) {
-      if (!hasNextInetSocketAddress()) {
-        if (!hasNextProxy()) {
-          if (!hasNextPostponed()) {
-            throw new NoSuchElementException();
-          }
-          return nextPostponed();
+    if (!hasNextInetSocketAddress()) {
+      if (!hasNextProxy()) {
+        if (!hasNextPostponed()) {
+          throw new NoSuchElementException();
         }
-        lastProxy = nextProxy();
+        return nextPostponed();
       }
-      lastInetSocketAddress = nextInetSocketAddress();
+      lastProxy = nextProxy();
     }
-    lastSpec = nextConnectionSpec();
+    lastInetSocketAddress = nextInetSocketAddress();
 
-    final boolean shouldSendTlsFallbackIndicator = shouldSendTlsFallbackIndicator(lastSpec);
-    Route route = new Route(address, lastProxy, lastInetSocketAddress, lastSpec,
-        shouldSendTlsFallbackIndicator);
+    Route route = new Route(address, lastProxy, lastInetSocketAddress);
     if (routeDatabase.shouldPostpone(route)) {
       postponedRoutes.add(route);
       // We will only recurse in order to skip previously failed routes. They will be tried last.
@@ -126,11 +109,6 @@ public final class RouteSelector {
     }
 
     return route;
-  }
-
-  private boolean shouldSendTlsFallbackIndicator(ConnectionSpec connectionSpec) {
-    return connectionSpec != connectionSpecs.get(0)
-        && connectionSpec.isTls();
   }
 
   /**
@@ -144,20 +122,6 @@ public final class RouteSelector {
     }
 
     routeDatabase.failed(failedRoute);
-
-    // If the previously returned route's problem was not related to the connection's spec, and the
-    // next route only changes that, we shouldn't even attempt it. This suppresses it in both this
-    // selector and also in the route database.
-    if (!(failure instanceof SSLHandshakeException) && !(failure instanceof SSLProtocolException)) {
-      while (nextSpecIndex < connectionSpecs.size()) {
-        ConnectionSpec connectionSpec = connectionSpecs.get(nextSpecIndex++);
-        final boolean shouldSendTlsFallbackIndicator =
-            shouldSendTlsFallbackIndicator(connectionSpec);
-        Route toSuppress = new Route(address, lastProxy, lastInetSocketAddress, connectionSpec,
-            shouldSendTlsFallbackIndicator);
-        routeDatabase.failed(toSuppress);
-      }
-    }
   }
 
   /** Prepares the proxy servers to try. */
@@ -224,6 +188,7 @@ public final class RouteSelector {
     for (InetAddress inetAddress : network.resolveInetAddresses(socketHost)) {
       inetSocketAddresses.add(new InetSocketAddress(inetAddress, socketPort));
     }
+
     nextInetSocketAddressIndex = 0;
   }
 
@@ -256,42 +221,7 @@ public final class RouteSelector {
       throw new SocketException("No route to " + address.getUriHost()
           + "; exhausted inet socket addresses: " + inetSocketAddresses);
     }
-    InetSocketAddress result = inetSocketAddresses.get(nextInetSocketAddressIndex++);
-    resetConnectionSpecs();
-    return result;
-  }
-
-  /** Prepares the connection specs to attempt. */
-  private void resetConnectionSpecs() {
-    connectionSpecs = new ArrayList<>();
-    List<ConnectionSpec> specs = address.getConnectionSpecs();
-    for (int i = 0, size = specs.size(); i < size; i++) {
-      ConnectionSpec spec = specs.get(i);
-      if (request.isHttps() == spec.isTls()) {
-        connectionSpecs.add(spec);
-      }
-    }
-    nextSpecIndex = 0;
-  }
-
-  /** Returns true if there's another connection spec to try. */
-  private boolean hasNextConnectionSpec() {
-    return nextSpecIndex < connectionSpecs.size();
-  }
-
-  /** Returns the next connection spec to try. */
-  private ConnectionSpec nextConnectionSpec() throws IOException {
-    if (connectionSpecs.isEmpty()) {
-      throw new UnknownServiceException("No route to "
-          + ((uri.getScheme() != null) ? (uri.getScheme() + "://") : "//") + address.getUriHost()
-          + "; no connection specs");
-    }
-    if (!hasNextConnectionSpec()) {
-      throw new SocketException("No route to "
-          + ((uri.getScheme() != null) ? (uri.getScheme() + "://") : "//") + address.getUriHost()
-          + "; exhausted connection specs: " + connectionSpecs);
-    }
-    return connectionSpecs.get(nextSpecIndex++);
+    return inetSocketAddresses.get(nextInetSocketAddressIndex++);
   }
 
   /** Returns true if there is another postponed route to try. */

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SocketConnector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SocketConnector.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import com.squareup.okhttp.Address;
+import com.squareup.okhttp.CertificatePinner;
+import com.squareup.okhttp.Connection;
+import com.squareup.okhttp.ConnectionPool;
+import com.squareup.okhttp.ConnectionSpec;
+import com.squareup.okhttp.Handshake;
+import com.squareup.okhttp.Protocol;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.Route;
+import com.squareup.okhttp.internal.Platform;
+import com.squareup.okhttp.internal.ConnectionSpecSelector;
+import com.squareup.okhttp.internal.Util;
+import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.Socket;
+import java.net.URL;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import okio.Source;
+
+import static com.squareup.okhttp.internal.Util.closeQuietly;
+import static com.squareup.okhttp.internal.Util.getDefaultPort;
+import static com.squareup.okhttp.internal.Util.getEffectivePort;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
+
+/**
+ * Helper that can establish a socket connection to a {@link com.squareup.okhttp.Route} using the
+ * specified {@link ConnectionSpec} set. A {@link SocketConnector} can be used multiple times.
+ */
+public class SocketConnector {
+  private final Connection connection;
+  private final ConnectionPool connectionPool;
+
+  public SocketConnector(Connection connection, ConnectionPool connectionPool) {
+    this.connection = connection;
+    this.connectionPool = connectionPool;
+  }
+
+  public ConnectedSocket connectCleartext(int connectTimeout, int readTimeout, Route route)
+      throws RouteException {
+    Socket socket = connectRawSocket(readTimeout, connectTimeout, route);
+    return new ConnectedSocket(route, socket);
+  }
+
+  public ConnectedSocket connectTls(int connectTimeout, int readTimeout,
+      int writeTimeout, Request request, Route route, List<ConnectionSpec> connectionSpecs,
+      boolean connectionRetryEnabled) throws RouteException {
+
+    Address address = route.getAddress();
+    ConnectionSpecSelector connectionSpecSelector = new ConnectionSpecSelector(connectionSpecs);
+    RouteException routeException = null;
+    do {
+      Socket socket = connectRawSocket(readTimeout, connectTimeout, route);
+      if (route.requiresTunnel()) {
+        createTunnel(readTimeout, writeTimeout, request, route, socket);
+      }
+
+      SSLSocket sslSocket = null;
+      try {
+        SSLSocketFactory sslSocketFactory = address.getSslSocketFactory();
+
+        // Create the wrapper over the connected socket.
+        sslSocket = (SSLSocket) sslSocketFactory
+            .createSocket(socket, address.getUriHost(), address.getUriPort(), true /* autoClose */);
+
+        // Configure the socket's ciphers, TLS versions, and extensions.
+        ConnectionSpec connectionSpec = connectionSpecSelector.configureSecureSocket(sslSocket);
+        Platform platform = Platform.get();
+        Handshake handshake = null;
+        Protocol alpnProtocol = null;
+        try {
+          if (connectionSpec.supportsTlsExtensions()) {
+            platform.configureTlsExtensions(
+                sslSocket, address.getUriHost(), address.getProtocols());
+          }
+          // Force handshake. This can throw!
+          sslSocket.startHandshake();
+
+          handshake = Handshake.get(sslSocket.getSession());
+
+          String maybeProtocol;
+          if (connectionSpec.supportsTlsExtensions()
+              && (maybeProtocol = platform.getSelectedProtocol(sslSocket)) != null) {
+            alpnProtocol = Protocol.get(maybeProtocol); // Throws IOE on unknown.
+          }
+        } finally {
+          platform.afterHandshake(sslSocket);
+        }
+
+        // Verify that the socket's certificates are acceptable for the target host.
+        if (!address.getHostnameVerifier().verify(address.getUriHost(), sslSocket.getSession())) {
+          X509Certificate cert = (X509Certificate) sslSocket.getSession()
+              .getPeerCertificates()[0];
+          throw new SSLPeerUnverifiedException(
+              "Hostname " + address.getUriHost() + " not verified:"
+              + "\n    certificate: " + CertificatePinner.pin(cert)
+              + "\n    DN: " + cert.getSubjectDN().getName()
+              + "\n    subjectAltNames: " + OkHostnameVerifier.allSubjectAltNames(cert));
+        }
+
+        // Check that the certificate pinner is satisfied by the certificates presented.
+        address.getCertificatePinner().check(address.getUriHost(), handshake.peerCertificates());
+
+        return new ConnectedSocket(route, sslSocket, alpnProtocol, handshake);
+      } catch (IOException e) {
+        boolean canRetry = connectionRetryEnabled && connectionSpecSelector.connectionFailed(e);
+        closeQuietly(sslSocket);
+        closeQuietly(socket);
+        if (routeException == null) {
+          routeException = new RouteException(e);
+        } else {
+          routeException.addConnectException(e);
+        }
+        if (!canRetry) {
+          throw routeException;
+        }
+      }
+    } while (true);
+  }
+
+  private Socket connectRawSocket(int soTimeout, int connectTimeout, Route route)
+      throws RouteException {
+    Platform platform = Platform.get();
+    try {
+      Proxy proxy = route.getProxy();
+      Address address = route.getAddress();
+      Socket socket;
+      if (proxy.type() == Proxy.Type.DIRECT || proxy.type() == Proxy.Type.HTTP) {
+        socket = address.getSocketFactory().createSocket();
+      } else {
+        socket = new Socket(proxy);
+      }
+      socket.setSoTimeout(soTimeout);
+      platform.connectSocket(socket, route.getSocketAddress(), connectTimeout);
+
+      return socket;
+    } catch (IOException e) {
+      throw new RouteException(e);
+    }
+  }
+
+  /**
+   * To make an HTTPS connection over an HTTP proxy, send an unencrypted
+   * CONNECT request to create the proxy connection. This may need to be
+   * retried if the proxy requires authorization.
+   */
+  private void createTunnel(int readTimeout, int writeTimeout, Request request, Route route,
+      Socket socket) throws RouteException {
+    // Make an SSL Tunnel on the first message pair of each SSL + proxy connection.
+    try {
+      Request tunnelRequest = createTunnelRequest(request);
+      HttpConnection tunnelConnection = new HttpConnection(connectionPool, connection, socket);
+      tunnelConnection.setTimeouts(readTimeout, writeTimeout);
+      URL url = tunnelRequest.url();
+      String requestLine = "CONNECT " + url.getHost() + ":" + url.getPort() + " HTTP/1.1";
+      while (true) {
+        tunnelConnection.writeRequest(tunnelRequest.headers(), requestLine);
+        tunnelConnection.flush();
+        Response response = tunnelConnection.readResponse().request(tunnelRequest).build();
+        // The response body from a CONNECT should be empty, but if it is not then we should consume
+        // it before proceeding.
+        long contentLength = OkHeaders.contentLength(response);
+        if (contentLength == -1L) {
+          contentLength = 0L;
+        }
+        Source body = tunnelConnection.newFixedLengthSource(contentLength);
+        Util.skipAll(body, Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
+        body.close();
+
+        switch (response.code()) {
+          case HTTP_OK:
+            // Assume the server won't send a TLS ServerHello until we send a TLS ClientHello. If
+            // that happens, then we will have buffered bytes that are needed by the SSLSocket!
+            // This check is imperfect: it doesn't tell us whether a handshake will succeed, just
+            // that it will almost certainly fail because the proxy has sent unexpected data.
+            if (tunnelConnection.bufferSize() > 0) {
+              throw new IOException("TLS tunnel buffered too many bytes!");
+            }
+            return;
+
+          case HTTP_PROXY_AUTH:
+            tunnelRequest = OkHeaders.processAuthHeader(
+                route.getAddress().getAuthenticator(), response, route.getProxy());
+            if (tunnelRequest != null) continue;
+            throw new IOException("Failed to authenticate with proxy");
+
+          default:
+            throw new IOException(
+                "Unexpected response code for CONNECT: " + response.code());
+        }
+      }
+    } catch (IOException e) {
+      throw new RouteException(e);
+    }
+  }
+
+  /**
+   * Returns a request that creates a TLS tunnel via an HTTP proxy, or null if
+   * no tunnel is necessary. Everything in the tunnel request is sent
+   * unencrypted to the proxy server, so tunnels include only the minimum set of
+   * headers. This avoids sending potentially sensitive data like HTTP cookies
+   * to the proxy unencrypted.
+   */
+  private Request createTunnelRequest(Request request) throws IOException {
+    String host = request.url().getHost();
+    int port = getEffectivePort(request.url());
+    String authority = (port == getDefaultPort("https")) ? host : (host + ":" + port);
+    Request.Builder result = new Request.Builder()
+        .url(new URL("https", host, port, "/"))
+        .header("Host", authority)
+        .header("Proxy-Connection", "Keep-Alive"); // For HTTP/1.0 proxies like Squid.
+
+    // Copy over the User-Agent header if it exists.
+    String userAgent = request.header("User-Agent");
+    if (userAgent != null) {
+      result.header("User-Agent", userAgent);
+    }
+
+    // Copy over the Proxy-Authorization header if it exists.
+    String proxyAuthorization = request.header("Proxy-Authorization");
+    if (proxyAuthorization != null) {
+      result.header("Proxy-Authorization", proxyAuthorization);
+    }
+
+    return result.build();
+  }
+
+  /**
+   * A connected socket with metadata.
+   */
+  public static class ConnectedSocket {
+    public final Route route;
+    public final Socket socket;
+    public final Protocol alpnProtocol;
+    public final Handshake handshake;
+
+    /** A connected plain / raw (i.e. unencrypted communication) socket. */
+    public ConnectedSocket(Route route, Socket socket) {
+      this.route = route;
+      this.socket = socket;
+      alpnProtocol = null;
+      handshake = null;
+    }
+
+    /** A connected {@link SSLSocket}. */
+    public ConnectedSocket(Route route, SSLSocket socket, Protocol alpnProtocol,
+        Handshake handshake) {
+      this.route = route;
+      this.socket = socket;
+      this.alpnProtocol = alpnProtocol;
+      this.handshake = handshake;
+    }
+  }
+}


### PR DESCRIPTION
API changes:
1) Added: Address.getCertificatePinner()
2) Incompatible API change: Address constructor no longer
includes ConnectionSpecs. Removed getConnectionSpecs().
3) Added: ConnectionSpec.isCompatible(SSLSocket)
4) Added: TlsVersion.javaNames()

Implicit / semantic / internal changes:

1) Connection now handles all attempts to connect via a route
(effectively a {proxy, socket address} pair), rather than just
one attempt. i.e. Connection now handles all the TLS negotiation
fallbacks internally.

2) Route no longer deals with TLS versions. Individual TLS
failures are not counted against a Route. If no connection
attempts to a route were successful the failure is counted
against the route.

3) The code makes a distinction between when various
IOExceptions occur, with the intention making retries a bit
smarter. It is now more obvious which exceptions happen during
setup, connection, HTTP communication and thus which can be
retried and whether the request might have been sent.