### PR TITLE
Add TlsVersion to the Handshake.

### DIFF
--- a/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
+++ b/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
@@ -127,8 +127,8 @@ public final class JavaApiConverter {
 
       String cipherSuiteString = httpsUrlConnection.getCipherSuite();
       CipherSuite cipherSuite = CipherSuite.forJavaName(cipherSuiteString);
-      Handshake handshake = Handshake.get(cipherSuite, nullSafeImmutableList(peerCertificates),
-          nullSafeImmutableList(localCertificates));
+      Handshake handshake = Handshake.get(null, cipherSuite,
+          nullSafeImmutableList(peerCertificates), nullSafeImmutableList(localCertificates));
       okResponseBuilder.handshake(handshake);
     }
 
@@ -254,7 +254,7 @@ public final class JavaApiConverter {
 
       String cipherSuiteString = javaSecureCacheResponse.getCipherSuite();
       CipherSuite cipherSuite = CipherSuite.forJavaName(cipherSuiteString);
-      Handshake handshake = Handshake.get(cipherSuite, peerCertificates, localCertificates);
+      Handshake handshake = Handshake.get(null, cipherSuite, peerCertificates, localCertificates);
       okResponseBuilder.handshake(handshake);
     }
 

--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/JavaApiConverterTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/JavaApiConverterTest.java
@@ -464,7 +464,7 @@ public class JavaApiConverterTest {
         .get()
         .url("https://secure/request")
         .build();
-    Handshake handshake = Handshake.get(CipherSuite.TLS_RSA_WITH_NULL_MD5,
+    Handshake handshake = Handshake.get(null, CipherSuite.TLS_RSA_WITH_NULL_MD5,
         Arrays.<Certificate>asList(SERVER_CERT), Arrays.<Certificate>asList(LOCAL_CERT));
     Response okResponse = createArbitraryOkResponse(okRequest).newBuilder()
         .handshake(handshake)
@@ -554,7 +554,7 @@ public class JavaApiConverterTest {
             .post(createRequestBody("RequestBody") )
             .build();
     ResponseBody responseBody = createResponseBody("ResponseBody");
-    Handshake handshake = Handshake.get(CipherSuite.TLS_RSA_WITH_NULL_MD5,
+    Handshake handshake = Handshake.get(null, CipherSuite.TLS_RSA_WITH_NULL_MD5,
         Arrays.<Certificate>asList(SERVER_CERT), Arrays.<Certificate>asList(LOCAL_CERT));
     Response okResponse = createArbitraryOkResponse(okRequest).newBuilder()
         .protocol(Protocol.HTTP_1_1)

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -1936,6 +1936,133 @@ public final class CacheTest {
     assertEquals("foo", response.header("etag"));
   }
 
+  /** Exercise the cache format in OkHttp 2.7 and all earlier releases. */
+  @Test public void testGoldenCacheHttpsResponseOkHttp27() throws Exception {
+    HttpUrl url = server.url("/");
+    String urlKey = Util.md5Hex(url.toString());
+    String entryMetadata = ""
+        + "" + url + "\n"
+        + "GET\n"
+        + "0\n"
+        + "HTTP/1.1 200 OK\n"
+        + "4\n"
+        + "Content-Length: 3\n"
+        + "OkHttp-Received-Millis: " + System.currentTimeMillis() + "\n"
+        + "OkHttp-Sent-Millis: " + System.currentTimeMillis() + "\n"
+        + "Cache-Control: max-age=60\n"
+        + "\n"
+        + "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\n"
+        + "1\n"
+        + "MIIBnDCCAQWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTUxMjIyMDEx"
+        + "MTQwWhcNMTUxMjIzMDExMTQwWjAUMRIwEAYDVQQDEwlsb2NhbGhvc3QwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJ"
+        + "AoGBAJTn2Dh8xYmegvpOSmsKb2Os6Cxf1L4fYbnHr/turInUD5r1P7ZAuxurY880q3GT5bUDoirS3IfucddrT1Ac"
+        + "AmUzEmk/FDjggiP8DlxFkY/XwXBlhRDVIp/mRuASPMGInckc0ZaixOkRFyrxADj+r1eaSmXCIvV5yTY6IaIokLj1"
+        + "AgMBAAEwDQYJKoZIhvcNAQELBQADgYEAFblnedqtfRqI9j2WDyPPoG0NTZf9xwjeUu+ju+Ktty8u9k7Lgrrd/DH2"
+        + "mQEtBD1Ctvp91MJfAClNg3faZzwClUyu5pd0QXRZEUwSwZQNen2QWDHRlVsItclBJ4t+AJLqTbwofWi4m4K8REOl"
+        + "593hD55E4+lY22JZiVQyjsQhe6I=\n"
+        + "0\n";
+    String entryBody = "abc";
+    String journalBody = ""
+        + "libcore.io.DiskLruCache\n"
+        + "1\n"
+        + "201105\n"
+        + "2\n"
+        + "\n"
+        + "DIRTY " + urlKey + "\n"
+        + "CLEAN " + urlKey + " " + entryMetadata.length() + " " + entryBody.length() + "\n";
+    writeFile(cache.getDirectory(), urlKey + ".0", entryMetadata);
+    writeFile(cache.getDirectory(), urlKey + ".1", entryBody);
+    writeFile(cache.getDirectory(), "journal", journalBody);
+    cache.close();
+    cache = new Cache(cache.getDirectory(), Integer.MAX_VALUE, fileSystem);
+    client.setCache(cache);
+
+    Response response = get(url);
+    assertEquals(entryBody, response.body().string());
+    assertEquals("3", response.header("Content-Length"));
+  }
+
+  /** The TLS version is present in OkHttp 3.0 and beyond. */
+  @Test public void testGoldenCacheHttpsResponseOkHttp30() throws Exception {
+    HttpUrl url = server.url("/");
+    String urlKey = Util.md5Hex(url.toString());
+    String entryMetadata = ""
+        + "" + url + "\n"
+        + "GET\n"
+        + "0\n"
+        + "HTTP/1.1 200 OK\n"
+        + "4\n"
+        + "Content-Length: 3\n"
+        + "OkHttp-Received-Millis: " + System.currentTimeMillis() + "\n"
+        + "OkHttp-Sent-Millis: " + System.currentTimeMillis() + "\n"
+        + "Cache-Control: max-age=60\n"
+        + "\n"
+        + "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\n"
+        + "1\n"
+        + "MIIBnDCCAQWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDEwlsb2NhbGhvc3QwHhcNMTUxMjIyMDEx"
+        + "MTQwWhcNMTUxMjIzMDExMTQwWjAUMRIwEAYDVQQDEwlsb2NhbGhvc3QwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJ"
+        + "AoGBAJTn2Dh8xYmegvpOSmsKb2Os6Cxf1L4fYbnHr/turInUD5r1P7ZAuxurY880q3GT5bUDoirS3IfucddrT1Ac"
+        + "AmUzEmk/FDjggiP8DlxFkY/XwXBlhRDVIp/mRuASPMGInckc0ZaixOkRFyrxADj+r1eaSmXCIvV5yTY6IaIokLj1"
+        + "AgMBAAEwDQYJKoZIhvcNAQELBQADgYEAFblnedqtfRqI9j2WDyPPoG0NTZf9xwjeUu+ju+Ktty8u9k7Lgrrd/DH2"
+        + "mQEtBD1Ctvp91MJfAClNg3faZzwClUyu5pd0QXRZEUwSwZQNen2QWDHRlVsItclBJ4t+AJLqTbwofWi4m4K8REOl"
+        + "593hD55E4+lY22JZiVQyjsQhe6I=\n"
+        + "0\n"
+        + "TLSv1.2\n";
+    String entryBody = "abc";
+    String journalBody = ""
+        + "libcore.io.DiskLruCache\n"
+        + "1\n"
+        + "201105\n"
+        + "2\n"
+        + "\n"
+        + "DIRTY " + urlKey + "\n"
+        + "CLEAN " + urlKey + " " + entryMetadata.length() + " " + entryBody.length() + "\n";
+    writeFile(cache.getDirectory(), urlKey + ".0", entryMetadata);
+    writeFile(cache.getDirectory(), urlKey + ".1", entryBody);
+    writeFile(cache.getDirectory(), "journal", journalBody);
+    cache.close();
+    cache = new Cache(cache.getDirectory(), Integer.MAX_VALUE, fileSystem);
+    client.setCache(cache);
+
+    Response response = get(url);
+    assertEquals(entryBody, response.body().string());
+    assertEquals("3", response.header("Content-Length"));
+  }
+
+  @Test public void testGoldenCacheHttpResponseOkHttp30() throws Exception {
+    HttpUrl url = server.url("/");
+    String urlKey = Util.md5Hex(url.toString());
+    String entryMetadata = ""
+        + "" + url + "\n"
+        + "GET\n"
+        + "0\n"
+        + "HTTP/1.1 200 OK\n"
+        + "4\n"
+        + "Cache-Control: max-age=60\n"
+        + "Content-Length: 3\n"
+        + "OkHttp-Received-Millis: " + System.currentTimeMillis() + "\n"
+        + "OkHttp-Sent-Millis: " + System.currentTimeMillis() + "\n";
+    String entryBody = "abc";
+    String journalBody = ""
+        + "libcore.io.DiskLruCache\n"
+        + "1\n"
+        + "201105\n"
+        + "2\n"
+        + "\n"
+        + "DIRTY " + urlKey + "\n"
+        + "CLEAN " + urlKey + " " + entryMetadata.length() + " " + entryBody.length() + "\n";
+    writeFile(cache.getDirectory(), urlKey + ".0", entryMetadata);
+    writeFile(cache.getDirectory(), urlKey + ".1", entryBody);
+    writeFile(cache.getDirectory(), "journal", journalBody);
+    cache.close();
+    cache = new Cache(cache.getDirectory(), Integer.MAX_VALUE, fileSystem);
+    client.setCache(cache);
+
+    Response response = get(url);
+    assertEquals(entryBody, response.body().string());
+    assertEquals("3", response.header("Content-Length"));
+  }
+
   @Test public void evictAll() throws Exception {
     server.enqueue(new MockResponse()
         .addHeader("Cache-Control: max-age=60")

--- a/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
@@ -86,6 +86,7 @@ public final class RecordedResponse {
 
   public RecordedResponse assertHandshake() {
     Handshake handshake = response.handshake();
+    assertNotNull(handshake.tlsVersion());
     assertNotNull(handshake.cipherSuite());
     assertNotNull(handshake.peerPrincipal());
     assertEquals(1, handshake.peerCertificates().size());


### PR DESCRIPTION
This is awkward because it adds another field to the cache. I've
decided to try to keep old values in the cache working. We will
probably do a change that'll disrupt the cache later, but that
is invasive and we don't need that yet.