### PR TITLE
Change Callback to take a Call.

### DIFF
--- a/benchmarks/src/main/java/okhttp3/benchmarks/OkHttpAsync.java
+++ b/benchmarks/src/main/java/okhttp3/benchmarks/OkHttpAsync.java
@@ -24,6 +24,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
+import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Dispatcher;
 import okhttp3.HttpUrl;
@@ -68,11 +69,11 @@ class OkHttpAsync implements HttpClient {
     }
 
     callback = new Callback() {
-      @Override public void onFailure(Request request, IOException e) {
+      @Override public void onFailure(Call call, IOException e) {
         System.out.println("Failed: " + e);
       }
 
-      @Override public void onResponse(Response response) throws IOException {
+      @Override public void onResponse(Call call, Response response) throws IOException {
         ResponseBody body = response.body();
         long total = SynchronousHttpClient.readAllAndClose(body.byteStream());
         long finish = System.nanoTime();

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -657,11 +657,11 @@ public final class CallTest {
         .build();
 
     client.newCall(request).enqueue(new Callback() {
-      @Override public void onFailure(Request request, IOException e) {
+      @Override public void onFailure(Call call, IOException e) {
         fail();
       }
 
-      @Override public void onResponse(Response response) throws IOException {
+      @Override public void onResponse(Call call, Response response) throws IOException {
         throw new IOException("a");
       }
     });
@@ -714,11 +714,11 @@ public final class CallTest {
 
     Request request = new Request.Builder().url(server.url("/a")).build();
     client.newCall(request).enqueue(new Callback() {
-      @Override public void onFailure(Request request, IOException e) {
+      @Override public void onFailure(Call call, IOException e) {
         throw new AssertionError();
       }
 
-      @Override public void onResponse(Response response) throws IOException {
+      @Override public void onResponse(Call call, Response response) throws IOException {
         InputStream bytes = response.body().byteStream();
         assertEquals('a', bytes.read());
         assertEquals('b', bytes.read());
@@ -1613,7 +1613,7 @@ public final class CallTest {
     Request request = new Request.Builder().url(server.url("/a")).build();
     client.newCall(request).enqueue(callback);
 
-    callback.await(server.url("/c"))
+    callback.await(server.url("/a"))
         .assertCode(200)
         .assertBody("C")
         .priorResponse()
@@ -1653,7 +1653,7 @@ public final class CallTest {
 
     Request request = new Request.Builder().url(server.url("/0")).build();
     client.newCall(request).enqueue(callback);
-    callback.await(server.url("/20"))
+    callback.await(server.url("/0"))
         .assertCode(200)
         .assertBody("Success!");
   }
@@ -1684,7 +1684,7 @@ public final class CallTest {
 
     Request request = new Request.Builder().url(server.url("/0")).build();
     client.newCall(request).enqueue(callback);
-    callback.await(server.url("/20")).assertFailure("Too many follow-up requests: 21");
+    callback.await(server.url("/0")).assertFailure("Too many follow-up requests: 21");
   }
 
   @Test public void http204WithBodyDisallowed() throws IOException {
@@ -1929,12 +1929,12 @@ public final class CallTest {
     Request request = new Request.Builder().url(server.url("/a")).build();
     final Call call = client.newCall(request);
     call.enqueue(new Callback() {
-      @Override public void onFailure(Request request, IOException e) {
+      @Override public void onFailure(Call call, IOException e) {
         failureRef.set(true);
         latch.countDown();
       }
 
-      @Override public void onResponse(Response response) throws IOException {
+      @Override public void onResponse(Call call, Response response) throws IOException {
         call.cancel();
         try {
           bodyRef.set(response.body().string());
@@ -2047,11 +2047,11 @@ public final class CallTest {
 
     final BlockingQueue<Response> responseRef = new SynchronousQueue<>();
     client.newCall(request).enqueue(new Callback() {
-      @Override public void onFailure(Request request, IOException e) {
+      @Override public void onFailure(Call call, IOException e) {
         throw new AssertionError();
       }
 
-      @Override public void onResponse(Response response) throws IOException {
+      @Override public void onResponse(Call call, Response response) throws IOException {
         try {
           responseRef.put(response);
         } catch (InterruptedException e) {

--- a/okhttp-tests/src/test/java/okhttp3/RecordingCallback.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordingCallback.java
@@ -29,14 +29,14 @@ public class RecordingCallback implements Callback {
 
   private final List<RecordedResponse> responses = new ArrayList<>();
 
-  @Override public synchronized void onFailure(Request request, IOException e) {
-    responses.add(new RecordedResponse(request, null, null, null, e));
+  @Override public synchronized void onFailure(Call call, IOException e) {
+    responses.add(new RecordedResponse(call.request(), null, null, null, e));
     notifyAll();
   }
 
-  @Override public synchronized void onResponse(Response response) throws IOException {
+  @Override public synchronized void onResponse(Call call, Response response) throws IOException {
     String body = response.body().string();
-    responses.add(new RecordedResponse(response.request(), response, null, body, null));
+    responses.add(new RecordedResponse(call.request(), response, null, body, null));
     notifyAll();
   }
 

--- a/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
@@ -92,7 +92,7 @@ public final class WebSocketCall {
    */
   public void enqueue(final WebSocketListener listener) {
     Callback responseCallback = new Callback() {
-      @Override public void onResponse(Response response) throws IOException {
+      @Override public void onResponse(Call call, Response response) throws IOException {
         try {
           createWebSocket(response, listener);
         } catch (IOException e) {
@@ -100,7 +100,7 @@ public final class WebSocketCall {
         }
       }
 
-      @Override public void onFailure(Request request, IOException e) {
+      @Override public void onFailure(Call call, IOException e) {
         listener.onFailure(e, null);
       }
     };

--- a/okhttp/src/main/java/okhttp3/Callback.java
+++ b/okhttp/src/main/java/okhttp3/Callback.java
@@ -23,7 +23,7 @@ public interface Callback {
    * timeout. Because networks can fail during an exchange, it is possible that the remote server
    * accepted the request before the failure.
    */
-  void onFailure(Request request, IOException e);
+  void onFailure(Call call, IOException e);
 
   /**
    * Called when the HTTP response was successfully returned by the remote server. The callback may
@@ -35,5 +35,5 @@ public interface Callback {
    * not necessarily indicate application-layer success: {@code response} may still indicate an
    * unhappy HTTP response code like 404 or 500.
    */
-  void onResponse(Response response) throws IOException;
+  void onResponse(Call call, Response response) throws IOException;
 }

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -127,18 +127,17 @@ final class RealCall implements Call {
         Response response = getResponseWithInterceptorChain(forWebSocket);
         if (canceled) {
           signalledCallback = true;
-          responseCallback.onFailure(originalRequest, new IOException("Canceled"));
+          responseCallback.onFailure(RealCall.this, new IOException("Canceled"));
         } else {
           signalledCallback = true;
-          responseCallback.onResponse(response);
+          responseCallback.onResponse(RealCall.this, response);
         }
       } catch (IOException e) {
         if (signalledCallback) {
           // Do not signal the callback twice!
           logger.log(Level.INFO, "Callback failure for " + toLoggableString(), e);
         } else {
-          Request request = engine == null ? originalRequest : engine.getRequest();
-          responseCallback.onFailure(request, e);
+          responseCallback.onFailure(RealCall.this, e);
         }
       } finally {
         client.dispatcher().finished(this);

--- a/samples/guide/src/main/java/okhttp3/recipes/AsynchronousGet.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/AsynchronousGet.java
@@ -16,6 +16,7 @@
 package okhttp3.recipes;
 
 import java.io.IOException;
+import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
@@ -31,11 +32,11 @@ public final class AsynchronousGet {
         .build();
 
     client.newCall(request).enqueue(new Callback() {
-      @Override public void onFailure(Request request, IOException e) {
+      @Override public void onFailure(Call call, IOException e) {
         e.printStackTrace();
       }
 
-      @Override public void onResponse(Response response) throws IOException {
+      @Override public void onResponse(Call call, Response response) throws IOException {
         if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);
 
         Headers responseHeaders = response.headers();


### PR DESCRIPTION
This makes it much easier to test if the call was canceled.

Note that the Call's request is always the original user request.
This is different than the previous request that was passed in, as
that could have been the follow up to a redirect.