### PR TITLE
Add optional Response to WS failure callback.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -674,7 +674,7 @@ public final class MockWebServer {
     new Thread(new Runnable() {
       @Override public void run() {
         try {
-          listener.onOpen(webSocket, fancyRequest, fancyResponse);
+          listener.onOpen(webSocket, fancyResponse);
         } catch (IOException e) {
           // TODO try to write close frame?
           connectionClose.countDown();

--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/AutobahnTester.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/AutobahnTester.java
@@ -69,7 +69,7 @@ public final class AutobahnTester {
           private final ExecutorService sendExecutor = Executors.newSingleThreadExecutor();
           private WebSocket webSocket;
 
-          @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+          @Override public void onOpen(WebSocket webSocket, Response response)
               throws IOException {
             System.out.println("Executing test case " + number + "/" + count);
             this.webSocket = webSocket;
@@ -100,7 +100,7 @@ public final class AutobahnTester {
             latch.countDown();
           }
 
-          @Override public void onFailure(IOException e) {
+          @Override public void onFailure(IOException e, Response response) {
             latch.countDown();
           }
         });
@@ -118,7 +118,7 @@ public final class AutobahnTester {
     final AtomicLong countRef = new AtomicLong();
     final AtomicReference<IOException> failureRef = new AtomicReference<>();
     newWebSocket("/getCaseCount").enqueue(new WebSocketListener() {
-      @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+      @Override public void onOpen(WebSocket webSocket, Response response)
           throws IOException {
       }
 
@@ -135,7 +135,7 @@ public final class AutobahnTester {
         latch.countDown();
       }
 
-      @Override public void onFailure(IOException e) {
+      @Override public void onFailure(IOException e, Response response) {
         failureRef.set(e);
         latch.countDown();
       }
@@ -157,7 +157,7 @@ public final class AutobahnTester {
   private void updateReports() {
     final CountDownLatch latch = new CountDownLatch(1);
     newWebSocket("/updateReports?agent=" + Version.userAgent()).enqueue(new WebSocketListener() {
-      @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+      @Override public void onOpen(WebSocket webSocket, Response response)
           throws IOException {
       }
 
@@ -172,7 +172,7 @@ public final class AutobahnTester {
         latch.countDown();
       }
 
-      @Override public void onFailure(IOException e) {
+      @Override public void onFailure(IOException e, Response response) {
         latch.countDown();
       }
     });

--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/WebSocketCallTest.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/WebSocketCallTest.java
@@ -70,7 +70,7 @@ public final class WebSocketCallTest {
 
   @Test public void serverMessage() throws IOException {
     WebSocketListener serverListener = new EmptyWebSocketListener() {
-      @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+      @Override public void onOpen(WebSocket webSocket, Response response)
           throws IOException {
         webSocket.sendMessage(TEXT, new Buffer().writeUtf8("Hello, WebSockets!"));
       }
@@ -96,7 +96,7 @@ public final class WebSocketCallTest {
 
   @Test public void serverStreamingMessage() throws IOException {
     WebSocketListener serverListener = new EmptyWebSocketListener() {
-      @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+      @Override public void onOpen(WebSocket webSocket, Response response)
           throws IOException {
         BufferedSink sink = webSocket.newMessageSink(TEXT);
         sink.writeUtf8("Hello, ").flush();
@@ -134,7 +134,8 @@ public final class WebSocketCallTest {
   }
 
   @Test public void wrongConnectionHeader() {
-    server.enqueue(new MockResponse().setResponseCode(101)
+    server.enqueue(new MockResponse()
+        .setResponseCode(101)
         .setHeader("Upgrade", "websocket")
         .setHeader("Connection", "Downgrade")
         .setHeader("Sec-WebSocket-Accept", "ujmZX4KXZqjwy6vi1aQFH5p4Ygk="));
@@ -234,7 +235,7 @@ public final class WebSocketCallTest {
     final AtomicReference<IOException> failureRef = new AtomicReference<>();
     final CountDownLatch latch = new CountDownLatch(1);
     call.enqueue(new WebSocketListener() {
-      @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+      @Override public void onOpen(WebSocket webSocket, Response response)
           throws IOException {
         webSocketRef.set(webSocket);
         responseRef.set(response);
@@ -254,8 +255,8 @@ public final class WebSocketCallTest {
         listener.onClose(code, reason);
       }
 
-      @Override public void onFailure(IOException e) {
-        listener.onFailure(e);
+      @Override public void onFailure(IOException e, Response response) {
+        listener.onFailure(e, null);
         failureRef.set(e);
         latch.countDown();
       }
@@ -273,7 +274,7 @@ public final class WebSocketCallTest {
   }
 
   private static class EmptyWebSocketListener implements WebSocketListener {
-    @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+    @Override public void onOpen(WebSocket webSocket, Response response)
         throws IOException {
     }
 
@@ -287,7 +288,7 @@ public final class WebSocketCallTest {
     @Override public void onClose(int code, String reason) {
     }
 
-    @Override public void onFailure(IOException e) {
+    @Override public void onFailure(IOException e, Response response) {
     }
   }
 }

--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/WebSocketRecorder.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/WebSocketRecorder.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.okhttp.ws;
 
-import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 import com.squareup.okhttp.internal.ws.WebSocketReader;
 import java.io.IOException;
@@ -44,7 +43,7 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
     this.delegate = delegate;
   }
 
-  @Override public void onOpen(WebSocket webSocket, Request request, Response response) {
+  @Override public void onOpen(WebSocket webSocket, Response response) {
   }
 
   @Override public void onMessage(BufferedSource source, WebSocket.PayloadType type)
@@ -72,7 +71,7 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
     events.add(new Close(code, reason));
   }
 
-  @Override public void onFailure(IOException e) {
+  @Override public void onFailure(IOException e, Response response) {
     events.add(e);
   }
 
@@ -109,7 +108,7 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
   }
 
   public void assertClose(int code, String reason) {
-      assertEquals(new Close(code, reason), nextEvent());
+    assertEquals(new Close(code, reason), nextEvent());
   }
 
   public void assertFailure(Class<? extends IOException> cls, String message) {

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/RealWebSocket.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/RealWebSocket.java
@@ -181,7 +181,7 @@ public abstract class RealWebSocket implements WebSocket {
     } catch (IOException ignored) {
     }
 
-    listener.onFailure(e);
+    listener.onFailure(e, null);
   }
 
   /** Perform any tear-down work on the connection (close the socket, recycle, etc.). */

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
@@ -102,12 +102,12 @@ public final class WebSocketCall {
         try {
           createWebSocket(response, listener);
         } catch (IOException e) {
-          listener.onFailure(e);
+          listener.onFailure(e, response);
         }
       }
 
       @Override public void onFailure(Request request, IOException e) {
-        listener.onFailure(e);
+        listener.onFailure(e, null);
       }
     };
     // TODO call.enqueue(responseCallback, true);
@@ -167,7 +167,7 @@ public final class WebSocketCall {
     // TODO connection.setOwner(webSocket);
     Internal.instance.connectionSetOwner(connection, webSocket);
 
-    listener.onOpen(webSocket, request, response);
+    listener.onOpen(webSocket, response);
 
     // Start a dedicated thread for reading the web socket.
     new Thread(new NamedRunnable("OkHttp WebSocket reader %s", request.urlString()) {

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketListener.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketListener.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.okhttp.ws;
 
-import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
 import java.io.IOException;
 import okio.Buffer;
@@ -25,7 +24,18 @@ import static com.squareup.okhttp.ws.WebSocket.PayloadType;
 
 /** Listener for server-initiated messages on a connected {@link WebSocket}. */
 public interface WebSocketListener {
-  void onOpen(WebSocket webSocket, Request request, Response response) throws IOException;
+  /**
+   * Called when the request has successfully been upgraded to a web socket.
+   */
+  void onOpen(WebSocket webSocket, Response response) throws IOException;
+
+  /**
+   * Called when the transport or protocol layer of this web socket errors during communication.
+   *
+   * @param response Present when the failure is a direct result of the response (e.g., failed
+   * upgrade, non-101 response code, etc.). {@code null} otherwise.
+   */
+  void onFailure(IOException e, Response response);
 
   /**
    * Called when a server message is received. The {@code type} indicates whether the
@@ -53,7 +63,4 @@ public interface WebSocketListener {
    * @param reason Reason for close or an empty string.
    */
   void onClose(int code, String reason);
-
-  /** Called when the transport or protocol layer of this web socket errors during communication. */
-  void onFailure(IOException e);
 }

--- a/samples/guide/src/main/java/com/squareup/okhttp/recipes/WebSocketEcho.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/recipes/WebSocketEcho.java
@@ -27,7 +27,7 @@ public final class WebSocketEcho implements WebSocketListener {
     client.getDispatcher().getExecutorService().shutdown();
   }
 
-  @Override public void onOpen(WebSocket webSocket, Request request, Response response)
+  @Override public void onOpen(WebSocket webSocket, Response response)
       throws IOException {
     webSocket.sendMessage(TEXT, new Buffer().writeUtf8("Hello..."));
     webSocket.sendMessage(TEXT, new Buffer().writeUtf8("...World!"));
@@ -57,7 +57,7 @@ public final class WebSocketEcho implements WebSocketListener {
     System.out.println("CLOSE: " + code + " " + reason);
   }
 
-  @Override public void onFailure(IOException e) {
+  @Override public void onFailure(IOException e, Response response) {
     e.printStackTrace();
   }
 


### PR DESCRIPTION
This also removes the explicit Request from WS open callback. It can be accessed by calling 'request()' on the supplied Response.

Closes #1639.