### PR TITLE
Fail properly when a port is out of range.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -33,8 +33,8 @@ import java.io.InterruptedIOException;
 import java.net.CookieManager;
 import java.net.HttpCookie;
 import java.net.HttpURLConnection;
-import java.net.UnknownServiceException;
 import java.net.URL;
+import java.net.UnknownServiceException;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -152,6 +152,15 @@ public final class CallTest {
       fail();
     } catch (IllegalArgumentException expected) {
     }
+  }
+
+  @Test public void invalidPort() throws Exception {
+    Request request = new Request.Builder()
+        .url("http://localhost:65536/")
+        .build();
+    client.newCall(request).enqueue(callback);
+    callback.await(request.url())
+        .assertFailure("No route to localhost:65536; port is out of range");
   }
 
   @Test public void getReturns500() throws Exception {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
@@ -30,7 +30,6 @@ import java.net.Proxy;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.net.UnknownServiceException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -196,7 +195,7 @@ public final class RouteSelector {
   }
 
   /** Prepares the socket addresses to attempt for the current proxy or host. */
-  private void resetNextInetSocketAddress(Proxy proxy) throws UnknownHostException {
+  private void resetNextInetSocketAddress(Proxy proxy) throws IOException {
     // Clear the addresses. Necessary if getAllByName() below throws!
     inetSocketAddresses = new ArrayList<>();
 
@@ -214,6 +213,11 @@ public final class RouteSelector {
       InetSocketAddress proxySocketAddress = (InetSocketAddress) proxyAddress;
       socketHost = getHostString(proxySocketAddress);
       socketPort = proxySocketAddress.getPort();
+    }
+
+    if (socketPort < 1 || socketPort > 65535) {
+      throw new SocketException("No route to " + socketHost + ":" + socketPort
+          + "; port is out of range");
     }
 
     // Try each address for best behavior in mixed IPv4/IPv6 environments.


### PR DESCRIPTION
Closes https://github.com/square/okhttp/issues/1358