### PR TITLE
Avoid extra MediaType.parse() calls by adding charset to MediaType in FormEncodingBuilder

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/FormEncodingBuilder.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/FormEncodingBuilder.java
@@ -23,7 +23,7 @@ import okio.Buffer;
  */
 public final class FormEncodingBuilder {
   private static final MediaType CONTENT_TYPE =
-      MediaType.parse("application/x-www-form-urlencoded");
+      MediaType.parse("application/x-www-form-urlencoded; charset=utf-8");
 
   private final Buffer content = new Buffer();
 


### PR DESCRIPTION
Add charset to MediaType in order to avoid it being added after calling .build()

RequestBody.create() always checks and adds utf-8 charset if undefined in MediaType causing an extra MediaType.parse() call for each use of FormEncodingBuilder