### PR TITLE
Don't require the CA root to be self-signed.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/tls/CertificateChainCleaner.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/CertificateChainCleaner.java
@@ -40,6 +40,9 @@ import javax.net.ssl.SSLPeerUnverifiedException;
  * TrustManagerImpl} and {@code TrustedCertificateIndex}.
  */
 public final class CertificateChainCleaner {
+  /** The maximum number of signers in a chain. We use 9 for consistency with OpenSSL. */
+  private static final int MAX_SIGNERS = 9;
+
   private final TrustRootIndex trustRootIndex;
 
   public CertificateChainCleaner(TrustRootIndex trustRootIndex) {
@@ -57,25 +60,25 @@ public final class CertificateChainCleaner {
     Deque<Certificate> queue = new ArrayDeque<>(chain);
     List<Certificate> result = new ArrayList<>();
     result.add(queue.removeFirst());
+    boolean foundTrustedCertificate = false;
 
     followIssuerChain:
-    while (true) {
+    for (int c = 0; c < MAX_SIGNERS; c++) {
       X509Certificate toVerify = (X509Certificate) result.get(result.size() - 1);
 
-      // If this cert has been signed by a trusted cert, use that. If that's also a self-signed
-      // cert, it's the root CA and we're done. Otherwise it might be a cached intermediate CA.
-      // Add the trusted certificate to the end of the chain, unless it's already present. (That
-      // would happen if the first certificate in the chain is itself a self-signed and trusted CA
-      // certificate.)
+      // If this cert has been signed by a trusted cert, use that. Add the trusted certificate to
+      // the end of the chain unless it's already present. (That would happen if the first
+      // certificate in the chain is itself a self-signed and trusted CA certificate.)
       X509Certificate trustedCert = trustRootIndex.findByIssuerAndSignature(toVerify);
       if (trustedCert != null) {
         if (result.size() > 1 || !toVerify.equals(trustedCert)) {
           result.add(trustedCert);
         }
         if (verifySignature(trustedCert, trustedCert)) {
-          return result; // The self-signed cert is the root CA. We're done.
+          return result; // The self-signed cert is a root CA. We're done.
         }
-        continue; // Trusted cert, but not a root.
+        foundTrustedCertificate = true;
+        continue;
       }
 
       // Search for the certificate in the chain that signed this certificate. This is typically the
@@ -89,8 +92,16 @@ public final class CertificateChainCleaner {
         }
       }
 
-      throw new SSLPeerUnverifiedException("Failed to find a cert that signed " + toVerify);
+      // We've reached the end of the chain. If any cert in the chain is trusted, we're done.
+      if (foundTrustedCertificate) {
+        return result;
+      }
+
+      // The last link isn't trusted. Fail.
+      throw new SSLPeerUnverifiedException("Failed to find a trusted cert that signed " + toVerify);
     }
+
+    throw new SSLPeerUnverifiedException("Certificate chain too long: " + result);
   }
 
   /** Returns true if {@code toVerify} was signed by {@code signingCert}'s public key. */


### PR DESCRIPTION
Some root certificates may not be.

Also test the limits of the certificate chain length, and put defense
in for weird unexpected cycles in the trusted certificates.