### PR TITLE
Gracefully recover from a failure to trim cache to size.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/FaultyFileSystem.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/FaultyFileSystem.java
@@ -29,16 +29,25 @@ import okio.Source;
 public final class FaultyFileSystem implements FileSystem {
   private final FileSystem delegate;
   private final Set<File> writeFaults = new LinkedHashSet<>();
+  private final Set<File> deleteFaults = new LinkedHashSet<>();
 
   public FaultyFileSystem(FileSystem delegate) {
     this.delegate = delegate;
   }
 
-  public void setFaulty(File file, boolean faulty) {
+  public void setFaultyWrite(File file, boolean faulty) {
     if (faulty) {
       writeFaults.add(file);
     } else {
       writeFaults.remove(file);
+    }
+  }
+
+  public void setFaultyDelete(File file, boolean faulty) {
+    if (faulty) {
+      deleteFaults.add(file);
+    } else {
+      deleteFaults.remove(file);
     }
   }
 
@@ -55,6 +64,7 @@ public final class FaultyFileSystem implements FileSystem {
   }
 
   @Override public void delete(File file) throws IOException {
+    if (deleteFaults.contains(file)) throw new IOException("boom!");
     delegate.delete(file);
   }
 


### PR DESCRIPTION
A first go at trying to gracefully recover from a failure to trim the cache to size. It took me awhile to reason through the various failure states, hopefully I didn't miss anything major. Assuming we can hash this one out, I can try to work through the rebuildJournal() case as a follow up.