### PR TITLE
Removed IOException from FileSystem exists method as this should never occur.

### DIFF
--- a/okhttp-testing-support/src/main/java/okhttp3/internal/io/InMemoryFileSystem.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/internal/io/InMemoryFileSystem.java
@@ -113,7 +113,7 @@ public final class InMemoryFileSystem implements FileSystem, TestRule {
     files.remove(file);
   }
 
-  @Override public boolean exists(File file) throws IOException {
+  @Override public boolean exists(File file) {
     return files.containsKey(file);
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/internal/DiskLruCacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/DiskLruCacheTest.java
@@ -1443,7 +1443,7 @@ public final class DiskLruCacheTest {
     writeFile(new File(dir2, "otherFile1"), "F");
   }
 
-  private void assertGarbageFilesAllDeleted() throws Exception {
+  private void assertGarbageFilesAllDeleted() {
     assertFalse(fileSystem.exists(getCleanFile("g1", 0)));
     assertFalse(fileSystem.exists(getCleanFile("g1", 1)));
     assertFalse(fileSystem.exists(getCleanFile("g2", 0)));

--- a/okhttp-tests/src/test/java/okhttp3/internal/FaultyFileSystem.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/FaultyFileSystem.java
@@ -68,7 +68,7 @@ public final class FaultyFileSystem implements FileSystem {
     delegate.delete(file);
   }
 
-  @Override public boolean exists(File file) throws IOException {
+  @Override public boolean exists(File file) {
     return delegate.exists(file);
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/io/FileSystem.java
+++ b/okhttp/src/main/java/okhttp3/internal/io/FileSystem.java
@@ -71,7 +71,7 @@ public interface FileSystem {
       }
     }
 
-    @Override public boolean exists(File file) throws IOException {
+    @Override public boolean exists(File file) {
       return file.exists();
     }
 
@@ -121,7 +121,7 @@ public interface FileSystem {
   void delete(File file) throws IOException;
 
   /** Returns true if {@code file} exists on the file system. */
-  boolean exists(File file) throws IOException;
+  boolean exists(File file);
 
   /** Returns the number of bytes stored in {@code file}, or 0 if it does not exist. */
   long size(File file);


### PR DESCRIPTION
I noticed that File#exists() doesn't throw IOException but FileSystem does. I wasn't sure if this was by design.