### PR TITLE
Stop returning HTTP/1.0 from Connection.getProtocol().

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -1904,7 +1904,7 @@ public final class CallTest {
   /** Test which headers are sent unencrypted to the HTTP proxy. */
   @Test public void proxyConnectOmitsApplicationHeaders() throws Exception {
     server.useHttps(sslContext.getSocketFactory(), true);
-    server.enqueue( new MockResponse()
+    server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
         .clearHeaders());
     server.enqueue(new MockResponse()
@@ -1942,7 +1942,7 @@ public final class CallTest {
     server.enqueue(new MockResponse()
         .setResponseCode(407)
         .addHeader("Proxy-Authenticate: Basic realm=\"localhost\""));
-    server.enqueue( new MockResponse()
+    server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
         .clearHeaders());
     server.enqueue(new MockResponse()
@@ -1979,7 +1979,7 @@ public final class CallTest {
    */
   @Test public void noProactiveProxyAuthorization() throws Exception {
     server.useHttps(sslContext.getSocketFactory(), true);
-    server.enqueue( new MockResponse()
+    server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
         .clearHeaders());
     server.enqueue(new MockResponse()

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/http/HeadersTest.java
@@ -100,8 +100,7 @@ public final class HeadersTest {
         .addHeader("set-cookie", "Cookie2")
         .header(":status", "200 OK")
         .build();
-    List<Header> headerBlock =
-        FramedTransport.writeNameValueBlock(request, Protocol.SPDY_3, "HTTP/1.1");
+    List<Header> headerBlock = FramedTransport.writeNameValueBlock(request, Protocol.SPDY_3);
     List<Header> expected = headerEntries(
         ":method", "GET",
         ":path", "/",
@@ -126,7 +125,7 @@ public final class HeadersTest {
         ":version", "HTTP/1.1",
         ":host", "square.com",
         ":scheme", "http");
-    assertEquals(expected, FramedTransport.writeNameValueBlock(request, Protocol.SPDY_3, "HTTP/1.1"));
+    assertEquals(expected, FramedTransport.writeNameValueBlock(request, Protocol.SPDY_3));
   }
 
   @Test public void toNameValueBlockDropsForbiddenHeadersHttp2() {
@@ -140,8 +139,7 @@ public final class HeadersTest {
         ":path", "/",
         ":authority", "square.com",
         ":scheme", "http");
-    assertEquals(expected,
-        FramedTransport.writeNameValueBlock(request, Protocol.HTTP_2, "HTTP/1.1"));
+    assertEquals(expected, FramedTransport.writeNameValueBlock(request, Protocol.HTTP_2));
   }
 
   @Test public void ofTrims() {

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -80,10 +80,6 @@ public class OkHttpClient implements Cloneable {
         return connection.recycleCount();
       }
 
-      @Override public void setProtocol(Connection connection, Protocol protocol) {
-        connection.setProtocol(protocol);
-      }
-
       @Override public void setOwner(Connection connection, HttpEngine httpEngine) {
         connection.setOwner(httpEngine);
       }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Internal.java
@@ -23,7 +23,6 @@ import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.internal.http.HttpEngine;
 import com.squareup.okhttp.internal.http.RouteException;
 import com.squareup.okhttp.internal.http.Transport;
@@ -58,8 +57,6 @@ public abstract class Internal {
   public abstract void closeIfOwnedBy(Connection connection, Object owner) throws IOException;
 
   public abstract int recycleCount(Connection connection);
-
-  public abstract void setProtocol(Connection connection, Protocol protocol);
 
   public abstract void setOwner(Connection connection, HttpEngine httpEngine);
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/FramedTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/FramedTransport.java
@@ -85,9 +85,8 @@ public final class FramedTransport implements Transport {
     httpEngine.writingRequestHeaders();
     boolean permitsRequestBody = httpEngine.permitsRequestBody(request);
     boolean hasResponseBody = true;
-    String version = RequestLine.version(httpEngine.getConnection().getProtocol());
     stream = framedConnection.newStream(
-        writeNameValueBlock(request, framedConnection.getProtocol(), version), permitsRequestBody,
+        writeNameValueBlock(request, framedConnection.getProtocol()), permitsRequestBody,
         hasResponseBody);
     stream.readTimeout().timeout(httpEngine.client.getReadTimeout(), TimeUnit.MILLISECONDS);
   }
@@ -109,15 +108,14 @@ public final class FramedTransport implements Transport {
    * Names are all lowercase. No names are repeated. If any name has multiple
    * values, they are concatenated using "\0" as a delimiter.
    */
-  public static List<Header> writeNameValueBlock(Request request, Protocol protocol,
-      String version) {
+  public static List<Header> writeNameValueBlock(Request request, Protocol protocol) {
     Headers headers = request.headers();
     List<Header> result = new ArrayList<>(headers.size() + 10);
     result.add(new Header(TARGET_METHOD, request.method()));
     result.add(new Header(TARGET_PATH, RequestLine.requestPath(request.httpUrl())));
     String host = Util.hostHeader(request.httpUrl());
     if (Protocol.SPDY_3 == protocol) {
-      result.add(new Header(VERSION, version));
+      result.add(new Header(VERSION, "HTTP/1.1"));
       result.add(new Header(TARGET_HOST, host));
     } else if (Protocol.HTTP_2 == protocol) {
       result.add(new Header(TARGET_AUTHORITY, host)); // Optional in HTTP/2

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -694,8 +694,7 @@ public final class HttpEngine {
       result.header("Host", Util.hostHeader(request.httpUrl()));
     }
 
-    if ((connection == null || connection.getProtocol() != Protocol.HTTP_1_0)
-        && request.header("Connection") == null) {
+    if (request.header("Connection") == null) {
       result.header("Connection", "Keep-Alive");
     }
 
@@ -920,7 +919,6 @@ public final class HttpEngine {
           .build();
     }
 
-    Internal.instance.setProtocol(connection, networkResponse.protocol());
     return networkResponse;
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpTransport.java
@@ -70,9 +70,8 @@ public final class HttpTransport implements Transport {
    */
   public void writeRequestHeaders(Request request) throws IOException {
     httpEngine.writingRequestHeaders();
-    String requestLine = RequestLine.get(request,
-        httpEngine.getConnection().getRoute().getProxy().type(),
-        httpEngine.getConnection().getProtocol());
+    String requestLine = RequestLine.get(
+        request, httpEngine.getConnection().getRoute().getProxy().type());
     httpConnection.writeRequest(request.headers(), requestLine);
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RequestLine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RequestLine.java
@@ -1,7 +1,6 @@
 package com.squareup.okhttp.internal.http;
 
 import com.squareup.okhttp.HttpUrl;
-import com.squareup.okhttp.Protocol;
 import com.squareup.okhttp.Request;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
@@ -15,7 +14,7 @@ public final class RequestLine {
    * to the application by {@link HttpURLConnection#getHeaderFields}, so it
    * needs to be set even if the transport is SPDY.
    */
-  static String get(Request request, Proxy.Type proxyType, Protocol protocol) {
+  static String get(Request request, Proxy.Type proxyType) {
     StringBuilder result = new StringBuilder();
     result.append(request.method());
     result.append(' ');
@@ -26,8 +25,7 @@ public final class RequestLine {
       result.append(requestPath(request.httpUrl()));
     }
 
-    result.append(' ');
-    result.append(version(protocol));
+    result.append(" HTTP/1.1");
     return result.toString();
   }
 
@@ -48,9 +46,5 @@ public final class RequestLine {
     String path = url.encodedPath();
     String query = url.encodedQuery();
     return query != null ? (path + '?' + query) : path;
-  }
-
-  public static String version(Protocol protocol) {
-    return protocol == Protocol.HTTP_1_0 ? "HTTP/1.0" : "HTTP/1.1";
   }
 }


### PR DESCRIPTION
This was updating the protocol as a side-effect of an HTTP/1.0 response.
This made the protocol field mutable, and the code more difficult to
trace.

One consequence of this change is that OkHttp will attempt HTTP/1.1 for
all requests, even if a server returns HTTP/1.0 from the first response.
This is closer to our implementation anyway.