### PR TITLE
Drop Request.uri(). Just use Request.url().uri().

### DIFF
--- a/okhttp-android-support/src/main/java/com/squareup/okhttp/internal/huc/CacheAdapter.java
+++ b/okhttp-android-support/src/main/java/com/squareup/okhttp/internal/huc/CacheAdapter.java
@@ -52,7 +52,7 @@ public final class CacheAdapter implements InternalCache {
   }
 
   @Override public CacheRequest put(Response response) throws IOException {
-    URI uri = response.request().uri();
+    URI uri = response.request().url().uri();
     HttpURLConnection connection = JavaApiConverter.createJavaUrlConnectionForCachePut(response);
     final java.net.CacheRequest request = delegate.put(uri, connection);
     if (request == null) {
@@ -100,6 +100,6 @@ public final class CacheAdapter implements InternalCache {
    */
   private CacheResponse getJavaCachedResponse(Request request) throws IOException {
     Map<String, List<String>> headers = JavaApiConverter.extractJavaHeaders(request);
-    return delegate.get(request.uri(), request.method(), headers);
+    return delegate.get(request.url().uri(), request.method(), headers);
   }
 }

--- a/okhttp-android-support/src/test/java/com/squareup/okhttp/internal/huc/JavaApiConverterTest.java
+++ b/okhttp-android-support/src/test/java/com/squareup/okhttp/internal/huc/JavaApiConverterTest.java
@@ -225,7 +225,7 @@ public class JavaApiConverterTest {
     Map<String,List<String>> javaRequestHeaders = null;
     Request request = JavaApiConverter.createOkRequest(uri, "POST", javaRequestHeaders);
     assertFalse(request.isHttps());
-    assertEquals(uri, request.uri());
+    assertEquals(uri, request.url().uri());
     Headers okRequestHeaders = request.headers();
     assertEquals(0, okRequestHeaders.size());
     assertEquals("POST", request.method());
@@ -238,7 +238,7 @@ public class JavaApiConverterTest {
     javaRequestHeaders.put("Foo", Arrays.asList("Bar"));
     Request request = JavaApiConverter.createOkRequest(uri, "POST", javaRequestHeaders);
     assertTrue(request.isHttps());
-    assertEquals(uri, request.uri());
+    assertEquals(uri, request.url().uri());
     Headers okRequestHeaders = request.headers();
     assertEquals(1, okRequestHeaders.size());
     assertEquals("Bar", okRequestHeaders.get("Foo"));
@@ -257,7 +257,7 @@ public class JavaApiConverterTest {
     javaRequestHeaders.put("Foo", Arrays.asList("Bar"));
     Request request = JavaApiConverter.createOkRequest(uri, "POST", javaRequestHeaders);
     assertTrue(request.isHttps());
-    assertEquals(uri, request.uri());
+    assertEquals(uri, request.url().uri());
     Headers okRequestHeaders = request.headers();
     assertEquals(1, okRequestHeaders.size());
     assertEquals("Bar", okRequestHeaders.get("Foo"));

--- a/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
+++ b/okhttp-tests/src/test/java/com/squareup/okhttp/RequestTest.java
@@ -119,7 +119,7 @@ public final class RequestTest {
 
   @Test public void uninitializedURI() throws Exception {
     Request request = new Request.Builder().url("http://localhost/api").build();
-    assertEquals(new URI("http://localhost/api"), request.uri());
+    assertEquals(new URI("http://localhost/api"), request.url().uri());
     assertEquals(HttpUrl.parse("http://localhost/api"), request.url());
   }
 

--- a/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/URLEncodingTest.java
+++ b/okhttp-urlconnection/src/test/java/com/squareup/okhttp/internal/huc/URLEncodingTest.java
@@ -26,13 +26,10 @@ import com.squareup.okhttp.internal.http.CacheRequest;
 import com.squareup.okhttp.internal.http.CacheStrategy;
 
 import java.io.IOException;
-import java.net.CacheResponse;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -132,7 +129,7 @@ public final class URLEncodingTest {
     Internal.instance.setCache(client, new InternalCache() {
       @Override
       public Response get(Request request) throws IOException {
-        uriReference.set(request.uri());
+        uriReference.set(request.url().uri());
         throw new UnsupportedOperationException();
       }
 

--- a/okhttp/src/main/java/com/squareup/okhttp/Request.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/Request.java
@@ -16,7 +16,6 @@
 package com.squareup.okhttp;
 
 import com.squareup.okhttp.internal.http.HttpMethod;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
@@ -45,15 +44,6 @@ public final class Request {
 
   public HttpUrl url() {
     return url;
-  }
-
-  public URI uri() throws IOException {
-    try {
-      URI result = javaNetUri;
-      return result != null ? result : (javaNetUri = url.uri());
-    } catch (IllegalStateException e) {
-      throw new IOException(e.getMessage());
-    }
   }
 
   public String method() {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpEngine.java
@@ -540,7 +540,7 @@ public final class HttpEngine {
       // affect cookie choice besides "Host".
       Map<String, List<String>> headers = OkHeaders.toMultimap(result.build().headers(), null);
 
-      Map<String, List<String>> cookies = cookieHandler.get(request.uri(), headers);
+      Map<String, List<String>> cookies = cookieHandler.get(request.url().uri(), headers);
 
       // Add any new cookies to the request.
       OkHeaders.addCookies(result, cookies);
@@ -877,7 +877,7 @@ public final class HttpEngine {
   public void receiveHeaders(Headers headers) throws IOException {
     CookieHandler cookieHandler = client.getCookieHandler();
     if (cookieHandler != null) {
-      cookieHandler.put(userRequest.uri(), OkHeaders.toMultimap(headers, null));
+      cookieHandler.put(userRequest.url().uri(), OkHeaders.toMultimap(headers, null));
     }
   }
 


### PR DESCRIPTION
There's a mostly-academic corner case on URLs like http://host/%xx that
have a malformed escape sequence. This changes the exceptions on those
URLs from checked to unchecked.

I think we may want a separate change to HttpUrl to fix those URLs to
be encoded as http://host/%25xx which avoids the problem altogether.

Closes: https://github.com/square/okhttp/issues/2106