### PR TITLE
Attempt an alternate route when a connect times out.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -2344,11 +2344,13 @@ public final class URLConnectionTest {
   }
 
   @Test public void connectionCloseWithRedirect() throws IOException, InterruptedException {
-    MockResponse response = new MockResponse().setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
+    MockResponse response = new MockResponse()
+        .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
         .addHeader("Location: /foo")
         .addHeader("Connection: close");
     server.enqueue(response);
-    server.enqueue(new MockResponse().setBody("This is the new location!"));
+    server.enqueue(new MockResponse()
+        .setBody("This is the new location!"));
 
     URLConnection connection = client.open(server.url("/").url());
     assertEquals("This is the new location!",

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/RecordingProxySelector.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/RecordingProxySelector.java
@@ -28,9 +28,9 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 public final class RecordingProxySelector extends ProxySelector {
-  final List<URI> requestedUris = new ArrayList<>();
-  List<Proxy> proxies = new ArrayList<>();
-  final List<String> failures = new ArrayList<>();
+  public final List<Proxy> proxies = new ArrayList<>();
+  public final List<URI> requestedUris = new ArrayList<>();
+  public final List<String> failures = new ArrayList<>();
 
   @Override public List<Proxy> select(URI uri) {
     requestedUris.add(uri);

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
@@ -469,7 +469,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       throw toThrow;
     } catch (RouteException e) {
       // The attempt to connect via a route failed. The request will not have been sent.
-      HttpEngine retryEngine = httpEngine.recover(e);
+      HttpEngine retryEngine = httpEngine.recover(e.getLastConnectException());
       if (retryEngine != null) {
         releaseConnection = false;
         httpEngine = retryEngine;

--- a/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
@@ -182,7 +182,7 @@ public final class WebSocketCall {
     @Override protected void close() throws IOException {
       replyExecutor.shutdown();
       streamAllocation.noNewStreams();
-      streamAllocation.streamFinished(streamAllocation.stream());
+      streamAllocation.streamFinished(true, streamAllocation.stream());
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/Call.java
+++ b/okhttp/src/main/java/okhttp3/Call.java
@@ -291,7 +291,7 @@ public class Call {
         throw e.getCause();
       } catch (RouteException e) {
         // The attempt to connect via a route failed. The request will not have been sent.
-        HttpEngine retryEngine = engine.recover(e);
+        HttpEngine retryEngine = engine.recover(e.getLastConnectException(), null);
         if (retryEngine != null) {
           releaseConnection = false;
           engine = retryEngine;

--- a/okhttp/src/main/java/okhttp3/internal/http/Http2xStream.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/Http2xStream.java
@@ -289,7 +289,7 @@ public final class Http2xStream implements HttpStream {
     }
 
     @Override public void close() throws IOException {
-      streamAllocation.streamFinished(Http2xStream.this);
+      streamAllocation.streamFinished(false, Http2xStream.this);
       super.close();
     }
   }

--- a/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
@@ -74,7 +74,7 @@ public final class RealConnection implements Connection {
   private Handshake handshake;
   private Protocol protocol;
   public volatile FramedConnection framedConnection;
-  public int streamCount;
+  public int successCount;
   public BufferedSource source;
   public BufferedSink sink;
   public final List<Reference<StreamAllocation>> allocations = new ArrayList<>();


### PR DESCRIPTION
This changes the new allocations model to keep the same route unless it
has been specifically found to have connectivity problems. Previously we
attempted to null out the route selector when a route succeeded; with
this we do the opposite by nulling out a route when it fails.

Closes: https://github.com/square/okhttp/issues/1736