### PR TITLE
New CookieJar interface.

### DIFF
--- a/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
+++ b/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
@@ -43,6 +43,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.internal.Internal;
+import okhttp3.internal.JavaNetHeaders;
 import okhttp3.internal.Util;
 import okhttp3.internal.http.CacheRequest;
 import okhttp3.internal.http.HttpMethod;
@@ -332,7 +333,7 @@ public final class JavaApiConverter {
         @Override
         public Map<String, List<String>> getHeaders() throws IOException {
           // Java requires that the entry with a null key be the status line.
-          return OkHeaders.toMultimap(headers, StatusLine.get(response).toString());
+          return JavaNetHeaders.toMultimap(headers, StatusLine.get(response).toString());
         }
 
         @Override
@@ -346,7 +347,7 @@ public final class JavaApiConverter {
         @Override
         public Map<String, List<String>> getHeaders() throws IOException {
           // Java requires that the entry with a null key be the status line.
-          return OkHeaders.toMultimap(headers, StatusLine.get(response).toString());
+          return JavaNetHeaders.toMultimap(headers, StatusLine.get(response).toString());
         }
 
         @Override
@@ -394,7 +395,7 @@ public final class JavaApiConverter {
    * Extracts an immutable request header map from the supplied {@link Headers}.
    */
   static Map<String, List<String>> extractJavaHeaders(Request request) {
-    return OkHeaders.toMultimap(request.headers(), null);
+    return JavaNetHeaders.toMultimap(request.headers(), null);
   }
 
   /**
@@ -585,7 +586,7 @@ public final class JavaApiConverter {
       // spec. There seems no good reason why this should fail while getRequestProperty() is ok.
       // We don't fail here, because we need all request header values for caching Vary responses
       // correctly.
-      return OkHeaders.toMultimap(request.headers(), null);
+      return JavaNetHeaders.toMultimap(request.headers(), null);
     }
 
     @Override
@@ -659,7 +660,7 @@ public final class JavaApiConverter {
 
     @Override
     public Map<String, List<String>> getHeaderFields() {
-      return OkHeaders.toMultimap(response.headers(), StatusLine.get(response).toString());
+      return JavaNetHeaders.toMultimap(response.headers(), StatusLine.get(response).toString());
     }
 
     @Override

--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
@@ -62,6 +62,7 @@ import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.OkUrlFactory;
 import okhttp3.internal.Internal;
+import okhttp3.internal.JavaNetCookieJar;
 import okhttp3.internal.SslContextBuilder;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -109,11 +110,9 @@ public final class ResponseCacheTest {
     AndroidInternal.setResponseCache(new OkUrlFactory(client), cache);
 
     cookieManager = new CookieManager();
-    CookieManager.setDefault(cookieManager);
   }
 
   @After public void tearDown() throws Exception {
-    CookieManager.setDefault(null);
     ResponseCache.setDefault(null);
   }
 
@@ -1468,6 +1467,7 @@ public final class ResponseCacheTest {
   }
 
   @Test public void cachePlusCookies() throws Exception {
+    client.setCookieJar(new JavaNetCookieJar(cookieManager));
     server.enqueue(new MockResponse()
         .addHeader("Set-Cookie: a=FIRST; domain=" + server.getCookieDomain() + ";")
         .addHeader("Last-Modified: " + formatDate(-1, TimeUnit.HOURS))

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -18,7 +18,6 @@ package okhttp3;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.HttpCookie;
 import java.net.HttpURLConnection;
@@ -41,6 +40,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import okhttp3.internal.Internal;
+import okhttp3.internal.JavaNetCookieJar;
 import okhttp3.internal.SslContextBuilder;
 import okhttp3.internal.Util;
 import okhttp3.internal.io.InMemoryFileSystem;
@@ -86,12 +86,11 @@ public final class CacheTest {
     server.setProtocolNegotiationEnabled(false);
     cache = new Cache(new File("/cache/"), Integer.MAX_VALUE, fileSystem);
     client.setCache(cache);
-    CookieHandler.setDefault(cookieManager);
+    client.setCookieJar(new JavaNetCookieJar(cookieManager));
   }
 
   @After public void tearDown() throws Exception {
     ResponseCache.setDefault(null);
-    CookieHandler.setDefault(null);
     cache.delete();
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -50,6 +50,7 @@ import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import okhttp3.internal.DoubleInetAddressDns;
+import okhttp3.internal.JavaNetCookieJar;
 import okhttp3.internal.RecordingOkAuthenticator;
 import okhttp3.internal.SingleInetAddressDns;
 import okhttp3.internal.SslContextBuilder;
@@ -1439,7 +1440,7 @@ public final class CallTest {
     String portList = Integer.toString(server.getPort());
     cookie.setPortlist(portList);
     cookieManager.getCookieStore().add(server.url("/").uri(), cookie);
-    client.setCookieHandler(cookieManager);
+    client.setCookieJar(new JavaNetCookieJar(cookieManager));
 
     Response response = client.newCall(new Request.Builder()
         .url(server.url("/page1"))

--- a/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
@@ -110,20 +110,17 @@ public final class OkHttpClientTest {
    */
   @Test public void copyWithDefaultsWhenDefaultIsGlobal() throws Exception {
     ProxySelector proxySelector = new RecordingProxySelector();
-    CookieManager cookieManager = new CookieManager();
     Authenticator authenticator = new RecordingAuthenticator();
     SocketFactory socketFactory = SocketFactory.getDefault(); // Global isn't configurable.
     OkHostnameVerifier hostnameVerifier = OkHostnameVerifier.INSTANCE; // Global isn't configurable.
     CertificatePinner certificatePinner = CertificatePinner.DEFAULT; // Global isn't configurable.
 
-    CookieManager.setDefault(cookieManager);
     ProxySelector.setDefault(proxySelector);
     Authenticator.setDefault(authenticator);
 
     OkHttpClient client = new OkHttpClient().copyWithDefaults();
 
     assertSame(proxySelector, client.getProxySelector());
-    assertSame(cookieManager, client.getCookieHandler());
     assertSame(AuthenticatorAdapter.INSTANCE, client.getAuthenticator());
     assertSame(AuthenticatorAdapter.INSTANCE, client.getProxyAuthenticator());
     assertSame(socketFactory, client.getSocketFactory());

--- a/okhttp-tests/src/test/java/okhttp3/internal/framed/HttpOverSpdyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/framed/HttpOverSpdyTest.java
@@ -37,6 +37,7 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.OkUrlFactory;
 import okhttp3.Protocol;
+import okhttp3.internal.JavaNetCookieJar;
 import okhttp3.internal.RecordingAuthenticator;
 import okhttp3.internal.SslContextBuilder;
 import okhttp3.internal.Util;
@@ -370,7 +371,7 @@ public abstract class HttpOverSpdyTest {
 
   @Test public void acceptAndTransmitCookies() throws Exception {
     CookieManager cookieManager = new CookieManager();
-    client.client().setCookieHandler(cookieManager);
+    client.client().setCookieJar(new JavaNetCookieJar(cookieManager));
 
     server.enqueue(new MockResponse()
         .addHeader("set-cookie: c=oreo; domain=" + server.getCookieDomain())

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/JavaNetCookieJar.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/JavaNetCookieJar.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import java.io.IOException;
+import java.net.CookieHandler;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import okhttp3.CookieJar;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+
+/** A cookie jar that delegates to a {@link java.net.CookieHandler}. */
+public final class JavaNetCookieJar implements CookieJar {
+  private final CookieHandler cookieHandler;
+
+  public JavaNetCookieJar(CookieHandler cookieHandler) {
+    this.cookieHandler = cookieHandler;
+  }
+
+  @Override public void saveFromResponse(HttpUrl url, Headers headers) {
+    if (cookieHandler != null) {
+      try {
+        cookieHandler.put(url.uri(), JavaNetHeaders.toMultimap(headers, null));
+      } catch (IOException e) {
+        Internal.logger.log(Level.WARNING, "Saving cookies failed for " + url.resolve("/..."), e);
+      }
+    }
+  }
+
+  @Override public Headers loadForRequest(HttpUrl url, Headers headers) {
+    try {
+      // Capture the request headers added so far so that they can be offered to the CookieHandler.
+      // This is mostly to stay close to the RI; it is unlikely any of the headers above would
+      // affect cookie choice besides "Host".
+      Map<String, List<String>> headersMultimap = JavaNetHeaders.toMultimap(headers, null);
+      Map<String, List<String>> cookies = cookieHandler.get(url.uri(), headersMultimap);
+
+      // Add any new cookies to the request.
+      Headers.Builder headersBuilder = headers.newBuilder();
+      addCookies(headersBuilder, cookies);
+      return headersBuilder.build();
+    } catch (IOException e) {
+      Internal.logger.log(Level.WARNING, "Loading cookies failed for " + url.resolve("/..."), e);
+      return headers;
+    }
+  }
+
+  public static void addCookies(Headers.Builder builder, Map<String, List<String>> cookieHeaders) {
+    for (Map.Entry<String, List<String>> entry : cookieHeaders.entrySet()) {
+      String key = entry.getKey();
+      if (("Cookie".equalsIgnoreCase(key) || "Cookie2".equalsIgnoreCase(key))
+          && !entry.getValue().isEmpty()) {
+        builder.add(key, buildCookieHeader(entry.getValue()));
+      }
+    }
+  }
+
+  /**
+   * Send all cookies in one big header, as recommended by <a
+   * href="http://tools.ietf.org/html/rfc6265#section-4.2.1">RFC 6265</a>.
+   */
+  private static String buildCookieHeader(List<String> cookies) {
+    if (cookies.size() == 1) return cookies.get(0);
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0, size = cookies.size(); i < size; i++) {
+      if (i > 0) sb.append("; ");
+      sb.append(cookies.get(i));
+    }
+    return sb.toString();
+  }
+}

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/JavaNetHeaders.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/JavaNetHeaders.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import okhttp3.Headers;
+
+public final class JavaNetHeaders {
+  private JavaNetHeaders() {
+  }
+
+  private static final Comparator<String> FIELD_NAME_COMPARATOR = new Comparator<String>() {
+    // @FindBugsSuppressWarnings("ES_COMPARING_PARAMETER_STRING_WITH_EQ")
+    @Override public int compare(String a, String b) {
+      if (a == b) {
+        return 0;
+      } else if (a == null) {
+        return -1;
+      } else if (b == null) {
+        return 1;
+      } else {
+        return String.CASE_INSENSITIVE_ORDER.compare(a, b);
+      }
+    }
+  };
+
+  /**
+   * Returns an immutable map containing each field to its list of values.
+   *
+   * @param valueForNullKey the request line for requests, or the status line for responses. If
+   * non-null, this value is mapped to the null key.
+   */
+  public static Map<String, List<String>> toMultimap(Headers headers, String valueForNullKey) {
+    Map<String, List<String>> result = new TreeMap<>(FIELD_NAME_COMPARATOR);
+    for (int i = 0, size = headers.size(); i < size; i++) {
+      String fieldName = headers.name(i);
+      String value = headers.value(i);
+
+      List<String> allValues = new ArrayList<>();
+      List<String> otherValues = result.get(fieldName);
+      if (otherValues != null) {
+        allValues.addAll(otherValues);
+      }
+      allValues.add(value);
+      result.put(fieldName, Collections.unmodifiableList(allValues));
+    }
+    if (valueForNullKey != null) {
+      result.put(null, Collections.unmodifiableList(Collections.singletonList(valueForNullKey)));
+    }
+    return Collections.unmodifiableMap(result);
+  }
+}

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
@@ -51,6 +51,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.Route;
 import okhttp3.internal.Internal;
+import okhttp3.internal.JavaNetHeaders;
 import okhttp3.internal.Platform;
 import okhttp3.internal.Util;
 import okhttp3.internal.Version;
@@ -210,7 +211,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
 
   @Override public final Map<String, List<String>> getHeaderFields() {
     try {
-      return OkHeaders.toMultimap(getHeaders(),
+      return JavaNetHeaders.toMultimap(getHeaders(),
           StatusLine.get(getResponse().getResponse()).toString());
     } catch (IOException e) {
       return Collections.emptyMap();
@@ -223,7 +224,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
           "Cannot access request header fields after connection is set");
     }
 
-    return OkHeaders.toMultimap(requestHeaders.build(), null);
+    return JavaNetHeaders.toMultimap(requestHeaders.build(), null);
   }
 
   @Override public final InputStream getInputStream() throws IOException {

--- a/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.HttpCookie;
 import java.net.HttpURLConnection;
@@ -46,6 +45,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import okhttp3.internal.Internal;
+import okhttp3.internal.JavaNetCookieJar;
 import okhttp3.internal.SslContextBuilder;
 import okhttp3.internal.Util;
 import okhttp3.internal.io.InMemoryFileSystem;
@@ -91,12 +91,11 @@ public final class UrlConnectionCacheTest {
     server.setProtocolNegotiationEnabled(false);
     cache = new Cache(new File("/cache/"), Integer.MAX_VALUE, fileSystem);
     client.client().setCache(cache);
-    CookieHandler.setDefault(cookieManager);
+    client.client().setCookieJar(new JavaNetCookieJar(cookieManager));
   }
 
   @After public void tearDown() throws Exception {
     ResponseCache.setDefault(null);
-    CookieHandler.setDefault(null);
     cache.delete();
   }
 

--- a/okhttp/src/main/java/okhttp3/CookieJar.java
+++ b/okhttp/src/main/java/okhttp3/CookieJar.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import java.net.HttpCookie;
+
+/**
+ * Provides <strong>policy</strong> and <strong>persistence</strong> for HTTP cookies.
+ *
+ * <p>As policy, implementations of this interface are responsible for selecting which cookies
+ * to accept and which to reject. A reasonable policy is to reject all cookies, though that may be
+ * interfere with session-based authentication schemes that require cookies.
+ *
+ * <p>As persistence, implementations of this interface must also provide storage of cookies. Simple
+ * implementations may store cookies in memory; sophisticated ones may use the file system or
+ * database to hold accepted cookies. The implementation should delete cookies that have expired
+ * and limit the resources required for cookie storage.
+ */
+public interface CookieJar {
+  /** A cookie jar that never accepts any cookies. */
+  CookieJar NO_COOKIES = new CookieJar() {
+    @Override public void saveFromResponse(HttpUrl url, Headers headers) {
+    }
+    @Override public Headers loadForRequest(HttpUrl url, Headers headers) {
+      return headers;
+    }
+  };
+
+  /**
+   * Saves cookies from HTTP response headers to this store according to this jar's policy.
+   *
+   * <p>Most implementations should use {@link java.net.HttpCookie#parse HttpCookie.parse()} to
+   * convert raw HTTP header strings into a cookie model.
+   *
+   * <p>Note that this method may be called a second time for a single HTTP response if the response
+   * includes a trailer. For this obscure HTTP feature, {@code headers} contains only the trailer
+   * fields.
+   *
+   * <p><strong>Warning:</strong> it is the implementor's responsibility to reject cookies that
+   * don't {@linkplain HttpCookie#domainMatches match} {@code url}. Otherwise an attacker on {@code
+   * https://attacker.example.com/} may set cookies for {@code https://victim.example.com/},
+   * resulting in session fixation.
+   */
+  void saveFromResponse(HttpUrl url, Headers headers);
+
+  /**
+   * Load cookies from the jar for an HTTP request to {@code url}. This method returns the full set
+   * of headers for the network request; this is typically a superset of {@code headers}.
+   *
+   * <p>Simple implementations will return the accepted cookies that have not yet expired and that
+   * {@linkplain HttpCookie#domainMatches match} {@code url}.
+   */
+  Headers loadForRequest(HttpUrl url, Headers headers);
+}

--- a/okhttp/src/main/java/okhttp3/Handshake.java
+++ b/okhttp/src/main/java/okhttp3/Handshake.java
@@ -29,8 +29,8 @@ import okhttp3.internal.Util;
  * A record of a TLS handshake. For HTTPS clients, the client is <i>local</i> and the remote server
  * is its <i>peer</i>.
  *
- * <p>This value object describes a completed handshake. Use {@link javax.net.ssl.SSLSocketFactory}
- * to set policy for new handshakes.
+ * <p>This value object describes a completed handshake. Use {@link ConnectionSpec} to set policy
+ * for new handshakes.
  */
 public final class Handshake {
   private final TlsVersion tlsVersion;

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -15,7 +15,6 @@
  */
 package okhttp3;
 
-import java.net.CookieHandler;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.ProxySelector;
@@ -124,7 +123,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
   private final List<Interceptor> interceptors = new ArrayList<>();
   private final List<Interceptor> networkInterceptors = new ArrayList<>();
   private ProxySelector proxySelector;
-  private CookieHandler cookieHandler;
+  private CookieJar cookieJar;
 
   /** Non-null if this client is caching; possibly by {@code cache}. */
   private InternalCache internalCache;
@@ -159,7 +158,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
     this.interceptors.addAll(okHttpClient.interceptors);
     this.networkInterceptors.addAll(okHttpClient.networkInterceptors);
     this.proxySelector = okHttpClient.proxySelector;
-    this.cookieHandler = okHttpClient.cookieHandler;
+    this.cookieJar = okHttpClient.cookieJar;
     this.cache = okHttpClient.cache;
     this.internalCache = cache != null ? cache.internalCache : okHttpClient.internalCache;
     this.socketFactory = okHttpClient.socketFactory;
@@ -271,18 +270,18 @@ public class OkHttpClient implements Cloneable, Call.Factory {
   }
 
   /**
-   * Sets the cookie handler to be used to read outgoing cookies and write incoming cookies.
+   * Sets the handler that can accept cookies from incoming HTTP responses and provides cookies to
+   * outgoing HTTP requests.
    *
-   * <p>If unset, the {@link CookieHandler#getDefault() system-wide default} cookie handler will be
-   * used.
+   * <p>If unset, {@linkplain CookieJar#NO_COOKIES no cookies} will be accepted nor provided.
    */
-  public OkHttpClient setCookieHandler(CookieHandler cookieHandler) {
-    this.cookieHandler = cookieHandler;
+  public OkHttpClient setCookieJar(CookieJar cookieJar) {
+    this.cookieJar = cookieJar;
     return this;
   }
 
-  public CookieHandler getCookieHandler() {
-    return cookieHandler;
+  public CookieJar getCookieJar() {
+    return cookieJar;
   }
 
   /** Sets the response cache to be used to read and write cached responses. */
@@ -594,8 +593,8 @@ public class OkHttpClient implements Cloneable, Call.Factory {
     if (result.proxySelector == null) {
       result.proxySelector = ProxySelector.getDefault();
     }
-    if (result.cookieHandler == null) {
-      result.cookieHandler = CookieHandler.getDefault();
+    if (result.cookieJar == null) {
+      result.cookieJar = CookieJar.NO_COOKIES;
     }
     if (result.socketFactory == null) {
       result.socketFactory = SocketFactory.getDefault();

--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okhttp3.internal;
 
 import java.io.Closeable;

--- a/okhttp/src/main/java/okhttp3/internal/http/OkHeaders.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/OkHeaders.java
@@ -1,12 +1,24 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okhttp3.internal.http;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import okhttp3.Challenge;
 import okhttp3.Headers;
@@ -19,20 +31,6 @@ import static okhttp3.internal.Util.equal;
 
 /** Headers and utilities for internal use by OkHttp. */
 public final class OkHeaders {
-  private static final Comparator<String> FIELD_NAME_COMPARATOR = new Comparator<String>() {
-    // @FindBugsSuppressWarnings("ES_COMPARING_PARAMETER_STRING_WITH_EQ")
-    @Override public int compare(String a, String b) {
-      if (a == b) {
-        return 0;
-      } else if (a == null) {
-        return -1;
-      } else if (b == null) {
-        return 1;
-      } else {
-        return String.CASE_INSENSITIVE_ORDER.compare(a, b);
-      }
-    }
-  };
 
   static final String PREFIX = Platform.get().getPrefix();
 
@@ -77,56 +75,6 @@ public final class OkHeaders {
     } catch (NumberFormatException e) {
       return -1;
     }
-  }
-
-  /**
-   * Returns an immutable map containing each field to its list of values.
-   *
-   * @param valueForNullKey the request line for requests, or the status line for responses. If
-   * non-null, this value is mapped to the null key.
-   */
-  public static Map<String, List<String>> toMultimap(Headers headers, String valueForNullKey) {
-    Map<String, List<String>> result = new TreeMap<>(FIELD_NAME_COMPARATOR);
-    for (int i = 0, size = headers.size(); i < size; i++) {
-      String fieldName = headers.name(i);
-      String value = headers.value(i);
-
-      List<String> allValues = new ArrayList<>();
-      List<String> otherValues = result.get(fieldName);
-      if (otherValues != null) {
-        allValues.addAll(otherValues);
-      }
-      allValues.add(value);
-      result.put(fieldName, Collections.unmodifiableList(allValues));
-    }
-    if (valueForNullKey != null) {
-      result.put(null, Collections.unmodifiableList(Collections.singletonList(valueForNullKey)));
-    }
-    return Collections.unmodifiableMap(result);
-  }
-
-  public static void addCookies(Request.Builder builder, Map<String, List<String>> cookieHeaders) {
-    for (Map.Entry<String, List<String>> entry : cookieHeaders.entrySet()) {
-      String key = entry.getKey();
-      if (("Cookie".equalsIgnoreCase(key) || "Cookie2".equalsIgnoreCase(key))
-          && !entry.getValue().isEmpty()) {
-        builder.addHeader(key, buildCookieHeader(entry.getValue()));
-      }
-    }
-  }
-
-  /**
-   * Send all cookies in one big header, as recommended by <a
-   * href="http://tools.ietf.org/html/rfc6265#section-4.2.1">RFC 6265</a>.
-   */
-  private static String buildCookieHeader(List<String> cookies) {
-    if (cookies.size() == 1) return cookies.get(0);
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0, size = cookies.size(); i < size; i++) {
-      if (i > 0) sb.append("; ");
-      sb.append(cookies.get(i));
-    }
-    return sb.toString();
   }
 
   /**


### PR DESCRIPTION
No good first-party implementation yet.

There is an implementation in okhttp-urlconnection that delegates to the java.net
CookieHandler. That should be good enough for AOSP.