### PR TITLE
Add policy for disconnecting request body halfway.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/SocketPolicy.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/SocketPolicy.java
@@ -50,6 +50,9 @@ public enum SocketPolicy {
    */
   DISCONNECT_AFTER_REQUEST,
 
+  /** Close connection after reading half of the request body (if present). */
+  DISCONNECT_DURING_REQUEST_BODY,
+
   /** Close connection after writing half of the response body (if present). */
   DISCONNECT_DURING_RESPONSE_BODY,
 


### PR DESCRIPTION
This also fixes a bug where specifying a policy to disconnect the response body would erroneously also apply to the request body.

Closes #1755. 