### PR TITLE
Don't build a trust root index on Android.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/Platform.java
@@ -33,6 +33,9 @@ import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Protocol;
+import okhttp3.internal.tls.AndroidTrustRootIndex;
+import okhttp3.internal.tls.RealTrustRootIndex;
+import okhttp3.internal.tls.TrustRootIndex;
 import okio.Buffer;
 
 import static okhttp3.internal.Internal.logger;
@@ -88,6 +91,10 @@ public class Platform {
 
   public X509TrustManager trustManager(SSLSocketFactory sslSocketFactory) {
     return null;
+  }
+
+  public TrustRootIndex trustRootIndex(X509TrustManager trustManager) {
+    return new RealTrustRootIndex(trustManager.getAcceptedIssuers());
   }
 
   /**
@@ -245,6 +252,12 @@ public class Platform {
       if (x509TrustManager != null) return x509TrustManager;
 
       return readFieldOrNull(context, X509TrustManager.class, "trustManager");
+    }
+
+    @Override public TrustRootIndex trustRootIndex(X509TrustManager trustManager) {
+      TrustRootIndex result = AndroidTrustRootIndex.get(trustManager);
+      if (result != null) return result;
+      return super.trustRootIndex(trustManager);
     }
 
     @Override public void configureTlsExtensions(

--- a/okhttp/src/main/java/okhttp3/internal/tls/AndroidTrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/AndroidTrustRootIndex.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.tls;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * A index of trusted root certificates that exploits knowledge of Android implementation details.
+ * This class is potentially much faster to initialize than {@link RealTrustRootIndex} because
+ * it doesn't need to load and index trusted CA certificates.
+ */
+public final class AndroidTrustRootIndex implements TrustRootIndex {
+  private final X509TrustManager trustManager;
+  private final Method findByIssuerAndSignatureMethod;
+
+  public AndroidTrustRootIndex(
+      X509TrustManager trustManager, Method findByIssuerAndSignatureMethod) {
+    this.findByIssuerAndSignatureMethod = findByIssuerAndSignatureMethod;
+    this.trustManager = trustManager;
+  }
+
+  @Override public X509Certificate findByIssuerAndSignature(X509Certificate cert) {
+    try {
+      TrustAnchor trustAnchor = (TrustAnchor) findByIssuerAndSignatureMethod.invoke(
+          trustManager, cert);
+      return trustAnchor.getTrustedCert();
+    } catch (IllegalAccessException e) {
+      throw new AssertionError();
+    } catch (InvocationTargetException e) {
+      return null;
+    }
+  }
+
+  public static TrustRootIndex get(X509TrustManager trustManager) {
+    // From org.conscrypt.TrustManagerImpl, we want the method with this signature:
+    // private TrustAnchor findTrustAnchorByIssuerAndSignature(X509Certificate lastCert);
+    try {
+      Method method = trustManager.getClass().getDeclaredMethod(
+          "findTrustAnchorByIssuerAndSignature", X509Certificate.class);
+      method.setAccessible(true);
+      return new AndroidTrustRootIndex(trustManager, method);
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/tls/CertificateChainCleaner.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/CertificateChainCleaner.java
@@ -17,56 +17,43 @@
 package okhttp3.internal.tls;
 
 import java.security.GeneralSecurityException;
-import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.auth.x500.X500Principal;
 
 /**
- * A set of trusted Certificate Authority (CA) certificates that are trusted to verify the TLS
- * certificates offered by remote web servers.
+ * Computes the effective certificate chain from the raw array returned by Java's built in TLS APIs.
+ * Cleaning a chain returns a list of certificates where the first element is {@code chain[0]}, each
+ * certificate is signed by the certificate that follows, and the last certificate is a trusted CA
+ * certificate.
+ *
+ * <p>Use of the chain cleaner is necessary to omit unexpected certificates that aren't relevant to
+ * the TLS handshake and to extract the trusted CA certificate for the benefit of certificate
+ * pinning.
  *
  * <p>This class includes code from <a href="https://conscrypt.org/">Conscrypt's</a> {@code
  * TrustManagerImpl} and {@code TrustedCertificateIndex}.
  */
-public final class CertificateAuthorityCouncil {
-  private final Map<X500Principal, List<X509Certificate>> subjectToCaCerts = new LinkedHashMap<>();
+public final class CertificateChainCleaner {
+  private final TrustRootIndex trustRootIndex;
 
-  public CertificateAuthorityCouncil(X509Certificate... caCerts) {
-    for (X509Certificate caCert : caCerts) {
-      X500Principal subject = caCert.getSubjectX500Principal();
-      List<X509Certificate> subjectCaCerts = subjectToCaCerts.get(subject);
-      if (subjectCaCerts == null) {
-        subjectCaCerts = new ArrayList<>(1);
-        subjectToCaCerts.put(subject, subjectCaCerts);
-      }
-      subjectCaCerts.add(caCert);
-    }
+  public CertificateChainCleaner(TrustRootIndex trustRootIndex) {
+    this.trustRootIndex = trustRootIndex;
   }
 
   /**
-   * Computes the effective certificate chain from the raw array returned by Java's built in TLS
-   * APIs. This method returns a list of certificates where the first element is {@code chain[0]},
-   * each certificate is signed by the certificate that follows, and the last certificate is a
-   * trusted CA certificate.
-   *
-   * <p>Use of this method is necessary to omit unexpected certificates that aren't relevant to the
-   * TLS handshake and to extract the trusted CA certificate for the benefit of certificate pinning.
+   * Returns a cleaned chain for {@code chain}.
    *
    * <p>This method throws if the complete chain to a trusted CA certificate cannot be constructed.
-   * This is unexpected unless the X509 trust manager in this class is different from the trust
-   * manager that was used to establish {@code chain}.
+   * This is unexpected unless the trust root index in this class has a different trust manager than
+   * what was used to establish {@code chain}.
    */
-  public List<Certificate> normalizeCertificateChain(List<Certificate> chain)
-      throws SSLPeerUnverifiedException {
+  public List<Certificate> clean(List<Certificate> chain) throws SSLPeerUnverifiedException {
     Deque<Certificate> queue = new ArrayDeque<>(chain);
     List<Certificate> result = new ArrayList<>();
     result.add(queue.removeFirst());
@@ -78,8 +65,8 @@ public final class CertificateAuthorityCouncil {
       // If this cert has been signed by a trusted CA cert, we're done. Add the trusted CA
       // certificate to the end of the chain, unless it's already present. (That would happen if the
       // first certificate in the chain is itself a self-signed and trusted CA certificate.)
-      X509Certificate caCert = findByIssuerAndSignature(toVerify);
-      if (caCert != null && verifySignature(toVerify, caCert)) {
+      X509Certificate caCert = trustRootIndex.findByIssuerAndSignature(toVerify);
+      if (caCert != null) {
         if (result.size() > 1 || !toVerify.equals(caCert)) {
           result.add(caCert);
         }
@@ -110,23 +97,5 @@ public final class CertificateAuthorityCouncil {
     } catch (GeneralSecurityException verifyFailed) {
       return false;
     }
-  }
-
-  /** Returns the trusted CA certificate that signed {@code cert}. */
-  private X509Certificate findByIssuerAndSignature(X509Certificate cert) {
-    X500Principal issuer = cert.getIssuerX500Principal();
-    List<X509Certificate> subjectCaCerts = subjectToCaCerts.get(issuer);
-    if (subjectCaCerts == null) return null;
-
-    for (X509Certificate caCert : subjectCaCerts) {
-      PublicKey publicKey = caCert.getPublicKey();
-      try {
-        cert.verify(publicKey);
-        return caCert;
-      } catch (Exception ignored) {
-      }
-    }
-
-    return null;
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/tls/RealTrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/RealTrustRootIndex.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.tls;
+
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.security.auth.x500.X500Principal;
+
+public final class RealTrustRootIndex implements TrustRootIndex {
+  private final Map<X500Principal, List<X509Certificate>> subjectToCaCerts;
+
+  public RealTrustRootIndex(X509Certificate... caCerts) {
+    subjectToCaCerts = new LinkedHashMap<>();
+    for (X509Certificate caCert : caCerts) {
+      X500Principal subject = caCert.getSubjectX500Principal();
+      List<X509Certificate> subjectCaCerts = subjectToCaCerts.get(subject);
+      if (subjectCaCerts == null) {
+        subjectCaCerts = new ArrayList<>(1);
+        subjectToCaCerts.put(subject, subjectCaCerts);
+      }
+      subjectCaCerts.add(caCert);
+    }
+  }
+
+  @Override public X509Certificate findByIssuerAndSignature(X509Certificate cert) {
+    X500Principal issuer = cert.getIssuerX500Principal();
+    List<X509Certificate> subjectCaCerts = subjectToCaCerts.get(issuer);
+    if (subjectCaCerts == null) return null;
+
+    for (X509Certificate caCert : subjectCaCerts) {
+      PublicKey publicKey = caCert.getPublicKey();
+      try {
+        cert.verify(publicKey);
+        return caCert;
+      } catch (Exception ignored) {
+      }
+    }
+
+    return null;
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/tls/TrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/TrustRootIndex.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.tls;
+
+import java.security.cert.X509Certificate;
+
+public interface TrustRootIndex {
+  /** Returns the trusted CA certificate that signed {@code cert}. */
+  X509Certificate findByIssuerAndSignature(X509Certificate cert);
+}


### PR DESCRIPTION
We can just cheat and use reflection to use Conscrypt's trust root index
directly. This results in a substantial savings in app startup - 500
milliseconds or more.

Closes: https://github.com/square/okhttp/issues/2321