### PR TITLE
Fix some stream leaks.

### DIFF
--- a/okhttp-logging-interceptor/src/test/java/com/squareup/okhttp/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/com/squareup/okhttp/logging/HttpLoggingInterceptorTest.java
@@ -20,6 +20,7 @@ import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.Response;
 import com.squareup.okhttp.logging.HttpLoggingInterceptor.Level;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
@@ -143,7 +144,8 @@ public final class HttpLoggingInterceptorTest {
     server.enqueue(new MockResponse()
         .setBody("Hello!")
         .setHeader("Content-Type", PLAIN));
-    client.newCall(request().build()).execute();
+    Response response = client.newCall(request().build()).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> GET " + url + " HTTP/1.1")
@@ -160,7 +162,8 @@ public final class HttpLoggingInterceptorTest {
     setLevel(Level.HEADERS);
 
     server.enqueue(new MockResponse());
-    client.newCall(request().build()).execute();
+    Response response = client.newCall(request().build()).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> GET " + url + " HTTP/1.1")
@@ -191,7 +194,9 @@ public final class HttpLoggingInterceptorTest {
     setLevel(Level.HEADERS);
 
     server.enqueue(new MockResponse());
-    client.newCall(request().post(RequestBody.create(PLAIN, "Hi?")).build()).execute();
+    Request request = request().post(RequestBody.create(PLAIN, "Hi?")).build();
+    Response response = client.newCall(request).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> POST " + url + " HTTP/1.1")
@@ -226,7 +231,9 @@ public final class HttpLoggingInterceptorTest {
     setLevel(Level.HEADERS);
 
     server.enqueue(new MockResponse());
-    client.newCall(request().post(RequestBody.create(null, "Hi?")).build()).execute();
+    Request request = request().post(RequestBody.create(null, "Hi?")).build();
+    Response response = client.newCall(request).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> POST " + url + " HTTP/1.1")
@@ -268,7 +275,8 @@ public final class HttpLoggingInterceptorTest {
         sink.writeUtf8("Hi!");
       }
     };
-    client.newCall(request().post(body).build()).execute();
+    Response response = client.newCall(request().post(body).build()).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> POST " + url + " HTTP/1.1")
@@ -304,7 +312,8 @@ public final class HttpLoggingInterceptorTest {
     server.enqueue(new MockResponse()
         .setBody("Hello!")
         .setHeader("Content-Type", PLAIN));
-    client.newCall(request().build()).execute();
+    Response response = client.newCall(request().build()).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> GET " + url + " HTTP/1.1")
@@ -337,7 +346,8 @@ public final class HttpLoggingInterceptorTest {
     setLevel(Level.BODY);
 
     server.enqueue(new MockResponse());
-    client.newCall(request().build()).execute();
+    Response response = client.newCall(request().build()).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> GET " + url + " HTTP/1.1")
@@ -377,7 +387,8 @@ public final class HttpLoggingInterceptorTest {
   private void bodyGetNoBody(int code) throws IOException {
     server.enqueue(new MockResponse()
         .setStatus("HTTP/1.1 " + code + " No Content"));
-    client.newCall(request().build()).execute();
+    Response response = client.newCall(request().build()).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> GET " + url + " HTTP/1.1")
@@ -408,7 +419,9 @@ public final class HttpLoggingInterceptorTest {
     setLevel(Level.BODY);
 
     server.enqueue(new MockResponse());
-    client.newCall(request().post(RequestBody.create(PLAIN, "Hi?")).build()).execute();
+    Request request = request().post(RequestBody.create(PLAIN, "Hi?")).build();
+    Response response = client.newCall(request).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> POST " + url + " HTTP/1.1")
@@ -449,7 +462,8 @@ public final class HttpLoggingInterceptorTest {
     server.enqueue(new MockResponse()
         .setBody("Hello!")
         .setHeader("Content-Type", PLAIN));
-    client.newCall(request().build()).execute();
+    Response response = client.newCall(request().build()).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> GET " + url + " HTTP/1.1")
@@ -488,7 +502,8 @@ public final class HttpLoggingInterceptorTest {
     server.enqueue(new MockResponse()
         .setChunkedBody("Hello!", 2)
         .setHeader("Content-Type", PLAIN));
-    client.newCall(request().build()).execute();
+    Response response = client.newCall(request().build()).execute();
+    response.body().close();
 
     applicationLogs
         .assertLogEqual("--> GET " + url + " HTTP/1.1")
@@ -529,7 +544,8 @@ public final class HttpLoggingInterceptorTest {
         .setHeader("Content-Type", PLAIN)
         .setBody(new Buffer().write(ByteString.decodeBase64(
             "H4sIAAAAAAAAAPNIzcnJ11HwQKIAdyO+9hMAAAA="))));
-    client.newCall(request().build()).execute();
+    Response response = client.newCall(request().build()).execute();
+    response.body().close();
 
     networkLogs
         .assertLogEqual("--> GET " + url + " HTTP/1.1")

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
@@ -391,7 +391,8 @@ public final class InterceptorTest {
 
     client.interceptors().add(new Interceptor() {
       @Override public Response intercept(Chain chain) throws IOException {
-        chain.proceed(chain.request());
+        Response response1 = chain.proceed(chain.request());
+        response1.body().close();
         return chain.proceed(chain.request());
       }
     });

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/Http1xStream.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/Http1xStream.java
@@ -248,7 +248,7 @@ public final class Http1xStream implements HttpStream {
     if (state != STATE_OPEN_RESPONSE_BODY) throw new IllegalStateException("state: " + state);
     if (streamAllocation == null) throw new IllegalStateException("streamAllocation == null");
     state = STATE_READING_RESPONSE_BODY;
-    streamAllocation.noNewStreamsOnConnection();
+    streamAllocation.noNewStreams();
     return new UnknownLengthSource();
   }
 
@@ -368,7 +368,7 @@ public final class Http1xStream implements HttpStream {
 
       state = STATE_CLOSED;
       if (streamAllocation != null) {
-        streamAllocation.noNewStreamsOnConnection();
+        streamAllocation.noNewStreams();
         streamAllocation.streamFinished(Http1xStream.this);
       }
     }

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -444,7 +444,7 @@ public final class HttpEngine {
       closeQuietly(userResponse.body());
     } else {
       // If this engine never achieved a response body, its stream allocation is dead.
-      streamAllocation.noNewStreams();
+      streamAllocation.connectionFailed();
     }
 
     return streamAllocation;
@@ -751,7 +751,7 @@ public final class HttpEngine {
 
     if ("close".equalsIgnoreCase(networkResponse.request().header("Connection"))
         || "close".equalsIgnoreCase(networkResponse.header("Connection"))) {
-      streamAllocation.noNewStreamsOnConnection();
+      streamAllocation.noNewStreams();
     }
 
     return networkResponse;

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/StreamAllocation.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/StreamAllocation.java
@@ -128,7 +128,7 @@ public final class StreamAllocation {
       if (connection.isHealthy(doExtensiveHealthChecks)) {
         return candidate;
       }
-      deallocate(true, false, true);
+      connectionFailed();
     }
   }
 
@@ -210,13 +210,7 @@ public final class StreamAllocation {
   }
 
   /** Forbid new streams from being created on the connection that hosts this allocation. */
-  public void noNewStreamsOnConnection() {
-    deallocate(true, false, false);
-  }
-
-  /** Forbid new streams from being created on this allocation. */
   public void noNewStreams() {
-    // TODO(jwilson): fix this for HTTP/2 to not nuke the socket connection.
     deallocate(true, false, false);
   }
 
@@ -285,6 +279,11 @@ public final class StreamAllocation {
         }
       }
     }
+    connectionFailed();
+  }
+
+  /** Finish the current stream and prevent new streams from being created. */
+  public void connectionFailed() {
     deallocate(true, false, true);
   }
 


### PR DESCRIPTION
There's a few places where OkHttp could leak a connection that needed to be
closed. With our new connection pool model this is easier to find. This fixes
two specific problems:
 - too many redirects doesn't release the last used connection
 - interceptors that throw runtime exceptions don't release the connection

There are likely more situations. I have hacked together a small little test
harness to make finding these leaks easier; that's not included in this PR.