### PR TITLE
Handle UnsupportedCharsetException in HttpLoggingInterceptor

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/com/squareup/okhttp/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/com/squareup/okhttp/logging/HttpLoggingInterceptor.java
@@ -29,6 +29,7 @@ import com.squareup.okhttp.ResponseBody;
 import com.squareup.okhttp.internal.Platform;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.concurrent.TimeUnit;
 import okio.Buffer;
 import okio.BufferedSource;
@@ -199,9 +200,12 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
         Charset charset = UTF8;
         MediaType contentType = responseBody.contentType();
-        if (contentType != null) {
-          charset = contentType.charset(UTF8);
-        }
+        if (contentType != null)
+          try {
+            charset = contentType.charset(UTF8);
+          } catch (UnsupportedCharsetException e) {
+            // unsupported charset, assume UTF8 nevertheless
+          }
 
         if (responseBody.contentLength() != 0) {
           logger.log("");

--- a/okhttp/src/main/java/com/squareup/okhttp/MediaType.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/MediaType.java
@@ -92,6 +92,7 @@ public final class MediaType {
   /**
    * Returns the charset of this media type, or null if this media type doesn't
    * specify a charset.
+   * @throws UnsupportedCharsetException if the desired charset is not supported by this runtime
    */
   public Charset charset() {
     return charset != null ? Charset.forName(charset) : null;


### PR DESCRIPTION
I got this runtime exception because I have used `HttpLoggingInterceptor` in an app, and it was quite unexpected. Maybe it's wise to point this possibility out in the docs.

Another approach would be that `MediaType.charset()` catches the exception and returns a default value. However, I don't think that's appropriate because the data (which are propbably in another charset, an unknown one) would become misinterpreted and corrupted. Unsupported/unknown charsets are an error condition and should be treated as such.

See also #1978.