### PR TITLE
Throw UnknownHostException not IllegalArgumentException for bad host …

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
@@ -16,6 +16,7 @@
 package com.squareup.okhttp.mockwebserver;
 
 import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.internal.Internal;
 import com.squareup.okhttp.ws.WebSocketListener;
 import java.util.ArrayList;
 import java.util.List;
@@ -102,6 +103,16 @@ public final class MockResponse implements Cloneable {
    */
   public MockResponse addHeader(String name, Object value) {
     headers.add(name, String.valueOf(value));
+    return this;
+  }
+
+  /**
+   * Adds a new header with the name and value. This may be used to add multiple
+   * headers with the same name. Unlike {@link #addHeader(String, Object)} this
+   * does not validate the name and value.
+   */
+  public MockResponse addHeaderLenient(String name, Object value) {
+    Internal.instance.addLenient(headers, name, String.valueOf(value));
     return this;
   }
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public final class HttpUrlTest {
@@ -40,6 +41,11 @@ public final class HttpUrlTest {
     assertEquals(expected, HttpUrl.parse("    http://host/    ")); // Both.
     assertEquals(expected, HttpUrl.parse("http://host/").resolve("   "));
     assertEquals(expected, HttpUrl.parse("http://host/").resolve("  .  "));
+  }
+
+  @Test public void parseHostAsciiNonPrintable() throws Exception {
+    String host = "host\u0001";
+    assertNull(HttpUrl.parse("http://" + host + "/"));
   }
 
   @Test public void parseDoesNotTrimOtherWhitespaceCharacters() throws Exception {

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
@@ -3212,6 +3212,25 @@ public final class URLConnectionTest {
     }
   }
 
+  @Test public void urlRedirectToHostWithNul() throws Exception {
+    String redirectUrl = "http://host\u0000/";
+    server.enqueue(new MockResponse().setResponseCode(302)
+        .addHeaderLenient("Location", redirectUrl));
+
+    HttpURLConnection urlConnection = client.open(server.getUrl("/"));
+    assertEquals(302, urlConnection.getResponseCode());
+    assertEquals(redirectUrl, urlConnection.getHeaderField("Location"));
+  }
+
+  @Test public void urlWithBadAsciiHost() throws Exception {
+    URLConnection urlConnection = client.open(new URL("http://host\u0001/"));
+    try {
+      urlConnection.getInputStream();
+      fail();
+    } catch (UnknownHostException expected) {
+    }
+  }
+
   /** Returns a gzipped copy of {@code bytes}. */
   public Buffer gzip(String data) throws IOException {
     Buffer result = new Buffer();


### PR DESCRIPTION
…chars

Before this change HttpURLConnection would parse the bad ASCII
characters like \u0001, but fail when setting them in the host
header.

After this change HttpURLConnection throws UnknownHostException.
Earlier versions of OkHttp would escape the bad characters, but
this behavior has not been retained.

Fix for issue #1833.

This change involves a public API change to Headers (addHeaderLenient)
to enable building of MockResponse objects containing response headers
that OkHttp considers invalid, and a behavior change for HttpUrl, and
consequently HttpURLConnectionImpl.