### PR TITLE
Do not rebuffer socket streams for web sockets, other fixes.

### DIFF
--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/internal/ws/WebSocketWriterTest.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/internal/ws/WebSocketWriterTest.java
@@ -206,12 +206,8 @@ public final class WebSocketWriterTest {
   }
 
   @Test public void closeWithOnlyReasonThrows() throws IOException {
-    try {
-      clientWriter.writeClose(0, "Hello");
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertEquals("Code required to include reason.", e.getMessage());
-    }
+    clientWriter.writeClose(0, "Hello");
+    assertData("888760b420bb60b468de0cd84f");
   }
 
   @Test public void closeCodeOutOfRangeThrows() throws IOException {

--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/AutobahnTester.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/AutobahnTester.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.ws;
+
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.internal.Version;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import okio.Buffer;
+import okio.BufferedSource;
+
+/**
+ * Exercises the web socket implementation against the
+ * <a href="http://autobahn.ws/testsuite/">Autobahn Testsuite</a>.
+ */
+public final class AutobahnTester {
+  private static final String HOST = "ws://localhost:9001";
+
+  public static void main(String... args) throws IOException {
+    new AutobahnTester().run();
+  }
+
+  final OkHttpClient client = new OkHttpClient();
+
+  private WebSocketCall newWebSocket(String path) {
+    Request request = new Request.Builder().url(HOST + path).build();
+    return WebSocketCall.create(client, request);
+  }
+
+  public void run() throws IOException {
+    try {
+      long count = getTestCount();
+      System.out.println("Test count: " + count);
+
+      for (long number = 1; number <= count; number++) {
+        runTest(number, count);
+      }
+
+      updateReports();
+    } finally {
+      client.getDispatcher().getExecutorService().shutdown();
+    }
+  }
+
+  private void runTest(final long number, final long count) throws IOException {
+    final CountDownLatch latch = new CountDownLatch(1);
+    newWebSocket("/runCase?case=" + number + "&agent=" + Version.userAgent()) //
+        .enqueue(new WebSocketListener() {
+          private final ExecutorService sendExecutor = Executors.newSingleThreadExecutor();
+          private WebSocket webSocket;
+
+          @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+              throws IOException {
+            System.out.println("Executing test case " + number + "/" + count);
+            this.webSocket = webSocket;
+          }
+
+          @Override public void onMessage(BufferedSource payload, final WebSocket.PayloadType type)
+              throws IOException {
+            final Buffer buffer = new Buffer();
+            payload.readAll(buffer);
+            payload.close();
+
+            sendExecutor.execute(new Runnable() {
+              @Override public void run() {
+                try {
+                  webSocket.sendMessage(type, buffer);
+                } catch (IOException e) {
+                  e.printStackTrace();
+                }
+              }
+            });
+          }
+
+          @Override public void onPong(Buffer payload) {
+          }
+
+          @Override public void onClose(int code, String reason) {
+            sendExecutor.shutdown();
+            latch.countDown();
+          }
+
+          @Override public void onFailure(IOException e) {
+            latch.countDown();
+          }
+        });
+    try {
+      if (!latch.await(10, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for count.");
+      }
+    } catch (InterruptedException e) {
+      throw new AssertionError();
+    }
+  }
+
+  private long getTestCount() throws IOException {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicLong countRef = new AtomicLong();
+    final AtomicReference<IOException> failureRef = new AtomicReference<>();
+    newWebSocket("/getCaseCount").enqueue(new WebSocketListener() {
+      @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+          throws IOException {
+      }
+
+      @Override public void onMessage(BufferedSource payload, WebSocket.PayloadType type)
+          throws IOException {
+        countRef.set(payload.readDecimalLong());
+        payload.close();
+      }
+
+      @Override public void onPong(Buffer payload) {
+      }
+
+      @Override public void onClose(int code, String reason) {
+        latch.countDown();
+      }
+
+      @Override public void onFailure(IOException e) {
+        failureRef.set(e);
+        latch.countDown();
+      }
+    });
+    try {
+      if (!latch.await(10, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for count.");
+      }
+    } catch (InterruptedException e) {
+      throw new AssertionError();
+    }
+    IOException failure = failureRef.get();
+    if (failure != null) {
+      throw failure;
+    }
+    return countRef.get();
+  }
+
+  private void updateReports() {
+    final CountDownLatch latch = new CountDownLatch(1);
+    newWebSocket("/updateReports?agent=" + Version.userAgent()).enqueue(new WebSocketListener() {
+      @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+          throws IOException {
+      }
+
+      @Override public void onMessage(BufferedSource payload, WebSocket.PayloadType type)
+          throws IOException {
+      }
+
+      @Override public void onPong(Buffer payload) {
+      }
+
+      @Override public void onClose(int code, String reason) {
+        latch.countDown();
+      }
+
+      @Override public void onFailure(IOException e) {
+        latch.countDown();
+      }
+    });
+    try {
+      if (!latch.await(10, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Timed out waiting for count.");
+      }
+    } catch (InterruptedException e) {
+      throw new AssertionError();
+    }
+  }
+}

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/WebSocketWriter.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/WebSocketWriter.java
@@ -93,12 +93,12 @@ public final class WebSocketWriter {
    * @param code Status code as defined by
    * <a href="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a> or
    * {@code 0}.
-   * @param reason Reason for shutting down or {@code null}. {@code code} is required if set.
+   * @param reason Reason for shutting down or {@code null}.
    */
   public void writeClose(int code, String reason) throws IOException {
     Buffer payload = null;
-    if (code != 0) {
-      if (code < 1000 || code >= 5000) {
+    if (code != 0 || reason != null) {
+      if (code != 0 && (code < 1000 || code >= 5000)) {
         throw new IllegalArgumentException("Code must be in range [1000,5000).");
       }
       payload = new Buffer();
@@ -106,8 +106,6 @@ public final class WebSocketWriter {
       if (reason != null) {
         payload.writeUtf8(reason);
       }
-    } else if (reason != null) {
-      throw new IllegalArgumentException("Code required to include reason.");
     }
 
     synchronized (sink) {

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
@@ -28,7 +28,6 @@ import com.squareup.okhttp.internal.ws.RealWebSocket;
 import com.squareup.okhttp.internal.ws.WebSocketProtocol;
 import java.io.IOException;
 import java.net.ProtocolException;
-import java.net.Socket;
 import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Random;
@@ -38,7 +37,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.ByteString;
-import okio.Okio;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -174,12 +172,16 @@ public final class WebSocketCall {
       throw new IllegalStateException("Unable to take ownership of connection.");
     }
 
-    Socket socket = connection.getSocket();
-    BufferedSource source = Okio.buffer(Okio.source(socket));
-    BufferedSink sink = Okio.buffer(Okio.sink(socket));
+    BufferedSource source = Internal.instance.connectionRawSource(connection);
+    BufferedSink sink = Internal.instance.connectionRawSink(connection);
 
     final RealWebSocket webSocket =
         ConnectionWebSocket.create(response, connection, source, sink, random, listener);
+
+    // TODO connection.setOwner(webSocket);
+    Internal.instance.connectionSetOwner(connection, webSocket);
+
+    listener.onOpen(webSocket, request, response);
 
     // Start a dedicated thread for reading the web socket.
     new Thread(new NamedRunnable("OkHttp WebSocket reader %s", request.urlString()) {
@@ -188,11 +190,6 @@ public final class WebSocketCall {
         }
       }
     }).start();
-
-    // TODO connection.setOwner(webSocket);
-    Internal.instance.connectionSetOwner(connection, webSocket);
-
-    listener.onOpen(webSocket, request, response);
   }
 
   // Keep static so that the WebSocketCall instance can be garbage collected.

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.net.Socket;
 import java.net.UnknownServiceException;
 import java.util.List;
+import okio.BufferedSink;
+import okio.BufferedSource;
 
 /**
  * The sockets and streams of an HTTP, HTTPS, or HTTPS+SPDY connection. May be
@@ -207,6 +209,16 @@ public final class Connection {
    */
   public Socket getSocket() {
     return socket;
+  }
+
+  BufferedSource rawSource() {
+    if (httpConnection == null) throw new UnsupportedOperationException();
+    return httpConnection.rawSource();
+  }
+
+  BufferedSink rawSink() {
+    if (httpConnection == null) throw new UnsupportedOperationException();
+    return httpConnection.rawSink();
   }
 
   /** Returns true if this connection is alive. */

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -39,6 +39,8 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+import okio.BufferedSink;
+import okio.BufferedSource;
 
 /**
  * Configures and creates HTTP connections. Most applications can use a single
@@ -133,6 +135,14 @@ public final class OkHttpClient implements Cloneable {
 
       @Override public Connection callEngineGetConnection(Call call) {
         return call.engine.getConnection();
+      }
+
+      @Override public BufferedSource connectionRawSource(Connection connection) {
+        return connection.rawSource();
+      }
+
+      @Override public BufferedSink connectionRawSink(Connection connection) {
+        return connection.rawSink();
       }
 
       @Override public void connectionSetOwner(Connection connection, Object owner) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
@@ -30,6 +30,8 @@ import com.squareup.okhttp.internal.http.Transport;
 import java.io.IOException;
 import java.util.logging.Logger;
 import javax.net.ssl.SSLSocket;
+import okio.BufferedSink;
+import okio.BufferedSource;
 
 /**
  * Escalate internal APIs in {@code com.squareup.okhttp} so they can be used
@@ -85,5 +87,7 @@ public abstract class Internal {
   public abstract void callEnqueue(Call call, Callback responseCallback, boolean forWebSocket);
   public abstract void callEngineReleaseConnection(Call call) throws IOException;
   public abstract Connection callEngineGetConnection(Call call);
+  public abstract BufferedSource connectionRawSource(Connection connection);
+  public abstract BufferedSink connectionRawSink(Connection connection);
   public abstract void connectionSetOwner(Connection connection, Object owner);
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java
@@ -257,6 +257,14 @@ public final class HttpConnection {
     return new UnknownLengthSource();
   }
 
+  public BufferedSink rawSink() {
+    return sink;
+  }
+
+  public BufferedSource rawSource() {
+    return source;
+  }
+
   /** An HTTP body with a fixed length known in advance. */
   private final class FixedLengthSink implements Sink {
     private boolean closed;


### PR DESCRIPTION
* Ensure onOpen is called before the reader thread starts.
* Allow close reason without code.
* Use ProtocolException for protocol errors to ensure a close response is written.

Closes #1071. Closes #1296.