### PR TITLE
Bump Okio to 1.5.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <!-- Compilation -->
     <java.version>1.7</java.version>
-    <okio.version>1.5.0-SNAPSHOT</okio.version>
+    <okio.version>1.5.0</okio.version>
     <!-- ALPN library targeted to Java 7 -->
     <alpn.jdk7.version>7.1.2.v20141202</alpn.jdk7.version>
     <!-- ALPN library targeted to Java 8 update 25. -->


### PR DESCRIPTION
Closes #1722. 