### PR TITLE
add OkHttpClient(ExecutorService) in order to give a custom executor service

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/OkHttpClientTest.java
@@ -32,6 +32,8 @@ import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.net.SocketFactory;
 import org.junit.After;
@@ -55,6 +57,12 @@ public final class OkHttpClientTest {
     CookieManager.setDefault(DEFAULT_COOKIE_HANDLER);
     ResponseCache.setDefault(DEFAULT_RESPONSE_CACHE);
     Authenticator.setDefault(DEFAULT_AUTHENTICATOR);
+  }
+
+  @Test public void constructorWithExecutorService() {
+    ExecutorService executorService = Executors.newFixedThreadPool(4);
+    OkHttpClient client = new OkHttpClient(executorService);
+    assertEquals(executorService, client.getDispatcher().getExecutorService());
   }
 
   @Test public void timeoutDefaults() {

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -25,6 +25,7 @@ import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.RouteException;
 import com.squareup.okhttp.internal.http.Transport;
 import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
+
 import java.io.IOException;
 import java.net.CookieHandler;
 import java.net.Proxy;
@@ -33,12 +34,15 @@ import java.net.URLConnection;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+
 import javax.net.SocketFactory;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+
 import okio.BufferedSink;
 import okio.BufferedSource;
 
@@ -194,6 +198,11 @@ public class OkHttpClient implements Cloneable {
   public OkHttpClient() {
     routeDatabase = new RouteDatabase();
     dispatcher = new Dispatcher();
+  }
+
+  public OkHttpClient(ExecutorService executorService) {
+    routeDatabase = new RouteDatabase();
+    dispatcher = new Dispatcher(executorService);
   }
 
   private OkHttpClient(OkHttpClient okHttpClient) {


### PR DESCRIPTION
I'd like to use fixed thread pools (e.g. via `Executors.newFixedThreadPool(int)`) so it's better if `OkHttpClient` has a constructor to take it.

Of course I am already able to change ExecutorService via `OkHttpClient.setDispatcher()` but it makes a garbage Dispatcher instance so this pull-request provides a better way to do it.

Can you review it please?