### PR TITLE
Make OkHttpClient and Call final.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
@@ -146,6 +146,15 @@ public final class OkHttpClientTest {
     assertNull(client.internalCache());
   }
 
+  @Test public void clonedInterceptorsListsAreIndependent() throws Exception {
+    OkHttpClient original = new OkHttpClient();
+    OkHttpClient clone = original.clone();
+    clone.interceptors().add(null);
+    clone.networkInterceptors().add(null);
+    assertEquals(0, original.interceptors().size());
+    assertEquals(0, original.networkInterceptors().size());
+  }
+
   /**
    * When copying the client, stateful things like the connection pool are
    * shared across all clients.
@@ -166,49 +175,6 @@ public final class OkHttpClientTest {
     assertSame(a.getDispatcher(), b.getDispatcher());
     assertSame(a.getConnectionPool(), b.getConnectionPool());
     assertSame(a.getSslSocketFactory(), b.getSslSocketFactory());
-  }
-
-  /** We don't want to run user code inside of HttpEngine, etc. */
-  @Test public void copyWithDefaultsDoesNotReturnSubclass() throws Exception {
-    OkHttpClient subclass = new OkHttpClient() {};
-    OkHttpClient copy = subclass.copyWithDefaults();
-    assertEquals(OkHttpClient.class, copy.getClass());
-  }
-
-  @Test public void cloneReturnsSubclass() throws Exception {
-    OkHttpClient subclass = new OkHttpClient() {};
-    OkHttpClient clone = subclass.clone();
-    assertEquals(subclass.getClass(), clone.getClass());
-  }
-
-  /** Exercise a synchronous mocking case. */
-  @Test public void mock() throws Exception {
-    final Request request = new Request.Builder()
-        .url("http://example.com/")
-        .build();
-    final Response response = new Response.Builder()
-        .protocol(Protocol.HTTP_1_1)
-        .request(request)
-        .code(200)
-        .message("Alright")
-        .build();
-
-    OkHttpClient mockClient = new OkHttpClient() {
-      @Override public Call newCall(Request request) {
-        return new Call(this, request) {
-          @Override public Response execute() throws IOException {
-            return response;
-          }
-          @Override public void enqueue(Callback responseCallback) {
-          }
-          @Override public void cancel() {
-          }
-        };
-      }
-    };
-
-    Response actualResponse = mockClient.newCall(request).execute();
-    assertSame(response, actualResponse);
   }
 
   @Test public void setProtocolsRejectsHttp10() throws Exception {

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
@@ -42,7 +42,7 @@ import okio.Okio;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class WebSocketCall {
+public final class WebSocketCall {
   /**
    * Prepares the {@code request} to create a web socket at some point in the future.
    */
@@ -55,7 +55,7 @@ public class WebSocketCall {
   private final Random random;
   private final String key;
 
-  protected WebSocketCall(OkHttpClient client, Request request) {
+  WebSocketCall(OkHttpClient client, Request request) {
     this(client, request, new SecureRandom());
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -31,7 +31,7 @@ import static com.squareup.okhttp.internal.http.HttpEngine.MAX_FOLLOW_UPS;
  * canceled. As this object represents a single request/response pair (stream),
  * it cannot be executed twice.
  */
-public class Call {
+public final class Call {
   private final OkHttpClient client;
 
   // Guarded by this.
@@ -42,7 +42,7 @@ public class Call {
   Request originalRequest;
   HttpEngine engine;
 
-  protected Call(OkHttpClient client, Request originalRequest) {
+  Call(OkHttpClient client, Request originalRequest) {
     // Copy the client. Otherwise changes (socket factory, redirect policy,
     // etc.) may incorrectly be reflected in the request when it is executed.
     this.client = client.copyWithDefaults();

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -49,7 +49,7 @@ import javax.net.ssl.SSLSocketFactory;
  * {@link #clone()} to make a shallow copy of the OkHttpClient that can be
  * safely modified with further configuration changes.
  */
-public class OkHttpClient implements Cloneable {
+public final class OkHttpClient implements Cloneable {
   private static final List<Protocol> DEFAULT_PROTOCOLS = Util.immutableList(
       Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1);
 
@@ -208,7 +208,7 @@ public class OkHttpClient implements Cloneable {
    *
    * @see URLConnection#setConnectTimeout(int)
    */
-  public final void setConnectTimeout(long timeout, TimeUnit unit) {
+  public void setConnectTimeout(long timeout, TimeUnit unit) {
     if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
     if (unit == null) throw new IllegalArgumentException("unit == null");
     long millis = unit.toMillis(timeout);
@@ -218,7 +218,7 @@ public class OkHttpClient implements Cloneable {
   }
 
   /** Default connect timeout (in milliseconds). */
-  public final int getConnectTimeout() {
+  public int getConnectTimeout() {
     return connectTimeout;
   }
 
@@ -228,7 +228,7 @@ public class OkHttpClient implements Cloneable {
    *
    * @see URLConnection#setReadTimeout(int)
    */
-  public final void setReadTimeout(long timeout, TimeUnit unit) {
+  public void setReadTimeout(long timeout, TimeUnit unit) {
     if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
     if (unit == null) throw new IllegalArgumentException("unit == null");
     long millis = unit.toMillis(timeout);
@@ -238,7 +238,7 @@ public class OkHttpClient implements Cloneable {
   }
 
   /** Default read timeout (in milliseconds). */
-  public final int getReadTimeout() {
+  public int getReadTimeout() {
     return readTimeout;
   }
 
@@ -246,7 +246,7 @@ public class OkHttpClient implements Cloneable {
    * Sets the default write timeout for new connections. A value of 0 means no timeout, otherwise
    * values must be between 1 and {@link Integer#MAX_VALUE} when converted to milliseconds.
    */
-  public final void setWriteTimeout(long timeout, TimeUnit unit) {
+  public void setWriteTimeout(long timeout, TimeUnit unit) {
     if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
     if (unit == null) throw new IllegalArgumentException("unit == null");
     long millis = unit.toMillis(timeout);
@@ -256,7 +256,7 @@ public class OkHttpClient implements Cloneable {
   }
 
   /** Default write timeout (in milliseconds). */
-  public final int getWriteTimeout() {
+  public int getWriteTimeout() {
     return writeTimeout;
   }
 
@@ -266,12 +266,12 @@ public class OkHttpClient implements Cloneable {
    * only honored when this proxy is null (which it is by default). To disable
    * proxy use completely, call {@code setProxy(Proxy.NO_PROXY)}.
    */
-  public final OkHttpClient setProxy(Proxy proxy) {
+  public OkHttpClient setProxy(Proxy proxy) {
     this.proxy = proxy;
     return this;
   }
 
-  public final Proxy getProxy() {
+  public Proxy getProxy() {
     return proxy;
   }
 
@@ -284,12 +284,12 @@ public class OkHttpClient implements Cloneable {
    * <p>If unset, the {@link ProxySelector#getDefault() system-wide default}
    * proxy selector will be used.
    */
-  public final OkHttpClient setProxySelector(ProxySelector proxySelector) {
+  public OkHttpClient setProxySelector(ProxySelector proxySelector) {
     this.proxySelector = proxySelector;
     return this;
   }
 
-  public final ProxySelector getProxySelector() {
+  public ProxySelector getProxySelector() {
     return proxySelector;
   }
 
@@ -300,32 +300,32 @@ public class OkHttpClient implements Cloneable {
    * <p>If unset, the {@link CookieHandler#getDefault() system-wide default}
    * cookie handler will be used.
    */
-  public final OkHttpClient setCookieHandler(CookieHandler cookieHandler) {
+  public OkHttpClient setCookieHandler(CookieHandler cookieHandler) {
     this.cookieHandler = cookieHandler;
     return this;
   }
 
-  public final CookieHandler getCookieHandler() {
+  public CookieHandler getCookieHandler() {
     return cookieHandler;
   }
 
   /** Sets the response cache to be used to read and write cached responses. */
-  final void setInternalCache(InternalCache internalCache) {
+  void setInternalCache(InternalCache internalCache) {
     this.internalCache = internalCache;
     this.cache = null;
   }
 
-  final InternalCache internalCache() {
+  InternalCache internalCache() {
     return internalCache;
   }
 
-  public final OkHttpClient setCache(Cache cache) {
+  public OkHttpClient setCache(Cache cache) {
     this.cache = cache;
     this.internalCache = null;
     return this;
   }
 
-  public final Cache getCache() {
+  public Cache getCache() {
     return cache;
   }
 
@@ -335,12 +335,12 @@ public class OkHttpClient implements Cloneable {
    * <p>If unset, the {@link SocketFactory#getDefault() system-wide default}
    * socket factory will be used.
    */
-  public final OkHttpClient setSocketFactory(SocketFactory socketFactory) {
+  public OkHttpClient setSocketFactory(SocketFactory socketFactory) {
     this.socketFactory = socketFactory;
     return this;
   }
 
-  public final SocketFactory getSocketFactory() {
+  public SocketFactory getSocketFactory() {
     return socketFactory;
   }
 
@@ -349,12 +349,12 @@ public class OkHttpClient implements Cloneable {
    *
    * <p>If unset, a lazily created SSL socket factory will be used.
    */
-  public final OkHttpClient setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+  public OkHttpClient setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
     this.sslSocketFactory = sslSocketFactory;
     return this;
   }
 
-  public final SSLSocketFactory getSslSocketFactory() {
+  public SSLSocketFactory getSslSocketFactory() {
     return sslSocketFactory;
   }
 
@@ -364,12 +364,12 @@ public class OkHttpClient implements Cloneable {
    *
    * <p>If unset, a default hostname verifier will be used.
    */
-  public final OkHttpClient setHostnameVerifier(HostnameVerifier hostnameVerifier) {
+  public OkHttpClient setHostnameVerifier(HostnameVerifier hostnameVerifier) {
     this.hostnameVerifier = hostnameVerifier;
     return this;
   }
 
-  public final HostnameVerifier getHostnameVerifier() {
+  public HostnameVerifier getHostnameVerifier() {
     return hostnameVerifier;
   }
 
@@ -379,12 +379,12 @@ public class OkHttpClient implements Cloneable {
    * SSL socket factory} to establish trust. Pinning certificates avoids the
    * need to trust certificate authorities.
    */
-  public final OkHttpClient setCertificatePinner(CertificatePinner certificatePinner) {
+  public OkHttpClient setCertificatePinner(CertificatePinner certificatePinner) {
     this.certificatePinner = certificatePinner;
     return this;
   }
 
-  public final CertificatePinner getCertificatePinner() {
+  public CertificatePinner getCertificatePinner() {
     return certificatePinner;
   }
 
@@ -395,12 +395,12 @@ public class OkHttpClient implements Cloneable {
    * <p>If unset, the {@link java.net.Authenticator#setDefault system-wide default}
    * authenticator will be used.
    */
-  public final OkHttpClient setAuthenticator(Authenticator authenticator) {
+  public OkHttpClient setAuthenticator(Authenticator authenticator) {
     this.authenticator = authenticator;
     return this;
   }
 
-  public final Authenticator getAuthenticator() {
+  public Authenticator getAuthenticator() {
     return authenticator;
   }
 
@@ -410,12 +410,12 @@ public class OkHttpClient implements Cloneable {
    * <p>If unset, the {@link ConnectionPool#getDefault() system-wide
    * default} connection pool will be used.
    */
-  public final OkHttpClient setConnectionPool(ConnectionPool connectionPool) {
+  public OkHttpClient setConnectionPool(ConnectionPool connectionPool) {
     this.connectionPool = connectionPool;
     return this;
   }
 
-  public final ConnectionPool getConnectionPool() {
+  public ConnectionPool getConnectionPool() {
     return connectionPool;
   }
 
@@ -426,21 +426,21 @@ public class OkHttpClient implements Cloneable {
    * <p>If unset, protocol redirects will be followed. This is different than
    * the built-in {@code HttpURLConnection}'s default.
    */
-  public final OkHttpClient setFollowSslRedirects(boolean followProtocolRedirects) {
+  public OkHttpClient setFollowSslRedirects(boolean followProtocolRedirects) {
     this.followSslRedirects = followProtocolRedirects;
     return this;
   }
 
-  public final boolean getFollowSslRedirects() {
+  public boolean getFollowSslRedirects() {
     return followSslRedirects;
   }
 
   /** Configure this client to follow redirects. If unset, redirects be followed. */
-  public final void setFollowRedirects(boolean followRedirects) {
+  public void setFollowRedirects(boolean followRedirects) {
     this.followRedirects = followRedirects;
   }
 
-  public final boolean getFollowRedirects() {
+  public boolean getFollowRedirects() {
     return followRedirects;
   }
 
@@ -462,15 +462,15 @@ public class OkHttpClient implements Cloneable {
    * Set this to false to avoid retrying requests when doing so is destructive. In this case the
    * calling application should do its own recovery of connectivity failures.
    */
-  public final void setRetryOnConnectionFailure(boolean retryOnConnectionFailure) {
+  public void setRetryOnConnectionFailure(boolean retryOnConnectionFailure) {
     this.retryOnConnectionFailure = retryOnConnectionFailure;
   }
 
-  public final boolean getRetryOnConnectionFailure() {
+  public boolean getRetryOnConnectionFailure() {
     return retryOnConnectionFailure;
   }
 
-  final RouteDatabase routeDatabase() {
+  RouteDatabase routeDatabase() {
     return routeDatabase;
   }
 
@@ -478,13 +478,13 @@ public class OkHttpClient implements Cloneable {
    * Sets the dispatcher used to set policy and execute asynchronous requests.
    * Must not be null.
    */
-  public final OkHttpClient setDispatcher(Dispatcher dispatcher) {
+  public OkHttpClient setDispatcher(Dispatcher dispatcher) {
     if (dispatcher == null) throw new IllegalArgumentException("dispatcher == null");
     this.dispatcher = dispatcher;
     return this;
   }
 
-  public final Dispatcher getDispatcher() {
+  public Dispatcher getDispatcher() {
     return dispatcher;
   }
 
@@ -518,7 +518,7 @@ public class OkHttpClient implements Cloneable {
    *     must contain {@link Protocol#HTTP_1_1}. It must not contain null or
    *     {@link Protocol#HTTP_1_0}.
    */
-  public final OkHttpClient setProtocols(List<Protocol> protocols) {
+  public OkHttpClient setProtocols(List<Protocol> protocols) {
     protocols = Util.immutableList(protocols);
     if (!protocols.contains(Protocol.HTTP_1_1)) {
       throw new IllegalArgumentException("protocols doesn't contain http/1.1: " + protocols);
@@ -533,16 +533,16 @@ public class OkHttpClient implements Cloneable {
     return this;
   }
 
-  public final List<Protocol> getProtocols() {
+  public List<Protocol> getProtocols() {
     return protocols;
   }
 
-  public final OkHttpClient setConnectionSpecs(List<ConnectionSpec> connectionSpecs) {
+  public OkHttpClient setConnectionSpecs(List<ConnectionSpec> connectionSpecs) {
     this.connectionSpecs = Util.immutableList(connectionSpecs);
     return this;
   }
 
-  public final List<ConnectionSpec> getConnectionSpecs() {
+  public List<ConnectionSpec> getConnectionSpecs() {
     return connectionSpecs;
   }
 
@@ -584,7 +584,7 @@ public class OkHttpClient implements Cloneable {
    * Returns a shallow copy of this OkHttpClient that uses the system-wide
    * default for each field that hasn't been explicitly configured.
    */
-  final OkHttpClient copyWithDefaults() {
+  OkHttpClient copyWithDefaults() {
     OkHttpClient result = new OkHttpClient(this);
     if (result.proxySelector == null) {
       result.proxySelector = ProxySelector.getDefault();
@@ -647,11 +647,7 @@ public class OkHttpClient implements Cloneable {
   }
 
   /** Returns a shallow copy of this OkHttpClient. */
-  @Override public final OkHttpClient clone() {
-    try {
-      return (OkHttpClient) super.clone();
-    } catch (CloneNotSupportedException e) {
-      throw new AssertionError();
-    }
+  @Override public OkHttpClient clone() {
+    return new OkHttpClient(this);
   }
 }


### PR DESCRIPTION
This will break mocks. We have a much simpler solution now, with
interceptors. Instead of mocking the HTTP client, use interceptors
to change its behavior.

Fix a bug where interceptor lists aren't independent after cloning
the OkHttpClient.