### PR TITLE
use URI constructor for encoding

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
@@ -930,16 +930,19 @@ public final class HttpUrlTest {
     assertEquals("http://host/?d=abc!@[]%5E%60%7B%7D%7C%5C", uri.toString());
   }
 
-  @Test public void toUriForbiddenCharacter() throws Exception {
-    HttpUrl httpUrl = HttpUrl.parse("http://host/a[b");
-    try {
-      httpUrl.uri();
-      fail();
-    } catch (IllegalStateException expected) {
-      assertEquals("not valid as a java.net.URI: http://host/a[b", expected.getMessage());
-    }
+  @Test public void toUriSpecialPathCharacters() throws Exception {
+    HttpUrl url = new HttpUrl.Builder()
+        .scheme("http")
+        .host("example.com")
+        .addPathSegment("data=[out:json];node[\"name\"~\"Karlsruhe\"]" +
+            "[\"place\"~\"city|village|town\"];out body;")
+        .build();
+    URI uri = url.uri();
+    assertEquals("http://example.com/data=%5Bout:json%5D;node%5B%22name%22~%22Karlsruhe%22%5D" +
+            "%5B%22place%22~%22city%7Cvillage%7Ctown%22%5D;out%20body;",
+        uri.toString());
   }
-
+  
   @Test public void fromJavaNetUrl() throws Exception {
     URL javaNetUrl = new URL("http://username:password@host/path?query#fragment");
     HttpUrl httpUrl = HttpUrl.get(javaNetUrl);

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
@@ -395,7 +395,7 @@ public final class URLConnectionTest {
     try {
       connection.connect();
       fail();
-    } catch (UnknownHostException expected) {
+    } catch (IllegalStateException expected) {
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -260,7 +260,6 @@ public final class HttpUrl {
   static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#";
   static final String QUERY_ENCODE_SET = " \"'<>#";
   static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>#&=";
-  static final String CONVERT_TO_URI_ENCODE_SET = "^`{}|\\";
   static final String FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~";
   static final String FRAGMENT_ENCODE_SET = "";
 
@@ -332,8 +331,12 @@ public final class HttpUrl {
    */
   public URI uri() {
     try {
-      String uriSafeUrl = canonicalize(url, CONVERT_TO_URI_ENCODE_SET, true, false);
-      return new URI(uriSafeUrl);
+      String uriUserInfo = username + ":" + password;
+      if (uriUserInfo.equals(":")) uriUserInfo = null;
+      final int uriPort = port == defaultPort(scheme) ? -1 : port; // Don't include default port
+      StringBuilder path = new StringBuilder();
+      pathSegmentsToString(path, pathSegments);
+      return new URI(scheme, uriUserInfo, host, uriPort, path.toString(), query(), fragment);
     } catch (URISyntaxException e) {
       throw new IllegalStateException("not valid as a java.net.URI: " + url);
     }


### PR DESCRIPTION
fixes - https://github.com/square/okhttp/issues/1872
1) Use the [URI's multi-parameter](http://docs.oracle.com/javase/7/docs/api/java/net/URI.html#URI%28java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20java.lang.String,%20java.lang.String,%20java.lang.String%29) constructor does piecewise encoding. 
2) Removed test (toUriForbiddenCharacter) that expects '[' to be invalid in the path segment since it will be encoded now.
3) Updated the `invalidHost` test to expect a different exception.  It appears that URI errors earlier in the process (URI creation) using this constructor.
4) reverts previous fix (https://github.com/square/okhttp/pull/1845)