### PR TITLE
Bugfix - Avoid null pointer when building an empty RequestBody

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java
@@ -51,7 +51,7 @@ public abstract class RequestBody {
         contentType = MediaType.parse(contentType + "; charset=utf-8");
       }
     }
-    byte[] bytes = content.getBytes(charset);
+    byte[] bytes = (null == content ? "" : content).getBytes(charset);
     return create(contentType, bytes);
   }
 


### PR DESCRIPTION
Theoretically, if a request does not merit a request body, then one shouldn't bother creating a request body when constructing the request object. However, if one passes `null` into `RequestBody.create(mediaType, null)`, then an error becomes thrown when getting the bytes for the request body's content https://github.com/square/okhttp/blob/8d0b2b9d3ca870a5b3a2b91c59d19c1e3bfc966a/okhttp/src/main/java/com/squareup/okhttp/RequestBody.java#L54

This addresses that breaking point by providing an empty string when generating the byte array when no content is provided, producing an empty byte array that gets used when producing the network request content and content length. In a perfect world, the developer wouldn't bother building a RequestBody when there's no actual.. request body. However, we encountered an issue where our abstraction didn't check if the request body was empty, and would include this step in the builder pattern for each `PUT`, `POST`, etc regardless.

This safeguards against trying to essentially perform `(null).getBytes()`, and instead, defaults to an empty string and thus an empty `byte` array.