### PR TITLE
Update test exception expectations + modify socket timeout exception

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpOverSpdyTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HttpOverSpdyTest.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.net.Authenticator;
 import java.net.CookieManager;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -307,8 +308,8 @@ public abstract class HttpOverSpdyTest {
     try {
       readAscii(connection.getInputStream(), Integer.MAX_VALUE);
       fail("Should have timed out!");
-    } catch (IOException e){
-      assertEquals("timeout", e.getMessage());
+    } catch (SocketTimeoutException expected) {
+      assertEquals("timeout", expected.getMessage());
     }
   }
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/URLConnectionTest.java
@@ -57,6 +57,7 @@ import java.net.ProxySelector;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -2202,7 +2203,7 @@ public final class URLConnectionTest {
     try {
       in.read(); // if Content-Length was accurate, this would return -1 immediately
       fail();
-    } catch (IOException expected) {
+    } catch (SocketTimeoutException expected) {
     }
   }
 
@@ -2238,7 +2239,7 @@ public final class URLConnectionTest {
       byte[] data = new byte[16 * 1024 * 1024]; // 16 MiB.
       out.write(data);
       fail();
-    } catch (IOException expected) {
+    } catch (SocketTimeoutException expected) {
     }
   }
 


### PR DESCRIPTION
In anticipation of taking a new Okio version containing https://github.com/square/okio/pull/154

Related to issue #1676.
Depends on https://github.com/square/okio/pull/154

URLConnection should throw SocketTimeoutException for timeouts
not InterruptedIOException.