### PR TITLE
Reduce flakiness in Spdy3ConnectionTest.headersOnlyStreamIsClosedAfterReply

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
@@ -196,9 +196,8 @@ public final class MockResponse implements Cloneable {
   }
 
   /**
-   * Throttles the response body writer to sleep for the given period after each
-   * series of {@code bytesPerPeriod} bytes are written. Use this to simulate
-   * network behavior.
+   * Throttles the request reader and response writer to sleep for the given period after each
+   * series of {@code bytesPerPeriod} bytes are transferred. Use this to simulate network behavior.
    */
   public MockResponse throttleBody(long bytesPerPeriod, long period, TimeUnit unit) {
     this.throttleBytesPerPeriod = bytesPerPeriod;

--- a/okhttp-tests/src/test/java/okhttp3/internal/framed/MockSpdyPeer.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/framed/MockSpdyPeer.java
@@ -16,11 +16,11 @@
 
 package okhttp3.internal.framed;
 
-import okhttp3.internal.Util;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Logger;
+import okhttp3.internal.Util;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.ByteString;
@@ -116,8 +117,9 @@ public final class MockSpdyPeer implements Closeable {
 
   public void play() throws IOException {
     if (serverSocket != null) throw new IllegalStateException();
-    serverSocket = new ServerSocket(0);
-    serverSocket.setReuseAddress(true);
+    serverSocket = new ServerSocket();
+    serverSocket.setReuseAddress(false);
+    serverSocket.bind(new InetSocketAddress("localhost", 0), 1);
     port = serverSocket.getLocalPort();
     executor.execute(new Runnable() {
       @Override public void run() {

--- a/okhttp-tests/src/test/java/okhttp3/internal/framed/Spdy3ConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/framed/Spdy3ConnectionTest.java
@@ -110,7 +110,6 @@ public final class Spdy3ConnectionTest {
 
     FramedConnection connection = connection(peer, SPDY3);
     FramedStream stream = connection.newStream(headerEntries("a", "android"), false, false);
-    assertEquals(1, connection.openStreamCount());
     assertEquals(headerEntries("b", "banana"), stream.getResponseHeaders());
     connection.ping().roundTripTime(); // Ensure that inFinished has been received.
     assertEquals(0, connection.openStreamCount());


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/1797