### PR TITLE
bug fix 2368

### DIFF
--- a/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
@@ -115,7 +115,7 @@ public final class WebSocketCall {
 
   private void createWebSocket(Response response, WebSocketListener listener) throws IOException {
     if (response.code() != 101) {
-    	//Util.closeQuietly(response.body());   
+//Util.closeQuietly(response.body());
       throw new ProtocolException("Expected HTTP 101 response but was '"
           + response.code()
           + " "

--- a/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
@@ -115,7 +115,6 @@ public final class WebSocketCall {
 
   private void createWebSocket(Response response, WebSocketListener listener) throws IOException {
     if (response.code() != 101) {
-//Util.closeQuietly(response.body());
       throw new ProtocolException("Expected HTTP 101 response but was '"
           + response.code()
           + " "

--- a/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
@@ -115,7 +115,7 @@ public final class WebSocketCall {
 
   private void createWebSocket(Response response, WebSocketListener listener) throws IOException {
     if (response.code() != 101) {
-      Util.closeQuietly(response.body());
+    	//Util.closeQuietly(response.body());   
       throw new ProtocolException("Expected HTTP 101 response but was '"
           + response.code()
           + " "

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -727,11 +727,7 @@ public final class HttpEngine {
         .header(OkHeaders.RECEIVED_MILLIS, Long.toString(System.currentTimeMillis()))
         .build();
 
-    if (!forWebSocket) {
-      networkResponse = networkResponse.newBuilder()
-          .body(httpStream.openResponseBody(networkResponse))
-          .build();
-    } else if (networkResponse.code() != 101) {
+    if (!forWebSocket || networkResponse.code() != 101) {
       networkResponse = networkResponse.newBuilder()
           .body(httpStream.openResponseBody(networkResponse))
           .build();

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -732,7 +732,12 @@ public final class HttpEngine {
           .body(httpStream.openResponseBody(networkResponse))
           .build();
     }
-
+    else if (networkResponse.code()!=101){
+      networkResponse = networkResponse.newBuilder()
+    	   .body(httpStream.openResponseBody(networkResponse))
+    	   .build();
+    }
+    
     if ("close".equalsIgnoreCase(networkResponse.request().header("Connection"))
         || "close".equalsIgnoreCase(networkResponse.header("Connection"))) {
       streamAllocation.noNewStreams();

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -731,13 +731,12 @@ public final class HttpEngine {
       networkResponse = networkResponse.newBuilder()
           .body(httpStream.openResponseBody(networkResponse))
           .build();
-    }
-    else if (networkResponse.code()!=101){
+    } else if (networkResponse.code() != 101) {
       networkResponse = networkResponse.newBuilder()
-    	   .body(httpStream.openResponseBody(networkResponse))
-    	   .build();
+          .body(httpStream.openResponseBody(networkResponse))
+          .build();
     }
-    
+
     if ("close".equalsIgnoreCase(networkResponse.request().header("Connection"))
         || "close".equalsIgnoreCase(networkResponse.header("Connection"))) {
       streamAllocation.noNewStreams();


### PR DESCRIPTION
The reason of bug was due to unhandled condition of non 101 during
websocket response readNetworkResponse() method  in http Engine. Also response body was being closed in createWebSocketCall when response code was non 101. I ran ws related testcases after making my changes.
This fix solves problem for issue #2368 and possibly #2264 as well.