### PR TITLE
OPTIONS allows body.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpMethod.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpMethod.java
@@ -34,6 +34,7 @@ public final class HttpMethod {
 
   public static boolean permitsRequestBody(String method) {
     return requiresRequestBody(method)
+        || method.equals("OPTIONS")
         || method.equals("DELETE")    // Permitted as spec is ambiguous.
         || method.equals("PROPFIND")  // (WebDAV) without body: request <allprop/>
         || method.equals("MKCOL")     // (WebDAV) may contain a body, but behaviour is unspecified


### PR DESCRIPTION
> If the OPTIONS request includes an entity-body (as indicated by the presence of Content-Length or Transfer-Encoding), then the media type MUST be indicated by a Content-Type field. Although this specification does not define any use for such a body, future extensions to HTTP might use the OPTIONS body to make more detailed queries on the server. A server that does not support such an extension MAY discard the request body.