### PR TITLE
Code quality fix - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockResponse.java
@@ -56,7 +56,7 @@ public final class MockResponse implements Cloneable {
       result.promises = new ArrayList<>(promises);
       return result;
     } catch (CloneNotSupportedException e) {
-      throw new AssertionError();
+      throw new AssertionError(e);
     }
   }
 

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -406,7 +406,7 @@ public final class MockWebServer implements TestRule {
         throw new IOException("Gave up waiting for executor to shut down");
       }
     } catch (InterruptedException e) {
-      throw new AssertionError();
+      throw new AssertionError(e);
     }
   }
 
@@ -785,7 +785,7 @@ public final class MockWebServer implements TestRule {
         try {
           Thread.sleep(periodDelayMs);
         } catch (InterruptedException e) {
-          throw new AssertionError();
+          throw new AssertionError(e);
         }
       }
     }

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -605,11 +605,11 @@ public final class MockWebServer implements TestRule {
         contentLength = Long.parseLong(header.substring(15).trim());
       }
       if (lowercaseHeader.startsWith("transfer-encoding:")
-          && lowercaseHeader.substring(18).trim().equals("chunked")) {
+          && "chunked".equals(lowercaseHeader.substring(18).trim())) {
         chunked = true;
       }
       if (lowercaseHeader.startsWith("expect:")
-          && lowercaseHeader.substring(7).trim().equals("100-continue")) {
+          && "100-continue".equals(lowercaseHeader.substring(7).trim())) {
         expectContinue = true;
       }
     }

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/QueueDispatcher.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/QueueDispatcher.java
@@ -30,7 +30,7 @@ public class QueueDispatcher extends Dispatcher {
   @Override public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
     // To permit interactive/browser testing, ignore requests for favicons.
     final String requestLine = request.getRequestLine();
-    if (requestLine != null && requestLine.equals("GET /favicon.ico HTTP/1.1")) {
+    if (requestLine != null && "GET /favicon.ico HTTP/1.1".equals(requestLine)) {
       System.out.println("served " + requestLine);
       return new MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND);
     }

--- a/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
+++ b/okcurl/src/main/java/com/squareup/okhttp/curl/Main.java
@@ -76,7 +76,7 @@ public class Main extends HelpOption implements Runnable {
       in.close();
       return prop.getProperty("version");
     } catch (IOException e) {
-      throw new AssertionError("Could not load okcurl-version.properties.");
+      throw new AssertionError("Could not load okcurl-version.properties.", e);
     }
   }
 

--- a/okhttp-android-support/src/main/java/com/squareup/okhttp/internal/huc/JavaApiConverter.java
+++ b/okhttp-android-support/src/main/java/com/squareup/okhttp/internal/huc/JavaApiConverter.java
@@ -177,7 +177,7 @@ public final class JavaApiConverter {
     for (String fieldName : varyFields) {
       List<String> fieldValues = requestProperties.get(fieldName);
       if (fieldValues == null) {
-        if (fieldName.equals("Accept-Encoding")) {
+        if ("Accept-Encoding".equals(fieldName)) {
           // Accept-Encoding is special. If OkHttp sees Accept-Encoding is unset it will add
           // "gzip". We don't have access to the request that was actually made so we must do the
           // same.

--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/OkUrlFactory.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/OkUrlFactory.java
@@ -53,8 +53,8 @@ public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
     OkHttpClient copy = client.copyWithDefaults();
     copy.setProxy(proxy);
 
-    if (protocol.equals("http")) return new HttpURLConnectionImpl(url, copy);
-    if (protocol.equals("https")) return new HttpsURLConnectionImpl(url, copy);
+    if ("http".equals(protocol)) return new HttpURLConnectionImpl(url, copy);
+    if ("https".equals(protocol)) return new HttpsURLConnectionImpl(url, copy);
     throw new IllegalArgumentException("Unexpected protocol: " + protocol);
   }
 
@@ -69,7 +69,7 @@ public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
    * }</pre>
    */
   @Override public URLStreamHandler createURLStreamHandler(final String protocol) {
-    if (!protocol.equals("http") && !protocol.equals("https")) return null;
+    if (!"http".equals(protocol) && !"https".equals(protocol)) return null;
 
     return new URLStreamHandler() {
       @Override protected URLConnection openConnection(URL url) {
@@ -81,8 +81,8 @@ public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
       }
 
       @Override protected int getDefaultPort() {
-        if (protocol.equals("http")) return 80;
-        if (protocol.equals("https")) return 443;
+        if ("http".equals(protocol)) return 80;
+        if ("https".equals(protocol)) return 443;
         throw new AssertionError();
       }
     };

--- a/okhttp/src/main/java/com/squareup/okhttp/Cache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Cache.java
@@ -218,7 +218,7 @@ public final class Cache {
       }
       return null;
     }
-    if (!requestMethod.equals("GET")) {
+    if (!"GET".equals(requestMethod)) {
       // Don't cache non-GET responses. We're technically allowed to cache
       // HEAD requests and some POST requests, but the complexity of doing
       // so is high and the benefit is low.

--- a/okhttp/src/main/java/com/squareup/okhttp/Cache.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Cache.java
@@ -630,7 +630,7 @@ public final class Cache {
         }
         return result;
       } catch (CertificateException e) {
-        throw new IOException(e.getMessage());
+        throw new IOException(e.getMessage(), e);
       }
     }
 
@@ -646,7 +646,7 @@ public final class Cache {
           sink.writeByte('\n');
         }
       } catch (CertificateEncodingException e) {
-        throw new IOException(e.getMessage());
+        throw new IOException(e.getMessage(), e);
       }
     }
 
@@ -685,7 +685,7 @@ public final class Cache {
       }
       return (int) result;
     } catch (NumberFormatException e) {
-      throw new IOException(e.getMessage());
+      throw new IOException(e.getMessage(), e);
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/CacheControl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/CacheControl.java
@@ -168,14 +168,14 @@ public final class CacheControl {
       String name = headers.name(i);
       String value = headers.value(i);
 
-      if (name.equalsIgnoreCase("Cache-Control")) {
+      if ("Cache-Control".equalsIgnoreCase(name)) {
         if (headerValue != null) {
           // Multiple cache-control headers means we can't use the raw value.
           canUseHeaderValue = false;
         } else {
           headerValue = value;
         }
-      } else if (name.equalsIgnoreCase("Pragma")) {
+      } else if ("Pragma".equalsIgnoreCase(name)) {
         // Might specify additional cache-control params. We invalidate just in case.
         canUseHeaderValue = false;
       } else {

--- a/okhttp/src/main/java/com/squareup/okhttp/Credentials.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Credentials.java
@@ -31,7 +31,7 @@ public final class Credentials {
       String encoded = ByteString.of(bytes).base64();
       return "Basic " + encoded;
     } catch (UnsupportedEncodingException e) {
-      throw new AssertionError();
+      throw new AssertionError(e);
     }
   }
 }

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -345,7 +345,7 @@ public final class HttpUrl {
   }
 
   public boolean isHttps() {
-    return scheme.equals("https");
+    return "https".equals(scheme);
   }
 
   /** Returns the username, or an empty string if none is set. */
@@ -401,9 +401,9 @@ public final class HttpUrl {
    * otherwise.
    */
   public static int defaultPort(String scheme) {
-    if (scheme.equals("http")) {
+    if ("http".equals(scheme)) {
       return 80;
-    } else if (scheme.equals("https")) {
+    } else if ("https".equals(scheme)) {
       return 443;
     } else {
       return -1;
@@ -661,9 +661,9 @@ public final class HttpUrl {
     public Builder scheme(String scheme) {
       if (scheme == null) {
         throw new IllegalArgumentException("scheme == null");
-      } else if (scheme.equalsIgnoreCase("http")) {
+      } else if ("http".equalsIgnoreCase(scheme)) {
         this.scheme = "http";
-      } else if (scheme.equalsIgnoreCase("https")) {
+      } else if ("https".equalsIgnoreCase(scheme)) {
         this.scheme = "https";
       } else {
         throw new IllegalArgumentException("unexpected scheme: " + scheme);
@@ -1092,14 +1092,14 @@ public final class HttpUrl {
     }
 
     private boolean isDot(String input) {
-      return input.equals(".") || input.equalsIgnoreCase("%2e");
+      return ".".equals(input) || "%2e".equalsIgnoreCase(input);
     }
 
     private boolean isDotDot(String input) {
-      return input.equals("..")
-          || input.equalsIgnoreCase("%2e.")
-          || input.equalsIgnoreCase(".%2e")
-          || input.equalsIgnoreCase("%2e%2e");
+      return "..".equals(input)
+          || "%2e.".equalsIgnoreCase(input)
+          || ".%2e".equalsIgnoreCase(input)
+          || "%2e%2e".equalsIgnoreCase(input);
     }
 
     /**

--- a/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/HttpUrl.java
@@ -1308,7 +1308,7 @@ public final class HttpUrl {
       try {
         return InetAddress.getByAddress(address);
       } catch (UnknownHostException e) {
-        throw new AssertionError();
+        throw new AssertionError(e);
       }
     }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/MediaType.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/MediaType.java
@@ -60,7 +60,7 @@ public final class MediaType {
       if (!parameter.lookingAt()) return null; // This is not a well-formed media type.
 
       String name = parameter.group(1);
-      if (name == null || !name.equalsIgnoreCase("charset")) continue;
+      if (name == null || !"charset".equalsIgnoreCase(name)) continue;
       String charsetParameter = parameter.group(2) != null
           ? parameter.group(2)  // Value is a token.
           : parameter.group(3); // Value is a quoted string.

--- a/okhttp/src/main/java/com/squareup/okhttp/MultipartBuilder.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/MultipartBuilder.java
@@ -101,7 +101,7 @@ public final class MultipartBuilder {
     if (type == null) {
       throw new NullPointerException("type == null");
     }
-    if (!type.type().equals("multipart")) {
+    if (!"multipart".equals(type.type())) {
       throw new IllegalArgumentException("multipart != " + type);
     }
     this.type = type;

--- a/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/OkHttpClient.java
@@ -671,7 +671,7 @@ public class OkHttpClient implements Cloneable {
         sslContext.init(null, null, null);
         defaultSslSocketFactory = sslContext.getSocketFactory();
       } catch (GeneralSecurityException e) {
-        throw new AssertionError(); // The system has no TLS. Just give up.
+        throw new AssertionError(e); // The system has no TLS. Just give up.
       }
     }
     return defaultSslSocketFactory;

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -58,7 +58,7 @@ public final class Request {
       URI result = javaNetUri;
       return result != null ? result : (javaNetUri = url.uri());
     } catch (IllegalStateException e) {
-      throw new IOException(e.getMessage());
+      throw new IOException(e.getMessage(), e);
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -350,14 +350,14 @@ public class Platform {
       if (args == null) {
         args = Util.EMPTY_STRING_ARRAY;
       }
-      if (methodName.equals("supports") && boolean.class == returnType) {
+      if ("supports".equals(methodName) && boolean.class == returnType) {
         return true; // ALPN is supported.
-      } else if (methodName.equals("unsupported") && void.class == returnType) {
+      } else if ("unsupported".equals(methodName) && void.class == returnType) {
         this.unsupported = true; // Peer doesn't support ALPN.
         return null;
-      } else if (methodName.equals("protocols") && args.length == 0) {
+      } else if ("protocols".equals(methodName) && args.length == 0) {
         return protocols; // Client advertises these protocols.
-      } else if ((methodName.equals("selectProtocol") || methodName.equals("select"))
+      } else if (("selectProtocol".equals(methodName) || "select".equals(methodName))
           && String.class == returnType && args.length == 1 && args[0] instanceof List) {
         List<String> peerProtocols = (List) args[0];
         // Pick the first known protocol the peer advertises.
@@ -367,7 +367,7 @@ public class Platform {
           }
         }
         return selected = protocols.get(0); // On no intersection, try peer's first protocol.
-      } else if ((methodName.equals("protocolSelected") || methodName.equals("selected"))
+      } else if (("protocolSelected".equals(methodName) || "selected".equals(methodName))
           && args.length == 1) {
         this.selected = (String) args[0]; // Server selected this protocol.
         return null;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -308,7 +308,7 @@ public class Platform {
       try {
         removeMethod.invoke(null, sslSocket);
       } catch (IllegalAccessException | InvocationTargetException ignored) {
-        throw new AssertionError();
+        throw new AssertionError(ignored);
       }
     }
 
@@ -323,7 +323,7 @@ public class Platform {
         }
         return provider.unsupported ? null : provider.selected;
       } catch (InvocationTargetException | IllegalAccessException e) {
-        throw new AssertionError();
+        throw new AssertionError(e);
       }
     }
   }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/framed/Spdy3.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/framed/Spdy3.java
@@ -91,7 +91,7 @@ public final class Spdy3 implements Variant {
           + ",application/xhtml+xml,text/plain,text/javascript,publicprivatemax-age=gzip,deflate,"
           + "sdchcharset=utf-8charset=iso-8859-1,utf-,*,enq=0.").getBytes(Util.UTF_8.name());
     } catch (UnsupportedEncodingException e) {
-      throw new AssertionError();
+      throw new AssertionError(e);
     }
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/FramedTransport.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/FramedTransport.java
@@ -122,7 +122,7 @@ public final class FramedTransport implements Transport {
     } else if (Protocol.HTTP_2 == protocol) {
       result.add(new Header(TARGET_AUTHORITY, host)); // Optional in HTTP/2
     } else {
-      throw new AssertionError();
+      throw new AssertionError("unknown protocol " + protocol == null ? "null" : protocol.name());
     }
     result.add(new Header(TARGET_SCHEME, request.httpUrl().scheme()));
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpMethod.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpMethod.java
@@ -17,27 +17,27 @@ package com.squareup.okhttp.internal.http;
 
 public final class HttpMethod {
   public static boolean invalidatesCache(String method) {
-    return method.equals("POST")
-        || method.equals("PATCH")
-        || method.equals("PUT")
-        || method.equals("DELETE")
-        || method.equals("MOVE");     // WebDAV
+    return "POST".equals(method)
+        || "PATCH".equals(method)
+        || "PUT".equals(method)
+        || "DELETE".equals(method)
+        || "MOVE".equals(method);     // WebDAV
   }
 
   public static boolean requiresRequestBody(String method) {
-    return method.equals("POST")
-        || method.equals("PUT")
-        || method.equals("PATCH")
-        || method.equals("PROPPATCH") // WebDAV
-        || method.equals("REPORT");   // CalDAV/CardDAV (defined in WebDAV Versioning)
+    return "POST".equals(method)
+        || "PUT".equals(method)
+        || "PATCH".equals(method)
+        || "PROPPATCH".equals(method) // WebDAV
+        || "REPORT".equals(method);   // CalDAV/CardDAV (defined in WebDAV Versioning)
   }
 
   public static boolean permitsRequestBody(String method) {
     return requiresRequestBody(method)
-        || method.equals("DELETE")    // Permitted as spec is ambiguous.
-        || method.equals("PROPFIND")  // (WebDAV) without body: request <allprop/>
-        || method.equals("MKCOL")     // (WebDAV) may contain a body, but behaviour is unspecified
-        || method.equals("LOCK");     // (WebDAV) body: create lock, without body: refresh lock
+        || "DELETE".equals(method)    // Permitted as spec is ambiguous.
+        || "PROPFIND".equals(method)  // (WebDAV) without body: request <allprop/>
+        || "MKCOL".equals(method)     // (WebDAV) may contain a body, but behaviour is unspecified
+        || "LOCK".equals(method);     // (WebDAV) body: create lock, without body: refresh lock
   }
 
   private HttpMethod() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1132

Please let me know if you have any questions.

Ahmed Daraz