### PR TITLE
Remote DNS resolving for connections through a SOCKS proxy

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/SocksProxy.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/SocksProxy.java
@@ -51,6 +51,8 @@ public final class SocksProxy {
 
   private static final Logger logger = Logger.getLogger(SocksProxy.class.getName());
 
+  public final String HOSTNAME_THAT_ONLY_THE_PROXY_KNOWS = "onlyProxyCanResolveMe.org";
+
   private final ExecutorService executor = Executors.newCachedThreadPool(
       Util.threadFactory("SocksProxy", false));
 
@@ -156,7 +158,16 @@ public final class SocksProxy {
       case ADDRESS_TYPE_DOMAIN_NAME:
         int domainNameLength = fromSource.readByte() & 0xff;
         String domainName = fromSource.readUtf8(domainNameLength);
-        toAddress = InetAddress.getByName(domainName);
+
+        // mockup for DNS resolving at the proxy
+        if (domainName.equalsIgnoreCase(HOSTNAME_THAT_ONLY_THE_PROXY_KNOWS))
+          toAddress = InetAddress.getLoopbackAddress(); // resolve
+          // HOSTNAME_THAT_ONLY_THE_PROXY_KNOWS to localhost
+        else
+          toAddress = InetAddress.getByName(domainName);  // really resolve the address
+
+        logger.log(Level.INFO, "SocksProxy resolved " + domainName + " to " + toAddress);
+
         break;
 
       default:

--- a/okhttp/src/main/java/com/squareup/okhttp/Connection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Connection.java
@@ -29,6 +29,7 @@ import com.squareup.okhttp.internal.http.OkHeaders;
 import com.squareup.okhttp.internal.http.RouteException;
 import com.squareup.okhttp.internal.http.Transport;
 import com.squareup.okhttp.internal.tls.OkHostnameVerifier;
+
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.Socket;
@@ -36,9 +37,11 @@ import java.net.UnknownServiceException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+
 import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.Source;
@@ -193,7 +196,7 @@ public final class Connection {
 
   /** Does all the work necessary to build a full HTTP or HTTPS connection on a raw socket. */
   private void connectSocket(int connectTimeout, int readTimeout, int writeTimeout,
-      ConnectionSpecSelector connectionSpecSelector) throws IOException {
+                             ConnectionSpecSelector connectionSpecSelector) throws IOException {
     socket.setSoTimeout(readTimeout);
     Platform.get().connectSocket(socket, route.getSocketAddress(), connectTimeout);
 
@@ -488,7 +491,7 @@ public final class Connection {
         + ", proxy="
         + route.proxy
         + " hostAddress="
-        + route.inetSocketAddress.getAddress().getHostAddress()
+        + route.inetSocketAddress.toString()
         + " cipherSuite="
         + (handshake != null ? handshake.cipherSuite() : "none")
         + " protocol="

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/RouteSelector.java
@@ -114,7 +114,7 @@ public final class RouteSelector {
     if (failedRoute.getProxy().type() != Proxy.Type.DIRECT && address.getProxySelector() != null) {
       // Tell the proxy selector when we fail to connect on a fresh connection.
       address.getProxySelector().connectFailed(
-          url.uri(), failedRoute.getProxy().address(), failure);
+              url.uri(), failedRoute.getProxy().address(), failure);
     }
 
     routeDatabase.failed(failedRoute);
@@ -180,11 +180,15 @@ public final class RouteSelector {
           + "; port is out of range");
     }
 
-    // Try each address for best behavior in mixed IPv4/IPv6 environments.
-    List<InetAddress> addresses = address.getDns().lookup(socketHost);
-    for (int i = 0, size = addresses.size(); i < size; i++) {
-      InetAddress inetAddress = addresses.get(i);
-      inetSocketAddresses.add(new InetSocketAddress(inetAddress, socketPort));
+    if (proxy.type() == Proxy.Type.SOCKS) {
+      inetSocketAddresses.add(InetSocketAddress.createUnresolved(socketHost, socketPort));
+    } else {
+      // Try each address for best behavior in mixed IPv4/IPv6 environments.
+      List<InetAddress> addresses = address.getDns().lookup(socketHost);
+      for (int i = 0, size = addresses.size(); i < size; i++) {
+        InetAddress inetAddress = addresses.get(i);
+        inetSocketAddresses.add(new InetSocketAddress(inetAddress, socketPort));
+      }
     }
 
     nextInetSocketAddressIndex = 0;


### PR DESCRIPTION
This small patch ensures that a connection through a SOCKS proxy will have its hostname resolved through the proxy as well. It includes a test case for that behaviour.