### PR TITLE
Test code refactoring

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -1889,8 +1889,9 @@ public final class CallTest {
     }
 
     @Override
-    protected void configureSocket(SSLSocket sslSocket) throws IOException {
+    protected SSLSocket configureSocket(SSLSocket sslSocket) throws IOException {
       socketsCreated.add(sslSocket);
+      return sslSocket;
     }
 
     public List<SSLSocket> getSocketsCreated() {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingSSLSocketFactory.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingSSLSocketFactory.java
@@ -90,7 +90,8 @@ public class DelegatingSSLSocketFactory extends SSLSocketFactory {
     return sslSocket;
   }
 
-  protected void configureSocket(SSLSocket sslSocket) throws IOException {
+  protected SSLSocket configureSocket(SSLSocket sslSocket) throws IOException {
     // No-op by default.
+    return sslSocket;
   }
 }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingServerSocketFactory.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingServerSocketFactory.java
@@ -35,33 +35,30 @@ public class DelegatingServerSocketFactory extends ServerSocketFactory {
   @Override
   public ServerSocket createServerSocket() throws IOException {
     ServerSocket serverSocket = delegate.createServerSocket();
-    configureServerSocket(serverSocket);
-    return serverSocket;
+    return configureServerSocket(serverSocket);
   }
 
   @Override
   public ServerSocket createServerSocket(int port) throws IOException {
     ServerSocket serverSocket = delegate.createServerSocket(port);
-    configureServerSocket(serverSocket);
-    return serverSocket;
+    return configureServerSocket(serverSocket);
   }
 
   @Override
   public ServerSocket createServerSocket(int port, int backlog) throws IOException {
     ServerSocket serverSocket = delegate.createServerSocket(port, backlog);
-    configureServerSocket(serverSocket);
-    return serverSocket;
+    return configureServerSocket(serverSocket);
   }
 
   @Override
   public ServerSocket createServerSocket(int port, int backlog, InetAddress ifAddress)
       throws IOException {
     ServerSocket serverSocket = delegate.createServerSocket(port, backlog, ifAddress);
-    configureServerSocket(serverSocket);
-    return serverSocket;
+    return configureServerSocket(serverSocket);
   }
 
-  protected void configureServerSocket(ServerSocket serverSocket) throws IOException {
+  protected ServerSocket configureServerSocket(ServerSocket serverSocket) throws IOException {
     // No-op by default.
+    return serverSocket;
   }
 }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingSocketFactory.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/DelegatingSocketFactory.java
@@ -36,41 +36,37 @@ public class DelegatingSocketFactory extends SocketFactory {
   @Override
   public Socket createSocket() throws IOException {
     Socket socket = delegate.createSocket();
-    configureSocket(socket);
-    return socket;
+    return configureSocket(socket);
   }
 
   @Override
   public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
     Socket socket = delegate.createSocket(host, port);
-    configureSocket(socket);
-    return socket;
+    return configureSocket(socket);
   }
 
   @Override
   public Socket createSocket(String host, int port, InetAddress localAddress, int localPort)
       throws IOException, UnknownHostException {
     Socket socket = delegate.createSocket(host, port, localAddress, localPort);
-    configureSocket(socket);
-    return socket;
+    return configureSocket(socket);
   }
 
   @Override
   public Socket createSocket(InetAddress host, int port) throws IOException {
     Socket socket = delegate.createSocket(host, port);
-    configureSocket(socket);
-    return socket;
+    return configureSocket(socket);
   }
 
   @Override
   public Socket createSocket(InetAddress host, int port, InetAddress localAddress, int localPort)
       throws IOException {
     Socket socket = delegate.createSocket(host, port, localAddress, localPort);
-    configureSocket(socket);
-    return socket;
+    return configureSocket(socket);
   }
 
-  protected void configureSocket(Socket socket) throws IOException {
+  protected Socket configureSocket(Socket socket) throws IOException {
     // No-op by default.
+    return socket;
   }
 }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/FallbackTestClientSocketFactory.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/FallbackTestClientSocketFactory.java
@@ -40,37 +40,8 @@ public class FallbackTestClientSocketFactory extends DelegatingSSLSocketFactory 
     super(delegate);
   }
 
-  @Override public SSLSocket createSocket(Socket s, String host, int port, boolean autoClose)
-      throws IOException {
-    SSLSocket socket = super.createSocket(s, host, port, autoClose);
-    return new TlsFallbackScsvDisabledSSLSocket(socket);
-  }
-
-  @Override public SSLSocket createSocket() throws IOException {
-    SSLSocket socket = super.createSocket();
-    return new TlsFallbackScsvDisabledSSLSocket(socket);
-  }
-
-  @Override public SSLSocket createSocket(String host,int port) throws IOException {
-    SSLSocket socket = super.createSocket(host, port);
-    return new TlsFallbackScsvDisabledSSLSocket(socket);
-  }
-
-  @Override public SSLSocket createSocket(String host,int port, InetAddress localHost,
-      int localPort) throws IOException {
-    SSLSocket socket = super.createSocket(host, port, localHost, localPort);
-    return new TlsFallbackScsvDisabledSSLSocket(socket);
-  }
-
-  @Override public SSLSocket createSocket(InetAddress host,int port) throws IOException {
-    SSLSocket socket = super.createSocket(host, port);
-    return new TlsFallbackScsvDisabledSSLSocket(socket);
-  }
-
-  @Override public SSLSocket createSocket(InetAddress address,int port,
-      InetAddress localAddress, int localPort) throws IOException {
-    SSLSocket socket = super.createSocket(address, port, localAddress, localPort);
-    return new TlsFallbackScsvDisabledSSLSocket(socket);
+  @Override protected SSLSocket configureSocket(SSLSocket sslSocket) throws IOException {
+    return new TlsFallbackScsvDisabledSSLSocket(sslSocket);
   }
 
   private static class TlsFallbackScsvDisabledSSLSocket extends DelegatingSSLSocket {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
@@ -2232,15 +2232,18 @@ public final class URLConnectionTest {
     server.setServerSocketFactory(
         new DelegatingServerSocketFactory(ServerSocketFactory.getDefault()) {
           @Override
-          protected void configureServerSocket(ServerSocket serverSocket) throws IOException {
+          protected ServerSocket configureServerSocket(ServerSocket serverSocket)
+              throws IOException {
             serverSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+            return serverSocket;
           }
         });
     client.client().setSocketFactory(new DelegatingSocketFactory(SocketFactory.getDefault()) {
       @Override
-      protected void configureSocket(Socket socket) throws IOException {
+      protected Socket configureSocket(Socket socket) throws IOException {
         socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
         socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
+        return socket;
       }
     });
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/DisconnectTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/DisconnectTest.java
@@ -55,15 +55,18 @@ public final class DisconnectTest {
     server.setServerSocketFactory(
         new DelegatingServerSocketFactory(ServerSocketFactory.getDefault()) {
           @Override
-          protected void configureServerSocket(ServerSocket serverSocket) throws IOException {
+          protected ServerSocket configureServerSocket(ServerSocket serverSocket)
+              throws IOException {
             serverSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+            return serverSocket;
           }
         });
     client.setSocketFactory(new DelegatingSocketFactory(SocketFactory.getDefault()) {
       @Override
-      protected void configureSocket(Socket socket) throws IOException {
+      protected Socket configureSocket(Socket socket) throws IOException {
         socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
         socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+        return socket;
       }
     });
   }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ThreadInterruptTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/ThreadInterruptTest.java
@@ -57,15 +57,18 @@ public final class ThreadInterruptTest {
     server.setServerSocketFactory(
         new DelegatingServerSocketFactory(ServerSocketFactory.getDefault()) {
           @Override
-          protected void configureServerSocket(ServerSocket serverSocket) throws IOException {
+          protected ServerSocket configureServerSocket(ServerSocket serverSocket)
+              throws IOException {
             serverSocket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+            return serverSocket;
           }
         });
     client.setSocketFactory(new DelegatingSocketFactory(SocketFactory.getDefault()) {
       @Override
-      protected void configureSocket(Socket socket) throws IOException {
+      protected Socket configureSocket(Socket socket) throws IOException {
         socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
         socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+        return socket;
       }
     });
   }


### PR DESCRIPTION
From comments in a different PR.

Modify the various Delegating*SocketFactory implementations
to return a *Socket from configureSocket() rather than assume
configuration just modifies the object supplied. Improves
flexibility and reduces the need to override multiple methods
in some places.