### PR TITLE
Accept ws: URLs in Request.Builder.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -499,11 +499,13 @@ public final class MockWebServer {
           throw new ProtocolException("unexpected data");
         }
 
+        boolean reuseSocket = true;
         boolean requestWantsWebSockets = "Upgrade".equalsIgnoreCase(request.getHeader("Connection"))
             && "websocket".equalsIgnoreCase(request.getHeader("Upgrade"));
         boolean responseWantsWebSockets = response.getWebSocketListener() != null;
         if (requestWantsWebSockets && responseWantsWebSockets) {
           handleWebSocketUpgrade(socket, source, sink, request, response);
+          reuseSocket = false;
         } else {
           writeHttpResponse(socket, sink, response);
         }
@@ -523,7 +525,7 @@ public final class MockWebServer {
         }
 
         sequenceNumber++;
-        return true;
+        return reuseSocket;
       }
     });
   }

--- a/okhttp-testing-support/src/main/java/com/squareup/okhttp/testing/RecordingHostnameVerifier.java
+++ b/okhttp-testing-support/src/main/java/com/squareup/okhttp/testing/RecordingHostnameVerifier.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.okhttp.internal;
+package com.squareup.okhttp.testing;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -17,7 +17,7 @@ package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.DoubleInetAddressNetwork;
 import com.squareup.okhttp.internal.Internal;
-import com.squareup.okhttp.internal.RecordingHostnameVerifier;
+import com.squareup.okhttp.testing.RecordingHostnameVerifier;
 import com.squareup.okhttp.internal.RecordingOkAuthenticator;
 import com.squareup.okhttp.internal.SingleInetAddressNetwork;
 import com.squareup.okhttp.internal.SslContextBuilder;

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/ConnectionPoolTest.java
@@ -16,7 +16,7 @@
 package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.Internal;
-import com.squareup.okhttp.internal.RecordingHostnameVerifier;
+import com.squareup.okhttp.testing.RecordingHostnameVerifier;
 import com.squareup.okhttp.internal.SslContextBuilder;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.http.AuthenticatorAdapter;

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -33,7 +33,7 @@ import com.squareup.okhttp.Response;
 import com.squareup.okhttp.TlsVersion;
 import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.internal.RecordingAuthenticator;
-import com.squareup.okhttp.internal.RecordingHostnameVerifier;
+import com.squareup.okhttp.testing.RecordingHostnameVerifier;
 import com.squareup.okhttp.internal.RecordingOkAuthenticator;
 import com.squareup.okhttp.internal.SingleInetAddressNetwork;
 import com.squareup.okhttp.internal.SslContextBuilder;

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
@@ -61,19 +61,6 @@ public final class WebSocketCall {
     if (!"GET".equals(request.method())) {
       throw new IllegalArgumentException("Request must be GET: " + request.method());
     }
-    String url = request.urlString();
-    String httpUrl;
-    if (url.startsWith("ws://")) {
-      httpUrl = "http://" + url.substring(5);
-    } else if (url.startsWith("wss://")) {
-      httpUrl = "https://" + url.substring(6);
-    } else if (url.startsWith("http://") || url.startsWith("https://")) {
-      httpUrl = url;
-    } else {
-      throw new IllegalArgumentException(
-          "Request url must use 'ws', 'wss', 'http', or 'https' scheme: " + url);
-    }
-
     this.random = random;
 
     byte[] nonce = new byte[16];
@@ -87,7 +74,6 @@ public final class WebSocketCall {
     client.setProtocols(Collections.singletonList(com.squareup.okhttp.Protocol.HTTP_1_1));
 
     request = request.newBuilder()
-        .url(httpUrl)
         .header("Upgrade", "websocket")
         .header("Connection", "Upgrade")
         .header("Sec-WebSocket-Key", key)

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -145,6 +145,14 @@ public final class Request {
 
     public Builder url(String url) {
       if (url == null) throw new IllegalArgumentException("url == null");
+
+      // Silently replace websocket URLs with HTTP URLs.
+      if (url.regionMatches(true, 0, "ws:", 0, 3)) {
+        url = "http:" + url.substring(3);
+      } else if (url.regionMatches(true, 0, "wss:", 0, 4)) {
+        url = "https:" + url.substring(4);
+      }
+
       HttpUrl parsed = HttpUrl.parse(url);
       if (parsed == null) throw new IllegalArgumentException("unexpected url: " + url);
       return url(parsed);


### PR DESCRIPTION
I contemplated supporting them in HttpUrl, but then realized I'd
either need to document that behavior (which is weird behavior)
or return ws from the scheme (which seems arbitrary.)

Doing it in Request seems less bad: we support websockets requests.