### PR TITLE
Force consumers to call WS#close on IO error.

### DIFF
--- a/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocket.java
+++ b/okhttp-ws/src/main/java/com/squareup/okhttp/ws/WebSocket.java
@@ -33,8 +33,8 @@ public interface WebSocket {
    * <p>The {@linkplain RequestBody#contentType() content type} of {@code message} should be either
    * {@link #TEXT} or {@link #BINARY}.
    *
-   * @throws IOException if unable to write the message. If thrown, an attempt to send a close
-   * frame with code 1001 will be made and this instance will no longer be valid to use.
+   * @throws IOException if unable to write the message. Clients must call {@link #close} when this
+   * happens to ensure resources are cleaned up.
    * @throws IllegalStateException if not connected, already closed, or another writer is active.
    */
   void sendMessage(RequestBody message) throws IOException;
@@ -42,8 +42,8 @@ public interface WebSocket {
   /**
    * Send a ping to the server with optional payload.
    *
-   * @throws IOException if unable to write the ping. If thrown, an attempt to send a close frame
-   * with code 1001 will be made and this instance will no longer be valid to use.
+   * @throws IOException if unable to write the ping.  Clients must call {@link #close} when this
+   * happens to ensure resources are cleaned up.
    * @throws IllegalStateException if already closed.
    */
   void sendPing(Buffer payload) throws IOException;
@@ -57,8 +57,7 @@ public interface WebSocket {
    * It is an error to call this method before calling close on an active writer. Calling this
    * method more than once has no effect.
    *
-   * @throws IOException if unable to write the close message. If thrown this instance will no
-   * longer be valid to use.
+   * @throws IOException if unable to write the close message. Resources will still be freed.
    * @throws IllegalStateException if already closed.
    */
   void close(int code, String reason) throws IOException;


### PR DESCRIPTION
This actually un-fixes #1931, but it formalizes the consumer behavior (and ensures that it will behave correctly).