### PR TITLE
Defer known-length payload writes when within a segment of completion.

### DIFF
--- a/okhttp-ws/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp-ws/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -125,7 +125,7 @@ public abstract class RealWebSocket implements WebSocket {
           + ". Must use WebSocket.TEXT or WebSocket.BINARY.");
     }
 
-    BufferedSink sink = Okio.buffer(writer.newMessageSink(formatOpcode));
+    BufferedSink sink = Okio.buffer(writer.newMessageSink(formatOpcode, message.contentLength()));
     try {
       message.writeTo(sink);
       sink.close();


### PR DESCRIPTION
This allows both really small bodies and very large buffered bodies to be written as a single frame.

Closes #2270.