### PR TITLE
New CertificateAuthorityCouncil class to normalize certificate chains.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/internal/HeldCertificate.java
+++ b/mockwebserver/src/main/java/okhttp3/internal/HeldCertificate.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.UUID;
+import javax.security.auth.x500.X500Principal;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.x509.X509V3CertificateGenerator;
+
+/**
+ * A certificate and its private key. This can be used on the server side by HTTPS servers, or on
+ * the client side to verify those HTTPS servers. A held certificate can also be used to sign other
+ * held certificates, as done in practice by certificate authorities.
+ */
+public final class HeldCertificate {
+  public final X509Certificate certificate;
+  public final KeyPair keyPair;
+
+  public HeldCertificate(X509Certificate certificate, KeyPair keyPair) {
+    this.certificate = certificate;
+    this.keyPair = keyPair;
+  }
+
+  public static final class Builder {
+    static {
+      Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private final long duration = 1000L * 60 * 60 * 24; // One day.
+    private String hostname;
+    private String serialNumber = "1";
+    private KeyPair keyPair;
+    private HeldCertificate issuedBy;
+
+    public Builder serialNumber(String serialNumber) {
+      this.serialNumber = serialNumber;
+      return this;
+    }
+
+    /**
+     * Set this certificate's hostname. This is the CN (common name) in the certificate. Will be a
+     * random string if no value is provided.
+     */
+    public Builder hostname(String hostname) {
+      this.hostname = hostname;
+      return this;
+    }
+
+    public Builder keyPair(KeyPair keyPair) {
+      this.keyPair = keyPair;
+      return this;
+    }
+
+    /**
+     * Set the certificate that signs this certificate. If unset, a self-signed certificate will be
+     * generated.
+     */
+    public Builder issuedBy(HeldCertificate signedBy) {
+      this.issuedBy = signedBy;
+      return this;
+    }
+
+    public HeldCertificate build() throws GeneralSecurityException {
+      // Subject, public & private keys for this certificate.
+      KeyPair heldKeyPair = keyPair != null
+          ? keyPair
+          : generateKeyPair();
+      X500Principal subject = hostname != null
+          ? new X500Principal("CN=" + hostname)
+          : new X500Principal("CN=" + UUID.randomUUID());
+
+      // Subject, public & private keys for this certificate's signer. It may be self signed!
+      KeyPair signedByKeyPair;
+      X500Principal signedByPrincipal;
+      if (issuedBy != null) {
+        signedByKeyPair = issuedBy.keyPair;
+        signedByPrincipal = issuedBy.certificate.getSubjectX500Principal();
+      } else {
+        signedByKeyPair = heldKeyPair;
+        signedByPrincipal = subject;
+      }
+
+      // Generate & sign the certificate.
+      long now = System.currentTimeMillis();
+      X509V3CertificateGenerator generator = new X509V3CertificateGenerator();
+      generator.setSerialNumber(new BigInteger(serialNumber));
+      generator.setIssuerDN(signedByPrincipal);
+      generator.setNotBefore(new Date(now));
+      generator.setNotAfter(new Date(now + duration));
+      generator.setSubjectDN(subject);
+      generator.setPublicKey(heldKeyPair.getPublic());
+      generator.setSignatureAlgorithm("SHA256WithRSAEncryption");
+      X509Certificate certificate = generator.generateX509Certificate(
+          signedByKeyPair.getPrivate(), "BC");
+      return new HeldCertificate(certificate, heldKeyPair);
+    }
+
+    public KeyPair generateKeyPair() throws GeneralSecurityException {
+      KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
+      keyPairGenerator.initialize(1024, new SecureRandom());
+      return keyPairGenerator.generateKeyPair();
+    }
+  }
+}

--- a/mockwebserver/src/main/java/okhttp3/internal/SslContextBuilder.java
+++ b/mockwebserver/src/main/java/okhttp3/internal/SslContextBuilder.java
@@ -13,29 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package okhttp3.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.cert.Certificate;
-import java.security.cert.X509Certificate;
-import java.util.Date;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
-import javax.security.auth.x500.X500Principal;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.x509.X509V3CertificateGenerator;
 
 /**
  * Constructs an SSL context for testing. This uses Bouncy Castle to generate a self-signed
@@ -45,16 +35,8 @@ import org.bouncycastle.x509.X509V3CertificateGenerator;
  * instances where possible.
  */
 public final class SslContextBuilder {
-  static {
-    Security.addProvider(new BouncyCastleProvider());
-  }
-
-  private static final long ONE_DAY_MILLIS = 1000L * 60 * 60 * 24;
   private static SSLContext localhost; // Lazily initialized.
-
   private final String hostName;
-  private long notBefore = System.currentTimeMillis();
-  private long notAfter = System.currentTimeMillis() + ONE_DAY_MILLIS;
 
   /**
    * @param hostName the subject of the host. For TLS this should be the domain name that the client
@@ -79,17 +61,19 @@ public final class SslContextBuilder {
   }
 
   public SSLContext build() throws GeneralSecurityException {
+    // Generate a self-signed cert for the server to serve and the client to trust.
+    HeldCertificate heldCertificate = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .hostname(hostName)
+        .build();
+
+    // Put the certificate in a key store.
     char[] password = "password".toCharArray();
-
-    // Generate public and private keys and use them to make a self-signed certificate.
-    KeyPair keyPair = generateKeyPair();
-    X509Certificate certificate = selfSignedCertificate(keyPair, "1");
-
-    // Put 'em in a key store.
     KeyStore keyStore = newEmptyKeyStore(password);
-    Certificate[] certificateChain = {certificate};
-    keyStore.setKeyEntry("private", keyPair.getPrivate(), password, certificateChain);
-    keyStore.setCertificateEntry("cert", certificate);
+    Certificate[] certificateChain = {heldCertificate.certificate};
+    keyStore.setKeyEntry("private",
+        heldCertificate.keyPair.getPrivate(), password, certificateChain);
+    keyStore.setCertificateEntry("cert", heldCertificate.certificate);
 
     // Wrap it up in an SSL context.
     KeyManagerFactory keyManagerFactory =
@@ -102,32 +86,6 @@ public final class SslContextBuilder {
     sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(),
         new SecureRandom());
     return sslContext;
-  }
-
-  public KeyPair generateKeyPair() throws GeneralSecurityException {
-    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
-    keyPairGenerator.initialize(1024, new SecureRandom());
-    return keyPairGenerator.generateKeyPair();
-  }
-
-  /**
-   * Generates a certificate for {@code hostName} containing {@code keyPair}'s public key, signed by
-   * {@code keyPair}'s private key.
-   */
-  @SuppressWarnings("deprecation") // use the old Bouncy Castle APIs to reduce dependencies.
-  public X509Certificate selfSignedCertificate(KeyPair keyPair, String serialNumber)
-      throws GeneralSecurityException {
-    X509V3CertificateGenerator generator = new X509V3CertificateGenerator();
-    X500Principal issuer = new X500Principal("CN=" + hostName);
-    X500Principal subject = new X500Principal("CN=" + hostName);
-    generator.setSerialNumber(new BigInteger(serialNumber));
-    generator.setIssuerDN(issuer);
-    generator.setNotBefore(new Date(notBefore));
-    generator.setNotAfter(new Date(notAfter));
-    generator.setSubjectDN(subject);
-    generator.setPublicKey(keyPair.getPublic());
-    generator.setSignatureAlgorithm("SHA256WithRSAEncryption");
-    return generator.generateX509Certificate(keyPair.getPrivate(), "BC");
   }
 
   private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {

--- a/okhttp-tests/src/test/java/okhttp3/CertificateAuthorityCouncilTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CertificateAuthorityCouncilTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import okhttp3.internal.HeldCertificate;
+import okhttp3.internal.tls.CertificateAuthorityCouncil;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public final class CertificateAuthorityCouncilTest {
+  @Test public void normalizeSingleSelfSignedCertificate() throws Exception {
+    HeldCertificate root = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .build();
+    CertificateAuthorityCouncil council = new CertificateAuthorityCouncil(root.certificate);
+    assertEquals(list(root), council.normalizeCertificateChain(list(root)));
+  }
+
+  @Test public void normalizeUnknownSelfSignedCertificate() throws Exception {
+    HeldCertificate root = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .build();
+    CertificateAuthorityCouncil council = new CertificateAuthorityCouncil();
+
+    try {
+      council.normalizeCertificateChain(list(root));
+      fail();
+    } catch (SSLPeerUnverifiedException expected) {
+    }
+  }
+
+  @Test public void orderedChainOfCertificatesWithRoot() throws Exception {
+    HeldCertificate root = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .build();
+    HeldCertificate certA = new HeldCertificate.Builder()
+        .serialNumber("2")
+        .issuedBy(root)
+        .build();
+    HeldCertificate certB = new HeldCertificate.Builder()
+        .serialNumber("3")
+        .issuedBy(certA)
+        .build();
+
+    CertificateAuthorityCouncil council = new CertificateAuthorityCouncil(root.certificate);
+    assertEquals(list(certB, certA, root),
+        council.normalizeCertificateChain(list(certB, certA, root)));
+  }
+
+  @Test public void orderedChainOfCertificatesWithoutRoot() throws Exception {
+    HeldCertificate root = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .build();
+    HeldCertificate certA = new HeldCertificate.Builder()
+        .serialNumber("2")
+        .issuedBy(root)
+        .build();
+    HeldCertificate certB = new HeldCertificate.Builder()
+        .serialNumber("3")
+        .issuedBy(certA)
+        .build();
+
+    CertificateAuthorityCouncil council = new CertificateAuthorityCouncil(root.certificate);
+    assertEquals(list(certB, certA, root),
+        council.normalizeCertificateChain(list(certB, certA))); // Root is added!
+  }
+
+  @Test public void unorderedChainOfCertificatesWithRoot() throws Exception {
+    HeldCertificate root = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .build();
+    HeldCertificate certA = new HeldCertificate.Builder()
+        .serialNumber("2")
+        .issuedBy(root)
+        .build();
+    HeldCertificate certB = new HeldCertificate.Builder()
+        .serialNumber("3")
+        .issuedBy(certA)
+        .build();
+    HeldCertificate certC = new HeldCertificate.Builder()
+        .serialNumber("4")
+        .issuedBy(certB)
+        .build();
+
+    CertificateAuthorityCouncil council = new CertificateAuthorityCouncil(root.certificate);
+    assertEquals(list(certC, certB, certA, root),
+        council.normalizeCertificateChain(list(certC, certA, root, certB)));
+  }
+
+  @Test public void unorderedChainOfCertificatesWithoutRoot() throws Exception {
+    HeldCertificate root = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .build();
+    HeldCertificate certA = new HeldCertificate.Builder()
+        .serialNumber("2")
+        .issuedBy(root)
+        .build();
+    HeldCertificate certB = new HeldCertificate.Builder()
+        .serialNumber("3")
+        .issuedBy(certA)
+        .build();
+    HeldCertificate certC = new HeldCertificate.Builder()
+        .serialNumber("4")
+        .issuedBy(certB)
+        .build();
+
+    CertificateAuthorityCouncil council = new CertificateAuthorityCouncil(root.certificate);
+    assertEquals(list(certC, certB, certA, root),
+        council.normalizeCertificateChain(list(certC, certA, certB)));
+  }
+
+  @Test public void unrelatedCertificatesAreOmitted() throws Exception {
+    HeldCertificate root = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .build();
+    HeldCertificate certA = new HeldCertificate.Builder()
+        .serialNumber("2")
+        .issuedBy(root)
+        .build();
+    HeldCertificate certB = new HeldCertificate.Builder()
+        .serialNumber("3")
+        .issuedBy(certA)
+        .build();
+    HeldCertificate certUnnecessary = new HeldCertificate.Builder()
+        .serialNumber("4")
+        .build();
+
+    CertificateAuthorityCouncil council = new CertificateAuthorityCouncil(root.certificate);
+    assertEquals(list(certB, certA, root),
+        council.normalizeCertificateChain(list(certB, certUnnecessary, certA, root)));
+  }
+
+  @Test public void unnecessaryTrustedCertificatesAreOmitted() throws Exception {
+    HeldCertificate superRoot = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .build();
+    HeldCertificate root = new HeldCertificate.Builder()
+        .serialNumber("2")
+        .issuedBy(superRoot)
+        .build();
+    HeldCertificate certA = new HeldCertificate.Builder()
+        .serialNumber("3")
+        .issuedBy(root)
+        .build();
+    HeldCertificate certB = new HeldCertificate.Builder()
+        .serialNumber("4")
+        .issuedBy(certA)
+        .build();
+
+    CertificateAuthorityCouncil council = new CertificateAuthorityCouncil(
+        superRoot.certificate, root.certificate);
+    assertEquals(list(certB, certA, root),
+        council.normalizeCertificateChain(list(certB, certA, root, superRoot)));
+  }
+
+  private List<Certificate> list(HeldCertificate... heldCertificates) {
+    List<Certificate> result = new ArrayList<>();
+    for (HeldCertificate heldCertificate : heldCertificates) {
+      result.add(heldCertificate.certificate);
+    }
+    return result;
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/CertificatePinnerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CertificatePinnerTest.java
@@ -16,11 +16,9 @@
 package okhttp3;
 
 import java.security.GeneralSecurityException;
-import java.security.KeyPair;
-import java.security.cert.X509Certificate;
 import java.util.Set;
 import javax.net.ssl.SSLPeerUnverifiedException;
-import okhttp3.internal.SslContextBuilder;
+import okhttp3.internal.HeldCertificate;
 import okio.ByteString;
 import org.junit.Test;
 
@@ -32,39 +30,35 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class CertificatePinnerTest {
-  static SslContextBuilder sslContextBuilder;
+  static HeldCertificate certA1;
+  static String certA1Pin;
+  static ByteString certA1PinBase64;
 
-  static KeyPair keyPairA;
-  static X509Certificate keypairACertificate1;
-  static String keypairACertificate1Pin;
-  static ByteString keypairACertificate1PinBase64;
+  static HeldCertificate certB1;
+  static String certB1Pin;
+  static ByteString certB1PinBase64;
 
-  static KeyPair keyPairB;
-  static X509Certificate keypairBCertificate1;
-  static String keypairBCertificate1Pin;
-  static ByteString keypairBCertificate1PinBase64;
-
-  static KeyPair keyPairC;
-  static X509Certificate keypairCCertificate1;
-  static String keypairCCertificate1Pin;
+  static HeldCertificate certC1;
+  static String certC1Pin;
 
   static {
     try {
-      sslContextBuilder = new SslContextBuilder("example.com");
+      certA1 = new HeldCertificate.Builder()
+          .serialNumber("100")
+          .build();
+      certA1Pin = CertificatePinner.pin(certA1.certificate);
+      certA1PinBase64 = pinToBase64(certA1Pin);
 
-      keyPairA = sslContextBuilder.generateKeyPair();
-      keypairACertificate1 = sslContextBuilder.selfSignedCertificate(keyPairA, "1");
-      keypairACertificate1Pin = CertificatePinner.pin(keypairACertificate1);
-      keypairACertificate1PinBase64 = pinToBase64(keypairACertificate1Pin);
+      certB1 = new HeldCertificate.Builder()
+          .serialNumber("200")
+          .build();
+      certB1Pin = CertificatePinner.pin(certB1.certificate);
+      certB1PinBase64 = pinToBase64(certB1Pin);
 
-      keyPairB = sslContextBuilder.generateKeyPair();
-      keypairBCertificate1 = sslContextBuilder.selfSignedCertificate(keyPairB, "1");
-      keypairBCertificate1Pin = CertificatePinner.pin(keypairBCertificate1);
-      keypairBCertificate1PinBase64 = pinToBase64(keypairBCertificate1Pin);
-
-      keyPairC = sslContextBuilder.generateKeyPair();
-      keypairCCertificate1 = sslContextBuilder.selfSignedCertificate(keyPairC, "1");
-      keypairCCertificate1Pin = CertificatePinner.pin(keypairCCertificate1);
+      certC1 = new HeldCertificate.Builder()
+          .serialNumber("300")
+          .build();
+      certC1Pin = CertificatePinner.pin(certC1.certificate);
     } catch (GeneralSecurityException e) {
       throw new AssertionError(e);
     }
@@ -94,40 +88,46 @@ public final class CertificatePinnerTest {
 
   /** Multiple certificates generated from the same keypair have the same pin. */
   @Test public void sameKeypairSamePin() throws Exception {
-    X509Certificate keypairACertificate2 = sslContextBuilder.selfSignedCertificate(keyPairA, "2");
-    String keypairACertificate2Pin = CertificatePinner.pin(keypairACertificate2);
+    HeldCertificate heldCertificateA2 = new HeldCertificate.Builder()
+        .keyPair(certA1.keyPair)
+        .serialNumber("101")
+        .build();
+    String keypairACertificate2Pin = CertificatePinner.pin(heldCertificateA2.certificate);
 
-    X509Certificate keypairBCertificate2 = sslContextBuilder.selfSignedCertificate(keyPairB, "2");
-    String keypairBCertificate2Pin = CertificatePinner.pin(keypairBCertificate2);
+    HeldCertificate heldCertificateB2 = new HeldCertificate.Builder()
+        .keyPair(certB1.keyPair)
+        .serialNumber("201")
+        .build();
+    String keypairBCertificate2Pin = CertificatePinner.pin(heldCertificateB2.certificate);
 
-    assertTrue(keypairACertificate1Pin.equals(keypairACertificate2Pin));
-    assertTrue(keypairBCertificate1Pin.equals(keypairBCertificate2Pin));
-    assertFalse(keypairACertificate1Pin.equals(keypairBCertificate1Pin));
+    assertTrue(certA1Pin.equals(keypairACertificate2Pin));
+    assertTrue(certB1Pin.equals(keypairBCertificate2Pin));
+    assertFalse(certA1Pin.equals(certB1Pin));
   }
 
   @Test public void successfulCheck() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("example.com", keypairACertificate1Pin)
+        .add("example.com", certA1Pin)
         .build();
 
-    certificatePinner.check("example.com", keypairACertificate1);
+    certificatePinner.check("example.com", certA1.certificate);
   }
 
   @Test public void successfulMatchAcceptsAnyMatchingCertificate() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("example.com", keypairBCertificate1Pin)
+        .add("example.com", certB1Pin)
         .build();
 
-    certificatePinner.check("example.com", keypairACertificate1, keypairBCertificate1);
+    certificatePinner.check("example.com", certA1.certificate, certB1.certificate);
   }
 
   @Test public void unsuccessfulCheck() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("example.com", keypairACertificate1Pin)
+        .add("example.com", certA1Pin)
         .build();
 
     try {
-      certificatePinner.check("example.com", keypairBCertificate1);
+      certificatePinner.check("example.com", certB1.certificate);
       fail();
     } catch (SSLPeerUnverifiedException expected) {
     }
@@ -135,52 +135,52 @@ public final class CertificatePinnerTest {
 
   @Test public void multipleCertificatesForOneHostname() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("example.com", keypairACertificate1Pin, keypairBCertificate1Pin)
+        .add("example.com", certA1Pin, certB1Pin)
         .build();
 
-    certificatePinner.check("example.com", keypairACertificate1);
-    certificatePinner.check("example.com", keypairBCertificate1);
+    certificatePinner.check("example.com", certA1.certificate);
+    certificatePinner.check("example.com", certB1.certificate);
   }
 
   @Test public void multipleHostnamesForOneCertificate() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("example.com", keypairACertificate1Pin)
-        .add("www.example.com", keypairACertificate1Pin)
+        .add("example.com", certA1Pin)
+        .add("www.example.com", certA1Pin)
         .build();
 
-    certificatePinner.check("example.com", keypairACertificate1);
-    certificatePinner.check("www.example.com", keypairACertificate1);
+    certificatePinner.check("example.com", certA1.certificate);
+    certificatePinner.check("www.example.com", certA1.certificate);
   }
 
   @Test public void absentHostnameMatches() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder().build();
-    certificatePinner.check("example.com", keypairACertificate1);
+    certificatePinner.check("example.com", certA1.certificate);
   }
 
   @Test public void successfulCheckForWildcardHostname() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("*.example.com", keypairACertificate1Pin)
+        .add("*.example.com", certA1Pin)
         .build();
 
-    certificatePinner.check("a.example.com", keypairACertificate1);
+    certificatePinner.check("a.example.com", certA1.certificate);
   }
 
   @Test public void successfulMatchAcceptsAnyMatchingCertificateForWildcardHostname()
       throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("*.example.com", keypairBCertificate1Pin)
+        .add("*.example.com", certB1Pin)
         .build();
 
-    certificatePinner.check("a.example.com", keypairACertificate1, keypairBCertificate1);
+    certificatePinner.check("a.example.com", certA1.certificate, certB1.certificate);
   }
 
   @Test public void unsuccessfulCheckForWildcardHostname() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("*.example.com", keypairACertificate1Pin)
+        .add("*.example.com", certA1Pin)
         .build();
 
     try {
-      certificatePinner.check("a.example.com", keypairBCertificate1);
+      certificatePinner.check("a.example.com", certB1.certificate);
       fail();
     } catch (SSLPeerUnverifiedException expected) {
     }
@@ -188,33 +188,33 @@ public final class CertificatePinnerTest {
 
   @Test public void multipleCertificatesForOneWildcardHostname() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("*.example.com", keypairACertificate1Pin, keypairBCertificate1Pin)
+        .add("*.example.com", certA1Pin, certB1Pin)
         .build();
 
-    certificatePinner.check("a.example.com", keypairACertificate1);
-    certificatePinner.check("a.example.com", keypairBCertificate1);
+    certificatePinner.check("a.example.com", certA1.certificate);
+    certificatePinner.check("a.example.com", certB1.certificate);
   }
 
   @Test public void successfulCheckForOneHostnameWithWildcardAndDirectCertificate()
       throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("*.example.com", keypairACertificate1Pin)
-        .add("a.example.com", keypairBCertificate1Pin)
+        .add("*.example.com", certA1Pin)
+        .add("a.example.com", certB1Pin)
         .build();
 
-    certificatePinner.check("a.example.com", keypairACertificate1);
-    certificatePinner.check("a.example.com", keypairBCertificate1);
+    certificatePinner.check("a.example.com", certA1.certificate);
+    certificatePinner.check("a.example.com", certB1.certificate);
   }
 
   @Test public void unsuccessfulCheckForOneHostnameWithWildcardAndDirectCertificate()
       throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("*.example.com", keypairACertificate1Pin)
-        .add("a.example.com", keypairBCertificate1Pin)
+        .add("*.example.com", certA1Pin)
+        .add("a.example.com", certB1Pin)
         .build();
 
     try {
-      certificatePinner.check("a.example.com", keypairCCertificate1);
+      certificatePinner.check("a.example.com", certC1.certificate);
       fail();
     } catch (SSLPeerUnverifiedException expected) {
     }
@@ -222,12 +222,11 @@ public final class CertificatePinnerTest {
 
   @Test public void successfulFindMatchingPins() {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("first.com", keypairACertificate1Pin, keypairBCertificate1Pin)
-        .add("second.com", keypairCCertificate1Pin)
+        .add("first.com", certA1Pin, certB1Pin)
+        .add("second.com", certC1Pin)
         .build();
 
-    Set<ByteString> expectedPins =
-        setOf(keypairACertificate1PinBase64, keypairBCertificate1PinBase64);
+    Set<ByteString> expectedPins = setOf(certA1PinBase64, certB1PinBase64);
     Set<ByteString> matchedPins = certificatePinner.findMatchingPins("first.com");
 
     assertEquals(expectedPins, matchedPins);
@@ -235,13 +234,12 @@ public final class CertificatePinnerTest {
 
   @Test public void successfulFindMatchingPinsForWildcardAndDirectCertificates() {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("*.example.com", keypairACertificate1Pin)
-        .add("a.example.com", keypairBCertificate1Pin)
-        .add("b.example.com", keypairCCertificate1Pin)
+        .add("*.example.com", certA1Pin)
+        .add("a.example.com", certB1Pin)
+        .add("b.example.com", certC1Pin)
         .build();
 
-    Set<ByteString> expectedPins =
-        setOf(keypairACertificate1PinBase64, keypairBCertificate1PinBase64);
+    Set<ByteString> expectedPins = setOf(certA1PinBase64, certB1PinBase64);
     Set<ByteString> matchedPins = certificatePinner.findMatchingPins("a.example.com");
 
     assertEquals(expectedPins, matchedPins);
@@ -249,7 +247,7 @@ public final class CertificatePinnerTest {
 
   @Test public void wildcardHostnameShouldNotMatchThroughDot() throws Exception {
     CertificatePinner certificatePinner = new CertificatePinner.Builder()
-        .add("*.example.com", keypairACertificate1Pin)
+        .add("*.example.com", certA1Pin)
         .build();
 
     assertNull(certificatePinner.findMatchingPins("example.com"));

--- a/okhttp/src/main/java/okhttp3/internal/tls/CertificateAuthorityCouncil.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/CertificateAuthorityCouncil.java
@@ -1,0 +1,120 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package okhttp3.internal.tls;
+
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * A set of trusted Certificate Authority (CA) certificates that are trusted to verify the TLS
+ * certificates offered by remote web servers.
+ *
+ * <p>This class includes code from <a href="https://conscrypt.org/">Conscrypt's</a> {@code
+ * TrustManagerImpl} and {@code TrustedCertificateIndex}.
+ */
+public final class CertificateAuthorityCouncil {
+  private final Map<X500Principal, List<X509Certificate>> subjectToCaCerts = new LinkedHashMap<>();
+
+  public CertificateAuthorityCouncil(X509Certificate... caCerts) {
+    for (X509Certificate caCert : caCerts) {
+      X500Principal subject = caCert.getSubjectX500Principal();
+      List<X509Certificate> subjectCaCerts = subjectToCaCerts.get(subject);
+      if (subjectCaCerts == null) {
+        subjectCaCerts = new ArrayList<>(1);
+        subjectToCaCerts.put(subject, subjectCaCerts);
+      }
+      subjectCaCerts.add(caCert);
+    }
+  }
+
+  /**
+   * Computes the effective certificate chain from the raw array returned by Java's built in TLS
+   * APIs. This method returns a list of certificates where the first element is {@code chain[0]},
+   * each certificate is signed by the certificate that follows, and the last certificate is a
+   * trusted CA certificate.
+   *
+   * <p>Use of this method is necessary to omit unexpected certificates that aren't relevant to the
+   * TLS handshake and to extract the trusted CA certificate for the benefit of certificate pinning.
+   *
+   * <p>This method throws if the complete chain to a trusted CA certificate cannot be constructed.
+   * This is unexpected unless the X509 trust manager in this class is different from the trust
+   * manager that was used to establish {@code chain}.
+   */
+  public List<Certificate> normalizeCertificateChain(List<Certificate> chain)
+      throws SSLPeerUnverifiedException {
+    Deque<Certificate> queue = new ArrayDeque<>(chain);
+    List<Certificate> result = new ArrayList<>();
+    result.add(queue.removeFirst());
+
+    followIssuerChain:
+    while (true) {
+      X509Certificate toVerify = (X509Certificate) result.get(result.size() - 1);
+
+      // If this cert has been signed by a trusted CA cert, we're done. Add the trusted CA
+      // certificate to the end of the chain, unless it's already present. (That would happen if the
+      // first certificate in the chain is itself a self-signed and trusted CA certificate.)
+      X509Certificate caCert = findByIssuerAndSignature(toVerify);
+      if (caCert != null) {
+        if (result.size() > 1 || !toVerify.equals(caCert)) {
+          result.add(caCert);
+        }
+        return result;
+      }
+
+      // Search for the certificate in the chain that signed this certificate. This is typically the
+      // next element in the chain, but it could be any element.
+      for (Iterator<Certificate> i = queue.iterator(); i.hasNext(); ) {
+        Certificate signingCert = i.next();
+        if (toVerify.getIssuerDN().equals(((X509Certificate) signingCert).getSubjectDN())) {
+          i.remove();
+          result.add(signingCert);
+          continue followIssuerChain;
+        }
+      }
+
+      throw new SSLPeerUnverifiedException("Failed to find a cert that signed " + toVerify);
+    }
+  }
+
+  /** Returns the trusted CA certificate that signed {@code cert}. */
+  private X509Certificate findByIssuerAndSignature(X509Certificate cert) {
+    X500Principal issuer = cert.getIssuerX500Principal();
+    List<X509Certificate> subjectCaCerts = subjectToCaCerts.get(issuer);
+    if (subjectCaCerts == null) return null;
+
+    for (X509Certificate caCert : subjectCaCerts) {
+      PublicKey publicKey = caCert.getPublicKey();
+      try {
+        cert.verify(publicKey);
+        return caCert;
+      } catch (Exception ignored) {
+      }
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
The goal of this is to get the root CA certificate into the certificate
chain, so that it can be considered by the certificate pinner. The work
to integrate CertificateAuthorityCouncil with CertificatePinner will
come in a follow-up PR.

See: https://github.com/square/okhttp/issues/1699