### PR TITLE
Add test for AsyncCall failure in application Interceptor

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -697,6 +697,17 @@ public final class CallTest {
     }
   }
 
+  @Test public void asyncCallEngineInitialized () {
+    OkHttpClient client = new OkHttpClient();
+    client.interceptors().add(new Interceptor() {
+
+      @Override public Response intercept(Chain chain) throws IOException {
+        throw new IOException();
+      }
+    });
+    client.newCall(new Request.Builder().url(server.url("http://a/1")).build()).enqueue(callback);
+  }
+
   @Test public void reusedSinksGetIndependentTimeoutInstances() throws Exception {
     server.enqueue(new MockResponse());
     server.enqueue(new MockResponse());


### PR DESCRIPTION
A failing test for https://github.com/square/okhttp/issues/1801
I am not sure this is the right place for the test, though.