### PR TITLE
Logging Interceptor - Use charset specified by the request body content type

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -188,7 +188,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
         Charset charset = UTF8;
         MediaType contentType = requestBody.contentType();
         if (contentType != null) {
-          contentType.charset(UTF8);
+          charset = contentType.charset(UTF8);
         }
 
         logger.log("");


### PR DESCRIPTION
It's read but never assigned.