### PR TITLE
Fix URLConnectionTest.writeTimeouts with large receive buffers

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -175,6 +175,8 @@ public final class MockWebServer implements TestRule {
   }
 
   public void setServerSocketFactory(ServerSocketFactory serverSocketFactory) {
+    if (executor != null) throw new IllegalStateException(
+        "setServerSocketFactory() must be called before start()");
     this.serverSocketFactory = serverSocketFactory;
   }
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/URLConnectionTest.java
@@ -2226,6 +2226,7 @@ public final class URLConnectionTest {
 
   /** Confirm that an unacknowledged write times out. */
   @Test public void writeTimeouts() throws IOException {
+    MockWebServer server = new MockWebServer();
     // Sockets on some platforms can have large buffers that mean writes do not block when
     // required. These socket factories explicitly set the buffer sizes on sockets created.
     final int SOCKET_BUFFER_SIZE = 4 * 1024;
@@ -2247,6 +2248,7 @@ public final class URLConnectionTest {
       }
     });
 
+    server.start();
     server.enqueue(new MockResponse()
         .throttleBody(1, 1, TimeUnit.SECONDS)); // Prevent the server from reading!
 


### PR DESCRIPTION
The test relies on small client send / server receive buffers
to force blocking and generate a timeout.

The switch to make MockWebServer a @Rule (commit
785d9e94387f404f571775a49c3a9438508bb659) moved the
MockWebServer.start() call earlier in the test execution.
Setting the ServerSocketFactory became a no-op so the server
receive buffer size was left as the default.

The test became reliant on either:
1) The default server socket receive buffer being small enough
(e.g. less than the data being transmitted).
2) The device being too slow to send the requested data in the
time allowed.

The test was recently made less reliable by:
1) The okio commit
f30955cb15eb234f874dd55819686832c960765b, which made the segment
size bigger (increasing throughput / transfer efficiency).
2) The OkHttp commit f30955cb15eb234f874dd55819686832c960765b,
which reduced the amount of data being sent in the test from
16MB to 2MB.
3) Recent Android devices have large default buffer sizes. e.g.
Nexus 5: 1MB, Nexus 5X: 6MB.