### PR TITLE
Code Quality fix - Exception handlers should preserve the original exception

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
@@ -56,7 +56,7 @@ public final class MockResponse implements Cloneable {
       result.promises = new ArrayList<>(promises);
       return result;
     } catch (CloneNotSupportedException e) {
-      throw new AssertionError();
+      throw new AssertionError(e);
     }
   }
 

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -406,7 +406,7 @@ public final class MockWebServer implements TestRule {
         throw new IOException("Gave up waiting for executor to shut down");
       }
     } catch (InterruptedException e) {
-      throw new AssertionError();
+      throw new AssertionError(e);
     }
   }
 
@@ -785,7 +785,7 @@ public final class MockWebServer implements TestRule {
         try {
           Thread.sleep(periodDelayMs);
         } catch (InterruptedException e) {
-          throw new AssertionError();
+          throw new AssertionError(e);
         }
       }
     }

--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -76,7 +76,7 @@ public class Main extends HelpOption implements Runnable {
       in.close();
       return prop.getProperty("version");
     } catch (IOException e) {
-      throw new AssertionError("Could not load okcurl-version.properties.");
+      throw new AssertionError("Could not load okcurl-version.properties.", e);
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Cache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Cache.java
@@ -630,7 +630,7 @@ public final class Cache {
         }
         return result;
       } catch (CertificateException e) {
-        throw new IOException(e.getMessage());
+        throw new IOException(e.getMessage(), e);
       }
     }
 
@@ -646,7 +646,7 @@ public final class Cache {
           sink.writeByte('\n');
         }
       } catch (CertificateEncodingException e) {
-        throw new IOException(e.getMessage());
+        throw new IOException(e.getMessage(), e);
       }
     }
 
@@ -685,7 +685,7 @@ public final class Cache {
       }
       return (int) result;
     } catch (NumberFormatException e) {
-      throw new IOException(e.getMessage());
+      throw new IOException(e.getMessage(), e);
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Credentials.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Credentials.java
@@ -31,7 +31,7 @@ public final class Credentials {
       String encoded = ByteString.of(bytes).base64();
       return "Basic " + encoded;
     } catch (UnsupportedEncodingException e) {
-      throw new AssertionError();
+      throw new AssertionError(e);
     }
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -1308,7 +1308,7 @@ public final class HttpUrl {
       try {
         return InetAddress.getByAddress(address);
       } catch (UnknownHostException e) {
-        throw new AssertionError();
+        throw new AssertionError(e);
       }
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -671,7 +671,7 @@ public class OkHttpClient implements Cloneable {
         sslContext.init(null, null, null);
         defaultSslSocketFactory = sslContext.getSocketFactory();
       } catch (GeneralSecurityException e) {
-        throw new AssertionError(); // The system has no TLS. Just give up.
+        throw new AssertionError(e); // The system has no TLS. Just give up.
       }
     }
     return defaultSslSocketFactory;

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -58,7 +58,7 @@ public final class Request {
       URI result = javaNetUri;
       return result != null ? result : (javaNetUri = url.uri());
     } catch (IllegalStateException e) {
-      throw new IOException(e.getMessage());
+      throw new IOException(e.getMessage(), e);
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -308,7 +308,7 @@ public class Platform {
       try {
         removeMethod.invoke(null, sslSocket);
       } catch (IllegalAccessException | InvocationTargetException ignored) {
-        throw new AssertionError();
+        throw new AssertionError(ignored);
       }
     }
 
@@ -323,7 +323,7 @@ public class Platform {
         }
         return provider.unsupported ? null : provider.selected;
       } catch (InvocationTargetException | IllegalAccessException e) {
-        throw new AssertionError();
+        throw new AssertionError(e);
       }
     }
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/framed/Spdy3.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/framed/Spdy3.java
@@ -91,7 +91,7 @@ public final class Spdy3 implements Variant {
           + ",application/xhtml+xml,text/plain,text/javascript,publicprivatemax-age=gzip,deflate,"
           + "sdchcharset=utf-8charset=iso-8859-1,utf-,*,enq=0.").getBytes(Util.UTF_8.name());
     } catch (UnsupportedEncodingException e) {
-      throw new AssertionError();
+      throw new AssertionError(e);
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/FramedTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/FramedTransport.java
@@ -122,7 +122,7 @@ public final class FramedTransport implements Transport {
     } else if (Protocol.HTTP_2 == protocol) {
       result.add(new Header(TARGET_AUTHORITY, host)); // Optional in HTTP/2
     } else {
-      throw new AssertionError();
+      throw new AssertionError("unknown protocol " + protocol == null ? "null" : protocol.name());
     }
     result.add(new Header(TARGET_SCHEME, request.httpUrl().scheme()));
 


### PR DESCRIPTION
DevFactory is committed to improving code quality and advancing open source. Our team contributes their time to researching and identifying areas for code quality improvement in open source projects. We identified a fix for okHttp.

This pull request is focused on resolving occurrences of Sonar rule squid:S1166 - “Exception handlers should preserve the original exception”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1166?layout=true

Please let me know if you have any questions. There is more to come.

Javed
DevFactory - Code Cleanup Team