### PR TITLE
Drop the global static shared connection pool.

### DIFF
--- a/okcurl/src/main/java/okhttp3/curl/Main.java
+++ b/okcurl/src/main/java/okhttp3/curl/Main.java
@@ -38,7 +38,6 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import okhttp3.ConnectionPool;
 import okhttp3.Headers;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -181,8 +180,6 @@ public class Main extends HelpOption implements Runnable {
       client.setSslSocketFactory(createInsecureSslSocketFactory());
       client.setHostnameVerifier(createInsecureHostnameVerifier());
     }
-    // If we don't set this reference, there's no way to clean shutdown persistent connections.
-    client.setConnectionPool(ConnectionPool.getDefault());
     return client;
   }
 

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -66,7 +66,6 @@ public final class HttpLoggingInterceptorTest {
   @Before public void setUp() {
     client.networkInterceptors().add(networkInterceptor);
     client.interceptors().add(applicationInterceptor);
-    client.setConnectionPool(null);
 
     host = server.getHostName() + ":" + server.getPort();
     url = server.url("/");

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -999,10 +999,6 @@ public final class CacheTest {
         .clearHeaders()
         .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED));
 
-    ConnectionPool pool = ConnectionPool.getDefault();
-    pool.evictAll();
-    client.setConnectionPool(pool);
-
     assertEquals("A", get(server.url("/")).body().string());
     assertEquals("A", get(server.url("/")).body().string());
     assertEquals(1, client.getConnectionPool().getIdleConnectionCount());

--- a/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
@@ -101,7 +101,7 @@ public final class ConnectionReuseTest {
   }
 
   @Test public void connectionsAreNotReusedIfPoolIsSizeZero() throws Exception {
-    client.setConnectionPool(new ConnectionPool(0, 5000));
+    client.setConnectionPool(new ConnectionPool(0, 5, TimeUnit.SECONDS));
     server.enqueue(new MockResponse().setBody("a"));
     server.enqueue(new MockResponse().setBody("b"));
 
@@ -112,7 +112,7 @@ public final class ConnectionReuseTest {
   }
 
   @Test public void connectionsReusedWithRedirectEvenIfPoolIsSizeZero() throws Exception {
-    client.setConnectionPool(new ConnectionPool(0, 5000));
+    client.setConnectionPool(new ConnectionPool(0, 5, TimeUnit.SECONDS));
     server.enqueue(new MockResponse()
         .setResponseCode(301)
         .addHeader("Location: /b")
@@ -129,7 +129,7 @@ public final class ConnectionReuseTest {
   }
 
   @Test public void connectionsNotReusedWithRedirectIfDiscardingResponseIsSlow() throws Exception {
-    client.setConnectionPool(new ConnectionPool(0, 5000));
+    client.setConnectionPool(new ConnectionPool(0, 5, TimeUnit.SECONDS));
     server.enqueue(new MockResponse()
         .setResponseCode(301)
         .addHeader("Location: /b")

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -1309,10 +1309,6 @@ public final class URLConnectionTest {
         .clearHeaders()
         .setSocketPolicy(DISCONNECT_AT_END));
 
-    ConnectionPool pool = ConnectionPool.getDefault();
-    pool.evictAll();
-    client.client().setConnectionPool(pool);
-
     HttpURLConnection connection = client.open(server.url("/").url());
     assertContent("{}", connection);
     assertEquals(0, client.client().getConnectionPool().getIdleConnectionCount());

--- a/okhttp-tests/src/test/java/okhttp3/internal/framed/HttpOverSpdyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/framed/HttpOverSpdyTest.java
@@ -32,8 +32,8 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import okhttp3.Cache;
-import okhttp3.ConnectionPool;
 import okhttp3.HttpUrl;
+import okhttp3.JavaNetAuthenticator;
 import okhttp3.OkHttpClient;
 import okhttp3.OkUrlFactory;
 import okhttp3.Protocol;
@@ -41,7 +41,6 @@ import okhttp3.internal.JavaNetCookieJar;
 import okhttp3.internal.RecordingAuthenticator;
 import okhttp3.internal.SslContextBuilder;
 import okhttp3.internal.Util;
-import okhttp3.JavaNetAuthenticator;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -396,9 +395,6 @@ public abstract class HttpOverSpdyTest {
 
   /** https://github.com/square/okhttp/issues/1191 */
   @Test public void disconnectWithStreamNotEstablished() throws Exception {
-    ConnectionPool connectionPool = new ConnectionPool(5, 5000);
-    client.client().setConnectionPool(connectionPool);
-
     server.enqueue(new MockResponse().setBody("abc"));
 
     // Disconnect before the stream is created. A connection is still established!
@@ -407,7 +403,7 @@ public abstract class HttpOverSpdyTest {
     connection1.disconnect();
 
     // That connection is pooled, and it works.
-    assertEquals(1, connectionPool.getMultiplexedConnectionCount());
+    assertEquals(1, client.client().getConnectionPool().getMultiplexedConnectionCount());
     HttpURLConnection connection2 = client.open(server.url("/").url());
     assertContent("abc", connection2, 3);
     assertEquals(0, server.takeRequest().getSequenceNumber());

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/SystemPropertiesConnectionPool.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/SystemPropertiesConnectionPool.java
@@ -1,0 +1,67 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package okhttp3.internal;
+
+import java.util.concurrent.TimeUnit;
+import okhttp3.ConnectionPool;
+
+/**
+ * A shared connection pool that uses system properties for tuning parameters:
+ *
+ * <ul>
+ *     <li>{@code http.keepAlive} true if HTTP and SPDY connections should be pooled at all. Default
+ *         is true.
+ *     <li>{@code http.maxConnections} maximum number of idle connections to each to keep in the
+ *         pool. Default is 5.
+ *     <li>{@code http.keepAliveDuration} Time in milliseconds to keep the connection alive in the
+ *         pool before closing it. Default is 5 minutes. This property isn't used by {@code
+ *         HttpURLConnection}.
+ * </ul>
+ *
+ * <p>The default instance <i>doesn't</i> adjust its configuration as system properties are changed.
+ * This assumes that the applications that set these parameters do so before making HTTP
+ * connections, and that this class is initialized lazily.
+ */
+public final class SystemPropertiesConnectionPool {
+  private static final long DEFAULT_KEEP_ALIVE_DURATION_MS = 5 * 60 * 1000; // 5 min
+
+  public static final ConnectionPool INSTANCE;
+  static {
+    String keepAlive = System.getProperty("http.keepAlive");
+    int maxIdleConnections;
+    if (keepAlive != null && !Boolean.parseBoolean(keepAlive)) {
+      maxIdleConnections = 0;
+    } else {
+      String maxIdleConnectionsString = System.getProperty("http.maxConnections");
+      if (maxIdleConnectionsString != null) {
+        maxIdleConnections = Integer.parseInt(maxIdleConnectionsString);
+      } else {
+        maxIdleConnections = 5;
+      }
+    }
+
+    String keepAliveDurationString = System.getProperty("http.keepAliveDuration");
+    long keepAliveDurationMs = keepAliveDurationString != null
+        ? Long.parseLong(keepAliveDurationString)
+        : DEFAULT_KEEP_ALIVE_DURATION_MS;
+
+    INSTANCE = new ConnectionPool(maxIdleConnections, keepAliveDurationMs, TimeUnit.MILLISECONDS);
+  }
+
+  private SystemPropertiesConnectionPool() {
+  }
+}

--- a/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
@@ -847,10 +847,6 @@ public final class UrlConnectionCacheTest {
         .clearHeaders()
         .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED));
 
-    ConnectionPool pool = ConnectionPool.getDefault();
-    pool.evictAll();
-    client.client().setConnectionPool(pool);
-
     assertEquals("A", readAscii(client.open(server.url("/").url())));
     assertEquals("A", readAscii(client.open(server.url("/").url())));
     assertEquals(1, client.client().getConnectionPool().getIdleConnectionCount());

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -134,7 +134,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
   private CertificatePinner certificatePinner;
   private Authenticator proxyAuthenticator;
   private Authenticator authenticator;
-  private ConnectionPool connectionPool;
+  private ConnectionPool connectionPool = new ConnectionPool();
   private Dns dns;
   private boolean followSslRedirects = true;
   private boolean followRedirects = true;
@@ -410,10 +410,10 @@ public class OkHttpClient implements Cloneable, Call.Factory {
   /**
    * Sets the connection pool used to recycle HTTP and HTTPS connections.
    *
-   * <p>If unset, the {@link ConnectionPool#getDefault() system-wide default} connection pool will
-   * be used.
+   * <p>If unset, a new connection pool will be used.
    */
   public OkHttpClient setConnectionPool(ConnectionPool connectionPool) {
+    if (connectionPool == null) throw new NullPointerException("connectionPool == null");
     this.connectionPool = connectionPool;
     return this;
   }
@@ -610,9 +610,6 @@ public class OkHttpClient implements Cloneable, Call.Factory {
     }
     if (result.proxyAuthenticator == null) {
       result.proxyAuthenticator = Authenticator.NONE;
-    }
-    if (result.connectionPool == null) {
-      result.connectionPool = ConnectionPool.getDefault();
     }
     if (result.protocols == null) {
       result.protocols = DEFAULT_PROTOCOLS;


### PR DESCRIPTION
Instead each new instance of OkHttpClient gets its own connection pool by
default. This makes the OkHttpClient instances a little more heavyweight
(in that two different instances yield two different connection pools, which
means two different cleanup threads) but it also means there's less weird
state sharing between instances.

One drawback of this is that if an application wants to immediately free
resources from an OkHttpClient it must call getConnectionPool().evictAll(),
otherwise the connection pool thread will remain alive for 5 minutes.