### PR TITLE
Expose WebSocket.closeConnection() to public API

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -650,7 +650,7 @@ public final class MockWebServer {
     final RealWebSocket webSocket =
         new RealWebSocket(false /* is server */, source, sink, new SecureRandom(), replyExecutor,
             listener, request.getPath()) {
-          @Override protected void closeConnection() throws IOException {
+          @Override public void closeConnection() throws IOException {
             connectionClose.countDown();
           }
         };

--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/internal/ws/RealWebSocketTest.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/internal/ws/RealWebSocketTest.java
@@ -60,7 +60,7 @@ public final class RealWebSocketTest {
 
     client = new RealWebSocket(true, server2client, client2Server, random, clientExecutor,
         clientListener, url) {
-      @Override protected void closeConnection() throws IOException {
+      @Override public void closeConnection() throws IOException {
         clientConnectionClosed = true;
         if (clientConnectionCloseThrows) {
           throw new IOException("Oops!");
@@ -69,7 +69,7 @@ public final class RealWebSocketTest {
     };
     server = new RealWebSocket(false, client2Server, server2client, random, serverExecutor,
         serverListener, url) {
-      @Override protected void closeConnection() throws IOException {
+      @Override public void closeConnection() throws IOException {
       }
     };
   }

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/RealWebSocket.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/RealWebSocket.java
@@ -183,7 +183,4 @@ public abstract class RealWebSocket implements WebSocket {
 
     listener.onFailure(e, null);
   }
-
-  /** Perform any tear-down work on the connection (close the socket, recycle, etc.). */
-  protected abstract void closeConnection() throws IOException;
 }

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocket.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocket.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.okhttp.ws;
 
+import com.squareup.okhttp.Connection;
 import java.io.IOException;
 import okio.Buffer;
 import okio.BufferedSink;
@@ -65,4 +66,16 @@ public interface WebSocket {
    * @throws IllegalStateException if already closed.
    */
   void close(int code, String reason) throws IOException;
+
+  /**
+   * Closes the underlying {@link Connection connection} backing the WebSocket.
+   * <p>
+   * The correct way to close a WebSocket is to call {@link WebSocket#close close()}. Calling this
+   * method will force the WebSocket to close its backing {@link Connection connection}, skipping
+   * the WebSocket close frame.
+   * See <a href="http://tools.ietf.org/html/rfc6455#section-5.5.1">Close Frame</a> for details
+   *
+   * @throws IOException
+   */
+  void closeConnection() throws IOException;
 }

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocketCall.java
@@ -118,8 +118,7 @@ public final class WebSocketCall {
     call.cancel();
   }
 
-  private void createWebSocket(Response response, WebSocketListener listener)
-      throws IOException {
+  private void createWebSocket(Response response, WebSocketListener listener) throws IOException {
     if (response.code() != 101) {
       // TODO call.engine.releaseConnection();
       Internal.instance.callEngineReleaseConnection(call);
@@ -194,7 +193,7 @@ public final class WebSocketCall {
       this.connection = connection;
     }
 
-    @Override protected void closeConnection() throws IOException {
+    @Override public void closeConnection() throws IOException {
       // TODO connection.closeIfOwnedBy(this);
       Internal.instance.closeIfOwnedBy(connection, this);
     }


### PR DESCRIPTION
The reason for doing this is to expose an API to the client that allows it to force the connection to close. The current `WebSocket.close()` method (correctly) attempts to send a `WebSocket` close frame before shutting down the backing `Connection`. But if the `Connection` is in an SSL timeout state (for example, when Android is connected to a WiFi router dropping a ton of WAN packets), then this function will hang and there will be no way to force the `WebSocket` to terminate. Giving the client the power to force a `Connection` shutdown allows it to set up connect and shutdown timers coupled with reachability and make the right decisions.