### PR TITLE
catch AssertionError

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -174,6 +174,9 @@ public class Call {
         } else {
           responseCallback.onFailure(engine.getRequest(), e);
         }
+      } catch (AssertionError are) {
+        // catch this exception
+        // Due to a Firmware issue up to android 4.2.2
       } finally {
         client.getDispatcher().finished(this);
       }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -194,6 +194,11 @@ public class Platform {
         IOException ioException = new IOException("Exception in connect");
         ioException.initCause(se);
         throw ioException;
+      } catch (IllegalArgumentException iae) {
+        //Catch this exception due to a Firmware issue up to android 4.2.2
+        IOException ioException = new IOException("Exception in connect");
+        ioException.initCause(iae);
+        throw ioException;
       }
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -102,6 +102,9 @@ public final class Util {
       } catch (RuntimeException rethrown) {
         throw rethrown;
       } catch (Exception ignored) {
+      } catch (AssertionError are) {
+        // catch this exception
+        // Due to a Firmware issue up to android 4.2.2
       }
     }
   }


### PR DESCRIPTION
An issue that impact android version up to 4.2.2 cause an exception to be thrown:
java.lang.AssertionError: libcore.io.ErrnoException: getsockname failed: EBADF (Bad file number)
caused by libcore.io.IoBridge.getSocketLocalPort(IoBridge.java:649)
 https://code.google.com/p/android/issues/detail?id=54072

I use okHttp on my application and I get some crashes regarding this issue. 
I cannot catch this exception on my code because this exception is thrown at a deeper level. 
But this exception can be catched by the okHttp code.
Most of my crashes can be fixed by this pull request.

This fix is related to this discussion : https://github.com/square/okhttp/issues/1684#issuecomment-117123290