### PR TITLE
No more canceling by tag.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
@@ -1,16 +1,23 @@
 package okhttp3;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import okhttp3.RealCall.AsyncCall;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class DispatcherTest {
@@ -116,12 +123,116 @@ public final class DispatcherTest {
 
   @Test public void cancelingRunningJobTakesNoEffectUntilJobFinishes() throws Exception {
     dispatcher.setMaxRequests(1);
-    client.newCall(newRequest("http://a/1", "tag1")).enqueue(callback);
-    client.newCall(newRequest("http://a/2")).enqueue(callback);
-    dispatcher.cancel("tag1");
+    Call c1 = client.newCall(newRequest("http://a/1", "tag1"));
+    Call c2 = client.newCall(newRequest("http://a/2"));
+    c1.enqueue(callback);
+    c2.enqueue(callback);
+    c1.cancel();
     executor.assertJobs("http://a/1");
     executor.finishJob("http://a/1");
     executor.assertJobs("http://a/2");
+  }
+
+  @Test public void asyncCallAccessors() throws Exception {
+    dispatcher.setMaxRequests(3);
+    Call a1 = client.newCall(newRequest("http://a/1"));
+    Call a2 = client.newCall(newRequest("http://a/2"));
+    Call a3 = client.newCall(newRequest("http://a/3"));
+    Call a4 = client.newCall(newRequest("http://a/4"));
+    Call a5 = client.newCall(newRequest("http://a/5"));
+    a1.enqueue(callback);
+    a2.enqueue(callback);
+    a3.enqueue(callback);
+    a4.enqueue(callback);
+    a5.enqueue(callback);
+    assertEquals(3, dispatcher.runningCallsCount());
+    assertEquals(2, dispatcher.queuedCallsCount());
+    assertEquals(set(a1, a2, a3), set(dispatcher.runningCalls()));
+    assertEquals(set(a4, a5), set(dispatcher.queuedCalls()));
+  }
+
+  @Test public void synchronousCallAccessors() throws Exception {
+    final CountDownLatch ready = new CountDownLatch(2);
+    final CountDownLatch waiting = new CountDownLatch(1);
+    client = client.newBuilder()
+        .addInterceptor(
+            new Interceptor() {
+              @Override public Response intercept(Chain chain) throws IOException {
+                try {
+                  ready.countDown();
+                  waiting.await();
+                } catch (InterruptedException e) {
+                  throw new AssertionError();
+                }
+                throw new IOException();
+              }
+            })
+        .build();
+
+    Call a1 = client.newCall(newRequest("http://a/1"));
+    Call a2 = client.newCall(newRequest("http://a/2"));
+    Call a3 = client.newCall(newRequest("http://a/3"));
+    Call a4 = client.newCall(newRequest("http://a/4"));
+    Thread t1 = makeSynchronousCall(a1);
+    Thread t2 = makeSynchronousCall(a2);
+
+    // We created 4 calls and started 2 of them. That's 2 running calls and 0 queued.
+    ready.await();
+    assertEquals(2, dispatcher.runningCallsCount());
+    assertEquals(0, dispatcher.queuedCallsCount());
+    assertEquals(set(a1, a2), set(dispatcher.runningCalls()));
+    assertEquals(Collections.emptyList(), dispatcher.queuedCalls());
+
+    // Cancel some calls. That doesn't impact running or queued.
+    a2.cancel();
+    a3.cancel();
+    assertEquals(set(a1, a2), set(dispatcher.runningCalls()));
+    assertEquals(Collections.emptyList(), dispatcher.queuedCalls());
+
+    // Let the calls finish.
+    waiting.countDown();
+    t1.join();
+    t2.join();
+
+    // Now we should have 0 running calls and 0 queued calls.
+    assertEquals(0, dispatcher.runningCallsCount());
+    assertEquals(0, dispatcher.queuedCallsCount());
+    assertEquals(Collections.emptyList(), dispatcher.runningCalls());
+    assertEquals(Collections.emptyList(), dispatcher.queuedCalls());
+
+    assertTrue(a1.isExecuted());
+    assertFalse(a1.isCanceled());
+
+    assertTrue(a2.isExecuted());
+    assertTrue(a2.isCanceled());
+
+    assertFalse(a3.isExecuted());
+    assertTrue(a3.isCanceled());
+
+    assertFalse(a4.isExecuted());
+    assertFalse(a4.isCanceled());
+  }
+
+  private <T> Set<T> set(T... values) {
+    return set(Arrays.asList(values));
+  }
+
+  private <T> Set<T> set(List<T> list) {
+    return new LinkedHashSet<>(list);
+  }
+
+  private Thread makeSynchronousCall(final Call call) {
+    Thread thread = new Thread() {
+      @Override public void run() {
+        try {
+          call.execute();
+          throw new AssertionError();
+        } catch (IOException expected) {
+        }
+      }
+    };
+    thread.start();
+    return thread;
   }
 
   class RecordingExecutor extends AbstractExecutorService {

--- a/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
@@ -24,9 +24,9 @@ import java.net.Proxy;
 import java.util.List;
 
 /**
- * Adapts {@link java.net.Authenticator} to {@link Authenticator}. Configure OkHttp to use
- * {@link java.net.Authenticator} with {@link OkHttpClient#setAuthenticator} or {@link
- * OkHttpClient#setProxyAuthenticator(Authenticator)}.
+ * Adapts {@link java.net.Authenticator} to {@link Authenticator}. Configure OkHttp to use {@link
+ * java.net.Authenticator} with {@link OkHttpClient.Builder#authenticator} or {@link
+ * OkHttpClient.Builder#proxyAuthenticator(Authenticator)}.
  */
 public final class JavaNetAuthenticator implements Authenticator {
   @Override public Request authenticate(Route route, Response response) throws IOException {

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -37,16 +37,24 @@ import okhttp3.internal.io.RealConnection;
 import okhttp3.internal.tls.OkHostnameVerifier;
 
 /**
- * Configures and creates HTTP connections. Most applications can use a single OkHttpClient for all
- * of their HTTP requests - benefiting from a shared response cache, thread pool, connection re-use,
- * etc.
+ * Factory for {@linkplain Call calls}, which can be used to send HTTP requests and read their
+ * responses. Most applications can use a single OkHttpClient for all of their HTTP requests,
+ * benefiting from a shared response cache, thread pool, connection re-use, etc.
  *
- * <p>Instances of OkHttpClient are intended to be fully configured before they're shared - once
- * shared they should be treated as immutable and can safely be used to concurrently open new
- * connections. If required, threads can call {@link #clone()} to make a shallow copy of the
- * OkHttpClient that can be safely modified with further configuration changes.
+ * <p>To create an {@code OkHttpClient} with the default settings, use the {@linkplain
+ * #OkHttpClient() default constructor}. Or create a configured instance with {@link
+ * OkHttpClient.Builder}. To adjust an existing client before making a request, use {@link
+ * #newBuilder()}. This example shows a call with a 30 second timeout:
+ * <pre>   {@code
+ *
+ *   OkHttpClient client = ...
+ *   OkHttpClient clientWith30sTimeout = client.newBuilder()
+ *       .readTimeout(30, TimeUnit.SECONDS)
+ *       .build();
+ *   Response response = clientWith30sTimeout.newCall(request).execute();
+ * }</pre>
  */
-public class OkHttpClient implements Cloneable, Call.Factory {
+public final class OkHttpClient implements Cloneable, Call.Factory {
   private static final List<Protocol> DEFAULT_PROTOCOLS = Util.immutableList(
       Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1);
 
@@ -292,15 +300,6 @@ public class OkHttpClient implements Cloneable, Call.Factory {
     return new RealCall(this, request);
   }
 
-  /**
-   * Cancels all scheduled or in-flight calls tagged with {@code tag}. Requests that are already
-   * complete cannot be canceled.
-   */
-  public OkHttpClient cancel(Object tag) {
-    dispatcher().cancel(tag);
-    return this;
-  }
-
   public Builder newBuilder() {
     return new Builder(this);
   }
@@ -424,9 +423,8 @@ public class OkHttpClient implements Cloneable, Call.Factory {
 
     /**
      * Sets the HTTP proxy that will be used by connections created by this client. This takes
-     * precedence over {@link #proxySelector}, which is only honored when this proxy is null
-     * (which it is by default). To disable proxy use completely, call {@code
-     * setProxy(Proxy.NO_PROXY)}.
+     * precedence over {@link #proxySelector}, which is only honored when this proxy is null (which
+     * it is by default). To disable proxy use completely, call {@code setProxy(Proxy.NO_PROXY)}.
      */
     public Builder proxy(Proxy proxy) {
       this.proxy = proxy;
@@ -515,8 +513,8 @@ public class OkHttpClient implements Cloneable, Call.Factory {
 
     /**
      * Sets the certificate pinner that constrains which certificates are trusted. By default HTTPS
-     * connections rely on only the {@link #sslSocketFactory SSL socket factory} to establish
-     * trust. Pinning certificates avoids the need to trust certificate authorities.
+     * connections rely on only the {@link #sslSocketFactory SSL socket factory} to establish trust.
+     * Pinning certificates avoids the need to trust certificate authorities.
      */
     public Builder certificatePinner(CertificatePinner certificatePinner) {
       this.certificatePinner = certificatePinner;


### PR DESCRIPTION
Instead Dispatcher exposes rich methods to access the in-flight calls,
which the application can cancel by whatever criteria is prefered.