### PR TITLE
Recover from Android 4.2.2 EBADF crashes.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -258,6 +258,9 @@ public final class Connection {
       handshake = unverifiedHandshake;
       socket = sslSocket;
       success = true;
+    } catch (AssertionError e) {
+      if (Util.isAndroidGetsocknameError(e)) throw new IOException(e);
+      throw e;
     } finally {
       if (sslSocket != null) {
         Platform.get().afterHandshake(sslSocket);

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Util.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Util.java
@@ -84,6 +84,8 @@ public final class Util {
     if (socket != null) {
       try {
         socket.close();
+      } catch (AssertionError e) {
+        if (!isAndroidGetsocknameError(e)) throw e;
       } catch (RuntimeException rethrown) {
         throw rethrown;
       } catch (Exception ignored) {
@@ -276,5 +278,14 @@ public final class Util {
       return buffer.readUtf8();
     }
     return s;
+  }
+
+  /**
+   * Returns true if {@code e} is due to a firmware bug fixed after Android 4.2.2.
+   * https://code.google.com/p/android/issues/detail?id=54072
+   */
+  public static boolean isAndroidGetsocknameError(AssertionError e) {
+    return e.getCause() != null && e.getMessage() != null
+        && e.getMessage().contains("getsockname failed");
   }
 }


### PR DESCRIPTION
Originally submitted by @pguilbot.

See also https://github.com/square/okhttp/issues/1684