### PR TITLE
Don't eagerly release pools on cache hits.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -467,6 +467,26 @@ public final class CacheTest {
     assertEquals("b", get(url).body().string());
   }
 
+  /** https://github.com/square/okhttp/issues/2198 */
+  @Test public void cachedRedirect() throws IOException {
+    server.enqueue(new MockResponse()
+        .setResponseCode(301)
+        .addHeader("Cache-Control: max-age=60")
+        .addHeader("Location: /bar"));
+    server.enqueue(new MockResponse()
+        .setBody("ABC"));
+    server.enqueue(new MockResponse()
+        .setBody("ABC"));
+
+    Request request1 = new Request.Builder().url(server.url("/")).build();
+    Response response1 = client.newCall(request1).execute();
+    assertEquals("ABC", response1.body().string());
+
+    Request request2 = new Request.Builder().url(server.url("/")).build();
+    Response response2 = client.newCall(request2).execute();
+    assertEquals("ABC", response2.body().string());
+  }
+
   @Test public void serverDisconnectsPrematurelyWithContentLengthHeader() throws IOException {
     testServerPrematureDisconnect(TransferKind.FIXED_LENGTH);
   }

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -243,8 +243,6 @@ public final class HttpEngine {
         }
       }
     } else {
-      streamAllocation.release();
-
       if (cacheResponse != null) {
         // We have a valid cached response. Promote it to the user response immediately.
         this.userResponse = cacheResponse.newBuilder()


### PR DESCRIPTION
We might still need them to handle a redirect.

Closes: https://github.com/square/okhttp/issues/2198