### PR TITLE
Implement SOCKS5 proxy for remote DNS resolving.

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -18,6 +18,7 @@ package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.ConnectionSpecSelector;
 import com.squareup.okhttp.internal.Platform;
+import com.squareup.okhttp.internal.SocksSocket;
 import com.squareup.okhttp.internal.Util;
 import com.squareup.okhttp.internal.Version;
 import com.squareup.okhttp.internal.framed.FramedConnection;
@@ -29,6 +30,7 @@ import com.squareup.okhttp.internal.http.OkHeaders;
 import com.squareup.okhttp.internal.http.RouteException;
 import com.squareup.okhttp.internal.http.Transport;
 import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
+
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.Socket;
@@ -36,9 +38,11 @@ import java.net.UnknownServiceException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+
 import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.Source;
@@ -168,7 +172,7 @@ public final class Connection {
       try {
         socket = proxy.type() == Proxy.Type.DIRECT || proxy.type() == Proxy.Type.HTTP
             ? address.getSocketFactory().createSocket()
-            : new Socket(proxy);
+            : new SocksSocket(proxy);
         connectSocket(connectTimeout, readTimeout, writeTimeout, connectionSpecSelector);
       } catch (IOException e) {
         Util.closeQuietly(socket);
@@ -191,9 +195,11 @@ public final class Connection {
     }
   }
 
-  /** Does all the work necessary to build a full HTTP or HTTPS connection on a raw socket. */
+  /**
+   * Does all the work necessary to build a full HTTP or HTTPS connection on a raw socket.
+   */
   private void connectSocket(int connectTimeout, int readTimeout, int writeTimeout,
-      ConnectionSpecSelector connectionSpecSelector) throws IOException {
+                             ConnectionSpecSelector connectionSpecSelector) throws IOException {
     socket.setSoTimeout(readTimeout);
     Platform.get().connectSocket(socket, route.getSocketAddress(), connectTimeout);
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/SocksProtocol.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/SocksProtocol.java
@@ -1,0 +1,120 @@
+package com.squareup.okhttp.internal;
+
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ProtocolException;
+import java.net.Socket;
+
+public class SocksProtocol {
+    private SocksProtocol() {
+    }
+
+    public static final byte VERSION_5 = 5;
+    public static final byte METHOD_NONE = (byte) 0xff;
+    public static final byte METHOD_NO_AUTHENTICATION_REQUIRED = 0;
+    public static final byte ADDRESS_TYPE_IPV4 = 1;
+    public static final byte ADDRESS_TYPE_DOMAIN_NAME = 3;
+    public static final byte COMMAND_CONNECT = 1;
+    public static final byte REPLY_SUCCEEDED = 0;
+
+
+    /**
+     * Parses a SocksMsg from a stream.
+     *
+     * @param in DataInputStream to parse
+     * @return reply byte of the message
+     * @throws IOException       in case of a network error
+     * @throws ProtocolException in case of unsupported responses
+     */
+    public static byte parseSocksMsg(DataInputStream in) throws IOException {
+        byte ver = in.readByte();
+        if (ver != VERSION_5)
+            throw new ProtocolException("SOCKS5: unsupported version");
+        byte response = in.readByte();
+        in.readByte(); //reserved
+        byte addrtype = in.readByte();
+        switch (addrtype) {
+            case (ADDRESS_TYPE_IPV4): //IPv4
+                in.skipBytes(4);
+                break;
+            case (ADDRESS_TYPE_DOMAIN_NAME)://host name
+                byte addressLen = in.readByte();
+                in.skipBytes(addressLen);
+                break;
+            default:
+                throw new ProtocolException();
+        }
+        in.skipBytes(2); //port
+        return response;
+    }
+
+
+    /**
+     * This method takes a socket and establishes a SOCKS5 connection to target.
+     *
+     * @param socket a (connected) socket to a proxy
+     * @param target the targets
+     * @throws IOException
+     */
+    public static void establish(Socket socket, InetSocketAddress target) throws IOException {
+        // negotiate authentication
+        byte[] cmd = new byte[3];
+        cmd[0] = VERSION_5; // version
+        cmd[1] = (byte) 0x01; // number of auth methods
+        cmd[2] = METHOD_NO_AUTHENTICATION_REQUIRED; // no-authentication
+
+        DataInputStream in = new DataInputStream(socket.getInputStream());
+        DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+        out.write(cmd);
+        out.flush();
+
+        byte[] resp = new byte[2];
+        in.readFully(resp);
+
+        // di we receive a valid answer?
+        if (resp[0] != VERSION_5 || resp[1] != METHOD_NO_AUTHENTICATION_REQUIRED) {
+            throw new ProtocolException("SOCKS5: unexpected answer: " + resp[0] + " " + resp[1]);
+        }
+
+        // connect to target
+        byte[] connectionReq;
+        connectionReq = createSocksConnectReq(target);
+        out.write(connectionReq);
+        out.flush();
+
+        // receive response
+        byte connectionResp;
+        connectionResp = parseSocksMsg(in);
+        if (connectionResp != REPLY_SUCCEEDED)
+            throw new ProtocolException("Proxy responded with a failure:" + connectionResp);
+    }
+
+
+    /**
+     * This method builds a request to connection to target.
+     *
+     * @param target the InetSocketAddress of the target, the hostname is resolved by the proxy
+     * @return request data
+     */
+    static byte[] createSocksConnectReq(InetSocketAddress target) {
+        byte[] addr = target.getHostName().getBytes();
+        short port = (short) target.getPort();
+
+        byte[] req = new byte[7 + addr.length];
+        req[0] = VERSION_5; // version (SOCKS5)
+        req[1] = COMMAND_CONNECT; // socks command
+        req[2] = (byte) 0x00; // reserved
+        req[3] = ADDRESS_TYPE_DOMAIN_NAME; // address type
+        req[4] = (byte) addr.length; // address len
+        System.arraycopy(addr, 0, req, 5, addr.length); // address
+        req[req.length - 2] = (byte) ((port >> 8) & 0xFF); // address port
+        req[req.length - 1] = (byte) (port & 0xFF);
+
+        return req;
+    }
+
+
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/SocksSocket.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/SocksSocket.java
@@ -1,0 +1,40 @@
+
+package com.squareup.okhttp.internal;
+
+import com.squareup.okhttp.Dns;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+import java.net.SocketAddress;
+
+/**
+ * An implementation of a minimal SOCKS5 client based on com/squareup/okhttp/SocksProxy.java and
+ * <a href="http://tools.ietf.org/html/rfc1928">RFC1928</a>. It wraps around a socket and
+ * establishes a connection through the proxy at connect time.
+ */
+
+public class SocksSocket extends Socket {
+    Proxy proxy = null;
+
+    public SocksSocket(Proxy proxy) {
+        super();
+        this.proxy = proxy;
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        if (proxy == null) {
+            super.connect(endpoint, timeout);
+        } else if (proxy.type() == Proxy.Type.SOCKS) {
+            InetSocketAddress proxyaddr = ((InetSocketAddress) proxy.address());
+            InetSocketAddress proxyaddrResolved = new InetSocketAddress(
+                    Dns.SYSTEM.lookup(proxyaddr.getHostString()).get(0), proxyaddr.getPort());
+
+            super.connect(proxyaddrResolved, timeout);
+            InetSocketAddress a = (InetSocketAddress) endpoint;
+            SocksProtocol.establish(this, a);
+        }
+    }
+}

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -644,12 +644,12 @@ public final class HttpEngine {
 
     GzipSource responseBody = new GzipSource(response.body().source());
     Headers strippedHeaders = response.headers().newBuilder()
-        .removeAll("Content-Encoding")
+            .removeAll("Content-Encoding")
         .removeAll("Content-Length")
-        .build();
+            .build();
     return response.newBuilder()
-        .headers(strippedHeaders)
-        .body(new RealResponseBody(strippedHeaders, Okio.buffer(responseBody)))
+            .headers(strippedHeaders)
+            .body(new RealResponseBody(strippedHeaders, Okio.buffer(responseBody)))
         .build();
   }
 
@@ -759,7 +759,7 @@ public final class HttpEngine {
             && requestBodyOut instanceof RetryableSink) {
           long contentLength = ((RetryableSink) requestBodyOut).contentLength();
           networkRequest = networkRequest.newBuilder()
-              .header("Content-Length", Long.toString(contentLength))
+                  .header("Content-Length", Long.toString(contentLength))
               .build();
         }
         transport.writeRequestHeaders(networkRequest);
@@ -787,11 +787,11 @@ public final class HttpEngine {
     if (cacheResponse != null) {
       if (validate(cacheResponse, networkResponse)) {
         userResponse = cacheResponse.newBuilder()
-            .request(userRequest)
-            .priorResponse(stripBody(priorResponse))
-            .headers(combine(cacheResponse.headers(), networkResponse.headers()))
+                .request(userRequest)
+                .priorResponse(stripBody(priorResponse))
+                .headers(combine(cacheResponse.headers(), networkResponse.headers()))
             .cacheResponse(stripBody(cacheResponse))
-            .networkResponse(stripBody(networkResponse))
+                .networkResponse(stripBody(networkResponse))
             .build();
         networkResponse.body().close();
         releaseConnection();
@@ -809,10 +809,10 @@ public final class HttpEngine {
     }
 
     userResponse = networkResponse.newBuilder()
-        .request(userRequest)
-        .priorResponse(stripBody(priorResponse))
-        .cacheResponse(stripBody(cacheResponse))
-        .networkResponse(stripBody(networkResponse))
+            .request(userRequest)
+            .priorResponse(stripBody(priorResponse))
+            .cacheResponse(stripBody(cacheResponse))
+            .networkResponse(stripBody(networkResponse))
         .build();
 
     if (hasBody(userResponse)) {
@@ -907,10 +907,10 @@ public final class HttpEngine {
     transport.finishRequest();
 
     Response networkResponse = transport.readResponseHeaders()
-        .request(networkRequest)
-        .handshake(connection.getHandshake())
-        .header(OkHeaders.SENT_MILLIS, Long.toString(sentRequestMillis))
-        .header(OkHeaders.RECEIVED_MILLIS, Long.toString(System.currentTimeMillis()))
+            .request(networkRequest)
+            .handshake(connection.getHandshake())
+            .header(OkHeaders.SENT_MILLIS, Long.toString(sentRequestMillis))
+            .header(OkHeaders.RECEIVED_MILLIS, Long.toString(System.currentTimeMillis()))
         .build();
 
     if (!forWebSocket) {
@@ -980,7 +980,7 @@ public final class HttpEngine {
     };
 
     return response.newBuilder()
-        .body(new RealResponseBody(response.headers(), Okio.buffer(cacheWritingSource)))
+            .body(new RealResponseBody(response.headers(), Okio.buffer(cacheWritingSource)))
         .build();
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
@@ -114,7 +114,7 @@ public final class RouteSelector {
     if (failedRoute.getProxy().type() != Proxy.Type.DIRECT && address.getProxySelector() != null) {
       // Tell the proxy selector when we fail to connect on a fresh connection.
       address.getProxySelector().connectFailed(
-          url.uri(), failedRoute.getProxy().address(), failure);
+              url.uri(), failedRoute.getProxy().address(), failure);
     }
 
     routeDatabase.failed(failedRoute);
@@ -180,11 +180,15 @@ public final class RouteSelector {
           + "; port is out of range");
     }
 
-    // Try each address for best behavior in mixed IPv4/IPv6 environments.
-    List<InetAddress> addresses = address.getDns().lookup(socketHost);
-    for (int i = 0, size = addresses.size(); i < size; i++) {
-      InetAddress inetAddress = addresses.get(i);
-      inetSocketAddresses.add(new InetSocketAddress(inetAddress, socketPort));
+    if (proxy.type() == Proxy.Type.SOCKS) {
+      inetSocketAddresses.add(InetSocketAddress.createUnresolved(socketHost, socketPort));
+    } else {
+      // Try each address for best behavior in mixed IPv4/IPv6 environments.
+      List<InetAddress> addresses = address.getDns().lookup(socketHost);
+      for (int i = 0, size = addresses.size(); i < size; i++) {
+        InetAddress inetAddress = addresses.get(i);
+        inetSocketAddresses.add(new InetSocketAddress(inetAddress, socketPort));
+      }
     }
 
     nextInetSocketAddressIndex = 0;


### PR DESCRIPTION
Hi,
I like yo to merge this patch that enables remote DNS resolution through a SOCKS5 proxy. One use case is to support .onion name resolution through the TOR SOCKS5 proxy. The patch includes a minimal implementation and a test case.

Thank you,
Richard