### PR TITLE
Create request/response API tests to match some URLConnectionTest tests.

### DIFF
--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/CacheAdapterTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/CacheAdapterTest.java
@@ -38,7 +38,7 @@ import okhttp3.internal.InternalCache;
 import okhttp3.internal.SslContextBuilder;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.testing.RecordingHostnameVerifier;
+import okhttp3.RecordingHostnameVerifier;
 import okio.Buffer;
 import org.junit.After;
 import org.junit.Before;

--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
@@ -68,7 +68,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import okhttp3.mockwebserver.SocketPolicy;
-import okhttp3.testing.RecordingHostnameVerifier;
+import okhttp3.RecordingHostnameVerifier;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;

--- a/okhttp-testing-support/src/main/java/okhttp3/FakeDns.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/FakeDns.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.internal.http;
+package okhttp3;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import okhttp3.Dns;
 
 import static org.junit.Assert.assertEquals;
 

--- a/okhttp-testing-support/src/main/java/okhttp3/FakeProxySelector.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/FakeProxySelector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class FakeProxySelector extends ProxySelector {
+  public final List<Proxy> proxies = new ArrayList<>();
+
+  public FakeProxySelector addProxy(Proxy proxy) {
+    proxies.add(proxy);
+    return this;
+  }
+
+  @Override public List<Proxy> select(URI uri) {
+    // Don't handle 'socket' schemes, which the RI's Socket class may request (for SOCKS).
+    return uri.getScheme().equals("http") || uri.getScheme().equals("https") ? proxies
+        : Collections.singletonList(Proxy.NO_PROXY);
+  }
+
+  @Override public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+  }
+}

--- a/okhttp-testing-support/src/main/java/okhttp3/FakeSSLSession.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/FakeSSLSession.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package okhttp3.internal.tls;
+package okhttp3;
 
 import java.security.Principal;
 import java.security.cert.Certificate;
@@ -23,7 +23,7 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
 import javax.security.cert.X509Certificate;
 
-final class FakeSSLSession implements SSLSession {
+public final class FakeSSLSession implements SSLSession {
   private final Certificate[] certificates;
 
   public FakeSSLSession(Certificate... certificates) throws Exception {

--- a/okhttp-testing-support/src/main/java/okhttp3/RecordingHostnameVerifier.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/RecordingHostnameVerifier.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.testing;
+package okhttp3;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
@@ -137,8 +137,14 @@ public final class RecordedResponse {
     return new RecordedResponse(cacheResponse.request(), cacheResponse, null, null, null);
   }
 
-  public void assertFailure(String... messages) {
+  public RecordedResponse assertFailure(Class<?> exceptionClass) {
+    assertTrue(exceptionClass.isInstance(failure));
+    return this;
+  }
+
+  public RecordedResponse assertFailure(String... messages) {
     assertNotNull(failure);
     assertTrue(failure.getMessage(), Arrays.asList(messages).contains(failure.getMessage()));
+    return this;
   }
 }

--- a/okhttp-tests/src/test/java/okhttp3/internal/framed/HttpOverSpdyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/framed/HttpOverSpdyTest.java
@@ -44,7 +44,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import okhttp3.mockwebserver.SocketPolicy;
-import okhttp3.testing.RecordingHostnameVerifier;
+import okhttp3.RecordingHostnameVerifier;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/RouteSelectorTest.java
@@ -35,6 +35,7 @@ import javax.net.ssl.SSLSocketFactory;
 import okhttp3.Address;
 import okhttp3.Authenticator;
 import okhttp3.ConnectionSpec;
+import okhttp3.FakeDns;
 import okhttp3.Protocol;
 import okhttp3.Route;
 import okhttp3.internal.RouteDatabase;

--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
@@ -23,6 +23,7 @@ import java.security.cert.X509Certificate;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
+import okhttp3.FakeSSLSession;
 import okhttp3.internal.Util;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/okhttp-ws-tests/src/test/java/okhttp3/ws/WebSocketCallTest.java
+++ b/okhttp-ws-tests/src/test/java/okhttp3/ws/WebSocketCallTest.java
@@ -30,7 +30,7 @@ import okhttp3.ResponseBody;
 import okhttp3.internal.SslContextBuilder;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.testing.RecordingHostnameVerifier;
+import okhttp3.RecordingHostnameVerifier;
 import okio.Buffer;
 import org.junit.After;
 import org.junit.Rule;


### PR DESCRIPTION
This is more work towards being able to later delete HttpURLConnectionImpl
without losing test coverage.

Also do some test cleanup.