### PR TITLE
Revert Call to a protected class instead of package-private

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -44,7 +44,7 @@ public class Call {
   Request originalRequest;
   HttpEngine engine;
 
-  Call(OkHttpClient client, Request originalRequest) {
+  protected Call(OkHttpClient client, Request originalRequest) {
     // Copy the client. Otherwise changes (socket factory, redirect policy,
     // etc.) may incorrectly be reflected in the request when it is executed.
     this.client = client.copyWithDefaults();


### PR DESCRIPTION
Monitoring libraries such as New Relic need to have the ability to subclass certain interesting classes in order to provide effective instrumentation. In previous versions of Okhttp, the Call constructor was protected, but it seems this changed in v2.4. This commit reverts Call from package-private to protected to allow for instrumentation. 