### PR TITLE
Build a harness for web platform tests.

### DIFF
--- a/okhttp-tests/pom.xml
+++ b/okhttp-tests/pom.xml
@@ -45,6 +45,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/WebPlatformTestRun.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/WebPlatformTestRun.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import com.google.gson.Gson;
+import com.squareup.okhttp.internal.Util;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+
+/**
+ * The result of a test run from the <a href="https://github.com/w3c/web-platform-tests">W3C web
+ * platform tests</a>. This class serves as a Gson model for browser test results.
+ *
+ * <p><strong>Note:</strong> When extracting the .json file from the browser after a test run, be
+ * careful to avoid text encoding problems. In one environment, Safari was corrupting UTF-8 data
+ * for download (but the clipboard was fine), and Firefox was corrupting UTF-8 data copied to the
+ * clipboard (but the download was fine).
+ */
+public final class WebPlatformTestRun {
+  List<TestResult> results;
+
+  public SubtestResult get(String testName, String subtestName) {
+    for (TestResult result : results) {
+      if (testName.equals(result.test)) {
+        for (SubtestResult subtestResult : result.subtests) {
+          if (subtestName.equals(subtestResult.name)) {
+            return subtestResult;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  public static WebPlatformTestRun load(InputStream in) throws IOException {
+    try {
+      return new Gson().getAdapter(WebPlatformTestRun.class)
+          .fromJson(new InputStreamReader(in, Util.UTF_8));
+    } finally {
+      Util.closeQuietly(in);
+    }
+  }
+
+  public static class TestResult {
+    String test;
+    List<SubtestResult> subtests;
+  }
+
+  public static class SubtestResult {
+    String name;
+    Status status;
+    String message;
+
+    public boolean isPass() {
+      return status == Status.PASS;
+    }
+  }
+
+  public enum Status {
+    PASS, FAIL
+  }
+}

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/WebPlatformUrlTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/WebPlatformUrlTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import com.squareup.okhttp.WebPlatformTestRun.SubtestResult;
+import com.squareup.okhttp.internal.Util;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import okio.BufferedSource;
+import okio.Okio;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/** Runs the web platform URL tests against Java URL models. */
+@RunWith(Parameterized.class)
+public final class WebPlatformUrlTest {
+  @Parameterized.Parameters(name = "{0}")
+  public static List<Object[]> parameters() {
+    try {
+      List<WebPlatformUrlTestData> tests = loadTests();
+
+      // The web platform tests are run in both HTML and XHTML variants. Major browsers pass more
+      // tests in HTML mode, so that's what we'll attempt to match.
+      String testName = "/url/a-element.html";
+      WebPlatformTestRun firefoxTestRun
+          = loadTestRun("/web-platform-test-results-url-firefox-37.0.json");
+      WebPlatformTestRun chromeTestRun
+          = loadTestRun("/web-platform-test-results-url-chrome-42.0.json");
+      WebPlatformTestRun safariTestRun
+          = loadTestRun("/web-platform-test-results-url-safari-7.1.json");
+
+      List<Object[]> result = new ArrayList<>();
+      for (WebPlatformUrlTestData urlTestData : tests) {
+        String subtestName = urlTestData.toString();
+        SubtestResult firefoxResult = firefoxTestRun.get(testName, subtestName);
+        SubtestResult chromeResult = chromeTestRun.get(testName, subtestName);
+        SubtestResult safariResult = safariTestRun.get(testName, subtestName);
+        result.add(new Object[] { urlTestData, firefoxResult, chromeResult, safariResult });
+      }
+      return result;
+    } catch (IOException e) {
+      throw new AssertionError();
+    }
+  }
+
+  @Parameter(0)
+  public WebPlatformUrlTestData testData;
+
+  @Parameter(1)
+  public SubtestResult firefoxResult;
+
+  @Parameter(2)
+  public SubtestResult chromeResultResult;
+
+  @Parameter(3)
+  public SubtestResult safariResult;
+
+  private static final List<String> JAVA_NET_URL_SCHEMES
+      = Util.immutableList("file", "ftp", "http", "https", "mailto");
+
+  /** Test how java.net.URL does against the web platform test suite. */
+  @Ignore // java.net.URL is broken. Not much we can do about that.
+  @Test public void javaNetUrl() throws Exception {
+    if (!testData.scheme.isEmpty() && !JAVA_NET_URL_SCHEMES.contains(testData.scheme)) {
+      System.out.println("Ignoring unsupported scheme " + testData.scheme);
+      return;
+    }
+
+    try {
+      testJavaNetUrl();
+    } catch (AssertionError e) {
+      if (tolerateFailure()) {
+        System.out.println("Tolerable failure: " + e.getMessage());
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private void testJavaNetUrl() {
+    URL url = null;
+    String failureMessage = "";
+    try {
+      if (testData.base.equals("about:blank")) {
+        url = new URL(testData.input);
+      } else {
+        URL baseUrl = new URL(testData.base);
+        url = new URL(baseUrl, testData.input);
+      }
+    } catch (MalformedURLException e) {
+      failureMessage = e.getMessage();
+    }
+
+    if (testData.expectParseFailure()) {
+      assertNull("Expected URL to fail parsing", url);
+    } else {
+      assertNotNull("Expected URL to parse successfully, but was " + failureMessage, url);
+      String effectivePort = url.getPort() != -1 ? Integer.toString(url.getPort()) : "";
+      String effectiveQuery = url.getQuery() != null ? "?" + url.getQuery() : "";
+      String effectiveFragment = url.getRef() != null ? "#" + url.getRef() : "";
+      assertEquals("scheme", testData.scheme, url.getProtocol());
+      assertEquals("host", testData.host, url.getHost());
+      assertEquals("port", testData.port, effectivePort);
+      assertEquals("path", testData.path, url.getPath());
+      assertEquals("query", testData.query, effectiveQuery);
+      assertEquals("fragment", testData.fragment, effectiveFragment);
+    }
+  }
+
+  /**
+   * Returns true if several major browsers also fail this test, in which case the test itself is
+   * questionable.
+   */
+  private boolean tolerateFailure() {
+    return !firefoxResult.isPass()
+        && !chromeResultResult.isPass()
+        && !safariResult.isPass();
+  }
+
+  private static List<WebPlatformUrlTestData> loadTests() throws IOException {
+    BufferedSource source = Okio.buffer(Okio.source(
+        WebPlatformUrlTest.class.getResourceAsStream("/web-platform-test-urltestdata.txt")));
+    return WebPlatformUrlTestData.load(source);
+  }
+
+  private static WebPlatformTestRun loadTestRun(String name) throws IOException {
+    return WebPlatformTestRun.load(WebPlatformUrlTest.class.getResourceAsStream(name));
+  }
+}

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/WebPlatformUrlTestData.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/WebPlatformUrlTestData.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okhttp;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import okio.Buffer;
+import okio.BufferedSource;
+
+/**
+ * A test from the <a href="https://github.com/w3c/web-platform-tests/tree/master/url">Web Platform
+ * URL test suite</a>. Each test is a line of the file {@code urltestdata.txt}; the format is
+ * informally specified by its JavaScript parser {@code urltestparser.js}; with which this class
+ * attempts to be compatible.
+ *
+ * <p>Each line of the urltestdata.text file specifies a test. Lines look like this: <pre>   {@code
+ *   http://example\t.\norg http://example.org/foo/bar s:http h:example.org p:/
+ * }
+ */
+public final class WebPlatformUrlTestData {
+  String input;
+  String base;
+  String scheme = "";
+  String username = "";
+  String password = null;
+  String host = "";
+  String port = "";
+  String path = "";
+  String query = "";
+  String fragment = "";
+
+  public boolean expectParseFailure() {
+    return scheme.isEmpty();
+  }
+
+  private void set(String name, String value) {
+    switch (name) {
+      case "s":
+        scheme = value;
+        break;
+      case "u":
+        username = value;
+        break;
+      case "pass":
+        password = value;
+        break;
+      case "h":
+        host = value;
+        break;
+      case "port":
+        port = value;
+        break;
+      case "p":
+        path = value;
+        break;
+      case "q":
+        query = value;
+        break;
+      case "f":
+        fragment = value;
+        break;
+      default:
+        throw new IllegalArgumentException("unexpected attribute: " + value);
+    }
+  }
+
+  @Override public String toString() {
+    return String.format("Parsing: <%s> against <%s>", input, base);
+  }
+
+  public static List<WebPlatformUrlTestData> load(BufferedSource source) throws IOException {
+    List<WebPlatformUrlTestData> list = new ArrayList<>();
+    for (String line; (line = source.readUtf8Line()) != null; ) {
+      if (line.isEmpty() || line.startsWith("#")) continue;
+
+      int i = 0;
+      String[] parts = line.split(" ");
+      WebPlatformUrlTestData element = new WebPlatformUrlTestData();
+      element.input = unescape(parts[i++]);
+
+      String base = i < parts.length ? parts[i++] : null;
+      element.base = (base == null || base.isEmpty())
+          ? list.get(list.size() - 1).base
+          : unescape(base);
+
+      for (; i < parts.length; i++) {
+        String piece = parts[i];
+        if (piece.startsWith("#")) continue;
+        String[] nameAndValue = piece.split(":", 2);
+        element.set(nameAndValue[0], unescape(nameAndValue[1]));
+      }
+
+      list.add(element);
+    }
+    return list;
+  }
+
+  private static String unescape(String s) throws EOFException {
+    Buffer in = new Buffer().writeUtf8(s);
+    StringBuilder result = new StringBuilder();
+    while (!in.exhausted()) {
+      int c = in.readUtf8CodePoint();
+      if (c != '\\') {
+        result.append((char) c);
+        continue;
+      }
+
+      switch (in.readUtf8CodePoint()) {
+        case '\\':
+          result.append('\\');
+          break;
+        case '#':
+          result.append('#');
+          break;
+        case 'n':
+          result.append('\n');
+          break;
+        case 'r':
+          result.append('\r');
+          break;
+        case 's':
+          result.append(' ');
+          break;
+        case 't':
+          result.append('\t');
+          break;
+        case 'f':
+          result.append('\f');
+          break;
+        case 'u':
+          result.append((char) Integer.parseInt(in.readUtf8(4), 16));
+          break;
+        default:
+          throw new IllegalArgumentException("unexpected escape character in " + s);
+      }
+    }
+
+    return result.toString();
+  }
+}

--- a/okhttp-tests/src/test/resources/web-platform-test-results-url-chrome-42.0.json
+++ b/okhttp-tests/src/test/resources/web-platform-test-results-url-chrome-42.0.json
@@ -1,0 +1,1341 @@
+{
+  "results": [
+    {
+      "test": "/url/a-element.html",
+      "subtests": [
+        {
+          "name": "Loading data…",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example\t.\norg> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://user:pass@foo:21/bar;par?b#c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:foo.com> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <\t   :foo.com   \n> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: < foo.com  > against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <a:\t foo.com> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:21/ b ? d # e > against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:0/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:00000000000000/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:00000000000000000000080/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:b/c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <http://f: /c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <http://f:\n/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:fifty-two/c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <http://f:999999/c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"http:\" but got \":\""
+        },
+        {
+          "name": "Parsing: <http://f: 21 / b ? d # e > against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <  \t> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:foo.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:foo.com\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:a> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:#> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#;?> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <?> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:23> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </:23> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <::> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <::23> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo://> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://a:b@c:29/d> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http::@c:29> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://&a:foo(b]c@d:2/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://&a:foo(b]c@d:2/\" but got \"http://&a:foo(b%5Dc@d:2/\""
+        },
+        {
+          "name": "Parsing: <http://::@c@d:2> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://::%40c@d:2/\" but got \"http://:%3A%40c@d:2/\""
+        },
+        {
+          "name": "Parsing: <http://foo.com:b@d/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo.com/\\@> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:\\\\foo.com\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:\\\\a\\b:c\\d@foo.com\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo:/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo:/bar.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo://///////> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo://///////bar.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo:////://///> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <c:/foo> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <//foo/bar> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo/path;a??e#f#g> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo/abcd?efgh?ijkl> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo/abcd#foo?bar> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <[61:24:74]:98> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:[61:27]/:foo> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://[1::2]:3:4> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <http://2001::1> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <http://2001::1]> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://2001::1]\" but got \"http://2001::1]/\""
+        },
+        {
+          "name": "Parsing: <http://2001::1]:80> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://2001::1]:80\" but got \"http://2001::1]/\""
+        },
+        {
+          "name": "Parsing: <http://[2001::1]> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <javascript:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <mailto:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <javascript:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <mailto:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a/b/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a/ /c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a%2fc> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a/%2f/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#β> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:text/html,test#test> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:c:\\foo\\bar.html> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/c:/foo/bar.html\" but got \"/tmp/mock/c:/foo/bar.html\""
+        },
+        {
+          "name": "Parsing: <  File:c|////foo\\bar.html> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/c:////foo/bar.html\" but got \"/tmp/mock/c%7C////foo/bar.html\""
+        },
+        {
+          "name": "Parsing: <C|/foo/bar> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/C:/foo/bar\" but got \"/tmp/mock/C%7C/foo/bar\""
+        },
+        {
+          "name": "Parsing: </C|\\foo\\bar> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/C:/foo/bar\" but got \"/C%7C/foo/bar\""
+        },
+        {
+          "name": "Parsing: <//C|/foo/bar> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"\" but got \"c%7C\""
+        },
+        {
+          "name": "Parsing: <//server/file> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <\\\\server\\file> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </\\server/file> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:///foo/bar.txt> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:///home/me> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <//> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <///> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <///test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file://test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file://localhost> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file://localhost/> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file://localhost/test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/././foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/./.foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/.> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/./> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/../> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/..bar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/../ton> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/../ton/../../a> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/../../..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/../../../ton> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/%2e> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/%2e%2> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo/%2e%2\" but got \"/foo/.%2\""
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/%2e./%2e%2e/.%2e/%2e.bar> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/%2e.bar\" but got \"/..bar\""
+        },
+        {
+          "name": "Parsing: <http://example.com////../..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar//../..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar//..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/%20foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%2> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%2zbar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%2Â©zbar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%41%7a> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo%41%7a\" but got \"/fooAz\""
+        },
+        {
+          "name": "Parsing: <http://example.com/foo\t%91> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%00%51> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"http:\" but got \":\""
+        },
+        {
+          "name": "Parsing: <http://example.com/(%28:%3A%29)> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/%3A%3a%3C%3c> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo\tbar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com\\\\foo\\\\bar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/%7Ffp3%3Eju%3Dduvgw%3Dd> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/@asdf%40> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/你好你好> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/‥/foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/﻿/foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/‮/foo/‭/bar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.google.com/foo?bar=baz#> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.google.com/foo?bar=baz# »> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:test# »> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: hash expected \"# »\" but got \"# %C2%BB\""
+        },
+        {
+          "name": "Parsing: <http://[www.google.com]/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.google.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://192.0x00A80001> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www/foo%2Ehtml> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo%2Ehtml\" but got \"/foo.html\""
+        },
+        {
+          "name": "Parsing: <http://www/foo/%2E/html> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://user:pass@/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://%25DOMAIN:foobar@foodomain.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:\\\\www.google.com\\foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo:81/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <httpa://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo:-80/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <https://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp://foo:21/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher://foo:70/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:81/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:815/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:81/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:815/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <javascript:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <mailto:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <javascript:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <mailto:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:a:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/a:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://a:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://@pple.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http::b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/:@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http:/:@/www.example.com\" but got \"http:///www.example.com\""
+        },
+        {
+          "name": "Parsing: <http://user@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http:@/www.example.com\" but got \"http:///www.example.com\""
+        },
+        {
+          "name": "Parsing: <http:/@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http:/@/www.example.com\" but got \"http:///www.example.com\""
+        },
+        {
+          "name": "Parsing: <http://@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://@/www.example.com\" but got \"http:///www.example.com\""
+        },
+        {
+          "name": "Parsing: <https:@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"https:@/www.example.com\" but got \"https:///www.example.com\""
+        },
+        {
+          "name": "Parsing: <http:a:b@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http:a:b@/www.example.com\" but got \"http://a:b@/www.example.com\""
+        },
+        {
+          "name": "Parsing: <http:/a:b@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http:/a:b@/www.example.com\" but got \"http://a:b@/www.example.com\""
+        },
+        {
+          "name": "Parsing: <http://a:b@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http::@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http::@/www.example.com\" but got \"http:///www.example.com\""
+        },
+        {
+          "name": "Parsing: <http:a:@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://a:@www.example.com/\" but got \"http://a@www.example.com/\""
+        },
+        {
+          "name": "Parsing: <http:/a:@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://a:@www.example.com/\" but got \"http://a@www.example.com/\""
+        },
+        {
+          "name": "Parsing: <http://a:@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://a:@www.example.com/\" but got \"http://a@www.example.com/\""
+        },
+        {
+          "name": "Parsing: <http://www.@pple.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:@:www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <http:/@:www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <http://@:www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"0\""
+        },
+        {
+          "name": "Parsing: <http://:@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://:@www.example.com/\" but got \"http://www.example.com/\""
+        },
+        {
+          "name": "Parsing: </> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <.> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <..> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <./test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <../test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <../aaa/test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <../../test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <中/test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.example2.com> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <//www.example2.com> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://ExAmPlE.CoM> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example example.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://Goo%20 goo%7C|.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://GOO 　goo.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://GOO​⁠﻿goo.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.foo。bar.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://﷐zyx.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://﷐zyx.com\" but got \"http://%EF%BF%BDzyx.com/\""
+        },
+        {
+          "name": "Parsing: <http://%ef%b7%90zyx.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://%ef%b7%90zyx.com\" but got \"http://%EF%BF%BDzyx.com/\""
+        },
+        {
+          "name": "Parsing: <http://Ｇｏ.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://％４１.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%ef%bc%85%ef%bc%94%ef%bc%91.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://％００.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://％００.com\" but got \"http://%00.com/\""
+        },
+        {
+          "name": "Parsing: <http://%ef%bc%85%ef%bc%90%ef%bc%90.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://%ef%bc%85%ef%bc%90%ef%bc%90.com\" but got \"http://%00.com/\""
+        },
+        {
+          "name": "Parsing: <http://你好你好> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://%zz%66%a.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://%zz%66%a.com\" but got \"http://%25zzf%25a.com/\""
+        },
+        {
+          "name": "Parsing: <http://%25> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://%25\" but got \"http://%25/\""
+        },
+        {
+          "name": "Parsing: <http://hello%00> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://hello%00\" but got \"http://hello%00/\""
+        },
+        {
+          "name": "Parsing: <http://%30%78%63%30%2e%30%32%35%30.01> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://%30%78%63%30%2e%30%32%35%30.01%2e> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"0xc0.0250.01.\" but got \"192.168.0.1\""
+        },
+        {
+          "name": "Parsing: <http://192.168.0.257> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://192.168.0.257\" but got \"http://192.168.0.257/\""
+        },
+        {
+          "name": "Parsing: <http://%3g%78%63%30%2e%30%32%35%30%2E.01> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://%3g%78%63%30%2e%30%32%35%30%2E.01\" but got \"http://%253gxc0.0250..01/\""
+        },
+        {
+          "name": "Parsing: <http://192.168.0.1 hello> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://０Ｘｃ０．０２５０．０１> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://[google.com]> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://[google.com]\" but got \"http://[google.com]/\""
+        },
+        {
+          "name": "Parsing: <http://foo:💩@example.com/bar> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <x> against <test:test>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"x\" but got \"\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/okhttp-tests/src/test/resources/web-platform-test-results-url-firefox-37.0.json
+++ b/okhttp-tests/src/test/resources/web-platform-test-results-url-firefox-37.0.json
@@ -1,0 +1,1341 @@
+{
+  "results": [
+    {
+      "test": "/url/a-element.html",
+      "subtests": [
+        {
+          "name": "Loading data…",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example\t.\norg> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://user:pass@foo:21/bar;par?b#c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:foo.com> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <\t   :foo.com   \n> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: < foo.com  > against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <a:\t foo.com> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \" foo.com\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http://f:21/ b ? d # e > against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://f:21/%20b%20?%20d%20# e\" but got \"http://f:21/%20b%20?%20d%20#%20e\""
+        },
+        {
+          "name": "Parsing: <http://f:/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:0/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:00000000000000/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:00000000000000000000080/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:b/c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://f: /c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://f:\n/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:fifty-two/c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://f:999999/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f: 21 / b ? d # e > against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <  \t> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:foo.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:foo.com\\> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo/:foo.com/\" but got \"/foo/:foo.com%5C\""
+        },
+        {
+          "name": "Parsing: <:> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:a> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:\\> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo/:/\" but got \"/foo/:%5C\""
+        },
+        {
+          "name": "Parsing: <:#> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#;?> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <?> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:23> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </:23> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <::> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <::23> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo://> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"//\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http://a:b@c:29/d> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http::@c:29> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo/:@c:29\" but got \"/foo/http::@c:29\""
+        },
+        {
+          "name": "Parsing: <http://&a:foo(b]c@d:2/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://&a:foo(b]c@d:2/\" but got \"http://&a:foo(b%5Dc@d:2/\""
+        },
+        {
+          "name": "Parsing: <http://::@c@d:2> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"d\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http://foo.com:b@d/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://foo.com:b@d/\" but got \"http://foo%2Ecom:b@d/\""
+        },
+        {
+          "name": "Parsing: <http://foo.com/\\@> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"//@\" but got \"/%5C@\""
+        },
+        {
+          "name": "Parsing: <http:\\\\foo.com\\> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"foo.com\" but got \"example.org\""
+        },
+        {
+          "name": "Parsing: <http:\\\\a\\b:c\\d@foo.com\\> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"a\" but got \"example.org\""
+        },
+        {
+          "name": "Parsing: <foo:/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <foo:/bar.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/bar.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <foo://///////> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/////////\" but got \"\""
+        },
+        {
+          "name": "Parsing: <foo://///////bar.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/////////bar.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <foo:////://///> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"////://///\" but got \"\""
+        },
+        {
+          "name": "Parsing: <c:/foo> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo\" but got \"\""
+        },
+        {
+          "name": "Parsing: <//foo/bar> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo/path;a??e#f#g> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo/abcd?efgh?ijkl> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo/abcd#foo?bar> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <[61:24:74]:98> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo/[61:24:74]:98\" but got \"/foo/%5B61:24:74%5D:98\""
+        },
+        {
+          "name": "Parsing: <http:[61:27]/:foo> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo/[61:27]/:foo\" but got \"/foo/%5B61:27%5D/:foo\""
+        },
+        {
+          "name": "Parsing: <http://[1::2]:3:4> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://2001::1> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://2001::1]> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://2001::1]:80> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://[2001::1]> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <file:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:/example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <gopher:/example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"example.com\" but got \"\""
+        },
+        {
+          "name": "Parsing: <ws:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:/example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"data:\" but got \"http:\""
+        },
+        {
+          "name": "Parsing: <javascript:/example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <mailto:/example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <ftps:example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <gopher:example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"example.com\" but got \"\""
+        },
+        {
+          "name": "Parsing: <ws:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"data:\" but got \"http:\""
+        },
+        {
+          "name": "Parsing: <javascript:example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <mailto:example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: </a/b/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a/ /c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a%2fc> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a/%2f/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#β> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://example.org/foo/bar#β\" but got \"http://example.org/foo/bar#%CE%B2\""
+        },
+        {
+          "name": "Parsing: <data:text/html,test#test> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"text/html,test\" but got \"\""
+        },
+        {
+          "name": "Parsing: <file:c:\\foo\\bar.html> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/c:/foo/bar.html\" but got \"/tmp/mock/c:%5Cfoo%5Cbar.html\""
+        },
+        {
+          "name": "Parsing: <  File:c|////foo\\bar.html> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/c:////foo/bar.html\" but got \"/tmp/mock/c|////foo%5Cbar.html\""
+        },
+        {
+          "name": "Parsing: <C|/foo/bar> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/C:/foo/bar\" but got \"/tmp/mock/C|/foo/bar\""
+        },
+        {
+          "name": "Parsing: </C|\\foo\\bar> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/C:/foo/bar\" but got \"/C|%5Cfoo%5Cbar\""
+        },
+        {
+          "name": "Parsing: <//C|/foo/bar> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/C:/foo/bar\" but got \"/foo/bar\""
+        },
+        {
+          "name": "Parsing: <//server/file> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"server\" but got \"\""
+        },
+        {
+          "name": "Parsing: <\\\\server\\file> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"server\" but got \"\""
+        },
+        {
+          "name": "Parsing: </\\server/file> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"server\" but got \"\""
+        },
+        {
+          "name": "Parsing: <file:///foo/bar.txt> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:///home/me> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <//> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <///> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <///test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file://test> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"test\" but got \"\""
+        },
+        {
+          "name": "Parsing: <file://localhost> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"localhost\" but got \"\""
+        },
+        {
+          "name": "Parsing: <file://localhost/> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"localhost\" but got \"\""
+        },
+        {
+          "name": "Parsing: <file://localhost/test> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"localhost\" but got \"\""
+        },
+        {
+          "name": "Parsing: <test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/././foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/./.foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/.> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/./> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/../> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/..bar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/../ton> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/../ton/../../a> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/../../..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/../../../ton> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/%2e> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo/\" but got \"/foo/%2e\""
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/%2e%2> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/%2e./%2e%2e/.%2e/%2e.bar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com////../..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar//../..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar//..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/%20foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%2> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%2zbar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%2Â©zbar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%41%7a> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo\t%91> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%00%51> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/(%28:%3A%29)> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/%3A%3a%3C%3c> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo\tbar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com\\\\foo\\\\bar> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"example.com\" but got \"example.com\\\\\\foo\\\\bar\""
+        },
+        {
+          "name": "Parsing: <http://example.com/%7Ffp3%3Eju%3Dduvgw%3Dd> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/@asdf%40> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/你好你好> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/‥/foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/﻿/foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/‮/foo/‭/bar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.google.com/foo?bar=baz#> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.google.com/foo?bar=baz# »> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://www.google.com/foo?bar=baz# »\" but got \"http://www.google.com/foo?bar=baz#%20%C2%BB\""
+        },
+        {
+          "name": "Parsing: <data:test# »> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"data:\" but got \"http:\""
+        },
+        {
+          "name": "Parsing: <http://[www.google.com]/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://www.google.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://192.0x00A80001> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"192.168.0.1\" but got \"192.0x00a80001\""
+        },
+        {
+          "name": "Parsing: <http://www/foo%2Ehtml> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www/foo/%2E/html> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://user:pass@/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%25DOMAIN:foobar@foodomain.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:\\\\www.google.com\\foo> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"www.google.com\" but got \"\\\\\\www.google.com\\foo\""
+        },
+        {
+          "name": "Parsing: <http://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo:81/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <httpa://foo:80/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"//foo:80/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http://foo:-80/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <https://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp://foo:21/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher://foo:70/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"foo\" but got \"\""
+        },
+        {
+          "name": "Parsing: <gopher://foo:443/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"foo\" but got \"\""
+        },
+        {
+          "name": "Parsing: <ws://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:81/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:815/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:81/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:815/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:/example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <file:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:/example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <gopher:/example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"example.com\" but got \"\""
+        },
+        {
+          "name": "Parsing: <ws:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:/example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"data:\" but got \"http:\""
+        },
+        {
+          "name": "Parsing: <javascript:/example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <mailto:/example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <ftps:example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <gopher:example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"example.com\" but got \"\""
+        },
+        {
+          "name": "Parsing: <ws:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"data:\" but got \"http:\""
+        },
+        {
+          "name": "Parsing: <javascript:example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <mailto:example.com/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"example.com/\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http:@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:a:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/a:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://a:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://@pple.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http::b@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"www.example.com\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http:/:b@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"www.example.com\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http://:b@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"www.example.com\" but got \"\""
+        },
+        {
+          "name": "Parsing: <http:/:@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://user@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http:@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http:/@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <https:@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http:a:b@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http:/a:b@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://a:b@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http::@/www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http:a:@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/a:@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://a:@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.@pple.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://www.@pple.com/\" but got \"http://www%2E@pple.com/\""
+        },
+        {
+          "name": "Parsing: <http:@:www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http:/@:www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://@:www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://:@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"www.example.com\" but got \"\""
+        },
+        {
+          "name": "Parsing: </> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <.> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <..> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <./test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <../test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <../aaa/test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <../../test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <中/test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.example2.com> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <//www.example2.com> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://ExAmPlE.CoM> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example example.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://Goo%20 goo%7C|.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://GOO 　goo.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://GOO​⁠﻿goo.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.foo。bar.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://﷐zyx.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%ef%b7%90zyx.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://Ｇｏ.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://％４１.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%ef%bc%85%ef%bc%94%ef%bc%91.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://％００.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%ef%bc%85%ef%bc%90%ef%bc%90.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://你好你好> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"xn--6qqa088eba\" but got \"你好你好\""
+        },
+        {
+          "name": "Parsing: <http://%zz%66%a.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%25> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://hello%00> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%30%78%63%30%2e%30%32%35%30.01> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"192.168.0.1\" but got \"%30%78%63%30%2e%30%32%35%30.01\""
+        },
+        {
+          "name": "Parsing: <http://%30%78%63%30%2e%30%32%35%30.01%2e> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"0xc0.0250.01.\" but got \"%30%78%63%30%2e%30%32%35%30.01%2e\""
+        },
+        {
+          "name": "Parsing: <http://192.168.0.257> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%3g%78%63%30%2e%30%32%35%30%2E.01> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://192.168.0.1 hello> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://０Ｘｃ０．０２５０．０１> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"192.168.0.1\" but got \"0xc0.0250.01\""
+        },
+        {
+          "name": "Parsing: <http://[google.com]> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://foo:💩@example.com/bar> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <x> against <test:test>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/okhttp-tests/src/test/resources/web-platform-test-results-url-safari-7.1.json
+++ b/okhttp-tests/src/test/resources/web-platform-test-results-url-safari-7.1.json
@@ -1,0 +1,1341 @@
+{
+  "results": [
+    {
+      "test": "/url/a-element.html",
+      "subtests": [
+        {
+          "name": "Loading data…",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example\t.\norg> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"http:\" but got \":\""
+        },
+        {
+          "name": "Parsing: <http://user:pass@foo:21/bar;par?b#c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:foo.com> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <\t   :foo.com   \n> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: < foo.com  > against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <a:\t foo.com> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:21/ b ? d # e > against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:0/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:00000000000000/c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://f:0/c\" but got \"http://f:00000000000000/c\""
+        },
+        {
+          "name": "Parsing: <http://f:00000000000000000000080/c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"\" but got \"80\""
+        },
+        {
+          "name": "Parsing: <http://f:b/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f: /c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:\n/c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"http:\" but got \":\""
+        },
+        {
+          "name": "Parsing: <http://f:fifty-two/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://f:999999/c> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: port expected \"999999\" but got \"65535\""
+        },
+        {
+          "name": "Parsing: <http://f: 21 / b ? d # e > against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://f: 21 / b ? d # e \" but got \"http://f: 21 / b ? d # e\""
+        },
+        {
+          "name": "Parsing: <> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <  \t> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:foo.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:foo.com\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:a> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:#> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#;?> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <?> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <:23> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </:23> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <::> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <::23> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo://> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://a:b@c:29/d> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http::@c:29> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://&a:foo(b]c@d:2/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"http:\" but got \":\""
+        },
+        {
+          "name": "Parsing: <http://::@c@d:2> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"http:\" but got \":\""
+        },
+        {
+          "name": "Parsing: <http://foo.com:b@d/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo.com/\\@> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:\\\\foo.com\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:\\\\a\\b:c\\d@foo.com\\> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo:/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo:/bar.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo://///////> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo://///////bar.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <foo:////://///> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <c:/foo> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <//foo/bar> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo/path;a??e#f#g> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo/abcd?efgh?ijkl> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo/abcd#foo?bar> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <[61:24:74]:98> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:[61:27]/:foo> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://[1::2]:3:4> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://2001::1> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://2001::1]> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://2001::1]:80> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://[2001::1]> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/example.com/> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"example.org\" but got \"example.com\""
+        },
+        {
+          "name": "Parsing: <ftp:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <javascript:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <mailto:/example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <javascript:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <mailto:example.com/> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a/b/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a/ /c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a%2fc> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </a/%2f/c> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <#β> against <http://example.org/foo/bar>",
+          "status": "FAIL",
+          "message": "assert_equals: hash expected \"#β\" but got \"#%CE%B2\""
+        },
+        {
+          "name": "Parsing: <data:text/html,test#test> against <http://example.org/foo/bar>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:c:\\foo\\bar.html> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/c:/foo/bar.html\" but got \"/tmp/mock/c:/foo/bar.html\""
+        },
+        {
+          "name": "Parsing: <  File:c|////foo\\bar.html> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/c:////foo/bar.html\" but got \"/tmp/mock/c|////foo/bar.html\""
+        },
+        {
+          "name": "Parsing: <C|/foo/bar> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/C:/foo/bar\" but got \"/tmp/mock/C|/foo/bar\""
+        },
+        {
+          "name": "Parsing: </C|\\foo\\bar> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/C:/foo/bar\" but got \"/C|/foo/bar\""
+        },
+        {
+          "name": "Parsing: <//C|/foo/bar> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"file:\" but got \":\""
+        },
+        {
+          "name": "Parsing: <//server/file> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <\\\\server\\file> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </\\server/file> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:///foo/bar.txt> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:///home/me> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <//> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <///> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <///test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file://test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file://localhost> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"localhost\" but got \"\""
+        },
+        {
+          "name": "Parsing: <file://localhost/> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"localhost\" but got \"\""
+        },
+        {
+          "name": "Parsing: <file://localhost/test> against <file:///tmp/mock/path>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"localhost\" but got \"\""
+        },
+        {
+          "name": "Parsing: <test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:test> against <file:///tmp/mock/path>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/././foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/./.foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/.> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/./> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/../> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/..bar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/../ton> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar/../ton/../../a> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/../../..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/../../../ton> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/%2e> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo/\" but got \"/foo/%2e\""
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/%2e%2> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/%2e./%2e%2e/.%2e/%2e.bar> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/%2e.bar\" but got \"/foo/%2e./%2e%2e/.%2e/%2e.bar\""
+        },
+        {
+          "name": "Parsing: <http://example.com////../..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar//../..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo/bar//..> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/%20foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%2> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%2zbar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%2Â©zbar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%41%7a> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo\t%91> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo%00%51> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/(%28:%3A%29)> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/%3A%3a%3C%3c> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/foo\tbar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com\\\\foo\\\\bar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/%7Ffp3%3Eju%3Dduvgw%3Dd> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/@asdf%40> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/你好你好> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/‥/foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/﻿/foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example.com/‮/foo/‭/bar> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.google.com/foo?bar=baz#> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.google.com/foo?bar=baz# »> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: hash expected \"# »\" but got \"# %C2%BB\""
+        },
+        {
+          "name": "Parsing: <data:test# »> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: hash expected \"# »\" but got \"# %C2%BB\""
+        },
+        {
+          "name": "Parsing: <http://[www.google.com]/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.google.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://192.0x00A80001> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"192.168.0.1\" but got \"192.0x00a80001\""
+        },
+        {
+          "name": "Parsing: <http://www/foo%2Ehtml> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www/foo/%2E/html> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: path expected \"/foo/html\" but got \"/foo/%2E/html\""
+        },
+        {
+          "name": "Parsing: <http://user:pass@/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://%25DOMAIN:foobar@foodomain.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:\\\\www.google.com\\foo> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo:81/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <httpa://foo:80/> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"\" but got \"foo\""
+        },
+        {
+          "name": "Parsing: <http://foo:-80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp://foo:21/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher://foo:70/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:81/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws://foo:815/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:80/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:81/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:443/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss://foo:815/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <file:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <javascript:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <mailto:/example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftp:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <madeupscheme:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ftps:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <gopher:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <ws:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <wss:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <data:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <javascript:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <mailto:example.com/> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:a:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/a:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://a:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://@pple.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http::b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://:b@www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/:@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://user@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <https:@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:a:b@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/a:b@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://a:b@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http::@/www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:a:@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://a:@www.example.com/\" but got \"http://a@www.example.com/\""
+        },
+        {
+          "name": "Parsing: <http:/a:@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://a:@www.example.com/\" but got \"http://a@www.example.com/\""
+        },
+        {
+          "name": "Parsing: <http://a:@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://a:@www.example.com/\" but got \"http://a@www.example.com/\""
+        },
+        {
+          "name": "Parsing: <http://www.@pple.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:@:www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http:/@:www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://@:www.example.com> against <about:blank>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://:@www.example.com> against <about:blank>",
+          "status": "FAIL",
+          "message": "assert_equals: href expected \"http://:@www.example.com/\" but got \"http://www.example.com/\""
+        },
+        {
+          "name": "Parsing: </> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: </test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <.> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <..> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <./test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <../test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <../aaa/test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <../../test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <中/test.txt> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.example2.com> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <//www.example2.com> against <http://www.example.com/test>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://ExAmPlE.CoM> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://example example.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://Goo%20 goo%7C|.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://GOO 　goo.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://GOO​⁠﻿goo.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://www.foo。bar.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://﷐zyx.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%ef%b7%90zyx.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://Ｇｏ.com> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://％４１.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%ef%bc%85%ef%bc%94%ef%bc%91.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://％００.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%ef%bc%85%ef%bc%90%ef%bc%90.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://你好你好> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://%zz%66%a.com> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%25> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://hello%00> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%30%78%63%30%2e%30%32%35%30.01> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"192.168.0.1\" but got \"%30%78%63%30%2e%30%32%35%30.01\""
+        },
+        {
+          "name": "Parsing: <http://%30%78%63%30%2e%30%32%35%30.01%2e> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"0xc0.0250.01.\" but got \"%30%78%63%30%2e%30%32%35%30.01%2e\""
+        },
+        {
+          "name": "Parsing: <http://192.168.0.257> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://%3g%78%63%30%2e%30%32%35%30%2E.01> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_unreached: Expected URL to fail parsing Reached unreachable code"
+        },
+        {
+          "name": "Parsing: <http://192.168.0.1 hello> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://０Ｘｃ０．０２５０．０１> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: host expected \"192.168.0.1\" but got \"0xc0.0250.01\""
+        },
+        {
+          "name": "Parsing: <http://[google.com]> against <http://other.com/>",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Parsing: <http://foo:💩@example.com/bar> against <http://other.com/>",
+          "status": "FAIL",
+          "message": "assert_equals: scheme expected \"http:\" but got \":\""
+        },
+        {
+          "name": "Parsing: <x> against <test:test>",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/okhttp-tests/src/test/resources/web-platform-test-urltestdata.txt
+++ b/okhttp-tests/src/test/resources/web-platform-test-urltestdata.txt
@@ -1,0 +1,342 @@
+# FORMAT NOT DOCUMENTED YET (parser is urltestparser.js)
+
+# Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/script-tests/segments.js
+http://example\t.\norg http://example.org/foo/bar s:http h:example.org p:/
+http://user:pass@foo:21/bar;par?b#c  s:http u:user pass:pass h:foo port:21 p:/bar;par q:?b f:#c
+http:foo.com  s:http h:example.org p:/foo/foo.com
+\t\s\s\s:foo.com\s\s\s\n  s:http h:example.org p:/foo/:foo.com
+\sfoo.com\s\s  s:http h:example.org p:/foo/foo.com
+a:\t\sfoo.com  s:a p:\sfoo.com
+http://f:21/\sb\s?\sd\s#\se\s  s:http h:f port:21 p:/%20b%20 q:?%20d%20 f:#\se
+http://f:/c  s:http h:f p:/c
+http://f:0/c  s:http h:f port:0 p:/c
+http://f:00000000000000/c  s:http h:f port:0 p:/c
+http://f:00000000000000000000080/c  s:http h:f p:/c
+http://f:b/c
+http://f:\s/c
+http://f:\n/c  s:http h:f p:/c
+http://f:fifty-two/c
+http://f:999999/c  s:http h:f port:999999 p:/c
+http://f:\s21\s/\sb\s?\sd\s#\se\s
+  s:http h:example.org p:/foo/bar
+\s\s\t  s:http h:example.org p:/foo/bar
+:foo.com/  s:http h:example.org p:/foo/:foo.com/
+:foo.com\\  s:http h:example.org p:/foo/:foo.com/
+:  s:http h:example.org p:/foo/:
+:a  s:http h:example.org p:/foo/:a
+:/  s:http h:example.org p:/foo/:/
+:\\  s:http h:example.org p:/foo/:/
+:#  s:http h:example.org p:/foo/: f:#
+\#  s:http h:example.org p:/foo/bar f:#
+\#/  s:http h:example.org p:/foo/bar f:#/
+\#\\  s:http h:example.org p:/foo/bar f:#\\
+\#;?  s:http h:example.org p:/foo/bar f:#;?
+?  s:http h:example.org p:/foo/bar q:?
+/  s:http h:example.org p:/
+:23  s:http h:example.org p:/foo/:23
+/:23  s:http h:example.org p:/:23
+::  s:http h:example.org p:/foo/::
+::23  s:http h:example.org p:/foo/::23
+foo://  s:foo p://
+http://a:b@c:29/d  s:http u:a pass:b h:c port:29 p:/d
+http::@c:29  s:http h:example.org p:/foo/:@c:29
+http://&a:foo(b]c@d:2/  s:http u:&a pass:foo(b]c h:d port:2 p:/
+http://::@c@d:2  s:http pass::%40c h:d port:2 p:/
+http://foo.com:b@d/  s:http u:foo.com pass:b h:d p:/
+http://foo.com/\\@  s:http h:foo.com p://@
+http:\\\\foo.com\\  s:http h:foo.com p:/
+http:\\\\a\\b:c\\d@foo.com\\  s:http h:a p:/b:c/d@foo.com/
+foo:/  s:foo p:/
+foo:/bar.com/  s:foo p:/bar.com/
+foo://///////  s:foo p://///////
+foo://///////bar.com/  s:foo p://///////bar.com/
+foo:////://///  s:foo p:////://///
+c:/foo  s:c p:/foo
+//foo/bar  s:http h:foo p:/bar
+http://foo/path;a??e#f#g  s:http h:foo p:/path;a q:??e f:#f#g
+http://foo/abcd?efgh?ijkl  s:http h:foo p:/abcd q:?efgh?ijkl
+http://foo/abcd#foo?bar  s:http h:foo p:/abcd f:#foo?bar
+[61:24:74]:98  s:http h:example.org p:/foo/[61:24:74]:98
+http:[61:27]/:foo  s:http h:example.org p:/foo/[61:27]/:foo
+http://[1::2]:3:4
+http://2001::1
+http://2001::1]
+http://2001::1]:80
+http://[2001::1]  s:http h:[2001::1] p:/
+http://[2001::1]:80  s:http h:[2001::1] p:/
+http:/example.com/  s:http h:example.org p:/example.com/
+ftp:/example.com/  s:ftp h:example.com p:/
+https:/example.com/  s:https h:example.com p:/
+madeupscheme:/example.com/  s:madeupscheme p:/example.com/
+file:/example.com/  s:file p:/example.com/
+ftps:/example.com/  s:ftps p:/example.com/
+gopher:/example.com/  s:gopher h:example.com p:/
+ws:/example.com/  s:ws h:example.com p:/
+wss:/example.com/  s:wss h:example.com p:/
+data:/example.com/  s:data p:/example.com/
+javascript:/example.com/  s:javascript p:/example.com/
+mailto:/example.com/  s:mailto p:/example.com/
+http:example.com/  s:http h:example.org p:/foo/example.com/
+ftp:example.com/  s:ftp h:example.com p:/
+https:example.com/  s:https h:example.com p:/
+madeupscheme:example.com/  s:madeupscheme p:example.com/
+ftps:example.com/  s:ftps p:example.com/
+gopher:example.com/  s:gopher h:example.com p:/
+ws:example.com/  s:ws h:example.com p:/
+wss:example.com/  s:wss h:example.com p:/
+data:example.com/  s:data p:example.com/
+javascript:example.com/  s:javascript p:example.com/
+mailto:example.com/  s:mailto p:example.com/
+/a/b/c  s:http h:example.org p:/a/b/c
+/a/\s/c  s:http h:example.org p:/a/%20/c
+/a%2fc  s:http h:example.org p:/a%2fc
+/a/%2f/c  s:http h:example.org p:/a/%2f/c
+\#\u03B2  s:http h:example.org p:/foo/bar f:#\u03B2
+data:text/html,test#test  s:data p:text/html,test f:#test
+
+# Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/file.html
+
+# Basic canonicalization, uppercase should be converted to lowercase
+file:c:\\foo\\bar.html file:///tmp/mock/path s:file p:/c:/foo/bar.html
+
+# Spaces should fail
+\s\sFile:c|////foo\\bar.html  s:file p:/c:////foo/bar.html
+
+# This should fail
+C|/foo/bar  s:file p:/C:/foo/bar
+
+# This should fail
+/C|\\foo\\bar  s:file p:/C:/foo/bar
+//C|/foo/bar  s:file p:/C:/foo/bar
+//server/file  s:file h:server p:/file
+\\\\server\\file  s:file h:server p:/file
+/\\server/file  s:file h:server p:/file
+file:///foo/bar.txt  s:file p:/foo/bar.txt
+file:///home/me  s:file p:/home/me
+//  s:file p:/
+///  s:file p:/
+///test  s:file p:/test
+file://test  s:file h:test p:/
+file://localhost  s:file h:localhost p:/
+file://localhost/  s:file h:localhost p:/
+file://localhost/test  s:file h:localhost p:/test
+test  s:file p:/tmp/mock/test
+file:test  s:file p:/tmp/mock/test
+
+# Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/script-tests/path.js
+http://example.com/././foo about:blank s:http h:example.com p:/foo
+http://example.com/./.foo  s:http h:example.com p:/.foo
+http://example.com/foo/.  s:http h:example.com p:/foo/
+http://example.com/foo/./  s:http h:example.com p:/foo/
+http://example.com/foo/bar/..  s:http h:example.com p:/foo/
+http://example.com/foo/bar/../  s:http h:example.com p:/foo/
+http://example.com/foo/..bar  s:http h:example.com p:/foo/..bar
+http://example.com/foo/bar/../ton  s:http h:example.com p:/foo/ton
+http://example.com/foo/bar/../ton/../../a  s:http h:example.com p:/a
+http://example.com/foo/../../..  s:http h:example.com p:/
+http://example.com/foo/../../../ton  s:http h:example.com p:/ton
+http://example.com/foo/%2e  s:http h:example.com p:/foo/
+http://example.com/foo/%2e%2  s:http h:example.com p:/foo/%2e%2
+http://example.com/foo/%2e./%2e%2e/.%2e/%2e.bar  s:http h:example.com p:/%2e.bar
+http://example.com////../..  s:http h:example.com p://
+http://example.com/foo/bar//../..  s:http h:example.com p:/foo/
+http://example.com/foo/bar//..  s:http h:example.com p:/foo/bar/
+http://example.com/foo  s:http h:example.com p:/foo
+http://example.com/%20foo  s:http h:example.com p:/%20foo
+http://example.com/foo%  s:http h:example.com p:/foo%
+http://example.com/foo%2  s:http h:example.com p:/foo%2
+http://example.com/foo%2zbar  s:http h:example.com p:/foo%2zbar
+http://example.com/foo%2\u00C2\u00A9zbar  s:http h:example.com p:/foo%2%C3%82%C2%A9zbar
+http://example.com/foo%41%7a  s:http h:example.com p:/foo%41%7a
+http://example.com/foo\t\u0091%91  s:http h:example.com p:/foo%C2%91%91
+http://example.com/foo%00%51  s:http h:example.com p:/foo%00%51
+http://example.com/(%28:%3A%29)  s:http h:example.com p:/(%28:%3A%29)
+http://example.com/%3A%3a%3C%3c  s:http h:example.com p:/%3A%3a%3C%3c
+http://example.com/foo\tbar  s:http h:example.com p:/foobar
+http://example.com\\\\foo\\\\bar  s:http h:example.com p://foo//bar
+http://example.com/%7Ffp3%3Eju%3Dduvgw%3Dd  s:http h:example.com p:/%7Ffp3%3Eju%3Dduvgw%3Dd
+http://example.com/@asdf%40  s:http h:example.com p:/@asdf%40
+http://example.com/\u4F60\u597D\u4F60\u597D  s:http h:example.com p:/%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD
+http://example.com/\u2025/foo  s:http h:example.com p:/%E2%80%A5/foo
+http://example.com/\uFEFF/foo  s:http h:example.com p:/%EF%BB%BF/foo
+http://example.com/\u202E/foo/\u202D/bar  s:http h:example.com p:/%E2%80%AE/foo/%E2%80%AD/bar
+
+# Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/script-tests/relative.js
+http://www.google.com/foo?bar=baz# about:blank s:http h:www.google.com p:/foo q:?bar=baz f:#
+http://www.google.com/foo?bar=baz#\s\u00BB  s:http h:www.google.com p:/foo q:?bar=baz f:#\s\u00BB
+data:test#\s\u00BB  s:data p:test f:#\s\u00BB
+http://[www.google.com]/
+http://www.google.com  s:http h:www.google.com p:/
+http://192.0x00A80001  s:http h:192.168.0.1 p:/
+http://www/foo%2Ehtml  s:http h:www p:/foo%2Ehtml
+http://www/foo/%2E/html  s:http h:www p:/foo/html
+http://user:pass@/
+http://%25DOMAIN:foobar@foodomain.com/  s:http u:%25DOMAIN pass:foobar h:foodomain.com p:/
+http:\\\\www.google.com\\foo  s:http h:www.google.com p:/foo
+http://foo:80/  s:http h:foo p:/
+http://foo:81/  s:http h:foo port:81 p:/
+httpa://foo:80/  s:httpa p://foo:80/
+http://foo:-80/
+https://foo:443/  s:https h:foo p:/
+https://foo:80/  s:https h:foo port:80 p:/
+ftp://foo:21/  s:ftp h:foo p:/
+ftp://foo:80/  s:ftp h:foo port:80 p:/
+gopher://foo:70/  s:gopher h:foo p:/
+gopher://foo:443/  s:gopher h:foo port:443 p:/
+ws://foo:80/  s:ws h:foo p:/
+ws://foo:81/  s:ws h:foo port:81 p:/
+ws://foo:443/  s:ws h:foo port:443 p:/
+ws://foo:815/  s:ws h:foo port:815 p:/
+wss://foo:80/  s:wss h:foo port:80 p:/
+wss://foo:81/  s:wss h:foo port:81 p:/
+wss://foo:443/  s:wss h:foo p:/
+wss://foo:815/  s:wss h:foo port:815 p:/
+http:/example.com/  s:http h:example.com p:/
+ftp:/example.com/  s:ftp h:example.com p:/
+https:/example.com/  s:https h:example.com p:/
+madeupscheme:/example.com/  s:madeupscheme p:/example.com/
+file:/example.com/  s:file p:/example.com/
+ftps:/example.com/  s:ftps p:/example.com/
+gopher:/example.com/  s:gopher h:example.com p:/
+ws:/example.com/  s:ws h:example.com p:/
+wss:/example.com/  s:wss h:example.com p:/
+data:/example.com/  s:data p:/example.com/
+javascript:/example.com/  s:javascript p:/example.com/
+mailto:/example.com/  s:mailto p:/example.com/
+http:example.com/  s:http h:example.com p:/
+ftp:example.com/  s:ftp h:example.com p:/
+https:example.com/  s:https h:example.com p:/
+madeupscheme:example.com/  s:madeupscheme p:example.com/
+ftps:example.com/  s:ftps p:example.com/
+gopher:example.com/  s:gopher h:example.com p:/
+ws:example.com/  s:ws h:example.com p:/
+wss:example.com/  s:wss h:example.com p:/
+data:example.com/  s:data p:example.com/
+javascript:example.com/  s:javascript p:example.com/
+mailto:example.com/  s:mailto p:example.com/
+
+# Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/segments-userinfo-vs-host.html
+http:@www.example.com about:blank s:http h:www.example.com p:/
+http:/@www.example.com  s:http h:www.example.com p:/
+http://@www.example.com  s:http h:www.example.com p:/
+http:a:b@www.example.com  s:http u:a pass:b h:www.example.com p:/
+http:/a:b@www.example.com  s:http u:a pass:b h:www.example.com p:/
+http://a:b@www.example.com  s:http u:a pass:b h:www.example.com p:/
+http://@pple.com  s:http h:pple.com p:/
+http::b@www.example.com  s:http pass:b h:www.example.com p:/
+http:/:b@www.example.com  s:http pass:b h:www.example.com p:/
+http://:b@www.example.com  s:http pass:b h:www.example.com p:/
+http:/:@/www.example.com
+http://user@/www.example.com
+http:@/www.example.com
+http:/@/www.example.com
+http://@/www.example.com
+https:@/www.example.com
+http:a:b@/www.example.com
+http:/a:b@/www.example.com
+http://a:b@/www.example.com
+http::@/www.example.com
+http:a:@www.example.com  s:http u:a pass: h:www.example.com p:/
+http:/a:@www.example.com  s:http u:a pass: h:www.example.com p:/
+http://a:@www.example.com  s:http u:a pass: h:www.example.com p:/
+http://www.@pple.com  s:http u:www. h:pple.com p:/
+http:@:www.example.com
+http:/@:www.example.com
+http://@:www.example.com
+http://:@www.example.com  s:http pass: h:www.example.com p:/
+
+#Others
+/ http://www.example.com/test s:http h:www.example.com p:/
+/test.txt  s:http h:www.example.com p:/test.txt
+.  s:http h:www.example.com p:/
+..  s:http h:www.example.com p:/
+test.txt  s:http h:www.example.com p:/test.txt
+./test.txt  s:http h:www.example.com p:/test.txt
+../test.txt  s:http h:www.example.com p:/test.txt
+../aaa/test.txt  s:http h:www.example.com p:/aaa/test.txt
+../../test.txt  s:http h:www.example.com p:/test.txt
+\u4E2D/test.txt  s:http h:www.example.com p:/%E4%B8%AD/test.txt
+http://www.example2.com  s:http h:www.example2.com p:/
+//www.example2.com  s:http h:www.example2.com p:/
+
+# Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/host.html
+
+# Basic canonicalization, uppercase should be converted to lowercase
+http://ExAmPlE.CoM http://other.com/ s:http p:/ h:example.com
+
+# Spaces should fail
+http://example\sexample.com
+
+# This should fail
+http://Goo%20\sgoo%7C|.com
+
+# U+3000 is mapped to U+0020 (space) which is disallowed
+http://GOO\u00a0\u3000goo.com
+
+# Other types of space (no-break, zero-width, zero-width-no-break) are
+# name-prepped away to nothing.
+# U+200B, U+2060, and U+FEFF, are ignored
+http://GOO\u200b\u2060\ufeffgoo.com  s:http p:/ h:googoo.com
+
+# Ideographic full stop (full-width period for Chinese, etc.) should be
+# treated as a dot.
+# U+3002 is mapped to U+002E (dot)
+http://www.foo\u3002bar.com  s:http p:/ h:www.foo.bar.com
+
+# Invalid unicode characters should fail...
+# U+FDD0 is disallowed; %ef%b7%90 is U+FDD0
+http://\ufdd0zyx.com
+
+# ...This is the same as previous but escaped.
+http://%ef%b7%90zyx.com
+
+# Test name prepping, fullwidth input should be converted to ASCII and NOT
+# IDN-ized. This is "Go" in fullwidth UTF-8/UTF-16.
+http://\uff27\uff4f.com  s:http p:/ h:go.com
+
+# URL spec forbids the following.
+# https://www.w3.org/Bugs/Public/show_bug.cgi?id=24257
+http://\uff05\uff14\uff11.com
+http://%ef%bc%85%ef%bc%94%ef%bc%91.com
+
+# ...%00 in fullwidth should fail (also as escaped UTF-8 input)
+http://\uff05\uff10\uff10.com
+http://%ef%bc%85%ef%bc%90%ef%bc%90.com
+
+# Basic IDN support, UTF-8 and UTF-16 input should be converted to IDN
+http://\u4f60\u597d\u4f60\u597d  s:http p:/ h:xn--6qqa088eba
+
+# Invalid escaped characters should fail and the percents should be
+# escaped. https://www.w3.org/Bugs/Public/show_bug.cgi?id=24191
+http://%zz%66%a.com
+
+# If we get an invalid character that has been escaped.
+http://%25
+http://hello%00
+
+# Escaped numbers should be treated like IP addresses if they are.
+# No special handling for IPv4 or IPv4-like URLs
+http://%30%78%63%30%2e%30%32%35%30.01  s:http p:/ h:192.168.0.1
+http://%30%78%63%30%2e%30%32%35%30.01%2e  s:http p:/ h:0xc0.0250.01.
+http://192.168.0.257
+
+# Invalid escaping should trigger the regular host error handling.
+http://%3g%78%63%30%2e%30%32%35%30%2E.01
+
+# Something that isn't exactly an IP should get treated as a host and
+# spaces escaped.
+http://192.168.0.1\shello
+
+# Fullwidth and escaped UTF-8 fullwidth should still be treated as IP.
+# These are "0Xc0.0250.01" in fullwidth.
+http://\uff10\uff38\uff43\uff10\uff0e\uff10\uff12\uff15\uff10\uff0e\uff10\uff11  s:http p:/ h:192.168.0.1
+
+# Broken IPv6
+http://[google.com]
+
+# Misc Unicode
+http://foo:\uD83D\uDCA9@example.com/bar  s:http h:example.com p:/bar u:foo pass:%F0%9F%92%A9
+
+# resolving a relative reference against an unknown scheme results in an error
+x test:test
+

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <!-- Compilation -->
     <java.version>1.7</java.version>
-    <okio.version>1.3.0</okio.version>
+    <okio.version>1.4.0-SNAPSHOT</okio.version>
     <!-- ALPN library targeted to Java 7 -->
     <alpn.jdk7.version>7.1.2.v20141202</alpn.jdk7.version>
     <!-- ALPN library targeted to Java 8 update 25. -->


### PR DESCRIPTION
This imports results from a few major browsers so we don't waste time
trying to pass tests that we shouldn't necessarily pass.