### PR TITLE
Allow interceptor to change method

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/FramedTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/FramedTransport.java
@@ -83,7 +83,7 @@ public final class FramedTransport implements Transport {
     if (stream != null) return;
 
     httpEngine.writingRequestHeaders();
-    boolean permitsRequestBody = httpEngine.permitsRequestBody();
+    boolean permitsRequestBody = httpEngine.permitsRequestBody(request);
     boolean hasResponseBody = true;
     String version = RequestLine.version(httpEngine.getConnection().getProtocol());
     stream = framedConnection.newStream(

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -252,7 +252,7 @@ public final class HttpEngine {
       // immediately. And that means we need to immediately write the request headers, so we can
       // start streaming the request body. (We may already have a request body if we're retrying a
       // failed POST.)
-      if (callerWritesRequestBody && permitsRequestBody() && requestBodyOut == null) {
+      if (callerWritesRequestBody && permitsRequestBody(networkRequest) && requestBodyOut == null) {
         long contentLength = OkHeaders.contentLength(request);
         if (bufferRequestBody) {
           if (contentLength > Integer.MAX_VALUE) {
@@ -358,8 +358,8 @@ public final class HttpEngine {
     sentRequestMillis = System.currentTimeMillis();
   }
 
-  boolean permitsRequestBody() {
-    return HttpMethod.permitsRequestBody(userRequest.method());
+  boolean permitsRequestBody(Request request) {
+    return HttpMethod.permitsRequestBody(request.method());
   }
 
   /** Returns the request body or null if this request doesn't have a body. */
@@ -881,7 +881,7 @@ public final class HttpEngine {
       //Update the networkRequest with the possibly updated interceptor request.
       networkRequest = request;
 
-      if (permitsRequestBody() && request.body() != null) {
+      if (permitsRequestBody(request) && request.body() != null) {
         Sink requestBodyOut = transport.createRequestBody(request, request.body().contentLength());
         BufferedSink bufferedRequestBody = Okio.buffer(requestBodyOut);
         request.body().writeTo(bufferedRequestBody);


### PR DESCRIPTION
Changing the request method from e.g. `GET` to `POST` in a network interceptor lead to the body not being written to the transport. That's because `HttpEngine#permitsRequestBody()` was using the original request to determine whether sending a request body was allowed.