### PR TITLE
One authenticate method on the authenticator interface.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -15,20 +15,6 @@
  */
 package okhttp3;
 
-import okhttp3.internal.DoubleInetAddressDns;
-import okhttp3.internal.RecordingOkAuthenticator;
-import okhttp3.internal.SingleInetAddressDns;
-import okhttp3.internal.SslContextBuilder;
-import okhttp3.internal.Util;
-import okhttp3.internal.Version;
-import okhttp3.internal.http.FakeDns;
-import okhttp3.internal.io.InMemoryFileSystem;
-import okhttp3.mockwebserver.Dispatcher;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-import okhttp3.mockwebserver.SocketPolicy;
-import okhttp3.testing.RecordingHostnameVerifier;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,6 +48,20 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+import okhttp3.internal.DoubleInetAddressDns;
+import okhttp3.internal.RecordingOkAuthenticator;
+import okhttp3.internal.SingleInetAddressDns;
+import okhttp3.internal.SslContextBuilder;
+import okhttp3.internal.Util;
+import okhttp3.internal.Version;
+import okhttp3.internal.http.FakeDns;
+import okhttp3.internal.io.InMemoryFileSystem;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
+import okhttp3.testing.RecordingHostnameVerifier;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
@@ -74,8 +74,8 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
-import static okhttp3.internal.Internal.logger;
 import static java.net.CookiePolicy.ACCEPT_ORIGINAL_SERVER;
+import static okhttp3.internal.Internal.logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -2077,7 +2077,7 @@ public final class CallTest {
 
     client.setSslSocketFactory(sslContext.getSocketFactory());
     client.setProxy(server.toProxyAddress());
-    client.setAuthenticator(new RecordingOkAuthenticator("password"));
+    client.setProxyAuthenticator(new RecordingOkAuthenticator("password"));
     client.setHostnameVerifier(new RecordingHostnameVerifier());
 
     Request request = new Request.Builder()

--- a/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
@@ -15,10 +15,6 @@
  */
 package okhttp3;
 
-import okhttp3.internal.RecordingAuthenticator;
-import okhttp3.internal.http.AuthenticatorAdapter;
-import okhttp3.internal.http.RecordingProxySelector;
-import okhttp3.internal.tls.OkHostnameVerifier;
 import java.io.IOException;
 import java.net.Authenticator;
 import java.net.CacheRequest;
@@ -34,6 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.net.SocketFactory;
+import okhttp3.internal.RecordingAuthenticator;
+import okhttp3.internal.http.AuthenticatorAdapter;
+import okhttp3.internal.http.RecordingProxySelector;
+import okhttp3.internal.tls.OkHostnameVerifier;
 import org.junit.After;
 import org.junit.Test;
 
@@ -126,6 +126,7 @@ public final class OkHttpClientTest {
     assertSame(proxySelector, client.getProxySelector());
     assertSame(cookieManager, client.getCookieHandler());
     assertSame(AuthenticatorAdapter.INSTANCE, client.getAuthenticator());
+    assertSame(AuthenticatorAdapter.INSTANCE, client.getProxyAuthenticator());
     assertSame(socketFactory, client.getSocketFactory());
     assertSame(hostnameVerifier, client.getHostnameVerifier());
     assertSame(certificatePinner, client.getCertificatePinner());

--- a/okhttp-tests/src/test/java/okhttp3/internal/RecordingOkAuthenticator.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/RecordingOkAuthenticator.java
@@ -15,12 +15,14 @@
  */
 package okhttp3.internal;
 
-import okhttp3.Authenticator;
-import okhttp3.Request;
-import okhttp3.Response;
+import java.io.IOException;
 import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.List;
+import okhttp3.Authenticator;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
 
 public final class RecordingOkAuthenticator implements Authenticator {
   public final List<Response> responses = new ArrayList<>();
@@ -41,19 +43,12 @@ public final class RecordingOkAuthenticator implements Authenticator {
     return proxies.get(0);
   }
 
-  @Override public Request authenticate(Proxy proxy, Response response) {
+  @Override public Request authenticate(Route route, Response response) throws IOException {
     responses.add(response);
-    proxies.add(proxy);
+    proxies.add(route.proxy());
+    String header = response.code() == 407 ? "Proxy-Authorization" : "Authorization";
     return response.request().newBuilder()
-        .addHeader("Authorization", credential)
-        .build();
-  }
-
-  @Override public Request authenticateProxy(Proxy proxy, Response response) {
-    responses.add(response);
-    proxies.add(proxy);
-    return response.request().newBuilder()
-        .addHeader("Proxy-Authorization", credential)
+        .addHeader(header, credential)
         .build();
   }
 }

--- a/okhttp/src/main/java/okhttp3/Address.java
+++ b/okhttp/src/main/java/okhttp3/Address.java
@@ -15,13 +15,13 @@
  */
 package okhttp3;
 
-import okhttp3.internal.Util;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.util.List;
 import javax.net.SocketFactory;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
+import okhttp3.internal.Util;
 
 import static okhttp3.internal.Util.equal;
 
@@ -39,7 +39,7 @@ public final class Address {
   final HttpUrl url;
   final Dns dns;
   final SocketFactory socketFactory;
-  final Authenticator authenticator;
+  final Authenticator proxyAuthenticator;
   final List<Protocol> protocols;
   final List<ConnectionSpec> connectionSpecs;
   final ProxySelector proxySelector;
@@ -50,7 +50,7 @@ public final class Address {
 
   public Address(String uriHost, int uriPort, Dns dns, SocketFactory socketFactory,
       SSLSocketFactory sslSocketFactory, HostnameVerifier hostnameVerifier,
-      CertificatePinner certificatePinner, Authenticator authenticator, Proxy proxy,
+      CertificatePinner certificatePinner, Authenticator proxyAuthenticator, Proxy proxy,
       List<Protocol> protocols, List<ConnectionSpec> connectionSpecs, ProxySelector proxySelector) {
     this.url = new HttpUrl.Builder()
         .scheme(sslSocketFactory != null ? "https" : "http")
@@ -64,8 +64,10 @@ public final class Address {
     if (socketFactory == null) throw new IllegalArgumentException("socketFactory == null");
     this.socketFactory = socketFactory;
 
-    if (authenticator == null) throw new IllegalArgumentException("authenticator == null");
-    this.authenticator = authenticator;
+    if (proxyAuthenticator == null) {
+      throw new IllegalArgumentException("proxyAuthenticator == null");
+    }
+    this.proxyAuthenticator = proxyAuthenticator;
 
     if (protocols == null) throw new IllegalArgumentException("protocols == null");
     this.protocols = Util.immutableList(protocols);
@@ -100,9 +102,9 @@ public final class Address {
     return socketFactory;
   }
 
-  /** Returns the client's authenticator. */
-  public Authenticator authenticator() {
-    return authenticator;
+  /** Returns the client's proxy authenticator. */
+  public Authenticator proxyAuthenticator() {
+    return proxyAuthenticator;
   }
 
   /**
@@ -153,7 +155,7 @@ public final class Address {
       Address that = (Address) other;
       return this.url.equals(that.url)
           && this.dns.equals(that.dns)
-          && this.authenticator.equals(that.authenticator)
+          && this.proxyAuthenticator.equals(that.proxyAuthenticator)
           && this.protocols.equals(that.protocols)
           && this.connectionSpecs.equals(that.connectionSpecs)
           && this.proxySelector.equals(that.proxySelector)
@@ -169,7 +171,7 @@ public final class Address {
     int result = 17;
     result = 31 * result + url.hashCode();
     result = 31 * result + dns.hashCode();
-    result = 31 * result + authenticator.hashCode();
+    result = 31 * result + proxyAuthenticator.hashCode();
     result = 31 * result + protocols.hashCode();
     result = 31 * result + connectionSpecs.hashCode();
     result = 31 * result + proxySelector.hashCode();

--- a/okhttp/src/main/java/okhttp3/internal/http/OkHeaders.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/OkHeaders.java
@@ -1,13 +1,5 @@
 package okhttp3.internal.http;
 
-import okhttp3.Authenticator;
-import okhttp3.Challenge;
-import okhttp3.Headers;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.internal.Platform;
-import java.io.IOException;
-import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -16,9 +8,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import okhttp3.Challenge;
+import okhttp3.Headers;
 import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.internal.Platform;
 
-import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
 import static okhttp3.internal.Util.equal;
 
 /** Headers and utilities for internal use by OkHttp. */
@@ -275,17 +271,5 @@ public final class OkHeaders {
       }
     }
     return result;
-  }
-
-  /**
-   * React to a failed authorization response by looking up new credentials.
-   * Returns a request for a subsequent attempt, or null if no further attempts
-   * should be made.
-   */
-  public static Request processAuthHeader(Authenticator authenticator, Response response,
-      Proxy proxy) throws IOException {
-    return response.code() == HTTP_PROXY_AUTH
-        ? authenticator.authenticateProxy(proxy, response)
-        : authenticator.authenticate(proxy, response);
   }
 }

--- a/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
@@ -15,30 +15,26 @@
  */
 package okhttp3.recipes;
 
+import java.io.IOException;
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import java.io.IOException;
-import java.net.Proxy;
+import okhttp3.Route;
 
 public final class Authenticate {
   private final OkHttpClient client = new OkHttpClient();
 
   public void run() throws Exception {
     client.setAuthenticator(new Authenticator() {
-      @Override public Request authenticate(Proxy proxy, Response response) {
+      @Override public Request authenticate(Route route, Response response) throws IOException {
         System.out.println("Authenticating for response: " + response);
         System.out.println("Challenges: " + response.challenges());
         String credential = Credentials.basic("jesse", "password1");
         return response.request().newBuilder()
             .header("Authorization", credential)
             .build();
-      }
-
-      @Override public Request authenticateProxy(Proxy proxy, Response response) {
-        return null; // Null indicates no attempt to authenticate.
       }
     });
 


### PR DESCRIPTION
Instead of having one instance of Authenticator, and that interface
defines two methods, we now have two instances of Authenticator and
that interface defines one method.

This prevents leaking request-specific configuration (the authenticator)
into shared connection configuration (the proxy authenticator).