### PR TITLE
null out Request.Builder.url when setting urlString

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -114,6 +114,18 @@ public final class RequestTest {
     assertEquals(new URL("http://localhost/api"), request.url());
   }
 
+  @Test public void newBuilderUrlResetsUrl() throws Exception {
+    Request requestWithoutCache = new Request.Builder().url("http://localhost/api").build();
+    Request builtRequestWithoutCache = requestWithoutCache.newBuilder().url("http://localhost/api/foo").build();
+    assertEquals(new URL("http://localhost/api/foo"), builtRequestWithoutCache.url());
+
+    Request requestWithCache = new Request.Builder().url("http://localhost/api").build();
+    // cache url object
+    requestWithCache.url();
+    Request builtRequestWithCache = requestWithCache.newBuilder().url("http://localhost/api/foo").build();
+    assertEquals(new URL("http://localhost/api/foo"), builtRequestWithCache.url());
+  }
+
   @Test public void cacheControl() throws Exception {
     Request request = new Request.Builder()
         .cacheControl(new CacheControl.Builder().noCache().build())

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -146,7 +146,8 @@ public final class Request {
 
     public Builder url(String url) {
       if (url == null) throw new IllegalArgumentException("url == null");
-      urlString = url;
+      this.urlString = url;
+      this.url = null;
       return this;
     }
 


### PR DESCRIPTION
If you have a request that has called `Request.url` a URL will be initialized and cached on the object. If you then call `Request.newBuilder` on the same request object it will copy over `url` and `urlString` to the builder.  If you then call `Request.Builder.url(String)` on the builder the `urlString` field is set, but not the `url` field.  Then when you call `Request.Builder.build`, you get the original `Request`'s url, *not* the url string set on the builder.

The suggested fix is to not copy `Request.url` to `Request.Builder.url` on initialization.