### PR TITLE
Always build full chains with CertificateChainCleaner.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CertificateChainCleanerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CertificateChainCleanerTest.java
@@ -152,17 +152,17 @@ public final class CertificateChainCleanerTest {
         council.clean(list(certB, certUnnecessary, certA, root)));
   }
 
-  @Test public void unnecessaryTrustedCertificatesAreOmitted() throws Exception {
-    HeldCertificate superRoot = new HeldCertificate.Builder()
+  @Test public void chainGoesAllTheWayToSelfSignedRoot() throws Exception {
+    HeldCertificate selfSigned = new HeldCertificate.Builder()
         .serialNumber("1")
         .build();
-    HeldCertificate root = new HeldCertificate.Builder()
+    HeldCertificate trusted = new HeldCertificate.Builder()
         .serialNumber("2")
-        .issuedBy(superRoot)
+        .issuedBy(selfSigned)
         .build();
     HeldCertificate certA = new HeldCertificate.Builder()
         .serialNumber("3")
-        .issuedBy(root)
+        .issuedBy(trusted)
         .build();
     HeldCertificate certB = new HeldCertificate.Builder()
         .serialNumber("4")
@@ -170,8 +170,13 @@ public final class CertificateChainCleanerTest {
         .build();
 
     CertificateChainCleaner council = new CertificateChainCleaner(
-        new RealTrustRootIndex(superRoot.certificate, root.certificate));
-    assertEquals(list(certB, certA, root), council.clean(list(certB, certA, root, superRoot)));
+        new RealTrustRootIndex(selfSigned.certificate, trusted.certificate));
+    assertEquals(list(certB, certA, trusted, selfSigned),
+        council.clean(list(certB, certA)));
+    assertEquals(list(certB, certA, trusted, selfSigned),
+        council.clean(list(certB, certA, trusted)));
+    assertEquals(list(certB, certA, trusted, selfSigned),
+        council.clean(list(certB, certA, trusted, selfSigned)));
   }
 
   private List<Certificate> list(HeldCertificate... heldCertificates) {

--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.tls;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import okhttp3.Call;
+import okhttp3.CertificatePinner;
+import okhttp3.OkHttpClient;
+import okhttp3.RecordingHostnameVerifier;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.internal.HeldCertificate;
+import okhttp3.internal.SslContextBuilder;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class CertificatePinnerChainValidationTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  /** The pinner should pull the root certificate from the trust manager. */
+  @Test public void pinRootNotPresentInChain() throws Exception {
+    HeldCertificate rootCa = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .ca(3)
+        .commonName("root")
+        .build();
+    HeldCertificate intermediateCa = new HeldCertificate.Builder()
+        .issuedBy(rootCa)
+        .ca(2)
+        .serialNumber("2")
+        .commonName("intermediate_ca")
+        .build();
+    HeldCertificate certificate = new HeldCertificate.Builder()
+        .issuedBy(intermediateCa)
+        .serialNumber("3")
+        .commonName(server.getHostName())
+        .build();
+    CertificatePinner certificatePinner = new CertificatePinner.Builder()
+        .add(server.getHostName(), CertificatePinner.pin(rootCa.certificate))
+        .build();
+    SSLContext clientContext = new SslContextBuilder()
+        .addTrustedCertificate(rootCa.certificate)
+        .build();
+    OkHttpClient client = new OkHttpClient.Builder()
+        .sslSocketFactory(clientContext.getSocketFactory())
+        .hostnameVerifier(new RecordingHostnameVerifier())
+        .certificatePinner(certificatePinner)
+        .build();
+
+    SSLContext serverSslContext = new SslContextBuilder()
+        .certificateChain(certificate, intermediateCa)
+        .build();
+    server.useHttps(serverSslContext.getSocketFactory(), false);
+
+    // The request should complete successfully.
+    server.enqueue(new MockResponse()
+        .setBody("abc")
+        .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END));
+    Call call1 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    Response response1 = call1.execute();
+    assertEquals("abc", response1.body().string());
+
+    // Confirm that a second request also succeeds. This should detect caching problems.
+    server.enqueue(new MockResponse()
+        .setBody("def")
+        .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END));
+    Call call2 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    Response response2 = call2.execute();
+    assertEquals("def", response2.body().string());
+  }
+
+  /** The pinner should accept an intermediate from the server's chain. */
+  @Test public void pinIntermediatePresentInChain() throws Exception {
+    HeldCertificate rootCa = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .ca(3)
+        .commonName("root")
+        .build();
+    HeldCertificate intermediateCa = new HeldCertificate.Builder()
+        .issuedBy(rootCa)
+        .ca(2)
+        .serialNumber("2")
+        .commonName("intermediate_ca")
+        .build();
+    HeldCertificate certificate = new HeldCertificate.Builder()
+        .issuedBy(intermediateCa)
+        .serialNumber("3")
+        .commonName(server.getHostName())
+        .build();
+    CertificatePinner certificatePinner = new CertificatePinner.Builder()
+        .add(server.getHostName(), CertificatePinner.pin(intermediateCa.certificate))
+        .build();
+    SSLContext clientContext = new SslContextBuilder()
+        .addTrustedCertificate(rootCa.certificate)
+        .build();
+    OkHttpClient client = new OkHttpClient.Builder()
+        .sslSocketFactory(clientContext.getSocketFactory())
+        .hostnameVerifier(new RecordingHostnameVerifier())
+        .certificatePinner(certificatePinner)
+        .build();
+
+    SSLContext serverSslContext = new SslContextBuilder()
+        .certificateChain(certificate, intermediateCa)
+        .build();
+    server.useHttps(serverSslContext.getSocketFactory(), false);
+
+    // The request should complete successfully.
+    server.enqueue(new MockResponse()
+        .setBody("abc")
+        .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END));
+    Call call1 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    Response response1 = call1.execute();
+    assertEquals("abc", response1.body().string());
+
+    // Confirm that a second request also succeeds. This should detect caching problems.
+    server.enqueue(new MockResponse()
+        .setBody("def")
+        .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END));
+    Call call2 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    Response response2 = call2.execute();
+    assertEquals("def", response2.body().string());
+  }
+
+  @Test public void unrelatedPinnedLeafCertificateInChain() throws Exception {
+    // Start with a trusted root CA certificate.
+    HeldCertificate rootCa = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .ca(3)
+        .commonName("root")
+        .build();
+
+    // Add a good intermediate CA, and have that issue a good certificate to localhost. Prepare an
+    // SSL context for an HTTP client under attack. It includes the trusted CA and a pinned
+    // certificate.
+    HeldCertificate goodIntermediateCa = new HeldCertificate.Builder()
+        .issuedBy(rootCa)
+        .ca(2)
+        .serialNumber("2")
+        .commonName("good_intermediate_ca")
+        .build();
+    HeldCertificate goodCertificate = new HeldCertificate.Builder()
+        .issuedBy(goodIntermediateCa)
+        .serialNumber("3")
+        .commonName(server.getHostName())
+        .build();
+    CertificatePinner certificatePinner = new CertificatePinner.Builder()
+        .add(server.getHostName(), CertificatePinner.pin(goodCertificate.certificate))
+        .build();
+    SSLContext clientContext = new SslContextBuilder()
+        .addTrustedCertificate(rootCa.certificate)
+        .build();
+    OkHttpClient client = new OkHttpClient.Builder()
+        .sslSocketFactory(clientContext.getSocketFactory())
+        .hostnameVerifier(new RecordingHostnameVerifier())
+        .certificatePinner(certificatePinner)
+        .build();
+
+    // Add a bad intermediate CA and have that issue a rogue certificate for localhost. Prepare
+    // an SSL context for an attacking webserver. It includes both these rogue certificates plus the
+    // trusted good certificate above. The attack is that by including the good certificate in the
+    // chain, we may trick the certificate pinner into accepting the rouge certificate.
+    HeldCertificate compromisedIntermediateCa = new HeldCertificate.Builder()
+        .issuedBy(rootCa)
+        .ca(2)
+        .serialNumber("4")
+        .commonName("bad_intermediate_ca")
+        .build();
+    HeldCertificate rogueCertificate = new HeldCertificate.Builder()
+        .serialNumber("5")
+        .issuedBy(compromisedIntermediateCa)
+        .commonName(server.getHostName())
+        .build();
+    SSLContext serverSslContext = new SslContextBuilder()
+        .certificateChain(rogueCertificate, compromisedIntermediateCa, goodCertificate, rootCa)
+        .build();
+    server.useHttps(serverSslContext.getSocketFactory(), false);
+    server.enqueue(new MockResponse()
+        .setBody("abc")
+        .addHeader("Content-Type: text/plain"));
+
+    // Make a request from client to server. It should succeed certificate checks (unfortunately the
+    // rogue CA is trusted) but it should fail certificate pinning.
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .build();
+    Call call = client.newCall(request);
+    try {
+      call.execute();
+      fail();
+    } catch (SSLPeerUnverifiedException expected) {
+      // Certificate pinning fails!
+      String message = expected.getMessage();
+      assertTrue(message, message.startsWith("Certificate pinning failure!"));
+    }
+  }
+
+  @Test public void unrelatedPinnedIntermediateCertificateInChain() throws Exception {
+    // Start with two root CA certificates, one is good and the other is compromised.
+    HeldCertificate rootCa = new HeldCertificate.Builder()
+        .serialNumber("1")
+        .ca(3)
+        .commonName("root")
+        .build();
+    HeldCertificate compromisedRootCa = new HeldCertificate.Builder()
+        .serialNumber("2")
+        .ca(3)
+        .commonName("compromised_root")
+        .build();
+
+    // Add a good intermediate CA, and have that issue a good certificate to localhost. Prepare an
+    // SSL context for an HTTP client under attack. It includes the trusted CA and a pinned
+    // certificate.
+    HeldCertificate goodIntermediateCa = new HeldCertificate.Builder()
+        .issuedBy(rootCa)
+        .ca(2)
+        .serialNumber("3")
+        .commonName("intermediate_ca")
+        .build();
+    CertificatePinner certificatePinner = new CertificatePinner.Builder()
+        .add(server.getHostName(), CertificatePinner.pin(goodIntermediateCa.certificate))
+        .build();
+    SSLContext clientContext = new SslContextBuilder()
+        .addTrustedCertificate(rootCa.certificate)
+        .addTrustedCertificate(compromisedRootCa.certificate)
+        .build();
+    OkHttpClient client = new OkHttpClient.Builder()
+        .sslSocketFactory(clientContext.getSocketFactory())
+        .hostnameVerifier(new RecordingHostnameVerifier())
+        .certificatePinner(certificatePinner)
+        .build();
+
+    // The attacker compromises the root CA, issues an intermediate with the same common name
+    // "intermediate_ca" as the good CA. This signs a rogue certificate for localhost. The server
+    // serves the good CAs certificate in the chain, which means the certificate pinner sees a
+    // different set of certificates than the SSL verifier.
+    HeldCertificate compromisedIntermediateCa = new HeldCertificate.Builder()
+        .issuedBy(compromisedRootCa)
+        .ca(2)
+        .serialNumber("4")
+        .commonName("intermediate_ca")
+        .build();
+    HeldCertificate rogueCertificate = new HeldCertificate.Builder()
+        .serialNumber("5")
+        .issuedBy(compromisedIntermediateCa)
+        .commonName(server.getHostName())
+        .build();
+    SSLContext serverSslContext = new SslContextBuilder()
+        .certificateChain(
+            rogueCertificate, goodIntermediateCa, compromisedIntermediateCa, compromisedRootCa)
+        .build();
+    server.useHttps(serverSslContext.getSocketFactory(), false);
+    server.enqueue(new MockResponse()
+        .setBody("abc")
+        .addHeader("Content-Type: text/plain"));
+
+    // Make a request from client to server. It should succeed certificate checks (unfortunately the
+    // rogue CA is trusted) but it should fail certificate pinning.
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .build();
+    Call call = client.newCall(request);
+    try {
+      call.execute();
+      fail();
+    } catch (SSLHandshakeException expected) {
+      // On Android, the handshake fails before the certificate pinner runs.
+      String message = expected.getMessage();
+      assertTrue(message, message.contains("Could not validate certificate"));
+    } catch (SSLPeerUnverifiedException expected) {
+      // On OpenJDK, the handshake succeeds but the certificate pinner fails.
+      String message = expected.getMessage();
+      assertTrue(message, message.startsWith("Certificate pinning failure!"));
+    }
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/tls/AndroidTrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/AndroidTrustRootIndex.java
@@ -40,7 +40,9 @@ public final class AndroidTrustRootIndex implements TrustRootIndex {
     try {
       TrustAnchor trustAnchor = (TrustAnchor) findByIssuerAndSignatureMethod.invoke(
           trustManager, cert);
-      return trustAnchor.getTrustedCert();
+      return trustAnchor != null
+          ? trustAnchor.getTrustedCert()
+          : null;
     } catch (IllegalAccessException e) {
       throw new AssertionError();
     } catch (InvocationTargetException e) {


### PR DESCRIPTION
We had a bug on Android where the trust root index would return trusted
intermediate certificates when we called findTrustAnchorByIssuerAndSignature().
This would lead to a partial chain, which would fail the pin check
unnecessarily.

Also permit that method to return null, as it does when the certificate
is not trusted.