### PR TITLE
Increase test timeout for slow devices

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/DiskLruCacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/DiskLruCacheTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.fail;
 
 public final class DiskLruCacheTest {
   @Rule public final TemporaryFolder tempDir = new TemporaryFolder();
-  @Rule public final Timeout timeout = new Timeout(30 * 1000);
+  @Rule public final Timeout timeout = new Timeout(60 * 1000);
 
   private final FaultyFileSystem fileSystem = new FaultyFileSystem(FileSystem.SYSTEM);
   private final int appVersion = 100;


### PR DESCRIPTION
OEMs have found some configurations of Android devices that cannot
meet the timeout. This change doubles the timeout from 30 to 60
seconds.

The Android bug reference is 27273056.