### PR TITLE
Fix SSLSocket configuration

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/ConnectionSpec.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/ConnectionSpec.java
@@ -137,15 +137,15 @@ public final class ConnectionSpec {
   }
 
   /**
-   * Returns a copy of this that omits cipher suites and TLS versions not enabled by {@code
+   * Returns a copy of this that omits cipher suites and TLS versions not supported by {@code
    * sslSocket}.
    */
   private ConnectionSpec supportedSpec(SSLSocket sslSocket, boolean isFallback) {
     String[] cipherSuitesIntersection = cipherSuites != null
-        ? Util.intersect(String.class, cipherSuites, sslSocket.getEnabledCipherSuites())
+        ? Util.intersect(String.class, cipherSuites, sslSocket.getSupportedCipherSuites())
         : sslSocket.getEnabledCipherSuites();
     String[] tlsVersionsIntersection = tlsVersions != null
-        ? Util.intersect(String.class, tlsVersions, sslSocket.getEnabledProtocols())
+        ? Util.intersect(String.class, tlsVersions, sslSocket.getSupportedProtocols())
         : sslSocket.getEnabledProtocols();
 
     // In accordance with https://tools.ietf.org/html/draft-ietf-tls-downgrade-scsv-00
@@ -162,14 +162,14 @@ public final class ConnectionSpec {
 
   /**
    * Returns {@code true} if the socket, as currently configured, supports this connection spec.
-   * In order for a socket to be compatible the enabled cipher suites and protocols must intersect.
+   * In order for a socket to be compatible the supported cipher suites and protocols must intersect.
    *
    * <p>For cipher suites, at least one of the {@link #cipherSuites() required cipher suites} must
-   * match the socket's enabled cipher suites. If there are no required cipher suites the socket
+   * match the socket's supported cipher suites. If there are no required cipher suites the socket
    * must have at least one cipher suite enabled.
    *
    * <p>For protocols, at least one of the {@link #tlsVersions() required protocols} must match the
-   * socket's enabled protocols.
+   * socket's supported protocols.
    */
   public boolean isCompatible(SSLSocket socket) {
     if (!tls) {
@@ -177,12 +177,12 @@ public final class ConnectionSpec {
     }
 
     if (tlsVersions != null
-        && !nonEmptyIntersection(tlsVersions, socket.getEnabledProtocols())) {
+        && !nonEmptyIntersection(tlsVersions, socket.getSupportedProtocols())) {
       return false;
     }
 
     if (cipherSuites != null
-        && !nonEmptyIntersection(cipherSuites, socket.getEnabledCipherSuites())) {
+        && !nonEmptyIntersection(cipherSuites, socket.getSupportedCipherSuites())) {
       return false;
     }
 


### PR DESCRIPTION
Trying to connect to a server supporting *only* the `"SSL_RSA_WITH_3DES_EDE_CBC_SHA"` cipher suite on Android 5.0 (API Level 21) and later fails with the following exception:

    javax.net.ssl.SSLHandshakeException: Connection closed by peer
    	at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
    	at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:302)
    	at com.squareup.okhttp.internal.io.RealConnection.connectTls(RealConnection.java:184)
    	at com.squareup.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:141)
    	at com.squareup.okhttp.internal.io.RealConnection.connect(RealConnection.java:104)
    	at com.squareup.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:176)
    	at com.squareup.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:124)
    	at com.squareup.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:93)
    	at com.squareup.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:283)
    	at com.squareup.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
    	at com.squareup.okhttp.Call.getResponse(Call.java:285)
    	at com.squareup.okhttp.Call$ApplicationInterceptorChain.proceed(Call.java:243)
    	at com.squareup.okhttp.Call.getResponseWithInterceptorChain(Call.java:205)
    	at com.squareup.okhttp.Call.execute(Call.java:80)

It used to work on Android 4.4 and earlier.

In Android 5.0, `"SSL_RSA_WITH_3DES_EDE_CBC_SHA"` (`CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA`) [is not enabled by default anymore][1] but is still supported.

When computing the supported `ConnectionSpec` for a given `SSLSocket`, the `cipherSuites` are intersected with the *enabled* cipher suites of the socket. By intersecting with the *supported* cipher suites instead, we ensure that the socket is properly configured with the cipher suites defined in the connection spec.

  [1]: http://developer.android.com/reference/javax/net/ssl/SSLEngine.html