### PR TITLE
Fix encoding set for query parameters

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
@@ -914,6 +914,12 @@ public final class HttpUrlTest {
     assertEquals("http://username:password@host/path?query#fragment", uri.toString());
   }
 
+  @Test public void toUriSpecialQueryCharacters() throws Exception {
+    HttpUrl httpUrl = HttpUrl.parse("http://host/?d=abc!@[]^`{}|\\");
+    URI uri = httpUrl.uri();
+    assertEquals("http://host/?d=abc!@[]%5E%60%7B%7D%7C%5C", uri.toString());
+  }
+
   @Test public void toUriForbiddenCharacter() throws Exception {
     HttpUrl httpUrl = HttpUrl.parse("http://host/a[b");
     try {

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -259,7 +259,7 @@ public final class HttpUrl {
   static final String PASSWORD_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#";
   static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#";
   static final String QUERY_ENCODE_SET = " \"'<>#";
-  static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>#&=";
+  static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>#&=^`{}|\\";
   static final String FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~";
   static final String FRAGMENT_ENCODE_SET = "";
 

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -259,7 +259,8 @@ public final class HttpUrl {
   static final String PASSWORD_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#";
   static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#";
   static final String QUERY_ENCODE_SET = " \"'<>#";
-  static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>#&=^`{}|\\";
+  static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>#&=";
+  static final String CONVERT_TO_URI_ENCODE_SET = "^`{}|\\";
   static final String FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~";
   static final String FRAGMENT_ENCODE_SET = "";
 
@@ -331,7 +332,8 @@ public final class HttpUrl {
    */
   public URI uri() {
     try {
-      return new URI(url);
+      String uriSafeUrl = canonicalize(url, CONVERT_TO_URI_ENCODE_SET, true, false);
+      return new URI(uriSafeUrl);
     } catch (URISyntaxException e) {
       throw new IllegalStateException("not valid as a java.net.URI: " + url);
     }


### PR DESCRIPTION
Added additional encoding characters that cause URI to throw an `URISyntaxException` when used in a query parameter.

fixes this issue (reported on retrofit, but belongs on okhttp) https://github.com/square/retrofit/issues/1058