### PR TITLE
We don't have resource leaks in interceptor crashes anymore.

### DIFF
--- a/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/InterceptorTest.java
@@ -475,8 +475,6 @@ public final class InterceptorTest {
   /**
    * When an interceptor throws an unexpected exception, synchronous callers can catch it and deal
    * with it.
-   *
-   * TODO(jwilson): test that resources are not leaked when this happens.
    */
   private void interceptorThrowsRuntimeExceptionSynchronous(
       List<Interceptor> interceptors) throws Exception {
@@ -533,8 +531,6 @@ public final class InterceptorTest {
   /**
    * When an interceptor throws an unexpected exception, asynchronous callers are left hanging. The
    * exception goes to the uncaught exception handler.
-   *
-   * TODO(jwilson): test that resources are not leaked when this happens.
    */
   private void interceptorThrowsRuntimeExceptionAsynchronous(
         List<Interceptor> interceptors) throws Exception {


### PR DESCRIPTION
Yay stream allocations.

Closes: https://github.com/square/okhttp/issues/1502