### PR TITLE
A way to catch that cleartext HTTP request was attempted.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import java.net.CookieManager;
 import java.net.HttpCookie;
 import java.net.HttpURLConnection;
-import java.net.SocketException;
+import java.net.UnknownServiceException;
 import java.net.URL;
 import java.security.cert.Certificate;
 import java.util.Arrays;
@@ -730,8 +730,8 @@ public final class CallTest {
     try {
       client.newCall(request).execute();
       fail();
-    } catch (SocketException expected) {
-      assertTrue(expected.getMessage().contains("exhausted connection specs"));
+    } catch (UnknownServiceException expected) {
+      assertTrue(expected.getMessage().contains("no connection specs"));
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
@@ -35,6 +35,7 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.net.UnknownServiceException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -314,8 +315,14 @@ public final class RouteSelector {
 
   /** Returns the next connection spec to try. */
   private ConnectionSpec nextConnectionSpec() throws IOException {
+    if (connectionSpecs.isEmpty()) {
+      throw new UnknownServiceException("No route to "
+          + ((uri.getScheme() != null) ? (uri.getScheme() + "://") : "//") + address.getUriHost()
+          + "; no connection specs");
+    }
     if (!hasNextConnectionSpec()) {
-      throw new SocketException("No route to " + address.getUriHost()
+      throw new SocketException("No route to "
+          + ((uri.getScheme() != null) ? (uri.getScheme() + "://") : "//") + address.getUriHost()
           + "; exhausted connection specs: " + connectionSpecs);
     }
     return connectionSpecs.get(nextSpecIndex++);


### PR DESCRIPTION
This makes the HTTP stack throw java.net.UnknownServiceException if
a request is attempted using a protocol which matches none of the
configured connection specs. For example, this will happen if a cleartext
HTTP request is attempted when ConnectionSpec.CLEARTEXT is not
configured.

Fixes #1392