### PR TITLE
Don't do health checks on brand new connections.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/StreamAllocation.java
@@ -124,11 +124,21 @@ public final class StreamAllocation {
       int writeTimeout, boolean connectionRetryEnabled, boolean doExtensiveHealthChecks)
       throws IOException, RouteException {
     while (true) {
-      RealConnection candidate = findConnection(
-          connectTimeout, readTimeout, writeTimeout, connectionRetryEnabled);
-      if (connection.isHealthy(doExtensiveHealthChecks)) {
+      RealConnection candidate = findConnection(connectTimeout, readTimeout, writeTimeout,
+          connectionRetryEnabled);
+
+      // If this is a brand new connection, we can skip the extensive health checks.
+      synchronized (connectionPool) {
+        if (candidate.successCount == 0) {
+          return candidate;
+        }
+      }
+
+      // Otherwise do a potentially-slow check to confirm that the pooled connection is still good.
+      if (candidate.isHealthy(doExtensiveHealthChecks)) {
         return candidate;
       }
+
       connectionFailed(new IOException());
     }
   }


### PR DESCRIPTION
This is imperfect, but it should save some unnecessary work and will
hopefully prevent RouteSelector from attempting a route when none is
available.

https://github.com/square/okhttp/issues/2151