### PR TITLE
Make matching of TlsVersion optionally stricter

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -1737,8 +1737,9 @@ public final class CallTest {
    * {@link com.squareup.okhttp.FallbackTestClientSocketFactory} for details.
    */
   private static void suppressTlsFallbackScsv(OkHttpClient client) {
+    TlsVersion[] enabledProtocols = { TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0 };
     FallbackTestClientSocketFactory clientSocketFactory =
-        new FallbackTestClientSocketFactory(sslContext.getSocketFactory());
+        new FallbackTestClientSocketFactory(sslContext.getSocketFactory(), enabledProtocols);
     client.setSslSocketFactory(clientSocketFactory);
   }
 }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -605,7 +605,8 @@ public final class URLConnectionTest {
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.FAIL_HANDSHAKE));
     server.enqueue(new MockResponse().setBody("this response comes via SSL"));
 
-    suppressTlsFallbackScsv(client.client());
+    installTestClientSocketFactory(client.client(),
+        TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0);
     client.client().setHostnameVerifier(new RecordingHostnameVerifier());
     connection = client.open(server.getUrl("/foo"));
 
@@ -621,7 +622,8 @@ public final class URLConnectionTest {
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.FAIL_HANDSHAKE));
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.FAIL_HANDSHAKE));
 
-    suppressTlsFallbackScsv(client.client());
+    installTestClientSocketFactory(client.client(),
+        TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0);
     Internal.instance.setNetwork(client.client(), new SingleInetAddressNetwork());
 
     client.client().setHostnameVerifier(new RecordingHostnameVerifier());
@@ -632,6 +634,34 @@ public final class URLConnectionTest {
       fail();
     } catch (IOException expected) {
       assertEquals(1, expected.getSuppressed().length);
+    }
+  }
+
+  @Test public void firstConnectionSpecAvoidedWhenPrimaryTlsVersionNotSupported() throws Exception {
+    server.get().useHttps(sslContext.getSocketFactory(), false);
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.FAIL_HANDSHAKE));
+    server.enqueue(new MockResponse().setBody("this request should not happen"));
+
+    ConnectionSpec requireTlsV11 = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+        .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_1)
+        .requireFirstTlsVersion(true)
+        .build();
+    ConnectionSpec requireTlsV10 = new ConnectionSpec.Builder(requireTlsV11)
+        .tlsVersions(TlsVersion.TLS_1_1)
+        .build();
+    client.client().setConnectionSpecs(Arrays.asList(requireTlsV11, requireTlsV10));
+
+    // Ensure the client socket enables one protocol. Only one connection attempt should be made
+    // because the first connection spec should be skipped.
+    installTestClientSocketFactory(client.client(), TlsVersion.TLS_1_1, TlsVersion.TLS_1_0);
+    client.client().setHostnameVerifier(new RecordingHostnameVerifier());
+    Internal.instance.setNetwork(client.client(), new SingleInetAddressNetwork());
+
+    connection = client.open(server.getUrl("/foo"));
+    try {
+      connection.getResponseCode();
+      fail();
+    } catch (IOException expected) {
     }
   }
 
@@ -648,7 +678,7 @@ public final class URLConnectionTest {
         .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END));
     server.enqueue(new MockResponse().setBody("def"));
 
-    suppressTlsFallbackScsv(client.client());
+    installTestClientSocketFactory(client.client(),  TlsVersion.TLS_1_2, TlsVersion.TLS_1_1);
     client.client().setHostnameVerifier(new RecordingHostnameVerifier());
 
     assertContent("abc", client.open(server.getUrl("/")));
@@ -3279,9 +3309,10 @@ public final class URLConnectionTest {
    * TLS_FALLBACK_SCSV cipher on fallback connections. See
    * {@link com.squareup.okhttp.FallbackTestClientSocketFactory} for details.
    */
-  private static void suppressTlsFallbackScsv(OkHttpClient client) {
+  private static void installTestClientSocketFactory(OkHttpClient client,
+      TlsVersion... enabledProtocols) {
     FallbackTestClientSocketFactory clientSocketFactory =
-        new FallbackTestClientSocketFactory(sslContext.getSocketFactory());
+        new FallbackTestClientSocketFactory(sslContext.getSocketFactory(), enabledProtocols);
     client.setSslSocketFactory(clientSocketFactory);
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/ConnectionSpec.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ConnectionSpec.java
@@ -78,6 +78,12 @@ public final class ConnectionSpec {
   /** Used if tls == true. The TLS protocol versions to use. */
   private final String[] tlsVersions;
 
+  /**
+   * Used if tls == true. Whether the first tlsVersion must be enabled for
+   * {@link #isCompatible(javax.net.ssl.SSLSocket)} to return true.
+   */
+  private final boolean requireFirstTlsVersion;
+
   final boolean supportsTlsExtensions;
 
   private ConnectionSpec(Builder builder) {
@@ -85,6 +91,7 @@ public final class ConnectionSpec {
     this.cipherSuites = builder.cipherSuites;
     this.tlsVersions = builder.tlsVersions;
     this.supportsTlsExtensions = builder.supportsTlsExtensions;
+    this.requireFirstTlsVersion = builder.requireFirstTlsVersion;
   }
 
   public boolean isTls() {
@@ -188,6 +195,9 @@ public final class ConnectionSpec {
     }
 
     String[] enabledProtocols = socket.getEnabledProtocols();
+    if (requireFirstTlsVersion && !contains(enabledProtocols, tlsVersions[0])) {
+      return false;
+    }
     boolean requiredProtocolsEnabled = nonEmptyIntersection(tlsVersions, enabledProtocols);
     if (!requiredProtocolsEnabled) {
       return false;
@@ -273,6 +283,7 @@ public final class ConnectionSpec {
     private String[] cipherSuites;
     private String[] tlsVersions;
     private boolean supportsTlsExtensions;
+    private boolean requireFirstTlsVersion;
 
     Builder(boolean tls) {
       this.tls = tls;
@@ -283,6 +294,7 @@ public final class ConnectionSpec {
       this.cipherSuites = connectionSpec.cipherSuites;
       this.tlsVersions = connectionSpec.tlsVersions;
       this.supportsTlsExtensions = connectionSpec.supportsTlsExtensions;
+      this.requireFirstTlsVersion = connectionSpec.requireFirstTlsVersion;
     }
 
     public Builder cipherSuites(CipherSuite... cipherSuites) {
@@ -335,6 +347,11 @@ public final class ConnectionSpec {
         this.tlsVersions = tlsVersions.clone();
       }
 
+      return this;
+    }
+
+    public Builder requireFirstTlsVersion(boolean requireFirstTlsVersion) {
+      this.requireFirstTlsVersion = requireFirstTlsVersion;
       return this;
     }
 


### PR DESCRIPTION
On Android there are 4 connection specs configured:
1) TLSv1.2, TLSv1.1, TLSv1.0, SSLv3
2) TLSv1.1, TLSv1.0, SSLv3
3) TLSv1.0, SSLv3
4) SSLv3

(Typically spec 4 is not tried because SSLv3 is not
enabled by default).

If only TLSv1.0 is enabled then OkHttp will
attempt 3 connections (1, 2 and 3 above), with exactly
the same enabled protocols enabled (just TLSv1.0).

This change adds an addition restriction: the first
protocol listed *must* be supported for the connection
negotiation to be attempted so only spec 3 would be
attempted after this change.

Note, this does not change default behavior.

OkHttp by default tries twice (MODERN_TLS + COMPATIBLE_TLS).
If only TLSv1.0 is enabled: it will still try to connect
twice with TLSv1.0.