### PR TITLE
Make OkHttp OSGi ready

### DIFF
--- a/okhttp-apache/pom.xml
+++ b/okhttp-apache/pom.xml
@@ -9,6 +9,7 @@
     <version>3.0.0-SNAPSHOT</version>
   </parent>
 
+  <packaging>bundle</packaging>
   <artifactId>okhttp-apache</artifactId>
   <name>OkHttp Apache HttpClient</name>
 
@@ -54,6 +55,20 @@
             <link>http://hc.apache.org/httpcomponents-client-4.3.x/httpclient/apidocs/</link>
             <link>https://hc.apache.org/httpcomponents-core-4.3.x/httpcore/apidocs/</link>
           </links>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Export-Package>
+              okhttp3.apache.*
+            </Export-Package>
+          </instructions>
         </configuration>
       </plugin>
     </plugins>

--- a/okhttp-logging-interceptor/pom.xml
+++ b/okhttp-logging-interceptor/pom.xml
@@ -9,6 +9,7 @@
     <version>3.0.0-SNAPSHOT</version>
   </parent>
 
+  <packaging>bundle</packaging>
   <artifactId>logging-interceptor</artifactId>
   <name>OkHttp Logging Interceptor</name>
 
@@ -37,4 +38,24 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Export-Package>
+              okhttp3.logging.*
+            </Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/okhttp-urlconnection/pom.xml
+++ b/okhttp-urlconnection/pom.xml
@@ -9,6 +9,7 @@
     <version>3.0.0-SNAPSHOT</version>
   </parent>
 
+  <packaging>bundle</packaging>
   <artifactId>okhttp-urlconnection</artifactId>
   <name>OkHttp URLConnection</name>
 
@@ -48,6 +49,29 @@
           <links>
             <link>http://square.github.io/okhttp/javadoc/</link>
           </links>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Require-Bundle>
+              com.squareup.okhttp3.okhttp
+            </Require-Bundle>
+            <Export-Package>
+              !okhttp3.internal.*,
+              okhttp3.*;-split-package:=merge-first
+            </Export-Package>
+            <Import-Package>
+              android.*;resolution:=optional,
+              *
+            </Import-Package>
+          </instructions>
         </configuration>
       </plugin>
     </plugins>

--- a/okhttp-ws/pom.xml
+++ b/okhttp-ws/pom.xml
@@ -9,6 +9,7 @@
     <version>3.0.0-SNAPSHOT</version>
   </parent>
 
+  <packaging>bundle</packaging>
   <artifactId>okhttp-ws</artifactId>
   <name>OkHttp Web Sockets</name>
 
@@ -30,6 +31,23 @@
           <links>
             <link>http://square.github.io/okhttp/javadoc/</link>
           </links>
+        </configuration>
+      </plugin>
+
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Export-Package>
+              !okhttp3.internal.ws.*,
+              okhttp3.ws.*;-noimport:=true
+            </Export-Package>
+          </instructions>
         </configuration>
       </plugin>
     </plugins>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -9,6 +9,7 @@
     <version>3.0.0-SNAPSHOT</version>
   </parent>
 
+  <packaging>bundle</packaging>
   <artifactId>okhttp</artifactId>
   <name>OkHttp</name>
 
@@ -46,6 +47,25 @@
           <links>
             <link>http://square.github.io/okio/</link>
           </links>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Export-Package>
+              okhttp3.internal.*;-noimport:=true,
+              okhttp3.*;-noimport:=true
+            </Export-Package>
+            <Import-Package>
+              android.*;resolution:=optional,
+              *
+            </Import-Package>
+          </instructions>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
 
     <!-- Test Dependencies -->
     <junit.version>4.11</junit.version>
+
+    <!-- Plugin Dependencies -->
+    <maven.bundle.plugin.version>3.0.1</maven.bundle.plugin.version>
   </properties>
 
   <scm>
@@ -168,6 +171,21 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.9</version>
         </plugin>
+
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>${maven.bundle.plugin.version}</version>
+          <extensions>true</extensions>
+          <executions>
+            <execution>
+              <goals>
+                <goal>manifest</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
This PR adds basic support for OSGi to okhttp jars by adding the proper meta-data to jar's MANIFEST.

Notes:
- okhttp-urlconnection is not well supported as this artifact has the same packages as main okhttp one but as far as I understand OkHttp as now a better replacement
- it would have be better if okhttp-ws had okhttp3.ws.internal instead of okhttp3.internal.ws so that there is a clear distinction between okhttp-ws internal and okhttp ones



