### PR TITLE
Add Protocol.SHOUTCAST to distinguish Shoutcast protocol from Request ob...

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Protocol.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Protocol.java
@@ -35,6 +35,8 @@ public enum Protocol {
    */
   HTTP_1_0("http/1.0"),
 
+  SHOUTCAST("icy"),
+
   /**
    * A plaintext framing that includes persistent connections.
    *
@@ -84,6 +86,7 @@ public enum Protocol {
     if (protocol.equals(HTTP_1_1.protocol)) return HTTP_1_1;
     if (protocol.equals(HTTP_2.protocol)) return HTTP_2;
     if (protocol.equals(SPDY_3.protocol)) return SPDY_3;
+    if (protocol.equals(SHOUTCAST.protocol)) return SHOUTCAST;
     throw new IOException("Unexpected protocol: " + protocol);
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/StatusLine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/StatusLine.java
@@ -48,7 +48,7 @@ public final class StatusLine {
       }
     } else if (statusLine.startsWith("ICY ")) {
       // Shoutcast uses ICY instead of "HTTP/1.0".
-      protocol = Protocol.HTTP_1_0;
+      protocol = Protocol.SHOUTCAST;
       codeStart = 4;
     } else {
       throw new ProtocolException("Unexpected status line: " + statusLine);


### PR DESCRIPTION
Shoutcast protocol is handled by HTTP_1_0 protocol. So there are no ways to distinguish HTTP/1.0 and Shoutcast protocol from the application.  Some application needs to distinguish them.

The Pull Requests add Shoutcast protocol to distinguish them.