### PR TITLE
Add basic URLFilter for HttpURLConnection

### DIFF
--- a/okhttp-urlconnection/src/main/java/okhttp3/OkUrlFactory.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/OkUrlFactory.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
+import okhttp3.internal.URLFilter;
 import okhttp3.internal.huc.HttpURLConnectionImpl;
 import okhttp3.internal.huc.HttpsURLConnectionImpl;
 
@@ -31,6 +32,7 @@ import okhttp3.internal.huc.HttpsURLConnectionImpl;
  */
 public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
   private OkHttpClient client;
+  private URLFilter urlFilter;
 
   public OkUrlFactory(OkHttpClient client) {
     this.client = client;
@@ -43,6 +45,10 @@ public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
   public OkUrlFactory setClient(OkHttpClient client) {
     this.client = client;
     return this;
+  }
+
+  void setUrlFilter(URLFilter filter) {
+    urlFilter = filter;
   }
 
   /**
@@ -63,8 +69,8 @@ public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
         .proxy(proxy)
         .build();
 
-    if (protocol.equals("http")) return new HttpURLConnectionImpl(url, copy);
-    if (protocol.equals("https")) return new HttpsURLConnectionImpl(url, copy);
+    if (protocol.equals("http")) return new HttpURLConnectionImpl(url, copy, urlFilter);
+    if (protocol.equals("https")) return new HttpsURLConnectionImpl(url, copy, urlFilter);
     throw new IllegalArgumentException("Unexpected protocol: " + protocol);
   }
 

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/URLFilter.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/URLFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Request filter based on the request's URL.
+ *
+ * @deprecated use {@link okhttp3.Interceptor} for non-HttpURLConnection filtering.
+ */
+public interface URLFilter {
+  /**
+   * Check whether request to the provided URL is permitted to be issued.
+   *
+   * @throws IOException if the request to the provided URL is not permitted.
+   */
+  void checkURLPermitted(URL url) throws IOException;
+}

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
@@ -53,6 +53,7 @@ import okhttp3.Route;
 import okhttp3.internal.Internal;
 import okhttp3.internal.JavaNetHeaders;
 import okhttp3.internal.Platform;
+import okhttp3.internal.URLFilter;
 import okhttp3.internal.Util;
 import okhttp3.internal.Version;
 import okhttp3.internal.http.HttpDate;
@@ -107,9 +108,16 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
    */
   Handshake handshake;
 
+  private URLFilter urlFilter;
+
   public HttpURLConnectionImpl(URL url, OkHttpClient client) {
     super(url);
     this.client = client;
+  }
+
+  public HttpURLConnectionImpl(URL url, OkHttpClient client, URLFilter urlFilter) {
+    this(url, client);
+    this.urlFilter = urlFilter;
   }
 
   @Override public final void connect() throws IOException {
@@ -456,6 +464,9 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
    */
   private boolean execute(boolean readResponse) throws IOException {
     boolean releaseConnection = true;
+    if (urlFilter != null) {
+      urlFilter.checkURLPermitted(httpEngine.getRequest().url().url());
+    }
     try {
       httpEngine.sendRequest();
       Connection connection = httpEngine.getConnection();

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpsURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpsURLConnectionImpl.java
@@ -21,12 +21,17 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 import okhttp3.Handshake;
 import okhttp3.OkHttpClient;
+import okhttp3.internal.URLFilter;
 
 public final class HttpsURLConnectionImpl extends DelegatingHttpsURLConnection {
   private final HttpURLConnectionImpl delegate;
 
   public HttpsURLConnectionImpl(URL url, OkHttpClient client) {
     this(new HttpURLConnectionImpl(url, client));
+  }
+
+  public HttpsURLConnectionImpl(URL url, OkHttpClient client, URLFilter filter) {
+    this(new HttpURLConnectionImpl(url, client, filter));
   }
 
   public HttpsURLConnectionImpl(HttpURLConnectionImpl delegate) {


### PR DESCRIPTION
This optional filter can be used to allow for blocking HTTP traffic to
certain URLs, for example in order to prevent accessing sensitive
content over HTTP instead of HTTPS.

This behavior is already possible for clients of OkHttpClient, this patch allows legacy clients using the HttpUrlConnection APIs to do basic blocking.

See #2269