### PR TITLE
Adding more content and example to Dispatcher

### DIFF
--- a/mockwebserver/README.md
+++ b/mockwebserver/README.md
@@ -116,6 +116,26 @@ assertEquals("{}", request.getUtf8Body());
 By default MockWebServer uses a queue to specify a series of responses. Use a
 Dispatcher to handle requests using another policy. One natural policy is to
 dispatch on the request path.
+You can, for example, filter the request instead of using `server.enqueue()`.
+
+```java
+final Dispatcher dispatcher = new Dispatcher() {
+
+    @Override
+    public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+
+        if (request.getPath().equals("/v1/login/auth/")){
+            return new MockResponse().setResponseCode(200));
+        } else if (request.getPath().equals("v1/check/version/")){
+            return new MockResponse().setResponseCode(200).setBody("version=9");
+        } else if (request.getPath().equals("/v1/profile/info")) {
+            return new MockResponse().setResponseCode(200).setBody("{\\\"info\\\":{\\\"name\":\"Lucas Albuquerque\",\"age\":\"21\",\"gender\":\"male\"}}");
+        }
+        return new MockResponse().setResponseCode(404);
+    }
+};
+server.setDispatcher(dispatcher);
+```
 
 
 ### Download


### PR DESCRIPTION
I realized that Dispatcher session in the README.md had few explanation and no quick example.
So I added one single line of explanation and a little example to quickly understanding.