### PR TITLE
feat: Need expanding 'QUERY_COMPONENT_ENCODE_SET' values in 'okhttp/H…

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -259,7 +259,7 @@ public final class HttpUrl {
   static final String PASSWORD_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#";
   static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#";
   static final String QUERY_ENCODE_SET = " \"'<>#";
-  static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>#&=";
+  static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>|#&=";
   static final String CONVERT_TO_URI_ENCODE_SET = "^`{}|\\";
   static final String FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~";
   static final String FRAGMENT_ENCODE_SET = "";


### PR DESCRIPTION
Is it possible that `QUERY_ENCODE_SET` or `QUERY_COMPONENT_ENCODE_SET` does not support `| (%7C)` like `FORM_ENCODE_SET`?  

Is it possible that `QUERY_ENCODE_SET` or `QUERY_COMPONENT_ENCODE_SET` does not support `| (%7C)` like `FORM_ENCODE_SET`?  Or would you tell me why because I might missing the basic knowledge of URL Encoding...

Thanks,

```java

  static final String USERNAME_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#";
  static final String PASSWORD_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#";
  static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#";
  static final String QUERY_ENCODE_SET = " \"'<>#";
  static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>#&=";
  static final String FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~";
  static final String FRAGMENT_ENCODE_SET = "";

```