### PR TITLE
Relaxed FormEncodingBuilder to allow building empty forms.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/FormEncodingBuilderTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/FormEncodingBuilderTest.java
@@ -78,4 +78,15 @@ public final class FormEncodingBuilderTest {
     formEncoding.writeTo(buffer);
     assertEquals(expected, buffer.readUtf8());
   }
+
+  @Test public void buildEmptyForm() throws Exception {
+    RequestBody formEncoding = new FormEncodingBuilder().build();
+
+    String expected = "";
+    assertEquals(expected.length(), formEncoding.contentLength());
+
+    Buffer buffer = new Buffer();
+    formEncoding.writeTo(buffer);
+    assertEquals(expected, buffer.readUtf8());
+  }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/FormEncodingBuilder.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/FormEncodingBuilder.java
@@ -54,9 +54,6 @@ public final class FormEncodingBuilder {
   }
 
   public RequestBody build() {
-    if (content.size() == 0) {
-      throw new IllegalStateException("Form encoded body must have at least one part.");
-    }
     return RequestBody.create(CONTENT_TYPE, content.snapshot());
   }
 }


### PR DESCRIPTION
This PR addresses: #1704 

I was not able to build a proper artifact to test integration as it looks like `com.squareup.okhttp.internal.Version` is missing. However, commenting out the relevant code allowed for the unit tests in `FormEncodingBuilder` to run and they passed.

Edit: looks like it's not missing, I just don't know how to build the project properly. :)