### PR TITLE
Make IPv6 request lines consistent with Firefox and Chrome.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
@@ -438,6 +438,15 @@ public final class HttpUrlTest {
     assertEquals("::", HttpUrl.parse("http://[0:0:0:0:0:0:0:0]/").host());
   }
 
+  /** The builder permits square braces but does not require them. */
+  @Test public void hostIPv6Builder() throws Exception {
+    HttpUrl base = HttpUrl.parse("http://example.com/");
+    assertEquals("http://[::1]/", base.newBuilder().host("[::1]").build().toString());
+    assertEquals("http://[::1]/", base.newBuilder().host("[::0001]").build().toString());
+    assertEquals("http://[::1]/", base.newBuilder().host("::1").build().toString());
+    assertEquals("http://[::1]/", base.newBuilder().host("::0001").build().toString());
+  }
+
   @Test public void hostIpv4CanonicalForm() throws Exception {
     assertEquals("255.255.255.255", HttpUrl.parse("http://255.255.255.255/").host());
     assertEquals("1.2.3.4", HttpUrl.parse("http://1.2.3.4/").host());

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -915,7 +915,7 @@ public final class URLConnectionTest {
     RecordedRequest connect = server.takeRequest();
     assertEquals("Connect line failure on proxy", "CONNECT android.com:443 HTTP/1.1",
         connect.getRequestLine());
-    assertEquals("android.com", connect.getHeader("Host"));
+    assertEquals("android.com:443", connect.getHeader("Host"));
 
     RecordedRequest get = server.takeRequest();
     assertEquals("GET /foo HTTP/1.1", get.getRequestLine());
@@ -951,7 +951,7 @@ public final class URLConnectionTest {
 
     RecordedRequest connect = server.takeRequest();
     assertEquals("CONNECT android.com:443 HTTP/1.1", connect.getRequestLine());
-    assertEquals("android.com", connect.getHeader("Host"));
+    assertEquals("android.com:443", connect.getHeader("Host"));
   }
 
   private void initResponseCache() throws IOException {
@@ -988,7 +988,7 @@ public final class URLConnectionTest {
     assertNull(connect.getHeader("Private"));
     assertNull(connect.getHeader("Proxy-Authorization"));
     assertEquals(Version.userAgent(), connect.getHeader("User-Agent"));
-    assertEquals("android.com", connect.getHeader("Host"));
+    assertEquals("android.com:443", connect.getHeader("Host"));
     assertEquals("Keep-Alive", connect.getHeader("Proxy-Connection"));
 
     RecordedRequest get = server.takeRequest();

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -1302,9 +1302,12 @@ public final class HttpUrl {
       // checked for IPv6 square braces. But Chrome does it first, and that's more lenient.
       String percentDecoded = percentDecode(input, pos, limit, false);
 
-      // If the input is encased in square braces "[...]", drop 'em. We have an IPv6 address.
-      if (percentDecoded.startsWith("[") && percentDecoded.endsWith("]")) {
-        InetAddress inetAddress = decodeIpv6(percentDecoded, 1, percentDecoded.length() - 1);
+      // If the input contains a :, it’s an IPv6 address.
+      if (percentDecoded.contains(":")) {
+        // If the input is encased in square braces "[...]", drop 'em.
+        InetAddress inetAddress = percentDecoded.startsWith("[") && percentDecoded.endsWith("]")
+            ? decodeIpv6(percentDecoded, 1, percentDecoded.length() - 1)
+            : decodeIpv6(percentDecoded, 0, percentDecoded.length());
         if (inetAddress == null) return null;
         byte[] address = inetAddress.getAddress();
         if (address.length == 16) return inet6AddressToAscii(address);

--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -286,11 +286,13 @@ public final class Util {
     return result;
   }
 
-  public static String hostHeader(HttpUrl url) {
-    // TODO: square braces for IPv6 ?
-    return url.port() != HttpUrl.defaultPort(url.scheme())
-        ? url.host() + ":" + url.port()
+  public static String hostHeader(HttpUrl url, boolean includeDefaultPort) {
+    String host = url.host().contains(":")
+        ? "[" + url.host() + "]"
         : url.host();
+    return includeDefaultPort || url.port() != HttpUrl.defaultPort(url.scheme())
+        ? host + ":" + url.port()
+        : host;
   }
 
   /** Returns {@code s} with control characters and non-ASCII characters replaced with '?'. */

--- a/okhttp/src/main/java/okhttp3/internal/http/Http2xStream.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/Http2xStream.java
@@ -161,7 +161,7 @@ public final class Http2xStream implements HttpStream {
     result.add(new Header(TARGET_METHOD, request.method()));
     result.add(new Header(TARGET_PATH, RequestLine.requestPath(request.url())));
     result.add(new Header(VERSION, "HTTP/1.1"));
-    result.add(new Header(TARGET_HOST, Util.hostHeader(request.url())));
+    result.add(new Header(TARGET_HOST, Util.hostHeader(request.url(), false)));
     result.add(new Header(TARGET_SCHEME, request.url().scheme()));
 
     Set<ByteString> names = new LinkedHashSet<>();
@@ -200,7 +200,7 @@ public final class Http2xStream implements HttpStream {
     List<Header> result = new ArrayList<>(headers.size() + 4);
     result.add(new Header(TARGET_METHOD, request.method()));
     result.add(new Header(TARGET_PATH, RequestLine.requestPath(request.url())));
-    result.add(new Header(TARGET_AUTHORITY, Util.hostHeader(request.url()))); // Optional.
+    result.add(new Header(TARGET_AUTHORITY, Util.hostHeader(request.url(), false))); // Optional.
     result.add(new Header(TARGET_SCHEME, request.url().scheme()));
 
     for (int i = 0, size = headers.size(); i < size; i++) {

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -502,7 +502,7 @@ public final class HttpEngine {
     Request.Builder result = request.newBuilder();
 
     if (request.header("Host") == null) {
-      result.header("Host", hostHeader(request.url()));
+      result.header("Host", hostHeader(request.url(), false));
     }
 
     if (request.header("Connection") == null) {

--- a/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
@@ -241,7 +241,7 @@ public final class RealConnection extends FramedConnection.Listener implements C
     // Make an SSL Tunnel on the first message pair of each SSL + proxy connection.
     Request tunnelRequest = createTunnelRequest();
     HttpUrl url = tunnelRequest.url();
-    String requestLine = "CONNECT " + url.host() + ":" + url.port() + " HTTP/1.1";
+    String requestLine = "CONNECT " + Util.hostHeader(url, true) + " HTTP/1.1";
     while (true) {
       Http1xStream tunnelConnection = new Http1xStream(null, source, sink);
       source.timeout().timeout(readTimeout, MILLISECONDS);
@@ -291,7 +291,7 @@ public final class RealConnection extends FramedConnection.Listener implements C
   private Request createTunnelRequest() throws IOException {
     return new Request.Builder()
         .url(route.address().url())
-        .header("Host", Util.hostHeader(route.address().url()))
+        .header("Host", Util.hostHeader(route.address().url(), true))
         .header("Proxy-Connection", "Keep-Alive")
         .header("User-Agent", Version.userAgent()) // For HTTP/1.0 proxies like Squid.
         .build();


### PR DESCRIPTION
Previously we omitted the square braces and explicit port on CONNECT requests
and the square braces in the Host header.

Closes https://github.com/square/okhttp/issues/2344