### PR TITLE
Throw the right exception if an interceptor returns null.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -872,6 +872,10 @@ public final class HttpEngine {
           throw new IllegalStateException("network interceptor " + interceptor
               + " must call proceed() exactly once");
         }
+        if (interceptedResponse == null) {
+          throw new NullPointerException("network interceptor " + interceptor
+              + " returned null");
+        }
 
         return interceptedResponse;
       }


### PR DESCRIPTION
Previously we were treating null as a sentinel 'canceled' value
for application interceptors, and crashing on network interceptors.

Closes https://github.com/square/okhttp/issues/1921