### PR TITLE
Add support for being able to fluently mock responses

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/EqualityPredicate.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/EqualityPredicate.java
@@ -1,0 +1,15 @@
+package com.squareup.okhttp.mockwebserver.exchanges;
+
+class EqualityPredicate<T> implements Predicate<T> {
+
+    private final T expected;
+
+    public EqualityPredicate(final T expected) {
+        this.expected = expected;
+    }
+
+    @Override
+    public boolean test(final T t) {
+        return expected.equals(t);
+    }
+}

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/ExchangeDispatcher.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/ExchangeDispatcher.java
@@ -1,0 +1,64 @@
+package com.squareup.okhttp.mockwebserver.exchanges;
+
+import com.squareup.okhttp.mockwebserver.Dispatcher;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+import java.net.HttpURLConnection;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class ExchangeDispatcher extends Dispatcher {
+
+  private static final Logger LOG = Logger.getLogger(ExchangeDispatcher.class.getName());
+  private static final MockResponse NOT_FOUND =
+          new MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND);
+
+  private final Queue<Exchange> exchanges = new ConcurrentLinkedQueue<>();
+
+  void stub(Predicate<RecordedRequest> request, Supplier<MockResponse> response) {
+    exchanges.add(new Exchange(request, response));
+  }
+
+  @Override
+  public MockResponse dispatch(final RecordedRequest request) throws InterruptedException {
+    final MockResponse response = getResponse(request);
+
+    if (LOG.isLoggable(Level.FINE)) {
+      LOG.log(Level.FINE, "served " + request + " with " + response);
+    }
+
+    return response;
+  }
+
+  private MockResponse getResponse(final RecordedRequest request) {
+    for (final Exchange exchange : exchanges) {
+      if (exchange.getRequest().test(request)) {
+        return exchange.getResponse();
+      }
+    }
+
+    return NOT_FOUND;
+  }
+
+  private static class Exchange {
+    private final Predicate<RecordedRequest> request;
+    private final Supplier<MockResponse> response;
+
+    private Exchange(final Predicate<RecordedRequest> request,
+                     final Supplier<MockResponse> response) {
+      this.request = request;
+      this.response = response;
+    }
+
+    private Predicate<RecordedRequest> getRequest() {
+      return request;
+    }
+
+    private MockResponse getResponse() {
+      return response.get();
+    }
+  }
+}

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/ExpectedExchangesRule.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/ExpectedExchangesRule.java
@@ -1,0 +1,209 @@
+package com.squareup.okhttp.mockwebserver.exchanges;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
+import org.junit.rules.ExternalResource;
+
+/**
+ * <p>
+ *   A JUnit {@link org.junit.Rule &#64;Rule} that is responsible for maintaining the
+ *   {@linkplain com.squareup.okhttp.mockwebserver.Dispatcher Dispatcher} which
+ *   manages the {@linkplain MockResponse MockResponses} and which one to select for a request.
+ * </p>
+ * <p>
+ *   Below is an example of using the {@linkplain MockWebServerRule} and
+ *   {@linkplain ExpectedExchangesRule} rules together.
+ * <pre>
+ * public class ExampleTest {
+ *
+ *   &#64;ClassRule
+ *   public static MockWebServerRule mockServer = new MockWebServerRule();
+ *
+ *   &#64;Rule
+ *   public ExpectedExchangesRule expectedExchanges = new ExpectedExchangesRule(mockServer);
+ *
+ *   &#64;Test
+ *   public void shouldTalkToDemoServer() {
+ *   ...
+ *   expectedExchanges.get("/demo/path")
+ *     .willReturn(response().withStatus(200).withBody("Hello, World!"));
+ *   ...
+ *   }
+ *
+ * }
+ * </pre>
+ * </p>
+ */
+public class ExpectedExchangesRule extends ExternalResource {
+
+  private final MockWebServerRule server;
+
+  private ExchangeDispatcher dispatcher;
+
+  /**
+   * Construct a new {@linkplain ExpectedExchangesRule} using the server managed by the given
+   * {@linkplain MockWebServerRule}.
+   * @param server Rule that is managing the mock web server.
+   */
+  public ExpectedExchangesRule(final MockWebServerRule server) {
+    this.server = server;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    dispatcher = new ExchangeDispatcher();
+    server.get().setDispatcher(dispatcher);
+  }
+
+  /**
+   * Begin matching a <code>GET</code> request for the given path.
+   * @param path Path that the request should come on.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest get(final String path) {
+    return new MatchingRecordedRequest(this, RequestMatchers.get(path));
+  }
+
+  /**
+   * Begin matching a <code>POST</code> request for the given path.
+   * @param path Path that the request should come on.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest post(final String path) {
+      return new MatchingRecordedRequest(this, RequestMatchers.post(path));
+  }
+
+  /**
+   * Begin matching a <code>PUT</code> request for the given path.
+   * @param path Path that the request should come on.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest put(final String path) {
+      return new MatchingRecordedRequest(this, RequestMatchers.put(path));
+  }
+
+  /**
+   * Begin matching a <code>PATCH</code> request for the given path.
+   * @param path Path that the request should come on.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest patch(final String path) {
+      return new MatchingRecordedRequest(this, RequestMatchers.patch(path));
+  }
+
+  /**
+   * Begin matching a <code>GET</code> request whose path matches the given
+   * <code>pathMatcher</code>.
+   * @param pathMatcher Matcher that the path that the request should come on must match.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest get(final Predicate<String> pathMatcher) {
+    return new MatchingRecordedRequest(this, RequestMatchers.get(pathMatcher));
+  }
+
+  /**
+   * Begin matching a <code>HEAD</code> request whose path matches the given
+   * <code>pathMatcher</code>.
+   * @param pathMatcher Matcher that the path that the request should come on must match.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest head(final Predicate<String> pathMatcher) {
+    return new MatchingRecordedRequest(this, RequestMatchers.head(pathMatcher));
+  }
+
+  /**
+   * Begin matching a <code>POST</code> request whose path matches the given
+   * <code>pathMatcher</code>.
+   * @param pathMatcher Matcher that the path that the request should come on must match.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest post(final Predicate<String> pathMatcher) {
+    return new MatchingRecordedRequest(this, RequestMatchers.post(pathMatcher));
+  }
+
+  /**
+   * Begin matching a <code>PUT</code> request whose path matches the given
+   * <code>pathMatcher</code>.
+   * @param pathMatcher Matcher that the path that the request should come on must match.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest put(final Predicate<String> pathMatcher) {
+    return new MatchingRecordedRequest(this, RequestMatchers.put(pathMatcher));
+  }
+
+  /**
+   * Begin matching a <code>DELETE</code> request whose path matches the given
+   * <code>pathMatcher</code>.
+   * @param pathMatcher Matcher that the path that the request should come on must match.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest delete(final Predicate<String> pathMatcher) {
+    return new MatchingRecordedRequest(this, RequestMatchers.delete(pathMatcher));
+  }
+
+  /**
+   * Begin matching a <code>TRACE</code> request whose path matches the given
+   * <code>pathMatcher</code>.
+   * @param pathMatcher Matcher that the path that the request should come on must match.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest trace(final Predicate<String> pathMatcher) {
+    return new MatchingRecordedRequest(this, RequestMatchers.trace(pathMatcher));
+  }
+
+  /**
+   * Begin matching a <code>OPTIONS</code> request whose path matches the given
+   * <code>pathMatcher</code>.
+   * @param pathMatcher Matcher that the path that the request should come on must match.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest options(final Predicate<String> pathMatcher) {
+    return new MatchingRecordedRequest(this, RequestMatchers.options(pathMatcher));
+  }
+
+  /**
+   * Begin matching a <code>CONNECT</code> request whose path matches the given
+   * <code>pathMatcher</code>.
+   * @param pathMatcher Matcher that the path that the request should come on must match.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest connect(final Predicate<String> pathMatcher) {
+    return new MatchingRecordedRequest(this, RequestMatchers.connect(pathMatcher));
+  }
+
+  /**
+   * Begin matching a <code>PATCH</code> request whose path matches the given
+   * <code>pathMatcher</code>.
+   * @param pathMatcher Matcher that the path that the request should come on must match.
+   * @return A {@linkplain MatchingRecordedRequest} to continue configuring the expected request
+   * and dummy response.
+   */
+  public MatchingRecordedRequest patch(final Predicate<String> pathMatcher) {
+    return new MatchingRecordedRequest(this, RequestMatchers.patch(pathMatcher));
+  }
+
+  /**
+   * Stub a request which matches the given <code>requestMatcher</code> and return the given
+   * <code>response</code>.
+   * @param requestMatcher Matcher that the request must match.
+   * @param response Supplier of the response that should be returned when a request matches.
+   */
+  public void stub(final Predicate<RecordedRequest> requestMatcher,
+                   final Supplier<MockResponse> response) {
+    dispatcher.stub(requestMatcher, response);
+  }
+
+}

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/MatchingRecordedRequest.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/MatchingRecordedRequest.java
@@ -1,0 +1,79 @@
+package com.squareup.okhttp.mockwebserver.exchanges;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+/**
+ * A helper class to allow responses to be assigned to requests fluently.
+ */
+public class MatchingRecordedRequest {
+
+  private final ExpectedExchangesRule rule;
+
+  private Predicate<RecordedRequest> matcher;
+
+  MatchingRecordedRequest(final ExpectedExchangesRule rule,
+                          final Predicate<RecordedRequest> requestMatcher) {
+    this.rule = rule;
+    this.matcher = requestMatcher;
+  }
+
+  /**
+   * Add another feature that the request should match to return the given response.
+   * @param matcher Matcher that the request must match.
+   * @return <code>this</code>.
+   */
+  public MatchingRecordedRequest with(final Predicate<RecordedRequest> matcher) {
+    this.matcher = new AndPredicate(this.matcher, matcher);
+    return this;
+  }
+
+  /**
+   * When a request matches the {@linkplain #with(Predicate) configured features}, return the
+   * supplied response.
+   * @param response Supplier of the response that should be returned when a request matches.
+   */
+  public void willReturn(final Supplier<MockResponse> response) {
+    rule.stub(matcher, response);
+  }
+
+  /**
+   * When a request matches the {@linkplain #with(Predicate) configured features}, return the
+   * given response.
+   * @param response Response that should be returned when a request matches.
+   */
+  public void willReturn(final MockResponse response) {
+    willReturn(new MockResponseSupplier(response));
+  }
+
+  private static class AndPredicate implements Predicate<RecordedRequest> {
+
+    private final Predicate<RecordedRequest> first;
+    private final Predicate<RecordedRequest> second;
+
+    private AndPredicate(final Predicate<RecordedRequest> first,
+                         final Predicate<RecordedRequest> second) {
+      this.first = first;
+      this.second = second;
+    }
+
+    @Override
+    public boolean test(final RecordedRequest recordedRequest) {
+      return first.test(recordedRequest) && second.test(recordedRequest);
+    }
+  }
+
+  private static class MockResponseSupplier implements Supplier<MockResponse> {
+
+    private final MockResponse response;
+
+    private MockResponseSupplier(final MockResponse response) {
+      this.response = response;
+    }
+
+    @Override
+    public MockResponse get() {
+      return response;
+    }
+  }
+}

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/Predicate.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/Predicate.java
@@ -1,0 +1,5 @@
+package com.squareup.okhttp.mockwebserver.exchanges;
+
+public interface Predicate<T> {
+  boolean test(T t);
+}

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/RequestMatchers.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/RequestMatchers.java
@@ -1,0 +1,250 @@
+package com.squareup.okhttp.mockwebserver.exchanges;
+
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+import java.nio.charset.Charset;
+import java.util.List;
+
+/**
+ * Helper class of predicates that can be used to describe the request that should be matched using
+ * the {@link MatchingRecordedRequest#with(Predicate)} method.
+ */
+public final class RequestMatchers {
+
+    private RequestMatchers() {
+        // utility class
+    }
+
+    static Predicate<RecordedRequest> request(final String method,
+                                              final Predicate<String> pathMatcher) {
+        return new Predicate<RecordedRequest>() {
+            @Override
+            public boolean test(final RecordedRequest recordedRequest) {
+                return method.equals(recordedRequest.getMethod())
+                        && pathMatcher.test(recordedRequest.getPath());
+            }
+        };
+    }
+
+    /**
+     * Constructs a predicate matching a GET request for the given path.
+     * @param path The path to match.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> get(String path) {
+        return get(new EqualityPredicate<>(path));
+    }
+
+    /**
+     * Constructs a predicate matching a GET request with a path matching the given predicate.
+     * @param pathMatcher The matcher to test the path with.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> get(final Predicate<String> pathMatcher) {
+        return request("GET", pathMatcher);
+    }
+
+    /**
+     * Constructs a predicate matching a POST request for the given path.
+     * @param path The path to match.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> post(String path) {
+        return post(new EqualityPredicate<>(path));
+    }
+
+    /**
+     * Constructs a predicate matching a POST request with a path matching the given predicate.
+     * @param pathMatcher The matcher to test the path with.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> post(final Predicate<String> pathMatcher) {
+        return request("POST", pathMatcher);
+    }
+
+    /**
+     * Constructs a predicate matching a PUT request for the given path.
+     * @param path The path to match.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> put(String path) {
+        return put(new EqualityPredicate<>(path));
+    }
+
+    /**
+     * Constructs a predicate matching a PUT request with a path matching the given predicate.
+     * @param pathMatcher The matcher to test the path with.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> put(final Predicate<String> pathMatcher) {
+        return request("PUT", pathMatcher);
+    }
+
+    /**
+     * Constructs a predicate matching a DELETE request for the given path.
+     * @param path The path to match.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> delete(String path) {
+        return delete(new EqualityPredicate<>(path));
+    }
+
+    /**
+     * Constructs a predicate matching a DELETE request with a path matching the given predicate.
+     * @param pathMatcher The matcher to test the path with.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> delete(final Predicate<String> pathMatcher) {
+        return request("DELETE", pathMatcher);
+    }
+
+    /**
+     * Constructs a predicate matching a HEAD request for the given path.
+     * @param path The path to match.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> head(String path) {
+        return head(new EqualityPredicate<>(path));
+    }
+
+    /**
+     * Constructs a predicate matching a HEAD request with a path matching the given predicate.
+     * @param pathMatcher The matcher to test the path with.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> head(final Predicate<String> pathMatcher) {
+        return request("HEAD", pathMatcher);
+    }
+
+    /**
+     * Constructs a predicate matching a PATH request for the given path.
+     * @param path The path to match.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> patch(String path) {
+        return patch(new EqualityPredicate<>(path));
+    }
+
+    /**
+     * Constructs a predicate matching a PATCH request with a path matching the given predicate.
+     * @param pathMatcher The matcher to test the path with.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> patch(final Predicate<String> pathMatcher) {
+        return request("PATCH", pathMatcher);
+    }
+
+    /**
+     * Constructs a predicate matching an OPTIONS request for the given path.
+     * @param path The path to match.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> options(String path) {
+        return options(new EqualityPredicate<>(path));
+    }
+
+    /**
+     * Constructs a predicate matching an OPTIONS request with a path matching the given predicate.
+     * @param pathMatcher The matcher to test the path with.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> options(final Predicate<String> pathMatcher) {
+        return request("OPTIONS", pathMatcher);
+    }
+
+    /**
+     * Constructs a predicate matching a TRACE request for the given path.
+     * @param path The path to match.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> trace(String path) {
+        return trace(new EqualityPredicate<>(path));
+    }
+
+    /**
+     * Constructs a predicate matching a TRACE request with a path matching the given predicate.
+     * @param pathMatcher The matcher to test the path with.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> trace(final Predicate<String> pathMatcher) {
+        return request("TRACE", pathMatcher);
+    }
+
+    /**
+     * Constructs a predicate matching a CONNECT request for the given path.
+     * @param path The path to match.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> connect(String path) {
+        return connect(new EqualityPredicate<>(path));
+    }
+
+    /**
+     * Constructs a predicate matching a CONNECT request with a path matching the given predicate.
+     * @param pathMatcher The matcher to test the path with.
+     * @return The predicate.
+     */
+    public static Predicate<RecordedRequest> connect(final Predicate<String> pathMatcher) {
+        return request("CONNECT", pathMatcher);
+    }
+
+    /**
+     * Matches a request when the given <code>bodyMatcher</code> matches the body of a request
+     * which has been passed as <code>UTF-8</code>.
+     * @param bodyMatcher Used to match the body of a request; should assume that the body has been
+     *                    passed as <code>UTF-8</code>.
+     * @return Something that will match a request when the <code>bodyMatcher</code> also matches.
+     */
+    public static Predicate<RecordedRequest> body(final Predicate<String> bodyMatcher) {
+        return new Predicate<RecordedRequest>() {
+            @Override
+            public boolean test(final RecordedRequest recordedRequest) {
+                final String contentType = recordedRequest.getHeader("Content-Encoding");
+
+                if (contentType != null) {
+                    return bodyMatcher.test(recordedRequest.getBody()
+                            .readString(Charset.forName(contentType)));
+                }
+                return bodyMatcher.test(recordedRequest.getBody().readUtf8());
+            }
+        };
+    }
+
+    /**
+     * Matches a request when there is only one header of name <code>name</code> and which also has
+     * a value which matches the given <code>valueMatcher</code>.
+     * @param name Name that the header should have.
+     * @param valueMatcher Value that the header should match against.
+     * @return Something that will match a request which has a header '<code>name</code>' with only
+     * one value and that matches <code>valueMatcher</code>.
+     */
+    public static Predicate<RecordedRequest> header(final String name,
+                                                    final Predicate<String> valueMatcher) {
+        return headers(name, new Predicate<List<String>>() {
+            @Override
+            public boolean test(final List<String> strings) {
+                return strings.size() == 1 && valueMatcher.test(strings.get(0));
+            }
+        });
+    }
+
+    /**
+     * Matches a request when there is a header of name <code>name</code> and which also has
+     * values that match the given <code>valuesMatcher</code>.
+     * @param name Name that the header should have.
+     * @param valuesMatcher Values that the header should match against.
+     * @return Something that will match a request which has a header '<code>name</code>' with
+     * values that match <code>valuesMatcher</code>.
+     */
+    public static Predicate<RecordedRequest> headers(final String name,
+                                                     final Predicate<List<String>> valuesMatcher) {
+        return new Predicate<RecordedRequest>() {
+            @Override
+            public boolean test(final RecordedRequest recordedRequest) {
+                final List<String> headers = recordedRequest.getHeaders().values(name);
+                return valuesMatcher.test(headers);
+            }
+        };
+    }
+
+}

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/Supplier.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/exchanges/Supplier.java
@@ -1,0 +1,5 @@
+package com.squareup.okhttp.mockwebserver.exchanges;
+
+public interface Supplier<T> {
+  T get();
+}

--- a/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/exchanges/ExpectedExchangesRuleTest.java
+++ b/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/exchanges/ExpectedExchangesRuleTest.java
@@ -1,0 +1,140 @@
+package com.squareup.okhttp.mockwebserver.exchanges;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.rule.MockWebServerRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ExpectedExchangesRuleTest {
+
+  @ClassRule
+  public static MockWebServerRule rule = new MockWebServerRule();
+  @Rule
+  public ExpectedExchangesRule expectedExchanges = new ExpectedExchangesRule(rule);
+
+  @Test
+  public void getShouldUsePredicatesToDetermineCorrectResponse() throws Throwable {
+
+    final String path = "/randomPathName";
+    final String expected = "expectedText";
+
+    expectedExchanges.get(path).willReturn(new MockResponse().setBody(expected));
+
+    final String actual = get(path);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void shouldBePossibleToDelaySendingAnyData() throws Throwable {
+
+    final String path = "/anotherPath";
+    final String expected = "iExpectThis";
+
+    expectedExchanges.get(path).willReturn(new Supplier<MockResponse>() {
+      @Override
+      public MockResponse get() {
+        try {
+          Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        return new MockResponse().setBody(expected);
+      }
+    });
+
+    final long start = System.currentTimeMillis();
+    final String actual = get(path);
+    final long end = System.currentTimeMillis();
+    assertTrue((end - start) > 750L);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void postShouldUsePredicatesToDetermineCorrectResponse() throws Throwable {
+
+    final String path = "/thisPath";
+    final String expectedBody = "the body that is expected";
+    final String expected = "expected response";
+
+    expectedExchanges.post(path).with(RequestMatchers.body(new EqualityPredicate<>(expectedBody))).willReturn(new MockResponse().setBody(expected));
+
+    final String actual = post(path, expectedBody);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void putShouldUsePredicatesToDetermineCorrectResponse() throws Throwable {
+
+    final String path = "/pathToFind";
+    final String expectedBody = "expected request body";
+    final String expected = "expected response body";
+
+    expectedExchanges.put(path).with(RequestMatchers.body(new EqualityPredicate<>(expectedBody))).willReturn(new MockResponse().setBody(expected));
+
+    final String actual = put(path, expectedBody);
+
+    assertEquals(expected, actual);
+  }
+
+  private String get(final String path) throws Throwable {
+
+    URL url = rule.get().getUrl(path);
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestProperty("Accept-Language", "en-US");
+    InputStream in = connection.getInputStream();
+    BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+
+    return reader.readLine();
+  }
+
+  private String post(final String path, final String body) throws Throwable {
+
+    URL url = rule.get().getUrl(path);
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestMethod("POST");
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Accept-Charset", StandardCharsets.UTF_8.displayName());
+    connection.setRequestProperty("Accept-Language", "en-US");
+    try (final OutputStream output = connection.getOutputStream()) {
+      output.write(body.getBytes(StandardCharsets.UTF_8));
+    }
+    InputStream in = connection.getInputStream();
+    BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+
+    return reader.readLine();
+  }
+
+  private String put(final String path, final String body) throws Throwable {
+
+    URL url = rule.get().getUrl(path);
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestMethod("PUT");
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Accept-Charset", StandardCharsets.UTF_8.displayName());
+    connection.setRequestProperty("Accept-Language", "en-US");
+    try (final OutputStream output = connection.getOutputStream()) {
+      output.write(body.getBytes(StandardCharsets.UTF_8));
+    }
+    InputStream in = connection.getInputStream();
+    BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+
+    return reader.readLine();
+  }
+
+}

--- a/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/exchanges/RequestMatchersTest.java
+++ b/mockwebserver/src/test/java/com/squareup/okhttp/mockwebserver/exchanges/RequestMatchersTest.java
@@ -1,0 +1,72 @@
+package com.squareup.okhttp.mockwebserver.exchanges;
+
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okio.Buffer;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RequestMatchersTest {
+
+  @Test
+  public void requestShouldMatchWhenMethodAndPathAreTheSame() throws Exception {
+    final String method = "oneString";
+    final String path = "anotherString";
+
+    assertTrue(RequestMatchers.request(method, new EqualityPredicate<>(path)).test(new RecordedRequest(method + " " + path + " ", Headers.of(), Collections.<Integer>emptyList(), 1, new Buffer(), 1, null)));
+  }
+
+  @Test
+  public void requestShouldNotMatchWhenMethodIsDifferent() throws Exception {
+    final String path = "randomPath";
+
+    assertFalse(RequestMatchers.request("anotherPath", new EqualityPredicate<>(path)).test(new RecordedRequest("evenMore" + " " + path + " ", Headers.of(), Collections.<Integer>emptyList(), 1, new Buffer(), 1, null)));
+  }
+
+  @Test
+  public void requestShouldNotMatchWhenPathIsDifferent() throws Exception {
+    final String method = "asdasdas";
+
+    assertFalse(RequestMatchers.request(method, new EqualityPredicate<>("iDoNotKnow")).test(new RecordedRequest(method + " " + "texdsaflkjasdflj" + " ", Headers.of(), Collections.<Integer>emptyList(), 1, new Buffer(), 1, null)));
+  }
+
+  @Test
+  public void bodyShouldMatchWhenPredicateMatches() {
+    final String body = "something or other";
+
+    assertTrue(RequestMatchers.body(new EqualityPredicate<>(body)).test(new RecordedRequest(null, Headers.of(), Collections.<Integer>emptyList(), 1, new Buffer().writeString(body, StandardCharsets.UTF_8), 1, null)));
+  }
+
+  @Test
+  public void bodyShouldNotMatchWhenPredicateDoesNotMatch() {
+    assertFalse(RequestMatchers.body(new EqualityPredicate<>("hello, world")).test(new RecordedRequest(null, Headers.of(), Collections.<Integer>emptyList(), 1, new Buffer().writeString("another string", StandardCharsets.UTF_8), 1, null)));
+  }
+
+  @Test
+  public void headerShouldMatchWhenNameAndValueMatch() {
+    final String name = "name";
+    final String value = "value";
+
+    assertTrue(RequestMatchers.header(name, new EqualityPredicate<>(value)).test(new RecordedRequest(null, Headers.of(name, value), Collections.<Integer>emptyList(), 1, new Buffer(), 1, null)));
+  }
+
+  @Test
+  public void headerShouldNotMatchWhenNameDoesNotMatch() {
+    final String value = "value";
+
+    assertFalse(RequestMatchers.header("expectedName", new EqualityPredicate<>(value)).test(new RecordedRequest(null, Headers.of("differentName", value), Collections.<Integer>emptyList(), 1, new Buffer(), 1, null)));
+  }
+
+  @Test
+  public void headerShouldNotMatchWhenValueDoesNotMatch() {
+    final String name = "name";
+
+    assertFalse(RequestMatchers.header(name, new EqualityPredicate<>("expectedValue")).test(new RecordedRequest(null, Headers.of(name, "differentValue"), Collections.<Integer>emptyList(), 1, new Buffer(), 1, null)));
+  }
+
+}


### PR DESCRIPTION
This adds support for being able to easily mock out some other web application. Note that this API has been written with Java 8 in mind.

```java
expectedExchanges.post("/url/to/get").with(RequestMatchers.body("expected body"::equals)
  .willReturn(new MockResponse().setBody(expected));
```