### PR TITLE
Use cache finally

### DIFF
--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/OkUrlFactory.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/OkUrlFactory.java
@@ -53,9 +53,13 @@ public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
     OkHttpClient copy = client.copyWithDefaults();
     copy.setProxy(proxy);
 
-    if (protocol.equals("http")) return new HttpURLConnectionImpl(url, copy);
-    if (protocol.equals("https")) return new HttpsURLConnectionImpl(url, copy);
-    throw new IllegalArgumentException("Unexpected protocol: " + protocol);
+    HttpURLConnection conn;
+    if (protocol.equals("http")) conn = new HttpURLConnectionImpl(url, copy);
+    else if (protocol.equals("https")) conn =  new HttpsURLConnectionImpl(url, copy);
+    else throw new IllegalArgumentException("Unexpected protocol: " + protocol);
+
+    if (copy.getCache() != null) conn.setUseCaches(true);
+    return conn;
   }
 
   /**

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -342,7 +342,7 @@ public class OkHttpClient implements Cloneable {
 
   public OkHttpClient setCache(Cache cache) {
     this.cache = cache;
-    this.internalCache = null;
+    this.internalCache = cache.internalCache;
     return this;
   }
 


### PR DESCRIPTION
I've been having the same problem as discussed in #831
I noticed that `cache` and `internalCache` are both null for `OkHttpClient` instance in `HttpEngine::sendRequest()`.
Also call `.setUseCaches(true)` to jump over the check in `HttpURLConnectionImpl::newHttpEngine()` line 358.