### PR TITLE
Code Quality fix - Mutable members should not be stored or returned directly

### DIFF
--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/JettyNegoProviderTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/JettyNegoProviderTest.java
@@ -1,0 +1,141 @@
+package com.squareup.okhttp.internal;
+import org.junit.Before;
+import org.junit.Test;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.Assert.*;
+
+public class JettyNegoProviderTest {
+    private InvocationHandler instance;
+    private Class clazz;
+    private List<String> peerProtocolList;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void init() throws Throwable {
+        /**
+         * I used Reflection for creation an instance of JettyNegoProvider because it is a static private class.
+         */
+        clazz = Class.forName("com.squareup.okhttp.internal.Platform$JettyNegoProvider");
+        final Constructor constructor = clazz.getConstructor(List.class);
+        peerProtocolList = new ArrayList<>();
+        peerProtocolList.add("firstPeerProtocol");
+        peerProtocolList.add("secondPeerProtocol");
+        instance = (InvocationHandler) constructor.newInstance(peerProtocolList);
+    }
+
+    private Method getProviderMethod(String name) throws NoSuchMethodException {
+        return StubALPNProvider.class.getMethod(name);
+    }
+
+    @Test
+    public void invokeSupports() throws Throwable {
+        Object supports = instance.invoke(null, getProviderMethod("supports"), new Object[0]);
+        assertTrue((boolean) supports);
+    }
+
+    @Test
+    public void invokeUnsupported() throws Throwable {
+        Object unsupported = instance.invoke(null, getProviderMethod("unsupported"), new Object[0]);
+        assertNull(unsupported);
+        //check private field unsupported
+        Field unsupportedField = clazz.getDeclaredField("unsupported");
+        unsupportedField.setAccessible(true);
+        assertTrue(unsupportedField.getBoolean(instance));
+    }
+
+    @Test
+    public void invokeProtocols() throws Throwable {
+        Object protocols = instance.invoke(null, getProviderMethod("protocols"), new Object[0]);
+        assertEquals(protocols, peerProtocolList);
+    }
+
+    @Test
+    public void invokeSelectProtocols() throws Throwable {
+        //selectProtocol method
+        List<String> servProtocol = new ArrayList<>();
+        servProtocol.add("firstServerProtocol");
+
+        //Check no intersection, will return peer's first protocol.
+        Object selectProtocol = instance.invoke(null, getProviderMethod("selectProtocol"), new Object[]{servProtocol});
+        assertEquals(selectProtocol, "firstPeerProtocol");
+
+        //Check intersection, will return common protocol
+        //make secondPeerProtocol common for peers and servers
+        servProtocol.add("secondPeerProtocol");
+        Object commonProtocol = instance.invoke(null, getProviderMethod("selectProtocol"), new Object[]{servProtocol});
+        assertEquals(commonProtocol, "secondPeerProtocol");
+    }
+
+    @Test
+    public void invokeSelect() throws Throwable {
+        //select method
+        List<String> servProtocol = new ArrayList<>();
+        servProtocol.add("firstServerProtocol");
+
+        //Check no intersection, will return peer's first protocol.
+        Object selectProtocol = instance.invoke(null, getProviderMethod("select"), new Object[]{servProtocol});
+        assertEquals(selectProtocol, "firstPeerProtocol");
+
+        //Check intersection, will return common protocol
+        //make secondPeerProtocol common for peers and servers
+        servProtocol.add("secondPeerProtocol");
+        Object commonProtocol = instance.invoke(null, getProviderMethod("select"), new Object[]{servProtocol});
+        assertEquals(commonProtocol, "secondPeerProtocol");
+    }
+
+    @Test
+    public void invokeProtocolSelected() throws Throwable {
+        Object selectProtocol = instance.invoke(null, getProviderMethod("protocolSelected"), new String[]{"firstServerProtocol"});
+        assertNull(selectProtocol);
+        //check private field selected
+        Field selectedField = clazz.getDeclaredField("selected");
+        selectedField.setAccessible(true);
+        assertEquals(selectedField.get(instance), "firstServerProtocol");
+    }
+
+    @Test
+    public void invokeSelected() throws Throwable {
+        Object selectProtocol = instance.invoke(null, getProviderMethod("selected"), new Object[]{"firstServerProtocol"});
+        assertNull(selectProtocol);
+        //check private field selected
+        Field selectedField = clazz.getDeclaredField("selected");
+        selectedField.setAccessible(true);
+        assertEquals(selectedField.get(instance), "firstServerProtocol");
+    }
+
+    public static class StubALPNProvider {
+        public boolean supports() {
+            return true;
+        }
+
+        public void unsupported() {
+
+        }
+
+        public void protocols() {
+
+        }
+
+        public String selectProtocol() {
+            return "";
+        }
+
+
+        public String select() {
+            return "";
+        }
+
+        public void protocolSelected() {
+
+        }
+
+        public void selected() {
+
+        }
+    }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/Headers.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Headers.java
@@ -53,7 +53,7 @@ public final class Headers {
   }
 
   private Headers(String[] namesAndValues) {
-    this.namesAndValues = namesAndValues;
+    this.namesAndValues = namesAndValues == null ? null : namesAndValues.clone();
   }
 
   /** Returns the last value corresponding to the specified field, or null. */

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/DiskLruCache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/DiskLruCache.java
@@ -772,13 +772,14 @@ public final class DiskLruCache implements Closeable {
     private Snapshot(String key, long sequenceNumber, Source[] sources, long[] lengths) {
       this.key = key;
       this.sequenceNumber = sequenceNumber;
-      this.sources = sources;
-      this.lengths = lengths;
+      this.sources = sources == null ? null : sources.clone();
+      this.lengths = lengths == null ? null : lengths.clone();
     }
 
     public String key() {
       return key;
     }
+
 
     /**
      * Returns an editor for this snapshot's entry, or null if either the

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -347,19 +347,17 @@ public class Platform {
     @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
       String methodName = method.getName();
       Class<?> returnType = method.getReturnType();
-      if (args == null) {
-        args = Util.EMPTY_STRING_ARRAY;
-      }
+      Object[] argsCopy = args == null ? Util.EMPTY_STRING_ARRAY : args.clone();
       if (methodName.equals("supports") && boolean.class == returnType) {
         return true; // ALPN is supported.
       } else if (methodName.equals("unsupported") && void.class == returnType) {
         this.unsupported = true; // Peer doesn't support ALPN.
         return null;
-      } else if (methodName.equals("protocols") && args.length == 0) {
+      } else if (methodName.equals("protocols") && argsCopy.length == 0) {
         return protocols; // Client advertises these protocols.
       } else if ((methodName.equals("selectProtocol") || methodName.equals("select"))
-          && String.class == returnType && args.length == 1 && args[0] instanceof List) {
-        List<String> peerProtocols = (List) args[0];
+          && String.class == returnType && argsCopy.length == 1 && argsCopy[0] instanceof List) {
+        List<String> peerProtocols = (List) argsCopy[0];
         // Pick the first known protocol the peer advertises.
         for (int i = 0, size = peerProtocols.size(); i < size; i++) {
           if (protocols.contains(peerProtocols.get(i))) {
@@ -368,11 +366,11 @@ public class Platform {
         }
         return selected = protocols.get(0); // On no intersection, try peer's first protocol.
       } else if ((methodName.equals("protocolSelected") || methodName.equals("selected"))
-          && args.length == 1) {
-        this.selected = (String) args[0]; // Server selected this protocol.
+          && argsCopy.length == 1) {
+        this.selected = (String) argsCopy[0]; // Server selected this protocol.
         return null;
       } else {
-        return method.invoke(this, args);
+        return method.invoke(this, argsCopy);
       }
     }
   }


### PR DESCRIPTION
DevFactory is committed to improving code quality and advancing open source. Our team contributes their time to researching and identifying areas for code quality improvement in open source projects. We identified a fix for okHttp.

This pull request is focused on resolving occurrences of Sonar rule squid:S2384 - “Mutable members should not be stored or returned directly”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2384?layout=true

Please let me know if you have any questions. There is more to come.

Javed
DevFactory - Code Cleanup Team