### PR TITLE
Install an UncaughtExceptionHandler during tests

### DIFF
--- a/mockwebserver/pom.xml
+++ b/mockwebserver/pom.xml
@@ -20,6 +20,12 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-testing-support</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp-ws</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/okcurl/pom.xml
+++ b/okcurl/pom.xml
@@ -19,6 +19,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-testing-support</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>

--- a/okhttp-android-support/pom.xml
+++ b/okhttp-android-support/pom.xml
@@ -16,6 +16,12 @@
   <dependencies>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-testing-support</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp-urlconnection</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/okhttp-apache/pom.xml
+++ b/okhttp-apache/pom.xml
@@ -19,6 +19,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-testing-support</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <scope>provided</scope>

--- a/okhttp-hpacktests/pom.xml
+++ b/okhttp-hpacktests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-hpacktests</artifactId>
@@ -21,6 +21,12 @@
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-testing-support</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/okhttp-testing-support/pom.xml
+++ b/okhttp-testing-support/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.squareup.okhttp</groupId>
+    <artifactId>parent</artifactId>
+    <version>2.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>okhttp-testing-support</artifactId>
+  <name>OkHttp test support classes</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>

--- a/okhttp-testing-support/src/main/java/com/squareup/okhttp/testing/InstallUncaughtExceptionHandlerListener.java
+++ b/okhttp-testing-support/src/main/java/com/squareup/okhttp/testing/InstallUncaughtExceptionHandlerListener.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.testing;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * A {@link org.junit.runner.notification.RunListener} used to install an aggressive default
+ * {@link java.lang.Thread.UncaughtExceptionHandler} similar to the one found on Android.
+ * No exceptions should escape from OkHttp that might cause apps to be killed or tests to fail on
+ * Android.
+ */
+public class InstallUncaughtExceptionHandlerListener extends RunListener {
+
+  private Thread.UncaughtExceptionHandler oldDefaultUncaughtExceptionHandler;
+  private Description lastTestStarted;
+
+  @Override public void testRunStarted(Description description) throws Exception {
+    System.err.println("Installing aggressive uncaught exception handler");
+    oldDefaultUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+    Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      @Override public void uncaughtException(Thread thread, Throwable throwable) {
+        StringWriter errorText = new StringWriter(256);
+        errorText.append("Uncaught exception in OkHttp thread \"");
+        errorText.append(thread.getName());
+        errorText.append("\"\n");
+        throwable.printStackTrace(new PrintWriter(errorText));
+        errorText.append("\n");
+        if (lastTestStarted != null) {
+          errorText.append("Last test to start was: ");
+          errorText.append(lastTestStarted.getDisplayName());
+          errorText.append("\n");
+        }
+        System.err.print(errorText.toString());
+        System.exit(-1);
+      }
+    });
+  }
+
+  @Override public void testStarted(Description description) throws Exception {
+    lastTestStarted = description;
+  }
+
+  @Override public void testRunFinished(Result result) throws Exception {
+    Thread.setDefaultUncaughtExceptionHandler(oldDefaultUncaughtExceptionHandler);
+    System.err.println("Uninstalled aggressive uncaught exception handler");
+  }
+}

--- a/okhttp-tests/pom.xml
+++ b/okhttp-tests/pom.xml
@@ -24,6 +24,12 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-testing-support</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp-urlconnection</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/okhttp-urlconnection/pom.xml
+++ b/okhttp-urlconnection/pom.xml
@@ -18,6 +18,12 @@
       <artifactId>okhttp</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-testing-support</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/okhttp-ws-tests/pom.xml
+++ b/okhttp-ws-tests/pom.xml
@@ -15,6 +15,12 @@
   <dependencies>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp-testing-support</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp-ws</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/spdy/SpdyConnection.java
@@ -575,7 +575,7 @@ public final class SpdyConnection implements Closeable {
         }
         connectionErrorCode = ErrorCode.NO_ERROR;
         streamErrorCode = ErrorCode.CANCEL;
-      } catch (IOException e) {
+      } catch (RuntimeException | IOException e) {
         connectionErrorCode = ErrorCode.PROTOCOL_ERROR;
         streamErrorCode = ErrorCode.PROTOCOL_ERROR;
       } finally {
@@ -640,8 +640,11 @@ public final class SpdyConnection implements Closeable {
             @Override public void execute() {
               try {
                 handler.receive(newStream);
-              } catch (IOException e) {
-                throw new RuntimeException(e);
+              } catch (RuntimeException | IOException e) {
+                try {
+                  newStream.close(ErrorCode.PROTOCOL_ERROR);
+                } catch (IOException ignored) {
+                }
               }
             }
           });

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <module>okhttp-android-support</module>
 
     <module>okhttp-apache</module>
+    <module>okhttp-testing-support</module>
     <module>okhttp-urlconnection</module>
 
     <module>okhttp-ws</module>
@@ -132,6 +133,19 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.17</version>
+          <configuration>
+            <properties>
+              <!--
+                Configure a listener for enforcing that no uncaught exceptions issue from OkHttp
+                tests. Every test must have a <scope>test</scope> dependency on
+                okhttp-testing-support.
+                -->
+              <property>
+                <name>listener</name>
+                <value>com.squareup.okhttp.testing.InstallUncaughtExceptionHandlerListener</value>
+              </property>
+            </properties>
+          </configuration>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>


### PR DESCRIPTION
This is to make the tests more brittle around uncaught exceptions
as they are on Android. No uncaught exceptions should escape.

For issue #1552 .

Probably not necessary to say this but right now it will cause the CI to fail. Needs #1554 to pass.