### PR TITLE
Updates to http/2 final

### DIFF
--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -25,7 +25,7 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 import com.squareup.okhttp.internal.http.StatusLine;
-import com.squareup.okhttp.internal.spdy.Http20Draft16;
+import com.squareup.okhttp.internal.spdy.Http2;
 
 import io.airlift.command.Arguments;
 import io.airlift.command.Command;
@@ -266,7 +266,7 @@ public class Main extends HelpOption implements Runnable {
   }
 
   private static void enableHttp2FrameLogging() {
-    Logger logger = Logger.getLogger(Http20Draft16.class.getName() + "$FrameLogger");
+    Logger logger = Logger.getLogger(Http2.class.getName() + "$FrameLogger");
     logger.setLevel(Level.FINE);
     ConsoleHandler handler = new ConsoleHandler();
     handler.setLevel(Level.FINE);

--- a/okhttp-hpacktests/pom.xml
+++ b/okhttp-hpacktests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp</groupId>
     <artifactId>parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-hpacktests</artifactId>

--- a/okhttp-hpacktests/src/test/java/com/squareup/okhttp/internal/spdy/HpackDecodeTestBase.java
+++ b/okhttp-hpacktests/src/test/java/com/squareup/okhttp/internal/spdy/HpackDecodeTestBase.java
@@ -51,7 +51,7 @@ public class HpackDecodeTestBase {
   }
 
   private final Buffer bytesIn = new Buffer();
-  private final HpackDraft10.Reader hpackReader = new HpackDraft10.Reader(4096, bytesIn);
+  private final Hpack.Reader hpackReader = new Hpack.Reader(4096, bytesIn);
 
   private final Story story;
 

--- a/okhttp-hpacktests/src/test/java/com/squareup/okhttp/internal/spdy/HpackRoundTripTest.java
+++ b/okhttp-hpacktests/src/test/java/com/squareup/okhttp/internal/spdy/HpackRoundTripTest.java
@@ -42,7 +42,7 @@ public class HpackRoundTripTest extends HpackDecodeTestBase {
   }
 
   private Buffer bytesOut = new Buffer();
-  private HpackDraft10.Writer hpackWriter = new HpackDraft10.Writer(bytesOut);
+  private Hpack.Writer hpackWriter = new Hpack.Writer(bytesOut);
 
   public HpackRoundTripTest(Story story) {
     super(story);

--- a/okhttp-hpacktests/src/test/java/com/squareup/okhttp/internal/spdy/hpackjson/HpackJsonUtil.java
+++ b/okhttp-hpacktests/src/test/java/com/squareup/okhttp/internal/spdy/hpackjson/HpackJsonUtil.java
@@ -31,7 +31,8 @@ import java.util.List;
  * Utilities for reading HPACK tests.
  */
 public final class HpackJsonUtil {
-  private static final int CURRENT_DRAFT = 9;
+  /** Earliest draft that is code-compatible with latest. */
+  private static final int BASE_DRAFT = 9;
 
   private static final String STORY_RESOURCE_FORMAT = "/hpack-test-case/%s/story_%02d.json";
 
@@ -49,7 +50,7 @@ public final class HpackJsonUtil {
       if (path.isDirectory() && Arrays.asList(path.list()).contains("story_00.json")) {
         try {
           Story firstStory = readStory(new FileInputStream(new File(path, "story_00.json")));
-          if (firstStory.getDraft() == CURRENT_DRAFT) {
+          if (firstStory.getDraft() >= BASE_DRAFT) {
             storyNames.add(path.getName());
           }
         } catch (IOException ignored) {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpOverHttp2Test.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class HttpOverHttp20Draft16Test extends HttpOverSpdyTest {
+public class HttpOverHttp2Test extends HttpOverSpdyTest {
 
-  public HttpOverHttp20Draft16Test() {
+  public HttpOverHttp2Test() {
     super(Protocol.HTTP_2);
     this.hostHeader = ":authority";
   }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/HpackTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/HpackTest.java
@@ -28,23 +28,23 @@ import static okio.ByteString.decodeHex;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public class HpackDraft10Test {
+public class HpackTest {
 
   private final Buffer bytesIn = new Buffer();
-  private HpackDraft10.Reader hpackReader;
+  private Hpack.Reader hpackReader;
   private Buffer bytesOut = new Buffer();
-  private HpackDraft10.Writer hpackWriter;
+  private Hpack.Writer hpackWriter;
 
   @Before public void reset() {
     hpackReader = newReader(bytesIn);
-    hpackWriter = new HpackDraft10.Writer(bytesOut);
+    hpackWriter = new Hpack.Writer(bytesOut);
   }
 
   /**
    * Variable-length quantity special cases strings which are longer than 127
    * bytes.  Values such as cookies can be 4KiB, and should be possible to send.
    *
-   * <p> http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#section-5.2
+   * <p> http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#section-5.2
    */
   @Test public void largeHeaderValue() throws IOException {
     char[] value = new char[4096];
@@ -163,7 +163,7 @@ public class HpackDraft10Test {
   }
 
   /**
-   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#appendix-C.2.1
+   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#appendix-C.2.1
    */
   @Test public void readLiteralHeaderFieldWithIndexing() throws IOException {
     bytesIn.writeByte(0x40); // Literal indexed
@@ -185,7 +185,7 @@ public class HpackDraft10Test {
   }
 
   /**
-   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#appendix-C.2.2
+   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#appendix-C.2.2
    */
   @Test public void literalHeaderFieldWithoutIndexingIndexedName() throws IOException {
     List<Header> headerBlock = headerEntries(":path", "/sample/path");
@@ -347,7 +347,7 @@ public class HpackDraft10Test {
   }
 
   /**
-   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#appendix-C.2.4
+   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#appendix-C.2.4
    */
   @Test public void readIndexedHeaderFieldFromStaticTableWithoutBuffering() throws IOException {
     bytesIn.writeByte(0x82); // == Indexed - Add ==
@@ -363,7 +363,7 @@ public class HpackDraft10Test {
   }
 
   /**
-   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#appendix-C.2
+   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#appendix-C.2
    */
   @Test public void readRequestExamplesWithoutHuffman() throws IOException {
     firstRequestWithoutHuffman();
@@ -492,7 +492,7 @@ public class HpackDraft10Test {
   }
 
   /**
-   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#appendix-C.4
+   * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#appendix-C.4
    */
   @Test public void readRequestExamplesWithHuffman() throws IOException {
     firstRequestWithHuffman();
@@ -692,8 +692,8 @@ public class HpackDraft10Test {
     assertEquals(ByteString.EMPTY, newReader(byteStream(0)).readByteString());
   }
 
-  private HpackDraft10.Reader newReader(Buffer source) {
-    return new HpackDraft10.Reader(4096, source);
+  private Hpack.Reader newReader(Buffer source) {
+    return new Hpack.Reader(4096, source);
   }
 
   private Buffer byteStream(int... bytes) {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2ConnectionTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class Http2ConnectionTest {
-  private static final Variant HTTP_2 = new Http20Draft16();
+  private static final Variant HTTP_2 = new Http2();
   private final MockSpdyPeer peer = new MockSpdyPeer();
 
   @After public void tearDown() throws Exception {
@@ -143,7 +143,7 @@ public final class Http2ConnectionTest {
 
     // verify the peer's settings were read and applied.
     assertEquals(0, connection.peerSettings.getHeaderTableSize());
-    Http20Draft16.Reader frameReader = (Http20Draft16.Reader) connection.readerRunnable.frameReader;
+    Http2.Reader frameReader = (Http2.Reader) connection.readerRunnable.frameReader;
     assertEquals(0, frameReader.hpackReader.maxDynamicTableByteCount());
     // TODO: when supported, check the frameWriter's compression table is unaffected.
   }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2FrameLoggerTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2FrameLoggerTest.java
@@ -20,22 +20,22 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_ACK;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_END_HEADERS;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_END_STREAM;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_NONE;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FrameLogger.formatFlags;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FrameLogger.formatHeader;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.TYPE_CONTINUATION;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.TYPE_DATA;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.TYPE_GOAWAY;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.TYPE_HEADERS;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.TYPE_PING;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.TYPE_PUSH_PROMISE;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.TYPE_SETTINGS;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_ACK;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_END_HEADERS;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_END_STREAM;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_NONE;
+import static com.squareup.okhttp.internal.spdy.Http2.FrameLogger.formatFlags;
+import static com.squareup.okhttp.internal.spdy.Http2.FrameLogger.formatHeader;
+import static com.squareup.okhttp.internal.spdy.Http2.TYPE_CONTINUATION;
+import static com.squareup.okhttp.internal.spdy.Http2.TYPE_DATA;
+import static com.squareup.okhttp.internal.spdy.Http2.TYPE_GOAWAY;
+import static com.squareup.okhttp.internal.spdy.Http2.TYPE_HEADERS;
+import static com.squareup.okhttp.internal.spdy.Http2.TYPE_PING;
+import static com.squareup.okhttp.internal.spdy.Http2.TYPE_PUSH_PROMISE;
+import static com.squareup.okhttp.internal.spdy.Http2.TYPE_SETTINGS;
 import static org.junit.Assert.assertEquals;
 
-public class Http20Draft16FrameLoggerTest {
+public class Http2FrameLoggerTest {
 
   /** Real stream traffic applied to the log format. */
   @Test public void exampleStream() {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2Test.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/Http2Test.java
@@ -28,26 +28,26 @@ import okio.Okio;
 import org.junit.Test;
 
 import static com.squareup.okhttp.TestUtil.headerEntries;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_COMPRESSED;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_END_HEADERS;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_END_STREAM;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_NONE;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_PADDED;
-import static com.squareup.okhttp.internal.spdy.Http20Draft16.FLAG_PRIORITY;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_COMPRESSED;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_END_HEADERS;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_END_STREAM;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_NONE;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_PADDED;
+import static com.squareup.okhttp.internal.spdy.Http2.FLAG_PRIORITY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class Http20Draft16Test {
+public class Http2Test {
   final Buffer frame = new Buffer();
-  final FrameReader fr = new Http20Draft16.Reader(frame, 4096, false);
+  final FrameReader fr = new Http2.Reader(frame, 4096, false);
   final int expectedStreamId = 15;
 
   @Test public void unknownFrameTypeSkipped() throws IOException {
     writeMedium(frame, 4); // has a 4-byte field
     frame.writeByte(99); // type 99
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(expectedStreamId);
     frame.writeInt(111111111); // custom data
 
@@ -59,7 +59,7 @@ public class Http20Draft16Test {
 
     Buffer headerBytes = literalHeaders(sentHeaders);
     writeMedium(frame, (int) headerBytes.size());
-    frame.writeByte(Http20Draft16.TYPE_HEADERS);
+    frame.writeByte(Http2.TYPE_HEADERS);
     frame.writeByte(FLAG_END_HEADERS | FLAG_END_STREAM);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeAll(headerBytes);
@@ -85,7 +85,7 @@ public class Http20Draft16Test {
 
     Buffer headerBytes = literalHeaders(sentHeaders);
     writeMedium(frame, (int) (headerBytes.size() + 5));
-    frame.writeByte(Http20Draft16.TYPE_HEADERS);
+    frame.writeByte(Http2.TYPE_HEADERS);
     frame.writeByte(FLAG_END_HEADERS | FLAG_PRIORITY);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeInt(0); // Independent stream.
@@ -120,15 +120,15 @@ public class Http20Draft16Test {
     Buffer headerBlock = literalHeaders(sentHeaders);
 
     // Write the first headers frame.
-    writeMedium(frame, Http20Draft16.INITIAL_MAX_FRAME_SIZE);
-    frame.writeByte(Http20Draft16.TYPE_HEADERS);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    writeMedium(frame, Http2.INITIAL_MAX_FRAME_SIZE);
+    frame.writeByte(Http2.TYPE_HEADERS);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(expectedStreamId & 0x7fffffff);
-    frame.write(headerBlock, Http20Draft16.INITIAL_MAX_FRAME_SIZE);
+    frame.write(headerBlock, Http2.INITIAL_MAX_FRAME_SIZE);
 
     // Write the continuation frame, specifying no more frames are expected.
     writeMedium(frame, (int) headerBlock.size());
-    frame.writeByte(Http20Draft16.TYPE_CONTINUATION);
+    frame.writeByte(Http2.TYPE_CONTINUATION);
     frame.writeByte(FLAG_END_HEADERS);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeAll(headerBlock);
@@ -162,8 +162,8 @@ public class Http20Draft16Test {
     // Write the push promise frame, specifying the associated stream ID.
     Buffer headerBytes = literalHeaders(pushPromise);
     writeMedium(frame, (int) (headerBytes.size() + 4));
-    frame.writeByte(Http20Draft16.TYPE_PUSH_PROMISE);
-    frame.writeByte(Http20Draft16.FLAG_END_PUSH_PROMISE);
+    frame.writeByte(Http2.TYPE_PUSH_PROMISE);
+    frame.writeByte(Http2.FLAG_END_PUSH_PROMISE);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeInt(expectedPromisedStreamId & 0x7fffffff);
     frame.writeAll(headerBytes);
@@ -189,16 +189,16 @@ public class Http20Draft16Test {
     Buffer headerBlock = literalHeaders(pushPromise);
 
     // Write the first headers frame.
-    writeMedium(frame, Http20Draft16.INITIAL_MAX_FRAME_SIZE);
-    frame.writeByte(Http20Draft16.TYPE_PUSH_PROMISE);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    writeMedium(frame, Http2.INITIAL_MAX_FRAME_SIZE);
+    frame.writeByte(Http2.TYPE_PUSH_PROMISE);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeInt(expectedPromisedStreamId & 0x7fffffff);
-    frame.write(headerBlock, Http20Draft16.INITIAL_MAX_FRAME_SIZE - 4);
+    frame.write(headerBlock, Http2.INITIAL_MAX_FRAME_SIZE - 4);
 
     // Write the continuation frame, specifying no more frames are expected.
     writeMedium(frame, (int) headerBlock.size());
-    frame.writeByte(Http20Draft16.TYPE_CONTINUATION);
+    frame.writeByte(Http2.TYPE_CONTINUATION);
     frame.writeByte(FLAG_END_HEADERS);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeAll(headerBlock);
@@ -218,8 +218,8 @@ public class Http20Draft16Test {
 
   @Test public void readRstStreamFrame() throws IOException {
     writeMedium(frame, 4);
-    frame.writeByte(Http20Draft16.TYPE_RST_STREAM);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_RST_STREAM);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeInt(ErrorCode.COMPRESSION_ERROR.httpCode);
 
@@ -235,8 +235,8 @@ public class Http20Draft16Test {
     final int reducedTableSizeBytes = 16;
 
     writeMedium(frame, 12); // 2 settings * 6 bytes (2 for the code and 4 for the value).
-    frame.writeByte(Http20Draft16.TYPE_SETTINGS);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_SETTINGS);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // Settings are always on the connection stream 0.
     frame.writeShort(1); // SETTINGS_HEADER_TABLE_SIZE
     frame.writeInt(reducedTableSizeBytes);
@@ -254,8 +254,8 @@ public class Http20Draft16Test {
 
   @Test public void readSettingsFrameInvalidPushValue() throws IOException {
     writeMedium(frame, 6); // 2 for the code and 4 for the value
-    frame.writeByte(Http20Draft16.TYPE_SETTINGS);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_SETTINGS);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // Settings are always on the connection stream 0.
     frame.writeShort(2);
     frame.writeInt(2);
@@ -270,8 +270,8 @@ public class Http20Draft16Test {
 
   @Test public void readSettingsFrameInvalidSettingId() throws IOException {
     writeMedium(frame, 6); // 2 for the code and 4 for the value
-    frame.writeByte(Http20Draft16.TYPE_SETTINGS);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_SETTINGS);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // Settings are always on the connection stream 0.
     frame.writeShort(7); // old number for SETTINGS_INITIAL_WINDOW_SIZE
     frame.writeInt(1);
@@ -286,8 +286,8 @@ public class Http20Draft16Test {
 
   @Test public void readSettingsFrameNegativeWindowSize() throws IOException {
     writeMedium(frame, 6); // 2 for the code and 4 for the value
-    frame.writeByte(Http20Draft16.TYPE_SETTINGS);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_SETTINGS);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // Settings are always on the connection stream 0.
     frame.writeShort(4); // SETTINGS_INITIAL_WINDOW_SIZE
     frame.writeInt(Integer.MIN_VALUE);
@@ -302,8 +302,8 @@ public class Http20Draft16Test {
 
   @Test public void readSettingsFrameNegativeFrameLength() throws IOException {
     writeMedium(frame, 6); // 2 for the code and 4 for the value
-    frame.writeByte(Http20Draft16.TYPE_SETTINGS);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_SETTINGS);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // Settings are always on the connection stream 0.
     frame.writeShort(5); // SETTINGS_MAX_FRAME_SIZE
     frame.writeInt(Integer.MIN_VALUE);
@@ -318,8 +318,8 @@ public class Http20Draft16Test {
 
   @Test public void readSettingsFrameTooShortFrameLength() throws IOException {
     writeMedium(frame, 6); // 2 for the code and 4 for the value
-    frame.writeByte(Http20Draft16.TYPE_SETTINGS);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_SETTINGS);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // Settings are always on the connection stream 0.
     frame.writeShort(5); // SETTINGS_MAX_FRAME_SIZE
     frame.writeInt((int) Math.pow(2, 14) - 1);
@@ -334,8 +334,8 @@ public class Http20Draft16Test {
 
   @Test public void readSettingsFrameTooLongFrameLength() throws IOException {
     writeMedium(frame, 6); // 2 for the code and 4 for the value
-    frame.writeByte(Http20Draft16.TYPE_SETTINGS);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_SETTINGS);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // Settings are always on the connection stream 0.
     frame.writeShort(5); // SETTINGS_MAX_FRAME_SIZE
     frame.writeInt((int) Math.pow(2, 24));
@@ -353,8 +353,8 @@ public class Http20Draft16Test {
     final int expectedPayload2 = 8;
 
     writeMedium(frame, 8); // length
-    frame.writeByte(Http20Draft16.TYPE_PING);
-    frame.writeByte(Http20Draft16.FLAG_ACK);
+    frame.writeByte(Http2.TYPE_PING);
+    frame.writeByte(Http2.FLAG_ACK);
     frame.writeInt(0); // connection-level
     frame.writeInt(expectedPayload1);
     frame.writeInt(expectedPayload2);
@@ -372,12 +372,12 @@ public class Http20Draft16Test {
   }
 
   @Test public void maxLengthDataFrame() throws IOException {
-    final byte[] expectedData = new byte[Http20Draft16.INITIAL_MAX_FRAME_SIZE];
+    final byte[] expectedData = new byte[Http2.INITIAL_MAX_FRAME_SIZE];
     Arrays.fill(expectedData, (byte) 2);
 
     writeMedium(frame, expectedData.length);
-    frame.writeByte(Http20Draft16.TYPE_DATA);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_DATA);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.write(expectedData);
 
@@ -389,7 +389,7 @@ public class Http20Draft16Test {
           int length) throws IOException {
         assertFalse(inFinished);
         assertEquals(expectedStreamId, streamId);
-        assertEquals(Http20Draft16.INITIAL_MAX_FRAME_SIZE, length);
+        assertEquals(Http2.INITIAL_MAX_FRAME_SIZE, length);
         ByteString data = source.readByteString(length);
         for (byte b : data.toByteArray()) {
           assertEquals(2, b);
@@ -400,13 +400,13 @@ public class Http20Draft16Test {
 
   /** We do not send SETTINGS_COMPRESS_DATA = 1, nor want to. Let's make sure we error. */
   @Test public void compressedDataFrameWhenSettingDisabled() throws IOException {
-    byte[] expectedData = new byte[Http20Draft16.INITIAL_MAX_FRAME_SIZE];
+    byte[] expectedData = new byte[Http2.INITIAL_MAX_FRAME_SIZE];
     Arrays.fill(expectedData, (byte) 2);
     Buffer zipped = gzip(expectedData);
     int zippedSize = (int) zipped.size();
 
     writeMedium(frame, zippedSize);
-    frame.writeByte(Http20Draft16.TYPE_DATA);
+    frame.writeByte(Http2.TYPE_DATA);
     frame.writeByte(FLAG_COMPRESSED);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     zipped.readAll(frame);
@@ -430,7 +430,7 @@ public class Http20Draft16Test {
     Arrays.fill(padding, (byte) 0);
 
     writeMedium(frame, dataLength + paddingLength + 1);
-    frame.writeByte(Http20Draft16.TYPE_DATA);
+    frame.writeByte(Http2.TYPE_DATA);
     frame.writeByte(FLAG_PADDED);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeByte(paddingLength);
@@ -447,7 +447,7 @@ public class Http20Draft16Test {
     Arrays.fill(expectedData, (byte) 2);
 
     writeMedium(frame, dataLength + 1);
-    frame.writeByte(Http20Draft16.TYPE_DATA);
+    frame.writeByte(Http2.TYPE_DATA);
     frame.writeByte(FLAG_PADDED);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeByte(0);
@@ -463,7 +463,7 @@ public class Http20Draft16Test {
 
     Buffer headerBlock = literalHeaders(headerEntries("foo", "barrr", "baz", "qux"));
     writeMedium(frame, (int) headerBlock.size() + paddingLength + 1);
-    frame.writeByte(Http20Draft16.TYPE_HEADERS);
+    frame.writeByte(Http2.TYPE_HEADERS);
     frame.writeByte(FLAG_END_HEADERS | FLAG_PADDED);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeByte(paddingLength);
@@ -477,7 +477,7 @@ public class Http20Draft16Test {
   @Test public void readPaddedHeadersFrameZeroPadding() throws IOException {
     Buffer headerBlock = literalHeaders(headerEntries("foo", "barrr", "baz", "qux"));
     writeMedium(frame, (int) headerBlock.size() + 1);
-    frame.writeByte(Http20Draft16.TYPE_HEADERS);
+    frame.writeByte(Http2.TYPE_HEADERS);
     frame.writeByte(FLAG_END_HEADERS | FLAG_PADDED);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeByte(0);
@@ -497,7 +497,7 @@ public class Http20Draft16Test {
 
     // Write the first headers frame.
     writeMedium(frame, (int) (headerBlock.size() / 2) + paddingLength + 1);
-    frame.writeByte(Http20Draft16.TYPE_HEADERS);
+    frame.writeByte(Http2.TYPE_HEADERS);
     frame.writeByte(FLAG_PADDED);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeByte(paddingLength);
@@ -506,7 +506,7 @@ public class Http20Draft16Test {
 
     // Write the continuation frame, specifying no more frames are expected.
     writeMedium(frame, (int) headerBlock.size());
-    frame.writeByte(Http20Draft16.TYPE_CONTINUATION);
+    frame.writeByte(Http2.TYPE_CONTINUATION);
     frame.writeByte(FLAG_END_HEADERS);
     frame.writeInt(expectedStreamId & 0x7fffffff);
     frame.writeAll(headerBlock);
@@ -528,8 +528,8 @@ public class Http20Draft16Test {
     final long expectedWindowSizeIncrement = 0x7fffffff;
 
     writeMedium(frame, 4); // length
-    frame.writeByte(Http20Draft16.TYPE_WINDOW_UPDATE);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_WINDOW_UPDATE);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(expectedStreamId);
     frame.writeInt((int) expectedWindowSizeIncrement);
 
@@ -565,8 +565,8 @@ public class Http20Draft16Test {
     final ErrorCode expectedError = ErrorCode.PROTOCOL_ERROR;
 
     writeMedium(frame, 8); // Without debug data there's only 2 32-bit fields.
-    frame.writeByte(Http20Draft16.TYPE_GOAWAY);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_GOAWAY);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // connection-scope
     frame.writeInt(expectedStreamId); // last good stream.
     frame.writeInt(expectedError.httpCode);
@@ -590,8 +590,8 @@ public class Http20Draft16Test {
 
     // Compose the expected GOAWAY frame without debug data.
     writeMedium(frame, 8 + expectedData.size());
-    frame.writeByte(Http20Draft16.TYPE_GOAWAY);
-    frame.writeByte(Http20Draft16.FLAG_NONE);
+    frame.writeByte(Http2.TYPE_GOAWAY);
+    frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // connection-scope
     frame.writeInt(0); // never read any stream!
     frame.writeInt(expectedError.httpCode);
@@ -611,10 +611,10 @@ public class Http20Draft16Test {
   }
 
   @Test public void frameSizeError() throws IOException {
-    Http20Draft16.Writer writer = new Http20Draft16.Writer(new Buffer(), true);
+    Http2.Writer writer = new Http2.Writer(new Buffer(), true);
 
     try {
-      writer.frameHeader(0, 16777216, Http20Draft16.TYPE_DATA, FLAG_NONE);
+      writer.frameHeader(0, 16777216, Http2.TYPE_DATA, FLAG_NONE);
       fail();
     } catch (IllegalArgumentException e) {
       // TODO: real max is based on settings between 16384 and 16777215
@@ -625,21 +625,21 @@ public class Http20Draft16Test {
   @Test public void ackSettingsAppliesMaxFrameSize() throws IOException {
     int newMaxFrameSize = 16777215;
 
-    Http20Draft16.Writer writer = new Http20Draft16.Writer(new Buffer(), true);
+    Http2.Writer writer = new Http2.Writer(new Buffer(), true);
 
     writer.ackSettings(new Settings().set(Settings.MAX_FRAME_SIZE, 0, newMaxFrameSize));
 
     assertEquals(newMaxFrameSize, writer.maxDataLength());
-    writer.frameHeader(0, newMaxFrameSize, Http20Draft16.TYPE_DATA, FLAG_NONE);
+    writer.frameHeader(0, newMaxFrameSize, Http2.TYPE_DATA, FLAG_NONE);
   }
 
   @Test public void streamIdHasReservedBit() throws IOException {
-    Http20Draft16.Writer writer = new Http20Draft16.Writer(new Buffer(), true);
+    Http2.Writer writer = new Http2.Writer(new Buffer(), true);
 
     try {
       int streamId = 3;
       streamId |= 1L << 31; // set reserved bit
-      writer.frameHeader(streamId, Http20Draft16.INITIAL_MAX_FRAME_SIZE, Http20Draft16.TYPE_DATA, FLAG_NONE);
+      writer.frameHeader(streamId, Http2.INITIAL_MAX_FRAME_SIZE, Http2.TYPE_DATA, FLAG_NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("reserved bit set: -2147483645", e.getMessage());
@@ -648,45 +648,45 @@ public class Http20Draft16Test {
 
   private Buffer literalHeaders(List<Header> sentHeaders) throws IOException {
     Buffer out = new Buffer();
-    new HpackDraft10.Writer(out).writeHeaders(sentHeaders);
+    new Hpack.Writer(out).writeHeaders(sentHeaders);
     return out;
   }
 
   private Buffer sendHeaderFrames(boolean outFinished, List<Header> headers) throws IOException {
     Buffer out = new Buffer();
-    new Http20Draft16.Writer(out, true).headers(outFinished, expectedStreamId, headers);
+    new Http2.Writer(out, true).headers(outFinished, expectedStreamId, headers);
     return out;
   }
 
   private Buffer sendPushPromiseFrames(int streamId, List<Header> headers) throws IOException {
     Buffer out = new Buffer();
-    new Http20Draft16.Writer(out, true).pushPromise(expectedStreamId, streamId, headers);
+    new Http2.Writer(out, true).pushPromise(expectedStreamId, streamId, headers);
     return out;
   }
 
   private Buffer sendPingFrame(boolean ack, int payload1, int payload2) throws IOException {
     Buffer out = new Buffer();
-    new Http20Draft16.Writer(out, true).ping(ack, payload1, payload2);
+    new Http2.Writer(out, true).ping(ack, payload1, payload2);
     return out;
   }
 
   private Buffer sendGoAway(int lastGoodStreamId, ErrorCode errorCode, byte[] debugData)
       throws IOException {
     Buffer out = new Buffer();
-    new Http20Draft16.Writer(out, true).goAway(lastGoodStreamId, errorCode, debugData);
+    new Http2.Writer(out, true).goAway(lastGoodStreamId, errorCode, debugData);
     return out;
   }
 
   private Buffer sendDataFrame(Buffer data) throws IOException {
     Buffer out = new Buffer();
-    new Http20Draft16.Writer(out, true).dataFrame(expectedStreamId, FLAG_NONE, data,
+    new Http2.Writer(out, true).dataFrame(expectedStreamId, FLAG_NONE, data,
         (int) data.size());
     return out;
   }
 
   private Buffer windowUpdate(long windowSizeIncrement) throws IOException {
     Buffer out = new Buffer();
-    new Http20Draft16.Writer(out, true).windowUpdate(expectedStreamId, windowSizeIncrement);
+    new Http2.Writer(out, true).windowUpdate(expectedStreamId, windowSizeIncrement);
     return out;
   }
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/spdy/MockSpdyPeer.java
@@ -299,7 +299,7 @@ public final class MockSpdyPeer implements Closeable {
 
     @Override
     public void pushPromise(int streamId, int associatedStreamId, List<Header> headerBlock) {
-      this.type = Http20Draft16.TYPE_PUSH_PROMISE;
+      this.type = Http2.TYPE_PUSH_PROMISE;
       this.streamId = streamId;
       this.associatedStreamId = associatedStreamId;
       this.headerBlock = headerBlock;

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -499,12 +499,12 @@ public class OkHttpClient implements Cloneable {
    * <ul>
    *   <li><a href="http://www.w3.org/Protocols/rfc2616/rfc2616.html">http/1.1</a>
    *   <li><a href="http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1">spdy/3.1</a>
-   *   <li><a href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-16">h2-16</a>
+   *   <li><a href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-17">h2</a>
    * </ul>
    *
-   * <p><strong>This is an evolving set.</strong> Future releases may drop
-   * support for transitional protocols (like h2-16), in favor of their
-   * successors (h2). The http/1.1 transport will never be dropped.
+   * <p><strong>This is an evolving set.</strong> Future releases include
+   * support for transitional protocols. The http/1.1 transport will never be
+   * dropped.
    *
    * <p>If multiple protocols are specified, <a
    * href="http://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg">ALPN</a>

--- a/okhttp/src/main/java/com/squareup/okhttp/Protocol.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Protocol.java
@@ -61,19 +61,12 @@ public enum Protocol {
    * multiplexing multiple requests on the same socket, and server-push.
    * HTTP/1.1 semantics are layered on HTTP/2.
    *
-   * <p>This version of OkHttp implements HTTP/2 <a
-   * href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-16">draft 16</a>
-   * with HPACK <a
-   * href="http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10">draft
-   * 10</a>. Future releases of OkHttp may use this identifier for a newer draft
-   * of these specs.
-   *
    * <p>HTTP/2 requires deployments of HTTP/2 that use TLS 1.2 support
    * {@linkplain com.squareup.okhttp.CipherSuite#TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}
    * , present in Java 8+ and Android 5+. Servers that enforce this may send an
    * exception message including the string {@code INADEQUATE_SECURITY}.
    */
-  HTTP_2("h2-16");
+  HTTP_2("h2");
 
   private final String protocol;
 
@@ -96,7 +89,7 @@ public enum Protocol {
 
   /**
    * Returns the string used to identify this protocol for ALPN, like
-   * "http/1.1", "spdy/3.1" or "h2-16".
+   * "http/1.1", "spdy/3.1" or "h2".
    */
   @Override public String toString() {
     return protocol;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/ErrorCode.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/ErrorCode.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.okhttp.internal.spdy;
 
-// http://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-7
+// http://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-7
 public enum ErrorCode {
   /** Not an error! For SPDY stream resets, prefer null over NO_ERROR. */
   NO_ERROR(0, -1, 0),

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Hpack.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Hpack.java
@@ -31,13 +31,13 @@ import okio.Source;
 /**
  * Read and write HPACK v10.
  *
- * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10
+ * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12
  *
  * This implementation uses an array for the dynamic table and a list for
  * indexed entries.  Dynamic entries are added to the array, starting in the
  * last position moving forward.  When the array fills, it is doubled.
  */
-final class HpackDraft10 {
+final class Hpack {
   private static final int PREFIX_4_BITS = 0x0f;
   private static final int PREFIX_5_BITS = 0x1f;
   private static final int PREFIX_6_BITS = 0x3f;
@@ -107,10 +107,10 @@ final class HpackDraft10 {
       new Header("www-authenticate", "")
   };
 
-  private HpackDraft10() {
+  private Hpack() {
   }
 
-  // http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#section-3.1
+  // http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#section-3.1
   static final class Reader {
 
     private final List<Header> headerList = new ArrayList<>();
@@ -374,7 +374,7 @@ final class HpackDraft10 {
     }
 
     /** This does not use "never indexed" semantics for sensitive headers. */
-    // http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#section-6.2.3
+    // http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#section-6.2.3
     void writeHeaders(List<Header> headerBlock) throws IOException {
       // TODO: implement index tracking
       for (int i = 0, size = headerBlock.size(); i < size; i++) {
@@ -392,7 +392,7 @@ final class HpackDraft10 {
       }
     }
 
-    // http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#section-4.1.1
+    // http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#section-4.1.1
     void writeInt(int value, int prefixMask, int bits) throws IOException {
       // Write the raw value for a single byte value.
       if (value < prefixMask) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Huffman.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/Huffman.java
@@ -31,7 +31,7 @@ import java.io.OutputStream;
 class Huffman {
 
   // Appendix C: Huffman Codes
-  // http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#appendix-B
+  // http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#appendix-B
   private static final int[] CODES = {
       0x1ff8, 0x7fffd8, 0xfffffe2, 0xfffffe3, 0xfffffe4, 0xfffffe5, 0xfffffe6, 0xfffffe7, 0xfffffe8,
       0xffffea, 0x3ffffffc, 0xfffffe9, 0xfffffea, 0x3ffffffd, 0xfffffeb, 0xfffffec, 0xfffffed,

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -131,7 +131,7 @@ public final class SpdyConnection implements Closeable {
     pushObserver = builder.pushObserver;
     client = builder.client;
     handler = builder.handler;
-    // http://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-5.1.1
+    // http://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-5.1.1
     nextStreamId = builder.client ? 1 : 2;
     if (builder.client && protocol == Protocol.HTTP_2) {
       nextStreamId += 2; // In HTTP/2, 1 on client is reserved for Upgrade.
@@ -150,14 +150,14 @@ public final class SpdyConnection implements Closeable {
     hostName = builder.hostName;
 
     if (protocol == Protocol.HTTP_2) {
-      variant = new Http20Draft16();
+      variant = new Http2();
       // Like newSingleThreadExecutor, except lazy creates the thread.
       pushExecutor = new ThreadPoolExecutor(0, 1, 60, TimeUnit.SECONDS,
           new LinkedBlockingQueue<Runnable>(),
           Util.threadFactory(String.format("OkHttp %s Push Observer", hostName), true));
-      // 1 less than SPDY http://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-6.9.2
+      // 1 less than SPDY http://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-6.9.2
       peerSettings.set(Settings.INITIAL_WINDOW_SIZE, 0, 65535);
-      peerSettings.set(Settings.MAX_FRAME_SIZE, 0, Http20Draft16.INITIAL_MAX_FRAME_SIZE);
+      peerSettings.set(Settings.MAX_FRAME_SIZE, 0, Http2.INITIAL_MAX_FRAME_SIZE);
     } else if (protocol == Protocol.SPDY_3) {
       variant = new Spdy3();
       pushExecutor = null;


### PR DESCRIPTION
Http2 and Hpack have been [submitted] (https://www.rfc-editor.org/queue2.html#draft-ietf-httpbis-http2) to the IETF. This change removes the draft alpn identifier, and renames types accordingly.

tested with okcurl against twitter.com using ALPN.

```java
$ cd okcurl/
$ java -Xbootclasspath/p:$HOME/.m2/repository/org/mortbay/jetty/alpn/alpn-boot/7.1.2.v20141202/alpn-boot-7.1.2.v20141202.jar -jar target/okcurl-2.3.0-SNAPSHOT-jar-with-dependencies.jar --frames https://twitter.com -X HEAD
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=utf8
>> CONNECTION 505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
>> 0x00000000     6 SETTINGS      
<< 0x00000000     6 SETTINGS      
>> 0x00000000     4 WINDOW_UPDATE 
>> 0x00000000     0 SETTINGS      ACK
>> 0x00000003    60 HEADERS       END_STREAM|END_HEADERS
<< 0x00000000     0 SETTINGS      ACK
<< 0x00000003  1045 HEADERS       END_STREAM|END_HEADERS
>> 0x00000000     8 GOAWAY   
```