### PR TITLE
Set readerSentClose to break reading loop and close frame

### DIFF
--- a/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/RealWebSocket.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/RealWebSocket.java
@@ -69,6 +69,7 @@ public abstract class RealWebSocket implements WebSocket {
       }
 
       @Override public void onClose(final int code, final String reason) {
+        readerSentClose = true;
         replyExecutor.execute(new NamedRunnable("OkHttp %s WebSocket Close Reply", url) {
           @Override protected void execute() {
             peerClose(code, reason);


### PR DESCRIPTION
We have to set readerSentClose = true to break frames reading loop otherwise we get IOException that will call callback.onFailure.. it is worst if onFailure will be called before onClose (most likely) so user can't make decition.

Would be great to integrate to 2.3 if it is planned for release 2.3.1
