### PR TITLE
Allow port number of the MockWebServerRule to be predefined.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/rule/MockWebServerRule.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/rule/MockWebServerRule.java
@@ -34,13 +34,22 @@ public class MockWebServerRule extends ExternalResource {
   private static final Logger logger = Logger.getLogger(MockWebServerRule.class.getName());
 
   private final MockWebServer server = new MockWebServer();
+  private final int port;
   private boolean started;
+
+  public MockWebServerRule() {
+    port = 0;
+  }
+
+  public MockWebServerRule(final int port) {
+    this.port = port;
+  }
 
   @Override protected void before() {
     if (started) return;
     started = true;
     try {
-      server.start();
+      server.start(port);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/rule/MockWebServerRuleTest.java
+++ b/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/rule/MockWebServerRuleTest.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
+import java.net.ServerSocket;
 import java.net.URL;
 import org.junit.After;
 import org.junit.Test;
@@ -45,6 +46,22 @@ public class MockWebServerRuleTest {
 
   @Test public void differentRulesGetDifferentPorts() throws IOException {
     assertNotEquals(server.getPort(), new MockWebServerRule().getPort());
+  }
+
+  @Test public void startUpOnPortAssigned() throws IOException {
+    server.before();
+
+    final ServerSocket socket = new ServerSocket(0);
+    final int expectedPort = socket.getLocalPort();
+
+    final MockWebServerRule server = new MockWebServerRule(expectedPort);
+    server.before();
+
+    try {
+      assertEquals(expectedPort, server.get().getPort());
+    } finally {
+      server.after();
+    }
   }
 
   @Test public void beforePlaysServer() throws Exception {


### PR DESCRIPTION
An example of when this feature would be required would be when testing a Spring Boot application which talks to some other web application.
When running tests in Spring, all of the configuration is read when the Spring context is first started which means that everything, including the port number of the other web application, must be the same for every Spring test.
It is possible to get hold of a free port before the tests start through the use of the `build-helper-maven-plugin`.