### PR TITLE
moved all body validations from Request.Builder to Request.validate()

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/CallTest.java
@@ -219,10 +219,30 @@ public final class CallTest {
   @Test public void getWithRequestBody() throws Exception {
     server.enqueue(new MockResponse());
 
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .method("GET", RequestBody.create(MediaType.parse("text/plain"), "abc"))
+        .build();
+
     try {
-      new Request.Builder().method("GET", RequestBody.create(MediaType.parse("text/plain"), "abc"));
-      fail();
-    } catch (IllegalArgumentException expected) {
+      executeSynchronously(request);
+      fail("GET cannot have a request body");
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void postWithoutRequestBody() throws Exception {
+    server.enqueue(new MockResponse());
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .method("POST", null)
+        .build();
+
+    try {
+      executeSynchronously(request);
+      fail("POST must have a request body");
+    } catch (IllegalStateException expected) {
     }
   }
 

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -174,6 +174,27 @@ public final class RequestTest {
     }
   }
 
+  @Test public void itDoesNotValidateTheRequest() throws Exception {
+
+    // Since Interceptors can rewrite an invalid Request to a valid Request,
+    // the builder should not validate it.
+
+    final String method = "PUT";
+    Request request = null;
+
+    try {
+      Request.Builder builder = new Request.Builder();
+      builder.url("http://localhost/api");
+      builder.method(method, null);
+      request = builder.build();
+    } catch (IllegalArgumentException e){
+      fail();
+    }
+
+    assertEquals(method, request.method());
+    assertNull(request.body());
+  }
+
   @Test public void headerForbidsControlCharacters() throws Exception {
     assertForbiddenHeader(null);
     assertForbiddenHeader("\u0000");

--- a/okhttp/src/main/java/com/squareup/okhttp/Call.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Call.java
@@ -239,6 +239,9 @@ public class Call {
         return interceptedResponse;
       }
 
+      // No more interceptors, check if the Request is still a valid Request
+      request.validate();
+
       // No more interceptors. Do HTTP.
       return getResponse(request, forWebSocket);
     }

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -117,6 +117,23 @@ public final class Request {
         + '}';
   }
 
+  /**
+   * Checks if the Request is valid.
+   *
+   * @throws IllegalStateException it is invalid.
+   */
+  public void validate() {
+    if (method == null || method.length() == 0) {
+      throw new IllegalStateException("method == null || method.length() == 0");
+    }
+    if (body != null && !HttpMethod.permitsRequestBody(method)) {
+      throw new IllegalStateException("method " + method + " must not have a request body.");
+    }
+    if (body == null && HttpMethod.requiresRequestBody(method)) {
+      throw new IllegalStateException("method " + method + " must have a request body.");
+    }
+  }
+
   public static class Builder {
     private HttpUrl url;
     private String method;
@@ -249,15 +266,6 @@ public final class Request {
     }
 
     public Builder method(String method, RequestBody body) {
-      if (method == null || method.length() == 0) {
-        throw new IllegalArgumentException("method == null || method.length() == 0");
-      }
-      if (body != null && !HttpMethod.permitsRequestBody(method)) {
-        throw new IllegalArgumentException("method " + method + " must not have a request body.");
-      }
-      if (body == null && HttpMethod.requiresRequestBody(method)) {
-        throw new IllegalArgumentException("method " + method + " must have a request body.");
-      }
       this.method = method;
       this.body = body;
       return this;


### PR DESCRIPTION
fixes #2069

Builder validates the Request before the Interceptor chain. The Interceptor chain can easily rewrite a request to become valid and vice versa, which makes this validation better suited after the chain has made its changes to the Request.