### PR TITLE
Log favicon request instead of using standard output

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/QueueDispatcher.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/QueueDispatcher.java
@@ -18,12 +18,14 @@ package com.squareup.okhttp.mockwebserver;
 import java.net.HttpURLConnection;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.logging.Logger;
 
 /**
  * Default dispatcher that processes a script of responses. Populate the script
  * by calling {@link #enqueueResponse(MockResponse)}.
  */
 public class QueueDispatcher extends Dispatcher {
+  private static final Logger logger = Logger.getLogger(QueueDispatcher.class.getName());
   protected final BlockingQueue<MockResponse> responseQueue = new LinkedBlockingQueue<>();
   private MockResponse failFastResponse;
 
@@ -31,7 +33,7 @@ public class QueueDispatcher extends Dispatcher {
     // To permit interactive/browser testing, ignore requests for favicons.
     final String requestLine = request.getRequestLine();
     if (requestLine != null && requestLine.equals("GET /favicon.ico HTTP/1.1")) {
-      System.out.println("served " + requestLine);
+      logger.info("served " + requestLine);
       return new MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND);
     }
 


### PR DESCRIPTION
`QueueDispatcher` currently logs favicon requests to `System.out`. We should use a `Logger` instead so these messages can be suppressed if required.