### PR TITLE
Add null check to HttpLoggingInterceptor.setLevel()

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/com/squareup/okhttp/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/com/squareup/okhttp/logging/HttpLoggingInterceptor.java
@@ -125,6 +125,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
   /** Change the level at which this interceptor logs. */
   public HttpLoggingInterceptor setLevel(Level level) {
+    if (level == null) throw new NullPointerException("level == null. Use Level.NONE instead.");
     this.level = level;
     return this;
   }

--- a/okhttp-logging-interceptor/src/test/java/com/squareup/okhttp/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/com/squareup/okhttp/logging/HttpLoggingInterceptorTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public final class HttpLoggingInterceptorTest {
   private static final MediaType PLAIN = MediaType.parse("text/plain; charset=utf-8");
@@ -52,6 +53,15 @@ public final class HttpLoggingInterceptorTest {
     interceptor = new HttpLoggingInterceptor(logger);
     client.networkInterceptors().add(interceptor);
     client.setConnectionPool(null);
+  }
+
+  @Test public void setLevelShouldPreventNullValue() {
+    try {
+      interceptor.setLevel(null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertEquals("level == null. Use Level.NONE instead.", expected.getMessage());
+    }
   }
 
   @Test public void setLevelShouldReturnSameInstanceOfInterceptor() {


### PR DESCRIPTION
@swankjesse as promised in twitter discussion.

JFYI: this is actually a little breaking change because in recently released 2.6 `null` value breaks the logic of the interceptor and it works as `Level.BASIC` (at first glance I thought it'll work as `NONE`, but, in fact, it works as `BASIC`). Not sure that @JakeWharton wanted such behavior (though if it was intended — just close this PR).