### PR TITLE
Change encoding/decoding rules for +.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/HttpUrlTest.java
@@ -28,9 +28,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public final class HttpUrlTest {
   @Test public void parseTrimsAsciiWhitespace() throws Exception {
@@ -777,6 +775,15 @@ public final class HttpUrlTest {
     assertEquals("/a/b/", base.newBuilder().addEncodedPathSegment("..\n").build().encodedPath());
   }
 
+  @Test public void addEncodedAndUnencodedPlusQueryParam() throws Exception {
+    HttpUrl base = HttpUrl.parse("http://host/a/b/c");
+    HttpUrl withPlus = base.newBuilder()
+     .addEncodedQueryParameter("preEncoded+", "+")
+     .addQueryParameter("unEncoded+", "+")
+     .build();
+    assertEquals("preEncoded+=+&unEncoded%2B=%2B", withPlus.encodedQuery());
+  }
+
   @Test public void setPathSegment() throws Exception {
     HttpUrl base = HttpUrl.parse("http://host/a/b/c");
     assertEquals("/d/b/c", base.newBuilder().setPathSegment(0, "d").build().encodedPath());
@@ -1005,8 +1012,8 @@ public final class HttpUrlTest {
   @Test public void composeQueryWithEncodedComponents() throws Exception {
     HttpUrl base = HttpUrl.parse("http://host/");
     HttpUrl url = base.newBuilder().addEncodedQueryParameter("a+=& b", "c+=& d").build();
-    assertEquals("http://host/?a%20%3D%26%20b=c%20%3D%26%20d", url.toString());
-    assertEquals("c =& d", url.queryParameter("a =& b"));
+    assertEquals("http://host/?a+%3D%26%20b=c+%3D%26%20d", url.toString());
+    assertEquals("c+=& d", url.queryParameter("a+=& b"));
   }
 
   @Test public void composeQueryRemoveQueryParameter() throws Exception {
@@ -1041,8 +1048,8 @@ public final class HttpUrlTest {
         .addEncodedQueryParameter("a+=& b", "c+=& d")
         .setEncodedQueryParameter("a+=& b", "ef")
         .build();
-    assertEquals("http://host/?a%20%3D%26%20b=ef", url.toString());
-    assertEquals("ef", url.queryParameter("a =& b"));
+    assertEquals("http://host/?a+%3D%26%20b=ef", url.toString());
+    assertEquals("ef", url.queryParameter("a+=& b"));
   }
 
   @Test public void composeQueryMultipleEncodedValuesForParameter() throws Exception {

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -301,16 +301,16 @@ public final class HttpUrl {
 
   private HttpUrl(Builder builder) {
     this.scheme = builder.scheme;
-    this.username = percentDecode(builder.encodedUsername);
-    this.password = percentDecode(builder.encodedPassword);
+    this.username = percentDecode(builder.encodedUsername, false);
+    this.password = percentDecode(builder.encodedPassword, false);
     this.host = builder.host;
     this.port = builder.effectivePort();
-    this.pathSegments = percentDecode(builder.encodedPathSegments);
+    this.pathSegments = percentDecode(builder.encodedPathSegments, false);
     this.queryNamesAndValues = builder.encodedQueryNamesAndValues != null
-        ? percentDecode(builder.encodedQueryNamesAndValues)
+        ? percentDecode(builder.encodedQueryNamesAndValues, true)
         : null;
     this.fragment = builder.encodedFragment != null
-        ? percentDecode(builder.encodedFragment)
+        ? percentDecode(builder.encodedFragment, false)
         : null;
     this.url = builder.toString();
   }
@@ -1227,7 +1227,7 @@ public final class HttpUrl {
     private static String canonicalizeHost(String input, int pos, int limit) {
       // Start by percent decoding the host. The WHATWG spec suggests doing this only after we've
       // checked for IPv6 square braces. But Chrome does it first, and that's more lenient.
-      String percentDecoded = percentDecode(input, pos, limit);
+      String percentDecoded = percentDecode(input, pos, limit, false);
 
       // If the input is encased in square braces "[...]", drop 'em. We have an IPv6 address.
       if (percentDecoded.startsWith("[") && percentDecoded.endsWith("]")) {
@@ -1447,19 +1447,19 @@ public final class HttpUrl {
     return limit;
   }
 
-  static String percentDecode(String encoded) {
-    return percentDecode(encoded, 0, encoded.length());
+  static String percentDecode(String encoded, boolean isQuery) {
+    return percentDecode(encoded, 0, encoded.length(), isQuery);
   }
 
-  private List<String> percentDecode(List<String> list) {
+  private List<String> percentDecode(List<String> list, boolean isQuery) {
     List<String> result = new ArrayList<>(list.size());
     for (String s : list) {
-      result.add(s != null ? percentDecode(s) : null);
+      result.add(s != null ? percentDecode(s, isQuery) : null);
     }
     return Collections.unmodifiableList(result);
   }
 
-  static String percentDecode(String encoded, int pos, int limit) {
+  static String percentDecode(String encoded, int pos, int limit, boolean isQuery) {
     for (int i = pos; i < limit; i++) {
       char c = encoded.charAt(i);
       if (c == '%') {
@@ -1472,7 +1472,12 @@ public final class HttpUrl {
     }
 
     // Fast path: no characters in [pos..limit) required decoding.
-    return encoded.substring(pos, limit);
+    String result = encoded.substring(pos, limit);
+    // + become ' ' for queries
+    if(isQuery) {
+      result = result.replace('+', ' ');
+    }
+    return result;
   }
 
   static void percentDecode(Buffer out, String encoded, int pos, int limit) {
@@ -1504,14 +1509,14 @@ public final class HttpUrl {
    * transformations:
    * <ul>
    *   <li>Tabs, newlines, form feeds and carriage returns are skipped.
-   *   <li>In queries, ' ' is encoded to '+' and '+' is encoded to "%2B".
+   *   <li>In queries, ' ' is encoded to '+'.
    *   <li>Characters in {@code encodeSet} are percent-encoded.
    *   <li>Control characters and non-ASCII characters are percent-encoded.
    *   <li>All other characters are copied without transformation.
    * </ul>
    *
    * @param alreadyEncoded true to leave '%' as-is; false to convert it to '%25'.
-   * @param query true if to encode ' ' as '+', and '+' as "%2B".
+   * @param query true if to encode ' ' as '+'.
    */
   static String canonicalize(String input, int pos, int limit, String encodeSet,
       boolean alreadyEncoded, boolean query) {
@@ -1522,7 +1527,7 @@ public final class HttpUrl {
           || codePoint >= 0x7f
           || encodeSet.indexOf(codePoint) != -1
           || (codePoint == '%' && !alreadyEncoded)
-          || (query && codePoint == '+')) {
+          || (!alreadyEncoded && query && codePoint == '+')) {
         // Slow path: the character at i requires encoding!
         Buffer out = new Buffer();
         out.writeUtf8(input, pos, i);


### PR DESCRIPTION
- Don't do percent encoding of + in query string.
- Always decode + to a ' ' (space).
