### PR TITLE
Update okhttp-loggin-interceptor

### DIFF
--- a/okhttp-logging-interceptor/README.md
+++ b/okhttp-logging-interceptor/README.md
@@ -42,7 +42,7 @@ Get via Maven:
 
 or via Gradle 
 ```groovy
-compile 'com.squareup.okhttp:logging-interceptor:(insert latest version)'
+compile 'com.squareup.okhttp3:logging-interceptor:(insert latest version)'
 ```
 
 


### PR DESCRIPTION
I found missed version. It must to include the okhttp '3' on dependency of gradle.