### PR TITLE
Adds upgrade failed callback to web sockets

### DIFF
--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/AutobahnTester.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/AutobahnTester.java
@@ -29,6 +29,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import okio.Buffer;
 import okio.BufferedSource;
 
+import static com.squareup.okhttp.ws.WebSocket.UpgradeFailureReason;
+
 /**
  * Exercises the web socket implementation against the
  * <a href="http://autobahn.ws/testsuite/">Autobahn Testsuite</a>.
@@ -103,6 +105,10 @@ public final class AutobahnTester {
           @Override public void onFailure(IOException e) {
             latch.countDown();
           }
+
+          @Override public void onUpgradeFailed(UpgradeFailureReason reason, Request request,
+              Response response) {
+          }
         });
     try {
       if (!latch.await(10, TimeUnit.SECONDS)) {
@@ -139,6 +145,10 @@ public final class AutobahnTester {
         failureRef.set(e);
         latch.countDown();
       }
+
+      @Override
+      public void onUpgradeFailed(UpgradeFailureReason reason, Request request, Response response) {
+      }
     });
     try {
       if (!latch.await(10, TimeUnit.SECONDS)) {
@@ -174,6 +184,10 @@ public final class AutobahnTester {
 
       @Override public void onFailure(IOException e) {
         latch.countDown();
+      }
+
+      @Override
+      public void onUpgradeFailed(UpgradeFailureReason reason, Request request, Response response) {
       }
     });
     try {

--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/WebSocketCallTest.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/WebSocketCallTest.java
@@ -34,6 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.squareup.okhttp.ws.WebSocket.PayloadType.TEXT;
+import static com.squareup.okhttp.ws.WebSocket.UpgradeFailureReason;
 
 public final class WebSocketCallTest {
   @Rule public final MockWebServerRule server = new MockWebServerRule();
@@ -109,22 +110,24 @@ public final class WebSocketCallTest {
   @Test public void okButNotOk() {
     server.enqueue(new MockResponse());
     awaitWebSocket();
+    listener.assertUpgradeFailure(UpgradeFailureReason.INVALID_RESPONSE_CODE, 200);
     listener.assertFailure(ProtocolException.class, "Expected HTTP 101 response but was '200 OK'");
   }
 
   @Test public void notFound() {
     server.enqueue(new MockResponse().setStatus("HTTP/1.1 404 Not Found"));
     awaitWebSocket();
+    listener.assertUpgradeFailure(UpgradeFailureReason.INVALID_RESPONSE_CODE, 404);
     listener.assertFailure(ProtocolException.class,
         "Expected HTTP 101 response but was '404 Not Found'");
   }
 
   @Test public void missingConnectionHeader() {
-    server.enqueue(new MockResponse()
-        .setResponseCode(101)
+    server.enqueue(new MockResponse().setResponseCode(101)
         .setHeader("Upgrade", "websocket")
         .setHeader("Sec-WebSocket-Accept", "ujmZX4KXZqjwy6vi1aQFH5p4Ygk="));
     awaitWebSocket();
+    listener.assertUpgradeFailure(UpgradeFailureReason.INVALID_UPGRADE_HEADERS, 101);
     listener.assertFailure(ProtocolException.class,
         "Expected 'Connection' header value 'Upgrade' but was 'null'");
   }
@@ -135,48 +138,49 @@ public final class WebSocketCallTest {
         .setHeader("Connection", "Downgrade")
         .setHeader("Sec-WebSocket-Accept", "ujmZX4KXZqjwy6vi1aQFH5p4Ygk="));
     awaitWebSocket();
+    listener.assertUpgradeFailure(UpgradeFailureReason.INVALID_UPGRADE_HEADERS, 101);
     listener.assertFailure(ProtocolException.class,
         "Expected 'Connection' header value 'Upgrade' but was 'Downgrade'");
   }
 
   @Test public void missingUpgradeHeader() {
-    server.enqueue(new MockResponse()
-        .setResponseCode(101)
+    server.enqueue(new MockResponse().setResponseCode(101)
         .setHeader("Connection", "Upgrade")
         .setHeader("Sec-WebSocket-Accept", "ujmZX4KXZqjwy6vi1aQFH5p4Ygk="));
     awaitWebSocket();
+    listener.assertUpgradeFailure(UpgradeFailureReason.INVALID_UPGRADE_HEADERS, 101);
     listener.assertFailure(ProtocolException.class,
         "Expected 'Upgrade' header value 'websocket' but was 'null'");
   }
 
   @Test public void wrongUpgradeHeader() {
-    server.enqueue(new MockResponse()
-        .setResponseCode(101)
+    server.enqueue(new MockResponse().setResponseCode(101)
         .setHeader("Connection", "Upgrade")
         .setHeader("Upgrade", "Pepsi")
         .setHeader("Sec-WebSocket-Accept", "ujmZX4KXZqjwy6vi1aQFH5p4Ygk="));
     awaitWebSocket();
+    listener.assertUpgradeFailure(UpgradeFailureReason.INVALID_UPGRADE_HEADERS, 101);
     listener.assertFailure(ProtocolException.class,
         "Expected 'Upgrade' header value 'websocket' but was 'Pepsi'");
   }
 
   @Test public void missingMagicHeader() {
-    server.enqueue(new MockResponse()
-        .setResponseCode(101)
+    server.enqueue(new MockResponse().setResponseCode(101)
         .setHeader("Connection", "Upgrade")
         .setHeader("Upgrade", "websocket"));
     awaitWebSocket();
+    listener.assertUpgradeFailure(UpgradeFailureReason.INVALID_SEC_ACCEPT_HASH, 101);
     listener.assertFailure(ProtocolException.class,
         "Expected 'Sec-WebSocket-Accept' header value 'ujmZX4KXZqjwy6vi1aQFH5p4Ygk=' but was 'null'");
   }
 
   @Test public void wrongMagicHeader() {
-    server.enqueue(new MockResponse()
-        .setResponseCode(101)
+    server.enqueue(new MockResponse().setResponseCode(101)
         .setHeader("Connection", "Upgrade")
         .setHeader("Upgrade", "websocket")
         .setHeader("Sec-WebSocket-Accept", "magic"));
     awaitWebSocket();
+    listener.assertUpgradeFailure(UpgradeFailureReason.INVALID_SEC_ACCEPT_HASH, 101);
     listener.assertFailure(ProtocolException.class,
         "Expected 'Sec-WebSocket-Accept' header value 'ujmZX4KXZqjwy6vi1aQFH5p4Ygk=' but was 'magic'");
   }
@@ -215,6 +219,12 @@ public final class WebSocketCallTest {
         failureRef.set(e);
         latch.countDown();
       }
+
+      @Override
+      public void onUpgradeFailed(UpgradeFailureReason reason, Request request, Response response)
+          throws IOException {
+        listener.onUpgradeFailed(reason, request, response);
+      }
     });
 
     try {
@@ -244,6 +254,11 @@ public final class WebSocketCallTest {
     }
 
     @Override public void onFailure(IOException e) {
+    }
+
+    @Override
+    public void onUpgradeFailed(UpgradeFailureReason reason, Request request, Response response)
+        throws IOException {
     }
   }
 }

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocket.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocket.java
@@ -29,6 +29,28 @@ public interface WebSocket {
     BINARY
   }
 
+  /** Describes why the Http request failed to upgrade to a web socket. */
+  enum UpgradeFailureReason {
+    /** The http response code was not 101 - https://tools.ietf.org/html/rfc6455#section-4.1. */
+    INVALID_RESPONSE_CODE,
+    /** The http [Connection:Upgrade] or [Upgrade:websocket] headers were missing or invalid. */
+    INVALID_UPGRADE_HEADERS,
+    /** The 'Sec-WebSocket-Accept' hash did not match the client hash. */
+    INVALID_SEC_ACCEPT_HASH;
+
+    @Override public String toString() {
+      switch (this) {
+        case INVALID_RESPONSE_CODE:
+          return "Invalid response code";
+        case INVALID_UPGRADE_HEADERS:
+          return "Invalid upgrade headers";
+        case INVALID_SEC_ACCEPT_HASH:
+          return "Invalid Sec-Accept-Hash";
+      }
+      return null;
+    }
+  }
+
   /**
    * Stream a message payload to the server of the specified {code type}.
    * <p>

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
@@ -40,6 +40,10 @@ import okio.ByteString;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import static com.squareup.okhttp.ws.WebSocket.UpgradeFailureReason.INVALID_RESPONSE_CODE;
+import static com.squareup.okhttp.ws.WebSocket.UpgradeFailureReason.INVALID_UPGRADE_HEADERS;
+import static com.squareup.okhttp.ws.WebSocket.UpgradeFailureReason.INVALID_SEC_ACCEPT_HASH;
+
 public final class WebSocketCall {
   /**
    * Prepares the {@code request} to create a web socket at some point in the future.
@@ -138,6 +142,7 @@ public final class WebSocketCall {
     if (response.code() != 101) {
       // TODO call.engine.releaseConnection();
       Internal.instance.callEngineReleaseConnection(call);
+      listener.onUpgradeFailed(INVALID_RESPONSE_CODE, request, response);
       throw new ProtocolException("Expected HTTP 101 response but was '"
           + response.code()
           + " "
@@ -147,17 +152,20 @@ public final class WebSocketCall {
 
     String headerConnection = response.header("Connection");
     if (!"Upgrade".equalsIgnoreCase(headerConnection)) {
+      listener.onUpgradeFailed(INVALID_UPGRADE_HEADERS, request, response);
       throw new ProtocolException(
           "Expected 'Connection' header value 'Upgrade' but was '" + headerConnection + "'");
     }
     String headerUpgrade = response.header("Upgrade");
     if (!"websocket".equalsIgnoreCase(headerUpgrade)) {
+      listener.onUpgradeFailed(INVALID_UPGRADE_HEADERS, request, response);
       throw new ProtocolException(
           "Expected 'Upgrade' header value 'websocket' but was '" + headerUpgrade + "'");
     }
     String headerAccept = response.header("Sec-WebSocket-Accept");
     String acceptExpected = Util.shaBase64(key + WebSocketProtocol.ACCEPT_MAGIC);
     if (!acceptExpected.equals(headerAccept)) {
+      listener.onUpgradeFailed(INVALID_SEC_ACCEPT_HASH, request, response);
       throw new ProtocolException("Expected 'Sec-WebSocket-Accept' header value '"
           + acceptExpected
           + "' but was '"

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketListener.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketListener.java
@@ -22,6 +22,7 @@ import okio.Buffer;
 import okio.BufferedSource;
 
 import static com.squareup.okhttp.ws.WebSocket.PayloadType;
+import static com.squareup.okhttp.ws.WebSocket.UpgradeFailureReason;
 
 /** Listener for server-initiated messages on a connected {@link WebSocket}. */
 public interface WebSocketListener {
@@ -56,4 +57,21 @@ public interface WebSocketListener {
 
   /** Called when the transport or protocol layer of this web socket errors during communication. */
   void onFailure(IOException e);
+
+  /**
+   * Called when the WebSocket upgrade failed. This could be for one the following reasons:
+   * <ul>
+   * <li>The pre-upgrade http request returned a non-101 status code
+   * <li>The upgrade headers were missing from the http response
+   * </ul>
+   *
+   * <p>{@link WebSocketListener#onFailure(IOException)} will be called after with a
+   * {@link java.net.ProtocolException}.
+   *
+   * @param failureReason The reason the upgrade from http to web socket failed.
+   * @param request The request object used to create the web socket connection.
+   * @param response The response object returned from the server.
+   */
+  void onUpgradeFailed(UpgradeFailureReason failureReason, Request request, Response response)
+      throws IOException;
 }

--- a/samples/guide/src/main/java/com/squareup/okhttp/recipes/WebSocketEcho.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/recipes/WebSocketEcho.java
@@ -13,14 +13,13 @@ import okio.BufferedSource;
 import static com.squareup.okhttp.ws.WebSocket.PayloadType;
 import static com.squareup.okhttp.ws.WebSocket.PayloadType.BINARY;
 import static com.squareup.okhttp.ws.WebSocket.PayloadType.TEXT;
+import static com.squareup.okhttp.ws.WebSocket.UpgradeFailureReason;
 
 public final class WebSocketEcho implements WebSocketListener {
   private void run() throws IOException {
     OkHttpClient client = new OkHttpClient();
 
-    Request request = new Request.Builder()
-        .url("ws://echo.websocket.org")
-        .build();
+    Request request = new Request.Builder().url("ws://echo.websocket.org").build();
     WebSocketCall.create(client, request).enqueue(this);
 
     // Trigger shutdown of the dispatcher's executor so this process can exit cleanly.
@@ -59,6 +58,11 @@ public final class WebSocketEcho implements WebSocketListener {
 
   @Override public void onFailure(IOException e) {
     e.printStackTrace();
+  }
+
+  @Override
+  public void onUpgradeFailed(UpgradeFailureReason reason, Request request, Response response) {
+    System.out.println("UPGRADE FAILED: [" + reason + "] with response code: " + response.code());
   }
 
   public static void main(String... args) throws IOException {


### PR DESCRIPTION
This, or some variant of it, is necessary for a consumer of the API can deal with non-101 http status codes from the server via [RFC2616](https://tools.ietf.org/html/rfc2616) (also specified in the WebSocket specs [RFC6455 Section 4.1](https://tools.ietf.org/html/rfc6455#section-4.1))

An alternative implementation might be to augment `onFailure()` to supply the `Response` and `Reason`, but this approach makes the upgrade path explicit. 

commit 8ce30f297f81c19d44ff0de2f7d31c3c07cdb0c8
Author: Peter Werry <pwerry@gmail.com>
Date:   Tue May 12 12:01:49 2015 +0100

    Update websocket tests for new onUpgradeFailed() callback

commit bd4db0ced6ad1944bbc111b23a2a7ff9dbb2085d
Author: Peter Werry <pwerry@gmail.com>
Date:   Sat May 9 14:57:33 2015 +0100

    Adds onUpgradeFailed() WebSocketListener callback