### PR TITLE
Fix for SslContextBuilder/MockWebServer disagreeing about localhost

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/internal/SslContextBuilder.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/internal/SslContextBuilder.java
@@ -68,7 +68,7 @@ public final class SslContextBuilder {
   public static synchronized SSLContext localhost() {
     if (localhost == null) {
       try {
-        localhost = new SslContextBuilder(InetAddress.getByName(null).getHostName()).build();
+        localhost = new SslContextBuilder(InetAddress.getByName("localhost").getHostName()).build();
       } catch (GeneralSecurityException e) {
         throw new RuntimeException(e);
       } catch (UnknownHostException e) {


### PR DESCRIPTION
MockWebServer binds to getByName("localhost"), SslContextBuilder was using
InetAddress.getByName(null) (null == any loopback). On Android, null
returns IPv6 loopback, which has the name "ip6-localhost".