### PR TITLE
Don't return null on call.proceed().

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -266,7 +266,7 @@ public final class Call {
     while (true) {
       if (canceled) {
         engine.releaseConnection();
-        return null;
+        throw new IOException("Canceled");
       }
 
       try {


### PR DESCRIPTION
Closes https://github.com/square/okhttp/issues/1512