### PR TITLE
Add Javadoc about self-signed certificates

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/CertificatePinner.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/CertificatePinner.java
@@ -100,6 +100,13 @@ import static java.util.Collections.unmodifiableList;
  * complexity and limit your ability to migrate between certificate authorities.
  * Do not use certificate pinning without the blessing of your server's TLS
  * administrator!
+ *
+ * <h4>Note about self-signed certificates</h4>
+ * {@link CertificatePinner} can not be used to pin self-signed certificate
+ * if such certificate is not accepted by {@link javax.net.ssl.TrustManager}.
+ *
+ * @see <a href="https://www.owasp.org/index.php/Certificate_and_Public_Key_Pinning">
+ *     OWASP: Certificate and Public Key Pinning</a>
  */
 public final class CertificatePinner {
   public static final CertificatePinner DEFAULT = new Builder().build();


### PR DESCRIPTION
This addition to Javadoc will help developers who want to use `CertificatePinner` to pin self-signed certificates. 

See https://github.com/square/okhttp/issues/1352

P.S. When I saw `CertificatePinner` I decided to pin self-signed certificate via without configuring `TrustManager` & `SSLSocketFactory`, of course I failed :)

But I didn't find any info about self-signed certificates in [CertificatePinner's Javadoc](http://square.github.io/okhttp/javadoc/com/squareup/okhttp/CertificatePinner.html), so I decided to help others