### PR TITLE
Fix HTTP/2 bug where we were using SPDY/3 style header concatenation.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -893,8 +893,14 @@ public final class MockWebServer implements TestRule {
           path = value;
         } else if (name.equals(Header.VERSION)) {
           version = value;
-        } else {
+        } else if (protocol == Protocol.SPDY_3) {
+          for (String s : value.split("\u0000", -1)) {
+            httpHeaders.add(name.utf8(), s);
+          }
+        } else if (protocol == Protocol.HTTP_2) {
           httpHeaders.add(name.utf8(), value);
+        } else {
+          throw new IllegalStateException();
         }
       }
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -182,6 +182,35 @@ public final class CallTest {
     get();
   }
 
+  @Test public void repeatedHeaderNames() throws Exception {
+    server.enqueue(new MockResponse()
+        .addHeader("B", "123")
+        .addHeader("B", "234"));
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .addHeader("A", "345")
+        .addHeader("A", "456")
+        .build();
+
+    executeSynchronously(request)
+        .assertCode(200)
+        .assertHeader("B", "123", "234");
+
+    RecordedRequest recordedRequest = server.takeRequest();
+    assertEquals(Arrays.asList("345", "456"), recordedRequest.getHeaders().values("A"));
+  }
+
+  @Test public void repeatedHeaderNames_SPDY_3() throws Exception {
+    enableProtocol(Protocol.SPDY_3);
+    repeatedHeaderNames();
+  }
+
+  @Test public void repeatedHeaderNames_HTTP_2() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+    repeatedHeaderNames();
+  }
+
   @Test public void getWithRequestBody() throws Exception {
     server.enqueue(new MockResponse());
 


### PR DESCRIPTION
When multiple headers have the same value in SPDY/3, they are concantenated
and separated by \u0000.

When multiple headers have the same value in HTTP/2, they are each written
independently.

This fixes the problem and rearranges the code to share less behavior than
previously. It gets us closer to being able to drop SPDY/3.

Closes https://github.com/square/okhttp/issues/1906