### PR TITLE
Expose running and queued call counts for monitoring

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Dispatcher.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Dispatcher.java
@@ -177,4 +177,12 @@ public final class Dispatcher {
   synchronized void finished(Call call) {
     if (!executedCalls.remove(call)) throw new AssertionError("Call wasn't in-flight!");
   }
+
+  public synchronized int getRunningCallCount() {
+    return runningCalls.size();
+  }
+
+  public synchronized int getQueuedCallCount() {
+    return readyCalls.size();
+  }
 }


### PR DESCRIPTION
goal: add monitoring around how many requests are queued, in-flight, and maximum capacity.