### PR TITLE
Provide interceptors as list with read-only methods

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -122,8 +122,8 @@ public final class OkHttpClient implements Cloneable, Call.Factory {
   final Proxy proxy;
   final List<Protocol> protocols;
   final List<ConnectionSpec> connectionSpecs;
-  final List<Interceptor> interceptors;
-  final List<Interceptor> networkInterceptors;
+  final UnmodifiableList<Interceptor> interceptors;
+  final UnmodifiableList<Interceptor> networkInterceptors;
   final ProxySelector proxySelector;
   final CookieJar cookieJar;
   final Cache cache;
@@ -152,8 +152,8 @@ public final class OkHttpClient implements Cloneable, Call.Factory {
     this.proxy = builder.proxy;
     this.protocols = builder.protocols;
     this.connectionSpecs = builder.connectionSpecs;
-    this.interceptors = Util.immutableList(builder.interceptors);
-    this.networkInterceptors = Util.immutableList(builder.networkInterceptors);
+    this.interceptors = new UnmodifiableList<>(builder.interceptors);
+    this.networkInterceptors = new UnmodifiableList<>(builder.networkInterceptors);
     this.proxySelector = builder.proxySelector;
     this.cookieJar = builder.cookieJar;
     this.cache = builder.cache;
@@ -280,7 +280,7 @@ public final class OkHttpClient implements Cloneable, Call.Factory {
    * the connection is established (if any) until after the response source is selected (either the
    * origin server, cache, or both).
    */
-  public List<Interceptor> interceptors() {
+  public UnmodifiableList<Interceptor> interceptors() {
     return interceptors;
   }
 
@@ -289,7 +289,7 @@ public final class OkHttpClient implements Cloneable, Call.Factory {
    * These interceptors must call {@link Interceptor.Chain#proceed} exactly once: it is an error for
    * a network interceptor to short-circuit or repeat a network request.
    */
-  public List<Interceptor> networkInterceptors() {
+  public UnmodifiableList<Interceptor> networkInterceptors() {
     return networkInterceptors;
   }
 
@@ -309,8 +309,8 @@ public final class OkHttpClient implements Cloneable, Call.Factory {
     Proxy proxy;
     List<Protocol> protocols;
     List<ConnectionSpec> connectionSpecs;
-    final List<Interceptor> interceptors = new ArrayList<>();
-    final List<Interceptor> networkInterceptors = new ArrayList<>();
+    final ArrayList<Interceptor> interceptors = new ArrayList<>();
+    final ArrayList<Interceptor> networkInterceptors = new ArrayList<>();
     ProxySelector proxySelector;
     CookieJar cookieJar;
     Cache cache;
@@ -356,8 +356,19 @@ public final class OkHttpClient implements Cloneable, Call.Factory {
       this.proxy = okHttpClient.proxy;
       this.protocols = okHttpClient.protocols;
       this.connectionSpecs = okHttpClient.connectionSpecs;
-      this.interceptors.addAll(okHttpClient.interceptors);
-      this.networkInterceptors.addAll(okHttpClient.networkInterceptors);
+
+      final int interceptorsSize = okHttpClient.interceptors.size();
+      this.interceptors.ensureCapacity(okHttpClient.interceptors.size());
+      for (int i = 0; i < interceptorsSize; i++) {
+        this.interceptors.add(okHttpClient.interceptors.get(i));
+      }
+
+      final int networkInterceptorsSize = okHttpClient.networkInterceptors.size();
+      this.networkInterceptors.ensureCapacity(networkInterceptorsSize);
+      for (int i = 0; i < networkInterceptorsSize; i++) {
+        this.networkInterceptors.add(okHttpClient.networkInterceptors.get(i));
+      }
+
       this.proxySelector = okHttpClient.proxySelector;
       this.cookieJar = okHttpClient.cookieJar;
       this.internalCache = okHttpClient.internalCache;

--- a/okhttp/src/main/java/okhttp3/UnmodifiableList.java
+++ b/okhttp/src/main/java/okhttp3/UnmodifiableList.java
@@ -1,0 +1,47 @@
+package okhttp3;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public final class UnmodifiableList<T> implements Iterable<T> {
+
+  private final List<T> realList;
+
+  public UnmodifiableList(List<T> realList) {
+    this.realList = new ArrayList<>(realList);
+  }
+
+  /**
+   * Returns the number of elements in this list.  If this list contains
+   * more than <tt>Integer.MAX_VALUE</tt> elements, returns
+   * <tt>Integer.MAX_VALUE</tt>.
+   *
+   * @return the number of elements in this list
+   */
+  public int size() {
+    return realList.size();
+  }
+
+  /**
+   * Returns the element at the specified position in this list.
+   *
+   * @param index index of the element to return
+   * @return the element at the specified position in this list
+   * @throws IndexOutOfBoundsException if the index is out of range
+   *         (<tt>index &lt; 0 || index &gt;= size()</tt>)
+   */
+  public T get(int index) {
+    return realList.get(index);
+  }
+
+  /**
+   * Returns an iterator over the elements in this list in proper sequence.
+   *
+   * @return an iterator over the elements in this list in proper sequence
+   */
+  @Override
+  public Iterator<T> iterator() {
+    return realList.iterator();
+  }
+}


### PR DESCRIPTION
Looks like a lot of projects and their developers will face `UnsupportedOperationException` at runtime after switching from v2 to v3: #2219, #2206.

Would be great if we could turn it into a compile time error.  