### PR TITLE
Streaming Response

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
@@ -17,6 +17,8 @@ package com.squareup.okhttp.mockwebserver;
 
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.internal.ws.WebSocketListener;
+
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -24,7 +26,7 @@ import okio.Buffer;
 
 /** A scripted response to be replayed by the mock web server. */
 public final class MockResponse implements Cloneable {
-  private static final String CHUNKED_BODY_HEADER = "Transfer-encoding: chunked";
+  private static final String CHUNKED_BODY_HEADER = "transfer-encoding: chunked";
 
   private String status = "HTTP/1.1 200 OK";
   private Headers.Builder headers = new Headers.Builder();
@@ -161,6 +163,26 @@ public final class MockResponse implements Cloneable {
     bytesOut.writeUtf8("0\r\n\r\n"); // Last chunk + empty trailer + CRLF.
 
     this.body = bytesOut;
+    return this;
+  }
+
+    /**
+     * Provide a list of chunks to be streamed back to the client.
+     *
+     * @param chunks
+     * @return
+     */
+  public MockResponse setChunkedBody(List<String> chunks) {
+    removeHeader("Content-Length");
+    headers.add(CHUNKED_BODY_HEADER);
+      Buffer bytesOut = new Buffer();
+    for (String s : chunks) {
+        bytesOut.writeUtf8(Integer.toHexString(s.getBytes(Charset.forName("UTF-8")).length));
+        bytesOut.writeUtf8("\r\n");
+        bytesOut.writeUtf8(s);
+        bytesOut.writeUtf8("\r\n");
+    }
+      this.body = bytesOut;
     return this;
   }
 

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/SocketPolicy.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/SocketPolicy.java
@@ -66,6 +66,18 @@ public enum SocketPolicy {
   SHUTDOWN_OUTPUT_AT_END,
 
   /**
+   * Response body should be split into chunks based on {@code \r\n}, and each chunk should be
+   * streamed individually back to the server, with
+   * {@link MockResponse#setBodyDelay(long, java.util.concurrent.TimeUnit)} between each
+   * transmission.
+   * <p>
+   * This policy means that the final chunk will be re-sent constantly until the socket is
+   * closed.
+   * </p>
+   */
+  STREAM_REPEAT_FINAL_CHUNK,
+
+  /**
    * Don't response to the request but keep the socket open. For testing
    * read response header timeout issue.
    */


### PR DESCRIPTION
Having been attempting to do some integration testing against a service that was using Twitters streaming API, I was hoping to use MockHTTP to do that, but it didn't work out so well, since as soon as the connection was closed, everything fell over in a horrible fashion. As such, I have made some modifications so that it is possible to create a connection to the mock service and have that connection stay open until we're done with it, and to send a "Keep Alive" chunk (basically a blank string) every so often.

This is my first draft of the code, so it might be a little wonky.