### PR TITLE
Reduce the memory requirements of a test

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
@@ -2228,7 +2228,7 @@ public final class URLConnectionTest {
   @Test public void writeTimeouts() throws IOException {
     // Sockets on some platforms can have large buffers that mean writes do not block when
     // required. These socket factories explicitly set the buffer sizes on sockets created.
-    final int SOCKET_BUFFER_SIZE = 256 * 1024;
+    final int SOCKET_BUFFER_SIZE = 4 * 1024;
     server.setServerSocketFactory(
         new DelegatingServerSocketFactory(ServerSocketFactory.getDefault()) {
           @Override
@@ -2256,7 +2256,7 @@ public final class URLConnectionTest {
     connection.setChunkedStreamingMode(0);
     OutputStream out = connection.getOutputStream();
     try {
-      byte[] data = new byte[16 * 1024 * 1024]; // 16 MiB.
+      byte[] data = new byte[2 * 1024 * 1024]; // 2 MiB.
       out.write(data);
       fail();
     } catch (SocketTimeoutException expected) {


### PR DESCRIPTION
URLConnectionTest.testWrites allocates a 16MB buffer.
It can run in less memory (and causes problems
on low-spec Android devices).

4k is the typical smallest allowable buffer size on Linux.