### PR TITLE
Interceptor request not returned in response

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -813,6 +813,9 @@ public final class HttpEngine {
 
       transport.writeRequestHeaders(request);
 
+      //Update the networkRequest with the possibly updated interceptor request.
+      networkRequest = request;
+
       if (permitsRequestBody() && request.body() != null) {
         Sink requestBodyOut = transport.createRequestBody(request, request.body().contentLength());
         BufferedSink bufferedRequestBody = Okio.buffer(requestBodyOut);


### PR DESCRIPTION
I found an issue when using interceptors to change the `"User-Agent"` header, that `response.request().headers()` was showing the me the old default `"User-Agent"`.

I took a peek and noticed that `networkRequest` does not update with the *possibly* modified interceptors request. 

Let me know if I'm missing something here! Thanks!