### PR TITLE
Keep track of failures during negotiation for debugging

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteExceptionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/RouteExceptionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp.internal.http;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertSame;
+
+/**
+ * Tests for {@link RouteException}.
+ */
+public class RouteExceptionTest {
+
+  @Test public void getConnectionIOException_single() {
+    IOException firstException = new IOException();
+    RouteException re = new RouteException(firstException);
+    assertSame(firstException, re.getLastConnectException());
+  }
+
+  @Test public void getConnectionIOException_multiple() {
+    IOException firstException = new IOException();
+    IOException secondException = new IOException();
+    IOException thirdException = new IOException();
+    RouteException re = new RouteException(firstException);
+    re.addConnectException(secondException);
+    re.addConnectException(thirdException);
+
+    IOException connectionIOException = re.getLastConnectException();
+    assertSame(thirdException, connectionIOException);
+    Throwable[] thirdSuppressedExceptions = thirdException.getSuppressed();
+    assertSame(secondException, thirdSuppressedExceptions[0]);
+
+    Throwable[] secondSuppressedException = secondException.getSuppressed();
+    assertSame(firstException, secondSuppressedException[0]);
+  }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteException.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteException.java
@@ -16,27 +16,46 @@
 package com.squareup.okhttp.internal.http;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 /**
  * An exception thrown to indicate a problem connecting via a single Route. Multiple attempts may
  * have been made with alternative protocols, none of which were successful.
  */
 public final class RouteException extends Exception {
-
-  private final List<IOException> connectExceptions = new ArrayList<IOException>();
+  private static final Method addSuppressedExceptionMethod;
+  static {
+    Method m;
+    try {
+      m = Throwable.class.getDeclaredMethod("addSuppressed", Throwable.class);
+    } catch (Exception e) {
+      m = null;
+    }
+    addSuppressedExceptionMethod = m;
+  }
+  private IOException lastException;
 
   public RouteException(IOException cause) {
     super(cause);
-    connectExceptions.add(cause);
+    lastException = cause;
   }
 
   public IOException getLastConnectException() {
-    return connectExceptions.get(connectExceptions.size() - 1);
+    return lastException;
   }
 
   public void addConnectException(IOException e) {
-    connectExceptions.add(e);
+    addSuppressedIfPossible(e, lastException);
+    lastException = e;
+  }
+
+  private void addSuppressedIfPossible(IOException e, IOException suppressed) {
+    if (addSuppressedExceptionMethod != null) {
+      try {
+        addSuppressedExceptionMethod.invoke(e, suppressed);
+      } catch (InvocationTargetException | IllegalAccessException ignored) {
+      }
+    }
   }
 }


### PR DESCRIPTION
When performing TLS fallback, add previous exceptions to later ones as suppressed exceptions to help when debugging negotiation issues.

Results in output like this:

SSLv3-only server, SSLv3 disabled:

    Caused by: javax.net.ssl.SSLHandshakeException: javax.net.ssl.SSLProtocolException: SSL handshake aborted: ssl=0xb81a4178: Failure in SSL library, usually a protocol error
    error:14077102:SSL routines:SSL23_GET_SERVER_HELLO:unsupported protocol (external/openssl/ssl/s23_clnt.c:714 0xb089cdf4:0x00000000)
    	at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:448)
    	at com.squareup.okhttp.internal.http.SocketConnector.connectTls(SocketConnector.java:103)
    	at com.squareup.okhttp.Connection.connect(Connection.java:143)
    	at com.squareup.okhttp.Connection.connectAndSetOwner(Connection.java:185)
    	at com.squareup.okhttp.OkHttpClient$1.connectAndSetOwner(OkHttpClient.java:128)
    	at com.squareup.okhttp.internal.http.HttpEngine.nextConnection(HttpEngine.java:341)
    	at com.squareup.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:330)
    	at com.squareup.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:248)
    	at com.squareup.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:433)
    	at com.squareup.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:384)
    	at com.squareup.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:231)
    	at com.squareup.okhttp.internal.huc.DelegatingHttpsURLConnection.getInputStream(DelegatingHttpsURLConnection.java:210)
    	at com.squareup.okhttp.internal.huc.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:25)
    	at TryConnect.main(TryConnect.java:19)
    	... 7 more
    	Suppressed: javax.net.ssl.SSLHandshakeException: javax.net.ssl.SSLProtocolException: SSL handshake aborted: ssl=0xb81a4178: Failure in SSL library, usually a protocol error
    error:14077102:SSL routines:SSL23_GET_SERVER_HELLO:unsupported protocol (external/openssl/ssl/s23_clnt.c:714 0xb089cdf4:0x00000000)
    		... 21 more
    	Caused by: javax.net.ssl.SSLProtocolException: SSL handshake aborted: ssl=0xb81a4178: Failure in SSL library, usually a protocol error
    error:14077102:SSL routines:SSL23_GET_SERVER_HELLO:unsupported protocol (external/openssl/ssl/s23_clnt.c:714 0xb089cdf4:0x00000000)
    		at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
    		at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:405)
    		... 20 more
    Caused by: javax.net.ssl.SSLProtocolException: SSL handshake aborted: ssl=0xb81a4178: Failure in SSL library, usually a protocol error
    error:14077102:SSL routines:SSL23_GET_SERVER_HELLO:unsupported protocol (external/openssl/ssl/s23_clnt.c:714 0xb089cdf4:0x00000000)
    	at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
    	at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:405)
    	... 20 more
