### PR TITLE
Fix flakiness in CallTest.cancelTagImmediatelyAfterEnqueue()

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -1525,13 +1525,13 @@ public final class CallTest {
   }
 
   @Test public void cancelTagImmediatelyAfterEnqueue() throws Exception {
+    server.enqueue(new MockResponse());
     Call call = client.newCall(new Request.Builder()
         .url(server.url("/a"))
         .tag("request")
         .build());
     call.enqueue(callback);
     client.cancel("request");
-    assertEquals(0, server.getRequestCount());
     callback.await(server.url("/a")).assertFailure("Canceled");
   }
 


### PR DESCRIPTION
There's a race where the HTTP engine has been created, but not yet connected
and the cancel isn't as immediate as it could be. Fix the test by making sure
there's a response to be retrieved.

With the upcoming connection pool changes we might make the implementation
more robust.

Closes: https://github.com/square/okhttp/issues/2001