### PR TITLE
socket.setSoTimeout after socket.connect

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/SocketConnector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/SocketConnector.java
@@ -156,8 +156,8 @@ public class SocketConnector {
       } else {
         socket = new Socket(proxy);
       }
-      socket.setSoTimeout(soTimeout);
       platform.connectSocket(socket, route.getSocketAddress(), connectTimeout);
+      socket.setSoTimeout(soTimeout);
 
       return socket;
     } catch (IOException e) {


### PR DESCRIPTION
The minimum probability triggers a TimeoutException on some special Android devices(eg: HM NOTE 1TD).