### PR TITLE
Change CookieJar to deal with Cookies, not Headers.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -202,15 +202,6 @@ public final class MockWebServer implements TestRule {
   }
 
   /**
-   * Returns a cookie domain for this server. This returns the server's non-loopback host name if it
-   * is known. Otherwise this returns ".local" for this server's loopback name.
-   */
-  public String getCookieDomain() {
-    String hostName = getHostName();
-    return hostName.contains(".") ? hostName : ".local";
-  }
-
-  /**
    * Sets the number of bytes of the POST body to keep in memory to the given limit.
    */
   public void setBodyLimit(long maxBodyLength) {

--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
@@ -62,7 +62,6 @@ import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.OkUrlFactory;
 import okhttp3.internal.Internal;
-import okhttp3.internal.JavaNetCookieJar;
 import okhttp3.internal.SslContextBuilder;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -1464,24 +1463,6 @@ public final class ResponseCacheTest {
     HttpURLConnection connection2 = openConnection(url);
     connection2.setRequestProperty("Accept-Language", "en-US");
     assertEquals("A", readAscii(connection2));
-  }
-
-  @Test public void cachePlusCookies() throws Exception {
-    client.setCookieJar(new JavaNetCookieJar(cookieManager));
-    server.enqueue(new MockResponse()
-        .addHeader("Set-Cookie: a=FIRST; domain=" + server.getCookieDomain() + ";")
-        .addHeader("Last-Modified: " + formatDate(-1, TimeUnit.HOURS))
-        .addHeader("Cache-Control: max-age=0")
-        .setBody("A"));
-    server.enqueue(new MockResponse()
-        .addHeader("Set-Cookie: a=SECOND; domain=" + server.getCookieDomain() + ";")
-        .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED));
-
-    URL url = server.url("/").url();
-    assertEquals("A", readAscii(openConnection(url)));
-    assertCookies(url, "a=FIRST");
-    assertEquals("A", readAscii(openConnection(url)));
-    assertCookies(url, "a=SECOND");
   }
 
   @Test public void getHeadersReturnsNetworkEndToEndHeaders() throws Exception {

--- a/okhttp-testing-support/src/main/java/okhttp3/RecordingCookieJar.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/RecordingCookieJar.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public final class RecordingCookieJar implements CookieJar {
+  private final Deque<List<Cookie>> requestCookies = new ArrayDeque<>();
+  private final Deque<List<Cookie>> responseCookies = new ArrayDeque<>();
+
+  public void enqueueRequestCookies(Cookie... cookies) {
+    requestCookies.add(Arrays.asList(cookies));
+  }
+
+  public List<Cookie> takeResponseCookies() {
+    return responseCookies.removeFirst();
+  }
+
+  public void assertResponseCookies(String... cookies) {
+    List<Cookie> actualCookies = takeResponseCookies();
+    List<String> actualCookieStrings = new ArrayList<>();
+    for (Cookie cookie : actualCookies) {
+      actualCookieStrings.add(cookie.toString());
+    }
+    assertEquals(Arrays.asList(cookies), actualCookieStrings);
+  }
+
+  @Override public void saveFromResponse(HttpUrl url, List<Cookie> cookies) {
+    responseCookies.add(cookies);
+  }
+
+  @Override public List<Cookie> loadForRequest(HttpUrl url) {
+    if (requestCookies.isEmpty()) return Collections.emptyList();
+    return requestCookies.removeFirst();
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -1670,20 +1670,23 @@ public final class CacheTest {
   }
 
   @Test public void cachePlusCookies() throws Exception {
+    RecordingCookieJar cookieJar = new RecordingCookieJar();
+    client.setCookieJar(cookieJar);
+
     server.enqueue(new MockResponse()
-        .addHeader("Set-Cookie: a=FIRST; domain=" + server.getCookieDomain() + ";")
+        .addHeader("Set-Cookie: a=FIRST")
         .addHeader("Last-Modified: " + formatDate(-1, TimeUnit.HOURS))
         .addHeader("Cache-Control: max-age=0")
         .setBody("A"));
     server.enqueue(new MockResponse()
-        .addHeader("Set-Cookie: a=SECOND; domain=" + server.getCookieDomain() + ";")
+        .addHeader("Set-Cookie: a=SECOND")
         .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED));
 
     HttpUrl url = server.url("/");
     assertEquals("A", get(url).body().string());
-    assertCookies(url, "a=FIRST");
+    cookieJar.assertResponseCookies("a=FIRST; path=/");
     assertEquals("A", get(url).body().string());
-    assertCookies(url, "a=SECOND");
+    cookieJar.assertResponseCookies("a=SECOND; path=/");
   }
 
   @Test public void getHeadersReturnsNetworkEndToEndHeaders() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/CookiesTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/CookiesTest.java
@@ -20,15 +20,13 @@ import java.io.IOException;
 import java.net.CookieManager;
 import java.net.HttpCookie;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URI;
 import java.net.URLConnection;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
-import okhttp3.CookieJar;
-import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.OkUrlFactory;
@@ -36,26 +34,17 @@ import okhttp3.internal.JavaNetCookieJar;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Before;
 import org.junit.Test;
 
 import static java.net.CookiePolicy.ACCEPT_ORIGINAL_SERVER;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Android's CookiesTest. */
 public class CookiesTest {
-
-  private OkHttpClient client;
-
-  @Before
-  public void setUp() throws Exception {
-    client = new OkHttpClient();
-  }
+  private final OkHttpClient client = new OkHttpClient();
 
   @Test
   public void testNetscapeResponse() throws Exception {
@@ -64,12 +53,13 @@ public class CookiesTest {
     MockWebServer server = new MockWebServer();
     server.start();
 
+    HttpUrl urlWithIpAddress = urlWithIpAddress(server, "/path/foo");
     server.enqueue(new MockResponse().addHeader("Set-Cookie: a=android; "
         + "expires=Fri, 31-Dec-9999 23:59:59 GMT; "
         + "path=/path; "
-        + "domain=" + server.getCookieDomain() + "; "
+        + "domain=" + urlWithIpAddress.host() + "; "
         + "secure"));
-    get(server, "/path/foo");
+    get(urlWithIpAddress);
 
     List<HttpCookie> cookies = cookieManager.getCookieStore().getCookies();
     assertEquals(1, cookies.size());
@@ -79,7 +69,6 @@ public class CookiesTest {
     assertEquals(null, cookie.getComment());
     assertEquals(null, cookie.getCommentURL());
     assertEquals(false, cookie.getDiscard());
-    assertTrue(server.getCookieDomain().equalsIgnoreCase(cookie.getDomain()));
     assertTrue(cookie.getMaxAge() > 100000000000L);
     assertEquals("/path", cookie.getPath());
     assertEquals(true, cookie.getSecure());
@@ -92,62 +81,26 @@ public class CookiesTest {
     MockWebServer server = new MockWebServer();
     server.start();
 
+    HttpUrl urlWithIpAddress = urlWithIpAddress(server, "/path/foo");
     server.enqueue(new MockResponse().addHeader("Set-Cookie: a=android; "
         + "Comment=this cookie is delicious; "
-        + "Domain=" + server.getCookieDomain() + "; "
+        + "Domain=" + urlWithIpAddress.host() + "; "
         + "Max-Age=60; "
         + "Path=/path; "
         + "Secure; "
         + "Version=1"));
-    get(server, "/path/foo");
+    get(urlWithIpAddress);
 
     List<HttpCookie> cookies = cookieManager.getCookieStore().getCookies();
     assertEquals(1, cookies.size());
     HttpCookie cookie = cookies.get(0);
     assertEquals("a", cookie.getName());
     assertEquals("android", cookie.getValue());
-    assertEquals("this cookie is delicious", cookie.getComment());
     assertEquals(null, cookie.getCommentURL());
     assertEquals(false, cookie.getDiscard());
-    assertTrue(server.getCookieDomain().equalsIgnoreCase(cookie.getDomain()));
-    assertEquals(60, cookie.getMaxAge());
+    assertEquals(60.0, cookie.getMaxAge(), 1.0); // Converting to a fixed date can cause rounding!
     assertEquals("/path", cookie.getPath());
     assertEquals(true, cookie.getSecure());
-    assertEquals(1, cookie.getVersion());
-  }
-
-  @Test public void testRfc2965Response() throws Exception {
-    CookieManager cookieManager = new CookieManager(null, ACCEPT_ORIGINAL_SERVER);
-    client.setCookieJar(new JavaNetCookieJar(cookieManager));
-    MockWebServer server = new MockWebServer();
-    server.start();
-
-    server.enqueue(new MockResponse().addHeader("Set-Cookie2: a=android; "
-        + "Comment=this cookie is delicious; "
-        + "CommentURL=http://google.com/; "
-        + "Discard; "
-        + "Domain=" + server.getCookieDomain() + "; "
-        + "Max-Age=60; "
-        + "Path=/path; "
-        + "Port=\"80,443," + server.getPort() + "\"; "
-        + "Secure; "
-        + "Version=1"));
-    get(server, "/path/foo");
-
-    List<HttpCookie> cookies = cookieManager.getCookieStore().getCookies();
-    assertEquals(1, cookies.size());
-    HttpCookie cookie = cookies.get(0);
-    assertEquals("a", cookie.getName());
-    assertEquals("android", cookie.getValue());
-    assertEquals("this cookie is delicious", cookie.getComment());
-    assertEquals("http://google.com/", cookie.getCommentURL());
-    assertEquals(true, cookie.getDiscard());
-    assertTrue(server.getCookieDomain().equalsIgnoreCase(cookie.getDomain()));
-    assertEquals(60, cookie.getMaxAge());
-    assertEquals("/path", cookie.getPath());
-    assertEquals("80,443," + server.getPort(), cookie.getPortlist());
-    assertEquals(true, cookie.getSecure());
-    assertEquals(1, cookie.getVersion());
   }
 
   @Test public void testQuotedAttributeValues() throws Exception {
@@ -156,32 +109,27 @@ public class CookiesTest {
     MockWebServer server = new MockWebServer();
     server.start();
 
-    server.enqueue(new MockResponse().addHeader("Set-Cookie2: a=\"android\"; "
+    HttpUrl urlWithIpAddress = urlWithIpAddress(server, "/path/foo");
+    server.enqueue(new MockResponse().addHeader("Set-Cookie: a=\"android\"; "
         + "Comment=\"this cookie is delicious\"; "
         + "CommentURL=\"http://google.com/\"; "
         + "Discard; "
-        + "Domain=\"" + server.getCookieDomain() + "\"; "
-        + "Max-Age=\"60\"; "
+        + "Domain=" + urlWithIpAddress.host() + "; "
+        + "Max-Age=60; "
         + "Path=\"/path\"; "
         + "Port=\"80,443," + server.getPort() + "\"; "
         + "Secure; "
         + "Version=\"1\""));
-    get(server, "/path/foo");
+    get(urlWithIpAddress);
 
     List<HttpCookie> cookies = cookieManager.getCookieStore().getCookies();
     assertEquals(1, cookies.size());
     HttpCookie cookie = cookies.get(0);
     assertEquals("a", cookie.getName());
     assertEquals("android", cookie.getValue());
-    assertEquals("this cookie is delicious", cookie.getComment());
-    assertEquals("http://google.com/", cookie.getCommentURL());
-    assertEquals(true, cookie.getDiscard());
-    assertTrue(server.getCookieDomain().equalsIgnoreCase(cookie.getDomain()));
-    assertEquals(60, cookie.getMaxAge());
+    assertEquals(60.0, cookie.getMaxAge(), 1.0); // Converting to a fixed date can cause rounding!
     assertEquals("/path", cookie.getPath());
-    assertEquals("80,443," + server.getPort(), cookie.getPortlist());
     assertEquals(true, cookie.getSecure());
-    assertEquals(1, cookie.getVersion());
   }
 
   @Test public void testSendingCookiesFromStore() throws Exception {
@@ -191,25 +139,19 @@ public class CookiesTest {
 
     CookieManager cookieManager = new CookieManager(null, ACCEPT_ORIGINAL_SERVER);
     HttpCookie cookieA = new HttpCookie("a", "android");
-    cookieA.setDomain(server.getCookieDomain());
+    cookieA.setDomain(server.getHostName());
     cookieA.setPath("/");
     cookieManager.getCookieStore().add(server.url("/").uri(), cookieA);
     HttpCookie cookieB = new HttpCookie("b", "banana");
-    cookieB.setDomain(server.getCookieDomain());
+    cookieB.setDomain(server.getHostName());
     cookieB.setPath("/");
     cookieManager.getCookieStore().add(server.url("/").uri(), cookieB);
     client.setCookieJar(new JavaNetCookieJar(cookieManager));
 
-    get(server, "/");
+    get(server.url("/"));
     RecordedRequest request = server.takeRequest();
 
-    assertEquals("$Version=\"1\"; "
-        + "a=\"android\";$Path=\"/\";$Domain=\""
-        + server.getCookieDomain()
-        + "\"; "
-        + "b=\"banana\";$Path=\"/\";$Domain=\""
-        + server.getCookieDomain()
-        + "\"", request.getHeader("Cookie"));
+    assertEquals("a=android; b=banana", request.getHeader("Cookie"));
   }
 
   @Test public void testRedirectsDoNotIncludeTooManyCookies() throws Exception {
@@ -225,22 +167,17 @@ public class CookiesTest {
 
     CookieManager cookieManager = new CookieManager(null, ACCEPT_ORIGINAL_SERVER);
     HttpCookie cookie = new HttpCookie("c", "cookie");
-    cookie.setDomain(redirectSource.getCookieDomain());
+    cookie.setDomain(redirectSource.getHostName());
     cookie.setPath("/");
     String portList = Integer.toString(redirectSource.getPort());
     cookie.setPortlist(portList);
     cookieManager.getCookieStore().add(redirectSource.url("/").uri(), cookie);
     client.setCookieJar(new JavaNetCookieJar(cookieManager));
 
-    get(redirectSource, "/");
+    get(redirectSource.url("/"));
     RecordedRequest request = redirectSource.takeRequest();
 
-    assertEquals("$Version=\"1\"; "
-        + "c=\"cookie\";$Path=\"/\";$Domain=\""
-        + redirectSource.getCookieDomain()
-        + "\";$Port=\""
-        + portList
-        + "\"", request.getHeader("Cookie"));
+    assertEquals("c=cookie", request.getHeader("Cookie"));
 
     for (String header : redirectTarget.takeRequest().getHeaders().names()) {
       if (header.startsWith("Cookie")) {
@@ -249,114 +186,38 @@ public class CookiesTest {
     }
   }
 
-  /**
-   * Test which headers show up where. The cookie manager should be notified of both user-specified
-   * and derived headers like {@code Host}. All headers returned from the cookie jar are retained
-   * including {@code Cookie}, {@code Cookie2}, and any other headers.
-   *
-   * <p>This behavior is different from {@link JavaNetCookieJar}, which retains only headers named
-   * {@code Cookie} and {@code Cookie2}.
-   */
-  @Test public void testHeadersSentToCookieHandler() throws IOException, InterruptedException {
-    final AtomicReference<Headers> requestHeadersRef = new AtomicReference<>();
-    client.setCookieJar(new CookieJar() {
-      @Override public void saveFromResponse(HttpUrl url, Headers headers) {
-      }
-
-      @Override public Headers loadForRequest(HttpUrl url, Headers headers) {
-        requestHeadersRef.set(headers);
-        Headers.Builder result = headers.newBuilder();
-        result.add("Cookie", "Bar=bar");
-        result.add("Cookie2", "Baz=baz");
-        result.add("Quux", "quux");
-        return result.build();
-      }
-    });
-    MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse());
-    server.start();
-
-    HttpURLConnection connection = new OkUrlFactory(client).open(server.url("/").url());
-    assertEquals(Collections.<String, List<String>>emptyMap(),
-        connection.getRequestProperties());
-
-    connection.setRequestProperty("Foo", "foo");
-    connection.setDoOutput(true);
-    connection.getOutputStream().write(5);
-    connection.getOutputStream().close();
-    connection.getInputStream().close();
-
-    RecordedRequest request = server.takeRequest();
-
-    Headers requestHeaders = requestHeadersRef.get();
-    assertEquals(Arrays.asList("foo"), requestHeaders.values("Foo"));
-    assertNotNull(requestHeadersRef.get().get("Content-Type"));
-    assertNotNull(requestHeadersRef.get().get("User-Agent"));
-    assertNotNull(requestHeadersRef.get().get("Connection"));
-    assertNotNull(requestHeadersRef.get().get("Host"));
-    assertNull(requestHeadersRef.get().get("Cookie"));
-
-    /*
-     * The API specifies that calling getRequestProperties() on a connected instance should fail
-     * with an IllegalStateException, but the RI violates the spec and returns a valid map.
-     * http://www.mail-archive.com/net-dev@openjdk.java.net/msg01768.html
-     */
-    try {
-      assertContainsAll(connection.getRequestProperties().keySet(), "Foo");
-      assertContainsAll(connection.getRequestProperties().keySet(),
-          "Content-type", "Content-Length", "User-Agent", "Connection", "Host");
-      assertContainsAll(connection.getRequestProperties().keySet(), "Cookie", "Cookie2");
-      assertFalse(connection.getRequestProperties().containsKey("Quux"));
-    } catch (IllegalStateException expected) {
-    }
-
-    assertEquals("foo", request.getHeader("Foo"));
-    assertEquals("Bar=bar", request.getHeader("Cookie"));
-    assertEquals("Baz=baz", request.getHeader("Cookie2"));
-    assertEquals("quux", request.getHeader("Quux"));
-  }
-
   @Test public void testCookiesSentIgnoresCase() throws Exception {
-    client.setCookieJar(new CookieJar() {
-      @Override public void saveFromResponse(HttpUrl url, Headers headers) {
+    client.setCookieJar(new JavaNetCookieJar(new CookieManager() {
+      @Override public Map<String, List<String>> get(URI uri,
+          Map<String, List<String>> requestHeaders) throws IOException {
+        Map<String, List<String>> result = new HashMap<>();
+        result.put("COOKIE", Collections.singletonList("Bar=bar"));
+        result.put("cooKIE2", Collections.singletonList("Baz=baz"));
+        return result;
       }
+    }));
 
-      @Override public Headers loadForRequest(HttpUrl url, Headers headers) {
-        return headers.newBuilder()
-            .add("COOKIE", "Bar=bar")
-            .add("cooKIE2", "Baz=baz")
-            .build();
-      }
-    });
     MockWebServer server = new MockWebServer();
     server.enqueue(new MockResponse());
     server.start();
 
-    get(server, "/");
+    get(server.url("/"));
 
     RecordedRequest request = server.takeRequest();
-    assertEquals("Bar=bar", request.getHeader("Cookie"));
-    assertEquals("Baz=baz", request.getHeader("Cookie2"));
+    assertEquals("Bar=bar; Baz=baz", request.getHeader("Cookie"));
+    assertNull(request.getHeader("Cookie2"));
     assertNull(request.getHeader("Quux"));
   }
 
-  private void assertContains(Collection<String> collection, String element) {
-    for (String c : collection) {
-      if (c != null && c.equalsIgnoreCase(element)) {
-        return;
-      }
-    }
-    fail("No " + element + " in " + collection);
+  private HttpUrl urlWithIpAddress(MockWebServer server, String path) throws Exception {
+    return server.url(path)
+        .newBuilder()
+        .host(InetAddress.getByName(server.getHostName()).getHostAddress())
+        .build();
   }
 
-  private void assertContainsAll(Collection<String> collection, String... toFind) {
-    for (String s : toFind) {
-      assertContains(collection, s);
-    }
-  }
-
-  private Map<String, List<String>> get(MockWebServer server, String path) throws Exception {
-    URLConnection connection = new OkUrlFactory(client).open(server.url(path).url());
+  private Map<String, List<String>> get(HttpUrl url) throws Exception {
+    URLConnection connection = new OkUrlFactory(client).open(url.url());
     Map<String, List<String>> headers = connection.getHeaderFields();
     connection.getInputStream().close();
     return headers;

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/JavaNetCookieJar.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/JavaNetCookieJar.java
@@ -17,12 +17,16 @@ package okhttp3.internal;
 
 import java.io.IOException;
 import java.net.CookieHandler;
+import java.net.HttpCookie;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
+import okhttp3.Cookie;
 import okhttp3.CookieJar;
-import okhttp3.Headers;
 import okhttp3.HttpUrl;
+
+import static java.util.logging.Level.WARNING;
 
 /** A cookie jar that delegates to a {@link java.net.CookieHandler}. */
 public final class JavaNetCookieJar implements CookieJar {
@@ -32,55 +36,70 @@ public final class JavaNetCookieJar implements CookieJar {
     this.cookieHandler = cookieHandler;
   }
 
-  @Override public void saveFromResponse(HttpUrl url, Headers headers) {
+  @Override public void saveFromResponse(HttpUrl url, List<Cookie> cookies) {
     if (cookieHandler != null) {
+      List<String> cookieStrings = new ArrayList<>();
+      for (Cookie cookie : cookies) {
+        cookieStrings.add(cookie.toString());
+      }
+      Map<String, List<String>> multimap = Collections.singletonMap("Set-Cookie", cookieStrings);
       try {
-        cookieHandler.put(url.uri(), JavaNetHeaders.toMultimap(headers, null));
+        cookieHandler.put(url.uri(), multimap);
       } catch (IOException e) {
-        Internal.logger.log(Level.WARNING, "Saving cookies failed for " + url.resolve("/..."), e);
+        Internal.logger.log(WARNING, "Saving cookies failed for " + url.resolve("/..."), e);
       }
     }
   }
 
-  @Override public Headers loadForRequest(HttpUrl url, Headers headers) {
+  @Override public List<Cookie> loadForRequest(HttpUrl url) {
+    // The RI passes all headers. We don't have 'em, so we don't pass 'em!
+    Map<String, List<String>> headers = Collections.emptyMap();
+    Map<String, List<String>> cookieHeaders;
     try {
-      // Capture the request headers added so far so that they can be offered to the CookieHandler.
-      // This is mostly to stay close to the RI; it is unlikely any of the headers above would
-      // affect cookie choice besides "Host".
-      Map<String, List<String>> headersMultimap = JavaNetHeaders.toMultimap(headers, null);
-      Map<String, List<String>> cookies = cookieHandler.get(url.uri(), headersMultimap);
-
-      // Add any new cookies to the request.
-      Headers.Builder headersBuilder = headers.newBuilder();
-      addCookies(headersBuilder, cookies);
-      return headersBuilder.build();
+      cookieHeaders = cookieHandler.get(url.uri(), headers);
     } catch (IOException e) {
-      Internal.logger.log(Level.WARNING, "Loading cookies failed for " + url.resolve("/..."), e);
-      return headers;
+      Internal.logger.log(WARNING, "Loading cookies failed for " + url.resolve("/..."), e);
+      return Collections.emptyList();
     }
-  }
 
-  public static void addCookies(Headers.Builder builder, Map<String, List<String>> cookieHeaders) {
+    List<Cookie> cookies = null;
     for (Map.Entry<String, List<String>> entry : cookieHeaders.entrySet()) {
       String key = entry.getKey();
       if (("Cookie".equalsIgnoreCase(key) || "Cookie2".equalsIgnoreCase(key))
           && !entry.getValue().isEmpty()) {
-        builder.add(key, buildCookieHeader(entry.getValue()));
+        for (String header : entry.getValue()) {
+          if (cookies == null) cookies = new ArrayList<>();
+          cookies.addAll(decodeHeaderAsJavaNetCookies(url, header));
+        }
       }
     }
+
+    return cookies != null
+        ? Collections.unmodifiableList(cookies)
+        : Collections.<Cookie>emptyList();
   }
 
   /**
-   * Send all cookies in one big header, as recommended by <a
-   * href="http://tools.ietf.org/html/rfc6265#section-4.2.1">RFC 6265</a>.
+   * Convert a request header to OkHttp's cookies via {@link HttpCookie}. That extra step handles
+   * multiple cookies in a single request header, which {@link Cookie#parse} doesn't support.
    */
-  private static String buildCookieHeader(List<String> cookies) {
-    if (cookies.size() == 1) return cookies.get(0);
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0, size = cookies.size(); i < size; i++) {
-      if (i > 0) sb.append("; ");
-      sb.append(cookies.get(i));
+  private List<Cookie> decodeHeaderAsJavaNetCookies(HttpUrl url, String header) {
+    List<HttpCookie> javaNetCookies;
+    try {
+      javaNetCookies = HttpCookie.parse(header);
+    } catch (IllegalArgumentException e) {
+      // Unfortunately sometimes java.net gives a Cookie like "$Version=1" which it can't parse!
+      Internal.logger.log(WARNING, "Parsing request cookie failed for " + url.resolve("/..."), e);
+      return Collections.emptyList();
     }
-    return sb.toString();
+    List<Cookie> result = new ArrayList<>();
+    for (HttpCookie javaNetCookie : javaNetCookies) {
+      result.add(new Cookie.Builder()
+          .name(javaNetCookie.getName())
+          .value(javaNetCookie.getValue())
+          .domain(url.host())
+          .build());
+    }
+    return result;
   }
 }

--- a/okhttp/src/main/java/okhttp3/CookieJar.java
+++ b/okhttp/src/main/java/okhttp3/CookieJar.java
@@ -15,53 +15,48 @@
  */
 package okhttp3;
 
-import java.net.HttpCookie;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Provides <strong>policy</strong> and <strong>persistence</strong> for HTTP cookies.
  *
- * <p>As policy, implementations of this interface are responsible for selecting which cookies
- * to accept and which to reject. A reasonable policy is to reject all cookies, though that may be
+ * <p>As policy, implementations of this interface are responsible for selecting which cookies to
+ * accept and which to reject. A reasonable policy is to reject all cookies, though that may be
  * interfere with session-based authentication schemes that require cookies.
  *
  * <p>As persistence, implementations of this interface must also provide storage of cookies. Simple
  * implementations may store cookies in memory; sophisticated ones may use the file system or
- * database to hold accepted cookies. The implementation should delete cookies that have expired
- * and limit the resources required for cookie storage.
+ * database to hold accepted cookies. The <a
+ * href="https://tools.ietf.org/html/rfc6265#section-5.3">cookie storage model</a> specifies
+ * policies for updating and expiring cookies.
  */
 public interface CookieJar {
   /** A cookie jar that never accepts any cookies. */
   CookieJar NO_COOKIES = new CookieJar() {
-    @Override public void saveFromResponse(HttpUrl url, Headers headers) {
+    @Override public void saveFromResponse(HttpUrl url, List<Cookie> cookies) {
     }
-    @Override public Headers loadForRequest(HttpUrl url, Headers headers) {
-      return headers;
+
+    @Override public List<Cookie> loadForRequest(HttpUrl url) {
+      return Collections.emptyList();
     }
   };
 
   /**
-   * Saves cookies from HTTP response headers to this store according to this jar's policy.
-   *
-   * <p>Most implementations should use {@link java.net.HttpCookie#parse HttpCookie.parse()} to
-   * convert raw HTTP header strings into a cookie model.
+   * Saves {@code cookies} from an HTTP response to this store according to this jar's policy.
    *
    * <p>Note that this method may be called a second time for a single HTTP response if the response
-   * includes a trailer. For this obscure HTTP feature, {@code headers} contains only the trailer
-   * fields.
-   *
-   * <p><strong>Warning:</strong> it is the implementor's responsibility to reject cookies that
-   * don't {@linkplain HttpCookie#domainMatches match} {@code url}. Otherwise an attacker on {@code
-   * https://attacker.com/} may set cookies for {@code https://victim.com/}, resulting in session
-   * fixation.
+   * includes a trailer. For this obscure HTTP feature, {@code cookies} contains only the trailer's
+   * cookies.
    */
-  void saveFromResponse(HttpUrl url, Headers headers);
+  void saveFromResponse(HttpUrl url, List<Cookie> cookies);
 
   /**
-   * Load cookies from the jar for an HTTP request to {@code url}. This method returns the full set
-   * of headers for the network request; this is typically a superset of {@code headers}.
+   * Load cookies from the jar for an HTTP request to {@code url}. This method returns a possibly
+   * empty list of cookies for the network request.
    *
    * <p>Simple implementations will return the accepted cookies that have not yet expired and that
-   * {@linkplain HttpCookie#domainMatches match} {@code url}.
+   * {@linkplain Cookie#matches match} {@code url}.
    */
-  Headers loadForRequest(HttpUrl url, Headers headers);
+  List<Cookie> loadForRequest(HttpUrl url);
 }


### PR DESCRIPTION
There's a big consequence to this for compatible with RFC 2965 Cookies. In particular,
this drops our ability to support 'Set-Cookie2' headers, and some features used there
including quoted attributes like 'Max-Age="25"'. This is the right move for interop with
browsers, and likely to make things better for application developers, but some
people who strictly followed the RFC 2965 spec will be broken. (That spec was never
seriously adopted anywhere, which is the entire motivation of RFC 6265.)

The upside is the CookieJar interface is now much more straightforward. This is
particularly good going forward, and for clients who don't have to worry about the
strangeness of things like $Version=1 in the RFC 2965 spec.