### PR TITLE
make the DiskLruCache's initialize() public through the Cache interface

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Cache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Cache.java
@@ -270,6 +270,23 @@ public final class Cache {
   }
 
   /**
+   * Initialize the cache. This will include reading the journal files from
+   * the storage and building up the necessary in-memory cache information.
+   * <p>
+   * The initialization time may vary depending on the journal file size and
+   * the current actual cache size. The application needs to be aware of calling
+   * this function during the initialization phase and preferrably in a background
+   * worker thread.
+   * <p>
+   * Note that if the application chooses to not call this method to initialize
+   * the cache. By default, the okhttp will perform lazy initialization upon the
+   * first usage of the cache.
+   */
+  public void initialize() throws IOException {
+    cache.initialize();
+  }
+
+  /**
    * Closes the cache and deletes all of its stored values. This will delete
    * all files in the cache directory including files that weren't created by
    * the cache.

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/DiskLruCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/DiskLruCache.java
@@ -197,8 +197,7 @@ public final class DiskLruCache implements Closeable {
     this.executor = executor;
   }
 
-  // Visible for testing.
-  void initialize() throws IOException {
+  public synchronized void initialize() throws IOException {
     assert Thread.holdsLock(this);
 
     if (initialized) {


### PR DESCRIPTION
The DiskLruCache’s cache does lazy initialization. The time spent in
initialization varies depending on the actual cache size and journal
file size.

On very low end device, the initialization time could be as long as
1000 ms once the cache reaches 100M for example on a 4.0 device. This
has significant performance impact on the very 1st cache hit.

So the proposed solution is to give the developer an opportunity to
explicitly do the initialization early on and in a back ground thread.
Without this change, the developer would have to call any method from
the Cache class to warm up the cache implicitly.