### PR TITLE
Progress recipe

### DIFF
--- a/samples/guide/src/main/java/com/squareup/okhttp/recipes/Progress.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/recipes/Progress.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.recipes;
+
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
+import com.squareup.okhttp.Request;
+import java.io.IOException;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.ForwardingSource;
+import okio.Okio;
+import okio.Source;
+
+public final class Progress {
+
+  private final OkHttpClient client = new OkHttpClient();
+
+  public void run() throws Exception {
+    Request request = new Request.Builder()
+        .url("https://publicobject.com/helloworld.txt")
+        .build();
+
+    final ProgressListener progressListener = new ProgressListener() {
+      @Override
+      public void update(long bytesRead, long contentLength, boolean done) {
+        System.out.println(bytesRead);
+        System.out.println(contentLength);
+        System.out.println(done);
+        System.out.format("%d%% done\n", (100 * bytesRead) / contentLength);
+      }
+    };
+
+    client.networkInterceptors().add(new Interceptor() {
+      @Override public Response intercept(Chain chain) throws IOException {
+        Response originalResponse = chain.proceed(chain.request());
+        return originalResponse.newBuilder()
+            .body(new ProgressResponseBody(originalResponse.body(), progressListener))
+            .build();
+        }
+    });
+
+    Response response = client.newCall(request).execute();
+    if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);
+
+    System.out.println(response.body().string());
+  }
+
+  public static void main(String... args) throws Exception {
+    new Progress().run();
+  }
+
+  private static class ProgressResponseBody extends ResponseBody {
+
+    private final ResponseBody responseBody;
+    private final ProgressListener progressListener;
+    private BufferedSource bufferedSource;
+
+    public ProgressResponseBody(ResponseBody responseBody, ProgressListener progressListener) {
+      this.responseBody = responseBody;
+      this.progressListener = progressListener;
+    }
+
+    @Override public MediaType contentType() {
+      return responseBody.contentType();
+    }
+
+    @Override public long contentLength() throws IOException {
+      return responseBody.contentLength();
+    }
+
+    @Override public BufferedSource source() throws IOException {
+      if (bufferedSource == null) {
+        bufferedSource = Okio.buffer(source(responseBody.source()));
+      }
+      return bufferedSource;
+    }
+
+    private Source source(Source source) {
+      return new ForwardingSource(source) {
+        long totalBytesRead = 0L;
+        @Override public long read(Buffer sink, long byteCount) throws IOException {
+          long bytesRead = super.read(sink, byteCount);
+          // read() returns the number of bytes read, or -1 if this source is exhausted.
+          totalBytesRead += bytesRead != -1 ? bytesRead : 0;
+          progressListener.update(totalBytesRead, responseBody.contentLength(), bytesRead != -1);
+          return bytesRead;
+        }
+      };
+    }
+  }
+
+  interface ProgressListener {
+    void update(long bytesRead, long contentLength, boolean done);
+  }
+}


### PR DESCRIPTION
This is the first draft of a (download) progress recipe, mentioned in #1471. 

Looking forward to suggestions for improvements. For example, the output is a bit verbose right now, for testing purposes, also the file is too small to actually show anything other than 100%, because it's <2KB which is the segment size of okio (from what I've gathered).

Also, am I missing something, there is no progress if I comment out line 56 (the `System.out` call), but that shouldn't influence the request afaik!?

Another thing, I'd like to provide another example for upload and split it into two files, `DownloadProgress.java` and `UploadProgress.java` or should it stay in one?