### PR TITLE
Changing the scheme will update the default port

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
@@ -602,6 +602,23 @@ public final class HttpUrlTest {
     assertEquals("fragment", url.fragment());
   }
 
+  @Test public void changingSchemeChangesDefaultPort() throws Exception {
+    assertEquals(443, HttpUrl.parse("http://example.com")
+        .newBuilder()
+        .scheme("https")
+        .build().port());
+
+    assertEquals(80, HttpUrl.parse("https://example.com")
+        .newBuilder()
+        .scheme("http")
+        .build().port());
+
+    assertEquals(1234, HttpUrl.parse("https://example.com:1234")
+        .newBuilder()
+        .scheme("http")
+        .build().port());
+  }
+
   @Test public void composeEncodesWhitespace() throws Exception {
     HttpUrl url = new HttpUrl.Builder()
         .scheme("http")

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -570,7 +570,12 @@ public final class HttpUrl {
     result.encodedUsername = encodedUsername();
     result.encodedPassword = encodedPassword();
     result.host = host;
-    result.port = port;
+    // If we're set to a default port, unset it, in case of a scheme change.
+    if (port == defaultPort(scheme)) {
+      result.port = -1;
+    } else {
+      result.port = port;
+    }
     result.encodedPathSegments.clear();
     result.encodedPathSegments.addAll(encodedPathSegments());
     result.encodedQuery(encodedQuery());


### PR DESCRIPTION
Addresses #1788 

Not really sure this is the best solution, but my idea was to check the port when you're building the Url, and if the port is a default (which would be assigned from parsing a http(s)), use the default port for the scheme instead. 

I'd be glad to make changes to my approach if you had something else in mind!