### PR TITLE
Fewer buffers in FramedConnections.

### DIFF
--- a/mockwebserver/src/main/java/com/squareup/okhttp/internal/framed/FramedServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/internal/framed/FramedServer.java
@@ -65,7 +65,8 @@ public final class FramedServer implements IncomingStreamHandler {
         if (protocol == null || !framedProtocols.contains(protocol)) {
           throw new ProtocolException("Protocol " + protocol + " unsupported");
         }
-        FramedConnection framedConnection = new FramedConnection.Builder(false, sslSocket)
+        FramedConnection framedConnection = new FramedConnection.Builder(false)
+            .socket(sslSocket)
             .protocol(protocol)
             .handler(this)
             .build();

--- a/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/com/squareup/okhttp/mockwebserver/MockWebServer.java
@@ -467,10 +467,11 @@ public final class MockWebServer implements TestRule {
 
         if (protocol != Protocol.HTTP_1_1) {
           FramedSocketHandler framedSocketHandler = new FramedSocketHandler(socket, protocol);
-          FramedConnection framedConnection =
-              new FramedConnection.Builder(false, socket).protocol(protocol)
-                  .handler(framedSocketHandler)
-                  .build();
+          FramedConnection framedConnection = new FramedConnection.Builder(false)
+              .socket(socket)
+              .protocol(protocol)
+              .handler(framedSocketHandler)
+              .build();
           openFramedConnections.add(framedConnection);
           openClientSockets.remove(socket);
           return;

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/framed/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/framed/Http2ConnectionTest.java
@@ -443,7 +443,8 @@ public final class Http2ConnectionTest {
 
     String longString = repeat('a', Http2.INITIAL_MAX_FRAME_SIZE + 1);
     Socket socket = peer.openSocket();
-    FramedConnection connection = new FramedConnection.Builder(true, socket)
+    FramedConnection connection = new FramedConnection.Builder(true)
+        .socket(socket)
         .pushObserver(IGNORE)
         .protocol(HTTP_2.getProtocol())
         .build();
@@ -488,7 +489,8 @@ public final class Http2ConnectionTest {
 
   private FramedConnection.Builder connectionBuilder(MockSpdyPeer peer, Variant variant)
       throws IOException {
-    return new FramedConnection.Builder(true, peer.openSocket())
+    return new FramedConnection.Builder(true)
+        .socket(peer.openSocket())
         .pushObserver(IGNORE)
         .protocol(variant.getProtocol());
   }

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/internal/framed/Spdy3ConnectionTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/internal/framed/Spdy3ConnectionTest.java
@@ -158,7 +158,10 @@ public final class Spdy3ConnectionTest {
         stream.reply(headerEntries("b", "banana"), true);
       }
     };
-    new FramedConnection.Builder(true, peer.openSocket()).handler(handler).build();
+    new FramedConnection.Builder(true)
+        .socket(peer.openSocket())
+        .handler(handler)
+        .build();
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame reply = peer.takeFrame();
@@ -621,7 +624,10 @@ public final class Spdy3ConnectionTest {
         stream.reply(headerEntries("c", "cola"), true);
       }
     };
-    new FramedConnection.Builder(true, peer.openSocket()).handler(handler).build();
+    new FramedConnection.Builder(true)
+        .socket(peer.openSocket())
+        .handler(handler)
+        .build();
 
     // verify the peer received what was expected
     MockSpdyPeer.InFrame reply = peer.takeFrame();
@@ -1315,7 +1321,8 @@ public final class Spdy3ConnectionTest {
 
     String longString = ByteString.of(randomBytes(2048)).base64();
     Socket socket = peer.openSocket();
-    FramedConnection connection = new FramedConnection.Builder(true, socket)
+    FramedConnection connection = new FramedConnection.Builder(true)
+        .socket(socket)
         .protocol(SPDY3.getProtocol())
         .build();
     socket.shutdownOutput();
@@ -1343,7 +1350,8 @@ public final class Spdy3ConnectionTest {
 
   private FramedConnection.Builder connectionBuilder(MockSpdyPeer peer, Variant variant)
       throws IOException {
-    return new FramedConnection.Builder(true, peer.openSocket())
+    return new FramedConnection.Builder(true)
+        .socket(peer.openSocket())
         .protocol(variant.getProtocol());
   }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/io/RealConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/io/RealConnection.java
@@ -82,7 +82,6 @@ public final class RealConnection implements Connection {
     this.route = route;
   }
 
-  // TODO(jwilson): make non public.
   public void connect(int connectTimeout, int readTimeout, int writeTimeout,
       List<ConnectionSpec> connectionSpecs, boolean connectionRetryEnabled) throws RouteException {
     if (protocol != null) throw new IllegalStateException("already connected");
@@ -149,7 +148,8 @@ public final class RealConnection implements Connection {
 
     if (protocol == Protocol.SPDY_3 || protocol == Protocol.HTTP_2) {
       socket.setSoTimeout(0); // Framed connection timeouts are set per-stream.
-      framedConnection = new FramedConnection.Builder(route.getAddress().url().host(), true, socket)
+      framedConnection = new FramedConnection.Builder(true)
+          .socket(socket, route.getAddress().url().host(), source, sink)
           .protocol(protocol).build();
       framedConnection.sendConnectionPreface();
     }


### PR DESCRIPTION
Previously we had a BufferedSource in the RealConnection and another
independent BufferedSource in the FramedConnection. We only need one.