### PR TITLE
Remove IOException throws from source() and close() on ResponseBody.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/ResponseBody.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ResponseBody.java
@@ -39,11 +39,11 @@ public abstract class ResponseBody implements Closeable {
    */
   public abstract long contentLength() throws IOException;
 
-  public final InputStream byteStream() throws IOException {
+  public final InputStream byteStream() {
     return source().inputStream();
   }
 
-  public abstract BufferedSource source() throws IOException;
+  public abstract BufferedSource source();
 
   public final byte[] bytes() throws IOException {
     long contentLength = contentLength();
@@ -69,7 +69,7 @@ public abstract class ResponseBody implements Closeable {
    * of the Content-Type header. If that header is either absent or lacks a
    * charset, this will attempt to decode the response body as UTF-8.
    */
-  public final Reader charStream() throws IOException {
+  public final Reader charStream() {
     Reader r = reader;
     return r != null ? r : (reader = new InputStreamReader(byteStream(), charset()));
   }
@@ -88,8 +88,10 @@ public abstract class ResponseBody implements Closeable {
     return contentType != null ? contentType.charset(UTF_8) : UTF_8;
   }
 
-  @Override public void close() throws IOException {
-    source().close();
+  @Override public void close() {
+    // Propagating IOException when calling close() puts the caller in an awkward position. There
+    // is no good action to be taken on their part. As such, we suppress it for them.
+    Util.closeQuietly(source());
   }
 
   /**

--- a/samples/guide/src/main/java/com/squareup/okhttp/recipes/Progress.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/recipes/Progress.java
@@ -84,7 +84,7 @@ public final class Progress {
       return responseBody.contentLength();
     }
 
-    @Override public BufferedSource source() throws IOException {
+    @Override public BufferedSource source() {
       if (bufferedSource == null) {
         bufferedSource = Okio.buffer(source(responseBody.source()));
       }


### PR DESCRIPTION
`source()` throwing was the result of legacy integrations which now eagerly open their streams. This eliminates the need for this method to throw as well as a few downstream methods like `byteStream()` and `charStream()`.

`close()` throwing puts the caller in an awkward position. They have already read the body (or are ignoring it) and just want to ensure resource cleanup happens. If this fails, however, and the `IOException` was throw there is no reasonable action for them to take other than ignoring. As such, we take the liberty of ignoring it for them.

Closes #1696.