### PR TITLE
Don't throw IllegalStateException after an IOException.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/TestUtil.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/TestUtil.java
@@ -27,4 +27,10 @@ public final class TestUtil {
   public static <T> Set<T> setOf(Collection<T> elements) {
     return new LinkedHashSet<>(elements);
   }
+
+  public static String repeat(char c, int count) {
+    char[] array = new char[count];
+    Arrays.fill(array, c);
+    return new String(array);
+  }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/framed/Http2.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/framed/Http2.java
@@ -425,7 +425,6 @@ public final class Http2 implements Variant {
     @Override public synchronized void pushPromise(int streamId, int promisedStreamId,
         List<Header> requestHeaders) throws IOException {
       if (closed) throw new IOException("closed");
-      if (hpackBuffer.size() != 0) throw new IllegalStateException();
       hpackWriter.writeHeaders(requestHeaders);
 
       long byteCount = hpackBuffer.size();
@@ -441,7 +440,6 @@ public final class Http2 implements Variant {
 
     void headers(boolean outFinished, int streamId, List<Header> headerBlock) throws IOException {
       if (closed) throw new IOException("closed");
-      if (hpackBuffer.size() != 0) throw new IllegalStateException();
       hpackWriter.writeHeaders(headerBlock);
 
       long byteCount = hpackBuffer.size();

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/framed/Spdy3.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/framed/Spdy3.java
@@ -406,7 +406,6 @@ public final class Spdy3 implements Variant {
     }
 
     private void writeNameValueBlockToBuffer(List<Header> headerBlock) throws IOException {
-      if (headerBlockBuffer.size() != 0) throw new IllegalStateException();
       headerBlockOut.writeInt(headerBlock.size());
       for (int i = 0, size = headerBlock.size(); i < size; i++) {
         ByteString name = headerBlock.get(i).name;


### PR DESCRIPTION
We were a little too aggressive in checking our preconditions. If a previous
write failed, we don't want the following write to crash. (It'll throw an
IOException anyway.)

Closes https://github.com/square/okhttp/issues/1651