### PR TITLE
Add an accessor to get a Call's Request.

### DIFF
--- a/okhttp/src/main/java/okhttp3/Call.java
+++ b/okhttp/src/main/java/okhttp3/Call.java
@@ -22,6 +22,9 @@ import java.io.IOException;
  * represents a single request/response pair (stream), it cannot be executed twice.
  */
 public interface Call {
+  /** Returns the original request that initiated this call. */
+  Request request();
+
   /**
    * Invokes the request immediately, and blocks until the response can be processed or is in
    * error.

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -45,6 +45,10 @@ final class RealCall implements Call {
     this.originalRequest = originalRequest;
   }
 
+  @Override public Request request() {
+    return originalRequest;
+  }
+
   @Override public Response execute() throws IOException {
     synchronized (this) {
       if (executed) throw new IllegalStateException("Already Executed");


### PR DESCRIPTION
In a follow up I'm going to drop support for canceling calls based on
their tag. Instead, dispatcher might be able to just expose all of the
in-flight calls, and the application layer can loop over those and
cancel based on tags or other criteria.