### PR TITLE
Fix MockWebServer with SPDY on Android.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -667,7 +667,7 @@ public final class MockWebServer {
         .build();
 
     // The callback might act synchronously. Give it its own thread.
-    new Thread(new Runnable() {
+    Runnable webSocketWriterRunnable = new Runnable() {
       @Override public void run() {
         try {
           listener.onOpen(webSocket, fancyRequest, fancyResponse);
@@ -676,7 +676,9 @@ public final class MockWebServer {
           connectionClose.countDown();
         }
       }
-    }, "MockWebServer WebSocket Writer " + request.getPath()).start();
+    };
+    Util.newThread("MockWebServer WebSocket Writer " + request.getPath(), false /* daemon */,
+        webSocketWriterRunnable).start();
 
     // Use this thread to continuously read messages.
     while (webSocket.readMessage()) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -169,7 +169,7 @@ public final class SpdyConnection implements Closeable {
     frameWriter = variant.newWriter(Okio.buffer(Okio.sink(builder.socket)), client);
 
     readerRunnable = new Reader();
-    new Thread(readerRunnable).start(); // Not a daemon thread.
+    Util.newThread("SpdyConnection Reader", false /* daemon */, readerRunnable).start();
   }
 
   /** The protocol as selected using ALPN. */


### PR DESCRIPTION
Fix for issue #1552
Related to commit f78f74f from issue #1294

SpdyConnection creates a non-daemon thread to handle the readerRunnable. If
that thread dies from a RuntimeException it triggers Android's default
UncaughtExceptionHandler, which kills the test process. Previously exceptions
were being swallowed, but commit f78f74f caused the exceptions to be
propagated.

Rather than fix the problem just in SpdyConnection the fix has been
made in Util.threadFactory() for consistency. A factory method Util.newThread()
has been created and all occurances (outside of tests) of new Thread() have
been moved over.

This does alter behavior on Android across OkHttp: Previously any unexpected
thread death due to an exception or error would have taken down the Android
process. Now it will be logged to System.err, but the process will continue.