### PR TITLE
Override the equals() and hashCode() methods of Cookie

### DIFF
--- a/okhttp/src/main/java/okhttp3/Cookie.java
+++ b/okhttp/src/main/java/okhttp3/Cookie.java
@@ -559,4 +559,24 @@ public final class Cookie {
 
     return result.toString();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof Cookie)) return false;
+
+    Cookie cookie = (Cookie) o;
+    return cookie.name().equalsIgnoreCase(name)
+            && cookie.domain().equalsIgnoreCase(domain)
+            && cookie.path().equalsIgnoreCase(path);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 7;
+    hash = 31 * hash + name.toLowerCase().hashCode();
+    hash = 31 * hash + domain.toLowerCase().hashCode();
+    hash = 31 * hash + path.toLowerCase().hashCode();
+
+    return hash;
+  }
 }

--- a/okhttp/src/main/java/okhttp3/Cookie.java
+++ b/okhttp/src/main/java/okhttp3/Cookie.java
@@ -565,17 +565,29 @@ public final class Cookie {
     if (!(o instanceof Cookie)) return false;
 
     Cookie cookie = (Cookie) o;
-    return cookie.name().equalsIgnoreCase(name)
-            && cookie.domain().equalsIgnoreCase(domain)
-            && cookie.path().equalsIgnoreCase(path);
+    return cookie.name.equals(name)
+            && cookie.value.equals(value)
+            && cookie.domain.equals(domain)
+            && cookie.path.equals(path)
+            && cookie.expiresAt == expiresAt
+            && cookie.secure == secure
+            && cookie.httpOnly == httpOnly
+            && cookie.persistent == persistent
+            && cookie.hostOnly == hostOnly;
   }
 
   @Override
   public int hashCode() {
     int hash = 7;
-    hash = 31 * hash + name.toLowerCase().hashCode();
-    hash = 31 * hash + domain.toLowerCase().hashCode();
-    hash = 31 * hash + path.toLowerCase().hashCode();
+    hash = 31 * hash + name.hashCode();
+    hash = 31 * hash + value.hashCode();
+    hash = 31 * hash + domain.hashCode();
+    hash = 31 * hash + path.hashCode();
+    hash = hash + Long.hashCode(expiresAt);
+    hash = hash + Boolean.hashCode(secure);
+    hash = hash + Boolean.hashCode(httpOnly);
+    hash = hash + Boolean.hashCode(persistent);
+    hash = hash + Boolean.hashCode(hostOnly);
 
     return hash;
   }

--- a/okhttp/src/main/java/okhttp3/Cookie.java
+++ b/okhttp/src/main/java/okhttp3/Cookie.java
@@ -583,11 +583,11 @@ public final class Cookie {
     hash = 31 * hash + value.hashCode();
     hash = 31 * hash + domain.hashCode();
     hash = 31 * hash + path.hashCode();
-    hash = hash + Long.hashCode(expiresAt);
-    hash = hash + Boolean.hashCode(secure);
-    hash = hash + Boolean.hashCode(httpOnly);
-    hash = hash + Boolean.hashCode(persistent);
-    hash = hash + Boolean.hashCode(hostOnly);
+    hash = hash + Long.valueOf(expiresAt).hashCode();
+    hash = hash + Boolean.valueOf(secure).hashCode();
+    hash = hash + Boolean.valueOf(httpOnly).hashCode();
+    hash = hash + Boolean.valueOf(persistent).hashCode();
+    hash = hash + Boolean.valueOf(hostOnly).hashCode();
 
     return hash;
   }


### PR DESCRIPTION
Now it is possible to use Cookies in Collections that depend on the hash function. (Useful when implementing an in-memory CookieJar)

Both methods takes into account the name, domain a path values as mentioned in the RFC6265 specs (https://tools.ietf.org/html/rfc6265#section-4.1.2):
"If the user agent receives a new cookie with the same cookie-name,domain-value, and path-value as a cookie that it has already stored, the existing cookie is evicted and replaced with the new cookie."