### PR TITLE
Consider digits in HttpUrl scheme as valid

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
@@ -83,6 +83,8 @@ public final class HttpUrlTest {
     assertEquals(HttpUrl.parse("http://host/"), HttpUrl.parse("HTTP://host/"));
     assertEquals(HttpUrl.parse("https://host/"), HttpUrl.parse("https://host/"));
     assertEquals(HttpUrl.parse("https://host/"), HttpUrl.parse("HTTPS://host/"));
+    assertEquals(HttpUrl.Builder.ParseResult.UNSUPPORTED_SCHEME,
+        new HttpUrl.Builder().parse(null, "image640://480.png"));
     assertEquals(null, HttpUrl.parse("httpp://host/"));
     assertEquals(null, HttpUrl.parse("0ttp://host/"));
     assertEquals(null, HttpUrl.parse("ht+tp://host/"));

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -1178,6 +1178,7 @@ public final class HttpUrl {
 
         if ((c >= 'a' && c <= 'z')
             || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9')
             || c == '+'
             || c == '-'
             || c == '.') {


### PR DESCRIPTION
Even though `HttpUrl` only supports http and https URLs, it should still consider a URI like `image640://480.png` as valid, even though it's unsupported. This changes `schemeDelimiterOffset()` to correctly account for digits in the scheme.

Specs: https://tools.ietf.org/html/rfc3986#page-17