### PR TITLE
Introduce intermediate storage for frame contents.

### DIFF
--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/internal/ws/RealWebSocketTest.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/internal/ws/RealWebSocketTest.java
@@ -247,13 +247,6 @@ public final class RealWebSocketTest {
         clientListener.assertClose(1000, "Hello!");
 
         try {
-          sink.writeUtf8("lo!").emit(); // No writing to the underlying sink.
-          fail();
-        } catch (IOException e) {
-          assertEquals("closed", e.getMessage());
-          sink.buffer().clear();
-        }
-        try {
           sink.flush(); // No flushing.
           fail();
         } catch (IOException e) {
@@ -320,7 +313,7 @@ public final class RealWebSocketTest {
     clientListener.assertClose(1000, "Bye!");
   }
 
-  @Test public void protocolErrorBeforeCloseSendsClose() {
+  @Test public void protocolErrorBeforeCloseSendsClose() throws IOException {
     server2client.write(ByteString.decodeHex("0a00")); // Invalid non-final ping frame.
 
     client.readMessage(); // Detects error, send close.

--- a/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/WebSocketRecorder.java
+++ b/okhttp-ws-tests/src/test/java/com/squareup/okhttp/ws/WebSocketRecorder.java
@@ -87,28 +87,48 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
     }
   }
 
-  public void assertTextMessage(String payload) {
+  public void assertTextMessage(String payload) throws IOException {
     Message message = new Message(TEXT);
     message.buffer.writeUtf8(payload);
-    assertEquals(message, nextEvent());
+    Object actual = nextEvent();
+    if (actual instanceof IOException) {
+      throw (IOException) actual;
+    }
+    assertEquals(message, actual);
   }
 
-  public void assertBinaryMessage(byte[] payload) {
+  public void assertBinaryMessage(byte[] payload) throws IOException {
     Message message = new Message(BINARY);
     message.buffer.write(payload);
-    assertEquals(message, nextEvent());
+    Object actual = nextEvent();
+    if (actual instanceof IOException) {
+      throw (IOException) actual;
+    }
+    assertEquals(message, actual);
   }
 
-  public void assertPing(Buffer payload) {
-    assertEquals(new Ping(payload), nextEvent());
+  public void assertPing(Buffer payload) throws IOException {
+    Object actual = nextEvent();
+    if (actual instanceof IOException) {
+      throw (IOException) actual;
+    }
+    assertEquals(new Ping(payload), actual);
   }
 
-  public void assertPong(Buffer payload) {
-    assertEquals(new Pong(payload), nextEvent());
+  public void assertPong(Buffer payload) throws IOException {
+    Object actual = nextEvent();
+    if (actual instanceof IOException) {
+      throw (IOException) actual;
+    }
+    assertEquals(new Pong(payload), actual);
   }
 
-  public void assertClose(int code, String reason) {
-    assertEquals(new Close(code, reason), nextEvent());
+  public void assertClose(int code, String reason) throws IOException {
+    Object actual = nextEvent();
+    if (actual instanceof IOException) {
+      throw (IOException) actual;
+    }
+    assertEquals(new Close(code, reason), actual);
   }
 
   public void assertFailure(Class<? extends IOException> cls, String message) {

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/WebSocketProtocol.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/WebSocketProtocol.java
@@ -68,14 +68,16 @@ public final class WebSocketProtocol {
   static final int OPCODE_CONTROL_PONG = 0xa;
 
   /**
-   * Maximum length of frame payload. Larger payloads, if supported, can use the special values
-   * {@link #PAYLOAD_SHORT} or {@link #PAYLOAD_LONG}.
+   * Maximum length of frame payload. Larger payloads, if supported by the frame type, can use the
+   * special values {@link #PAYLOAD_SHORT} or {@link #PAYLOAD_LONG}.
    */
-  static final int PAYLOAD_MAX = 125;
+  static final long PAYLOAD_BYTE_MAX = 125L;
   /**
    * Value for {@link #B1_MASK_LENGTH} which indicates the next two bytes are the unsigned length.
    */
   static final int PAYLOAD_SHORT = 126;
+  /** Maximum length of a frame payload to be denoted as {@link #PAYLOAD_SHORT}. */
+  static final long PAYLOAD_SHORT_MAX = 0xffffL;
   /**
    * Value for {@link #B1_MASK_LENGTH} which indicates the next eight bytes are the unsigned
    * length.

--- a/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/WebSocketReader.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/internal/ws/WebSocketReader.java
@@ -42,7 +42,7 @@ import static com.squareup.okhttp.internal.ws.WebSocketProtocol.OPCODE_CONTROL_P
 import static com.squareup.okhttp.internal.ws.WebSocketProtocol.OPCODE_FLAG_CONTROL;
 import static com.squareup.okhttp.internal.ws.WebSocketProtocol.OPCODE_TEXT;
 import static com.squareup.okhttp.internal.ws.WebSocketProtocol.PAYLOAD_LONG;
-import static com.squareup.okhttp.internal.ws.WebSocketProtocol.PAYLOAD_MAX;
+import static com.squareup.okhttp.internal.ws.WebSocketProtocol.PAYLOAD_BYTE_MAX;
 import static com.squareup.okhttp.internal.ws.WebSocketProtocol.PAYLOAD_SHORT;
 import static com.squareup.okhttp.internal.ws.WebSocketProtocol.toggleMask;
 import static java.lang.Integer.toHexString;
@@ -147,8 +147,8 @@ public final class WebSocketReader {
     }
     frameBytesRead = 0;
 
-    if (isControlFrame && frameLength > PAYLOAD_MAX) {
-      throw new ProtocolException("Control frame must be less than " + PAYLOAD_MAX + "B.");
+    if (isControlFrame && frameLength > PAYLOAD_BYTE_MAX) {
+      throw new ProtocolException("Control frame must be less than " + PAYLOAD_BYTE_MAX + "B.");
     }
 
     if (isMasked) {

--- a/samples/guide/src/main/java/com/squareup/okhttp/recipes/WebSocketEcho.java
+++ b/samples/guide/src/main/java/com/squareup/okhttp/recipes/WebSocketEcho.java
@@ -17,10 +17,6 @@ import okio.ByteString;
 import static com.squareup.okhttp.ws.WebSocket.BINARY;
 import static com.squareup.okhttp.ws.WebSocket.TEXT;
 
-/**
- * NOTE: This is currently broken because the Echo server does not correctly echo empty frames
- * which OkHttp uses for final frames on streamed messages.
- */
 public final class WebSocketEcho implements WebSocketListener {
   private final Executor writeExecutor = Executors.newSingleThreadExecutor();
 


### PR DESCRIPTION
This eliminates the need to always send a frame for every `FrameSink#write` and to always send an empty frame for `FrameSink#close`. Now, we only emit bytes once Okio reports complete segments.