### PR TITLE
Remove -SNAPSHOT from okio version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <!-- Compilation -->
     <java.version>1.7</java.version>
-    <okio.version>1.3.0-SNAPSHOT</okio.version>
+    <okio.version>1.3.0</okio.version>
     <!-- ALPN library targeted to Java 7 -->
     <alpn.jdk7.version>7.1.2.v20141202</alpn.jdk7.version>
     <!-- ALPN library targeted to Java 8 update 25. -->


### PR DESCRIPTION
This seems to be required for me to build successfully.