### PR TITLE
Do IPv6 parsing natively.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/WebPlatformUrlTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/WebPlatformUrlTest.java
@@ -59,46 +59,37 @@ public final class WebPlatformUrlTest {
       "Parsing: <http://f:999999/c> against <http://example.org/foo/bar>",
       "Parsing: <#β> against <http://example.org/foo/bar>",
       "Parsing: <http://www.google.com/foo?bar=baz# »> against <about:blank>",
-      "Parsing: <http://[www.google.com]/> against <about:blank>",
       "Parsing: <http://192.0x00A80001> against <about:blank>",
-      "Parsing: <http://user:pass@/> against <about:blank>",
-      "Parsing: <http:/:@/www.example.com> against <about:blank>",
+      // This test fails on Java 7 but passes on Java 8. See HttpUrlTest.hostWithTrailingDot().
       "Parsing: <http://%30%78%63%30%2e%30%32%35%30.01%2e> against <http://other.com/>",
-      "Parsing: <http://user@/www.example.com> against <about:blank>",
-      "Parsing: <http:@/www.example.com> against <about:blank>",
-      "Parsing: <http:/@/www.example.com> against <about:blank>",
-      "Parsing: <http://@/www.example.com> against <about:blank>",
-      "Parsing: <https:@/www.example.com> against <about:blank>",
-      "Parsing: <http:a:b@/www.example.com> against <about:blank>",
-      "Parsing: <http:/a:b@/www.example.com> against <about:blank>",
-      "Parsing: <http://a:b@/www.example.com> against <about:blank>",
-      "Parsing: <http::@/www.example.com> against <about:blank>",
       "Parsing: <http://%30%78%63%30%2e%30%32%35%30.01> against <http://other.com/>",
       "Parsing: <http://192.168.0.257> against <http://other.com/>",
       "Parsing: <http://０Ｘｃ０．０２５０．０１> against <http://other.com/>",
       "Parsing: <http://[2001::1]> against <http://example.org/foo/bar>",
-      "Parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>",
-      "Parsing: <http://[google.com]> against <http://other.com/>"
+      "Parsing: <http://[2001::1]:80> against <http://example.org/foo/bar>"
   );
 
   /** Test how {@link HttpUrl} does against the web platform test suite. */
   @Test public void httpUrl() throws Exception {
     if (!testData.scheme.isEmpty() && !HTTP_URL_SCHEMES.contains(testData.scheme)) {
-      System.out.println("Ignoring unsupported scheme " + testData.scheme);
+      System.err.println("Ignoring unsupported scheme " + testData.scheme);
       return;
     }
     if (!testData.base.startsWith("https:")
         && !testData.base.startsWith("http:")
         && !testData.base.equals("about:blank")) {
-      System.out.println("Ignoring unsupported base " + testData.base);
+      System.err.println("Ignoring unsupported base " + testData.base);
       return;
     }
 
     try {
       testHttpUrl();
+      if (KNOWN_FAILURES.contains(testData.toString())) {
+        System.err.println("Expected failure but was success: " + testData);
+      }
     } catch (Throwable e) {
       if (KNOWN_FAILURES.contains(testData.toString())) {
-        System.out.println("Ignoring known failure: " + testData);
+        System.err.println("Ignoring known failure: " + testData);
         e.printStackTrace();
       } else {
         throw e;

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -736,17 +737,118 @@ public final class HttpUrl {
       return idnDecoded;
     }
 
+    /** Decodes an IPv6 address like 1111:2222:3333:4444:5555:6666:7777:8888 or ::1. */
     private static InetAddress decodeIpv6(String input, int pos, int limit) {
-      try {
-        return InetAddress.getByName(input.substring(pos, limit));
-      } catch (UnknownHostException e) {
-        return null;
+      byte[] address = new byte[16];
+      int b = 0;
+      int compress = -1;
+      int groupOffset = -1;
+
+      for (int i = pos; i < limit; ) {
+        if (b == address.length) return null; // Too many groups.
+
+        // Read a delimiter.
+        if (i + 2 <= limit && input.regionMatches(i, "::", 0, 2)) {
+          // Compression "::" delimiter, which is anywhere in the input, including its prefix.
+          if (compress != -1) return null; // Multiple "::" delimiters.
+          i += 2;
+          b += 2;
+          compress = b;
+          if (i == limit) break;
+        } else if (b != 0) {
+          // Group separator ":" delimiter.
+          if (input.regionMatches(i, ":", 0, 1)) {
+            i++;
+          } else if (input.regionMatches(i, ".", 0, 1)) {
+            // If we see a '.', rewind to the beginning of the previous group and parse as IPv4.
+            if (!decodeIpv4Suffix(input, groupOffset, limit, address, b - 2)) return null;
+            b += 2; // We rewound two bytes and then added four.
+            break;
+          } else {
+            return null; // Wrong delimiter.
+          }
+        }
+
+        // Read a group, one to four hex digits.
+        int value = 0;
+        groupOffset = i;
+        for (; i < limit; i++) {
+          char c = input.charAt(i);
+          int hexDigit = decodeHexDigit(c);
+          if (hexDigit == -1) break;
+          value = (value << 4) + hexDigit;
+        }
+        int groupLength = i - groupOffset;
+        if (groupLength == 0 || groupLength > 4) return null; // Group is the wrong size.
+
+        // We've successfully read a group. Assign its value to our byte array.
+        address[b++] = (byte) ((value >>> 8) & 0xff);
+        address[b++] = (byte) (value & 0xff);
       }
+
+      // All done. If compression happened, we need to move bytes to the right place in the
+      // address. Here's a sample:
+      //
+      //      input: "1111:2222:3333::7777:8888"
+      //     before: { 11, 11, 22, 22, 33, 33, 00, 00, 77, 77, 88, 88, 00, 00, 00, 00  }
+      //   compress: 6
+      //          b: 10
+      //      after: { 11, 11, 22, 22, 33, 33, 00, 00, 00, 00, 00, 00, 77, 77, 88, 88 }
+      //
+      if (b != address.length) {
+        if (compress == -1) return null; // Address didn't have compression or enough groups.
+        System.arraycopy(address, compress, address, address.length - (b - compress), b - compress);
+        Arrays.fill(address, compress, compress + (address.length - b), (byte) 0);
+      }
+
+      try {
+        return InetAddress.getByAddress(address);
+      } catch (UnknownHostException e) {
+        throw new AssertionError();
+      }
+    }
+
+    /** Decodes an IPv4 address suffix of an IPv6 address, like 1111::5555:6666:192.168.0.1. */
+    private static boolean decodeIpv4Suffix(
+        String input, int pos, int limit, byte[] address, int addressOffset) {
+      int b = addressOffset;
+
+      for (int i = pos; i < limit; ) {
+        if (b == address.length) return false; // Too many groups.
+
+        // Read a delimiter.
+        if (b != addressOffset) {
+          if (input.charAt(i) != '.') return false; // Wrong delimiter.
+          i++;
+        }
+
+        // Read 1 or more decimal digits for a value in 0..255.
+        int value = 0;
+        int groupOffset = i;
+        for (; i < limit; i++) {
+          char c = input.charAt(i);
+          if (c < '0' || c > '9') break;
+          if (value == 0 && groupOffset != i) return false; // Reject unnecessary leading '0's.
+          value = (value * 10) + c - '0';
+          if (value > 255) return false; // Value out of range.
+        }
+        int groupLength = i - groupOffset;
+        if (groupLength == 0) return false; // No digits.
+
+        // We've successfully read a byte.
+        address[b++] = (byte) value;
+      }
+
+      if (b != addressOffset + 4) return false; // Too few groups. We wanted exactly four.
+      return true; // Success.
     }
 
     private static String domainToAscii(String input) {
       try {
-        return IDN.toASCII(input).toLowerCase(Locale.US);
+        String result = IDN.toASCII(input).toLowerCase(Locale.US);
+        if (result.isEmpty()) return null;
+        // TODO: implement all label limits.
+        return result;
       } catch (IllegalArgumentException e) {
         return null;
       }


### PR DESCRIPTION
Avoid any risk of doing DNS during HTTP URL parsing.

Closes https://github.com/square/okhttp/issues/1613