### PR TITLE
Replace IAE with NPE for null parameters

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CookieTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CookieTest.java
@@ -399,7 +399,7 @@ public final class CookieTest {
     try {
       new Cookie.Builder().hostOnlyDomain(null);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (NullPointerException expected) {
     }
     try {
       new Cookie.Builder().hostOnlyDomain("a/b");

--- a/okhttp-tests/src/test/java/okhttp3/RequestTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/RequestTest.java
@@ -175,7 +175,7 @@ public final class RequestTest {
   }
 
   @Test public void headerForbidsControlCharacters() throws Exception {
-    assertForbiddenHeader(null);
+    assertNullHeader(null);
     assertForbiddenHeader("\u0000");
     assertForbiddenHeader("\r");
     assertForbiddenHeader("\n");
@@ -184,6 +184,30 @@ public final class RequestTest {
     assertForbiddenHeader("\u007f");
     assertForbiddenHeader("\u0080");
     assertForbiddenHeader("\ud83c\udf69");
+  }
+
+  private void assertNullHeader(String s) {
+    Request.Builder builder = new Request.Builder();
+    try {
+      builder.header(s, "Value");
+      fail();
+    } catch (NullPointerException expected) {
+    }
+    try {
+      builder.addHeader(s, "Value");
+      fail();
+    } catch (NullPointerException expected) {
+    }
+    try {
+      builder.header("Name", s);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+    try {
+      builder.addHeader("Name", s);
+      fail();
+    } catch (NullPointerException expected) {
+    }
   }
 
   private void assertForbiddenHeader(String s) {

--- a/okhttp-tests/src/test/java/okhttp3/RequestTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/RequestTest.java
@@ -174,8 +174,31 @@ public final class RequestTest {
     }
   }
 
+  @Test public void headerForbidsNullArguments() throws Exception {
+    Request.Builder builder = new Request.Builder();
+    try {
+      builder.header(null, "Value");
+      fail();
+    } catch (NullPointerException expected) {
+    }
+    try {
+      builder.addHeader(null, "Value");
+      fail();
+    } catch (NullPointerException expected) {
+    }
+    try {
+      builder.header("Name", null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+    try {
+      builder.addHeader("Name", null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
   @Test public void headerForbidsControlCharacters() throws Exception {
-    assertNullHeader(null);
     assertForbiddenHeader("\u0000");
     assertForbiddenHeader("\r");
     assertForbiddenHeader("\n");
@@ -184,30 +207,6 @@ public final class RequestTest {
     assertForbiddenHeader("\u007f");
     assertForbiddenHeader("\u0080");
     assertForbiddenHeader("\ud83c\udf69");
-  }
-
-  private void assertNullHeader(String s) {
-    Request.Builder builder = new Request.Builder();
-    try {
-      builder.header(s, "Value");
-      fail();
-    } catch (NullPointerException expected) {
-    }
-    try {
-      builder.addHeader(s, "Value");
-      fail();
-    } catch (NullPointerException expected) {
-    }
-    try {
-      builder.header("Name", s);
-      fail();
-    } catch (NullPointerException expected) {
-    }
-    try {
-      builder.addHeader("Name", s);
-      fail();
-    } catch (NullPointerException expected) {
-    }
   }
 
   private void assertForbiddenHeader(String s) {

--- a/okhttp/src/main/java/okhttp3/Address.java
+++ b/okhttp/src/main/java/okhttp3/Address.java
@@ -57,24 +57,24 @@ public final class Address {
         .port(uriPort)
         .build();
 
-    if (dns == null) throw new IllegalArgumentException("dns == null");
+    if (dns == null) throw new NullPointerException("dns == null");
     this.dns = dns;
 
-    if (socketFactory == null) throw new IllegalArgumentException("socketFactory == null");
+    if (socketFactory == null) throw new NullPointerException("socketFactory == null");
     this.socketFactory = socketFactory;
 
     if (proxyAuthenticator == null) {
-      throw new IllegalArgumentException("proxyAuthenticator == null");
+      throw new NullPointerException("proxyAuthenticator == null");
     }
     this.proxyAuthenticator = proxyAuthenticator;
 
-    if (protocols == null) throw new IllegalArgumentException("protocols == null");
+    if (protocols == null) throw new NullPointerException("protocols == null");
     this.protocols = Util.immutableList(protocols);
 
-    if (connectionSpecs == null) throw new IllegalArgumentException("connectionSpecs == null");
+    if (connectionSpecs == null) throw new NullPointerException("connectionSpecs == null");
     this.connectionSpecs = Util.immutableList(connectionSpecs);
 
-    if (proxySelector == null) throw new IllegalArgumentException("proxySelector == null");
+    if (proxySelector == null) throw new NullPointerException("proxySelector == null");
     this.proxySelector = proxySelector;
 
     this.proxy = proxy;

--- a/okhttp/src/main/java/okhttp3/CertificatePinner.java
+++ b/okhttp/src/main/java/okhttp3/CertificatePinner.java
@@ -312,7 +312,7 @@ public final class CertificatePinner {
      * Info, base64-encoded and prefixed with either {@code sha256/} or {@code sha1/}.
      */
     public Builder add(String pattern, String... pins) {
-      if (pattern == null) throw new IllegalArgumentException("pattern == null");
+      if (pattern == null) throw new NullPointerException("pattern == null");
 
       for (String pin : pins) {
         this.pins.add(new Pin(pattern, pin));

--- a/okhttp/src/main/java/okhttp3/Cookie.java
+++ b/okhttp/src/main/java/okhttp3/Cookie.java
@@ -75,9 +75,9 @@ public final class Cookie {
   }
 
   private Cookie(Builder builder) {
-    if (builder.name == null) throw new IllegalArgumentException("builder.name == null");
-    if (builder.value == null) throw new IllegalArgumentException("builder.value == null");
-    if (builder.domain == null) throw new IllegalArgumentException("builder.domain == null");
+    if (builder.name == null) throw new NullPointerException("builder.name == null");
+    if (builder.value == null) throw new NullPointerException("builder.value == null");
+    if (builder.domain == null) throw new NullPointerException("builder.domain == null");
 
     this.name = builder.name;
     this.value = builder.value;
@@ -498,7 +498,7 @@ public final class Cookie {
     }
 
     private Builder domain(String domain, boolean hostOnly) {
-      if (domain == null) throw new IllegalArgumentException("domain == null");
+      if (domain == null) throw new NullPointerException("domain == null");
       String canonicalDomain = Util.domainToAscii(domain);
       if (canonicalDomain == null) {
         throw new IllegalArgumentException("unexpected domain: " + domain);

--- a/okhttp/src/main/java/okhttp3/Handshake.java
+++ b/okhttp/src/main/java/okhttp3/Handshake.java
@@ -74,7 +74,7 @@ public final class Handshake {
 
   public static Handshake get(TlsVersion tlsVersion, CipherSuite cipherSuite,
       List<Certificate> peerCertificates, List<Certificate> localCertificates) {
-    if (cipherSuite == null) throw new IllegalArgumentException("cipherSuite == null");
+    if (cipherSuite == null) throw new NullPointerException("cipherSuite == null");
     return new Handshake(tlsVersion, cipherSuite, Util.immutableList(peerCertificates),
         Util.immutableList(localCertificates));
   }

--- a/okhttp/src/main/java/okhttp3/Headers.java
+++ b/okhttp/src/main/java/okhttp3/Headers.java
@@ -148,7 +148,8 @@ public final class Headers {
    * arguments, and they must alternate between header names and values.
    */
   public static Headers of(String... namesAndValues) {
-    if (namesAndValues == null || namesAndValues.length % 2 != 0) {
+    if (namesAndValues == null ) throw new NullPointerException("namesAndValues == null");
+    if (namesAndValues.length % 2 != 0) {
       throw new IllegalArgumentException("Expected alternating header names and values");
     }
 
@@ -175,9 +176,7 @@ public final class Headers {
    * Returns headers for the header names and values in the {@link Map}.
    */
   public static Headers of(Map<String, String> headers) {
-    if (headers == null) {
-      throw new IllegalArgumentException("Expected map with header names and values");
-    }
+    if (headers == null) throw new NullPointerException("headers == null");
 
     // Make a defensive copy and clean it up.
     String[] namesAndValues = new String[headers.size() * 2];
@@ -267,7 +266,7 @@ public final class Headers {
     }
 
     private void checkNameAndValue(String name, String value) {
-      if (name == null) throw new IllegalArgumentException("name == null");
+      if (name == null) throw new NullPointerException("name == null");
       if (name.isEmpty()) throw new IllegalArgumentException("name is empty");
       for (int i = 0, length = name.length(); i < length; i++) {
         char c = name.charAt(i);
@@ -276,7 +275,7 @@ public final class Headers {
               "Unexpected char %#04x at %d in header name: %s", (int) c, i, name));
         }
       }
-      if (value == null) throw new IllegalArgumentException("value == null");
+      if (value == null) throw new NullPointerException("value == null");
       for (int i = 0, length = value.length(); i < length; i++) {
         char c = value.charAt(i);
         if (c <= '\u001f' || c >= '\u007f') {

--- a/okhttp/src/main/java/okhttp3/Headers.java
+++ b/okhttp/src/main/java/okhttp3/Headers.java
@@ -148,7 +148,7 @@ public final class Headers {
    * arguments, and they must alternate between header names and values.
    */
   public static Headers of(String... namesAndValues) {
-    if (namesAndValues == null ) throw new NullPointerException("namesAndValues == null");
+    if (namesAndValues == null) throw new NullPointerException("namesAndValues == null");
     if (namesAndValues.length % 2 != 0) {
       throw new IllegalArgumentException("Expected alternating header names and values");
     }

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -707,7 +707,7 @@ public final class HttpUrl {
 
     public Builder scheme(String scheme) {
       if (scheme == null) {
-        throw new IllegalArgumentException("scheme == null");
+        throw new NullPointerException("scheme == null");
       } else if (scheme.equalsIgnoreCase("http")) {
         this.scheme = "http";
       } else if (scheme.equalsIgnoreCase("https")) {
@@ -719,26 +719,26 @@ public final class HttpUrl {
     }
 
     public Builder username(String username) {
-      if (username == null) throw new IllegalArgumentException("username == null");
+      if (username == null) throw new NullPointerException("username == null");
       this.encodedUsername = canonicalize(username, USERNAME_ENCODE_SET, false, false, false, true);
       return this;
     }
 
     public Builder encodedUsername(String encodedUsername) {
-      if (encodedUsername == null) throw new IllegalArgumentException("encodedUsername == null");
+      if (encodedUsername == null) throw new NullPointerException("encodedUsername == null");
       this.encodedUsername = canonicalize(
           encodedUsername, USERNAME_ENCODE_SET, true, false, false, true);
       return this;
     }
 
     public Builder password(String password) {
-      if (password == null) throw new IllegalArgumentException("password == null");
+      if (password == null) throw new NullPointerException("password == null");
       this.encodedPassword = canonicalize(password, PASSWORD_ENCODE_SET, false, false, false, true);
       return this;
     }
 
     public Builder encodedPassword(String encodedPassword) {
-      if (encodedPassword == null) throw new IllegalArgumentException("encodedPassword == null");
+      if (encodedPassword == null) throw new NullPointerException("encodedPassword == null");
       this.encodedPassword = canonicalize(
           encodedPassword, PASSWORD_ENCODE_SET, true, false, false, true);
       return this;
@@ -749,7 +749,7 @@ public final class HttpUrl {
      * address.
      */
     public Builder host(String host) {
-      if (host == null) throw new IllegalArgumentException("host == null");
+      if (host == null) throw new NullPointerException("host == null");
       String encoded = canonicalizeHost(host, 0, host.length());
       if (encoded == null) throw new IllegalArgumentException("unexpected host: " + host);
       this.host = encoded;
@@ -767,7 +767,7 @@ public final class HttpUrl {
     }
 
     public Builder addPathSegment(String pathSegment) {
-      if (pathSegment == null) throw new IllegalArgumentException("pathSegment == null");
+      if (pathSegment == null) throw new NullPointerException("pathSegment == null");
       push(pathSegment, 0, pathSegment.length(), false, false);
       return this;
     }
@@ -777,13 +777,13 @@ public final class HttpUrl {
      * {@code pathSegments} starts with a slash, the resulting URL will have empty path segment.
      */
     public Builder addPathSegments(String pathSegments) {
-      if (pathSegments == null) throw new IllegalArgumentException("pathSegments == null");
+      if (pathSegments == null) throw new NullPointerException("pathSegments == null");
       return addPathSegments(pathSegments, false);
     }
 
     public Builder addEncodedPathSegment(String encodedPathSegment) {
       if (encodedPathSegment == null) {
-        throw new IllegalArgumentException("encodedPathSegment == null");
+        throw new NullPointerException("encodedPathSegment == null");
       }
       push(encodedPathSegment, 0, encodedPathSegment.length(), false, true);
       return this;
@@ -796,7 +796,7 @@ public final class HttpUrl {
      */
     public Builder addEncodedPathSegments(String encodedPathSegments) {
       if (encodedPathSegments == null) {
-        throw new IllegalArgumentException("encodedPathSegments == null");
+        throw new NullPointerException("encodedPathSegments == null");
       }
       return addPathSegments(encodedPathSegments, true);
     }
@@ -813,7 +813,7 @@ public final class HttpUrl {
     }
 
     public Builder setPathSegment(int index, String pathSegment) {
-      if (pathSegment == null) throw new IllegalArgumentException("pathSegment == null");
+      if (pathSegment == null) throw new NullPointerException("pathSegment == null");
       String canonicalPathSegment = canonicalize(
           pathSegment, 0, pathSegment.length(), PATH_SEGMENT_ENCODE_SET, false, false, false, true);
       if (isDot(canonicalPathSegment) || isDotDot(canonicalPathSegment)) {
@@ -825,7 +825,7 @@ public final class HttpUrl {
 
     public Builder setEncodedPathSegment(int index, String encodedPathSegment) {
       if (encodedPathSegment == null) {
-        throw new IllegalArgumentException("encodedPathSegment == null");
+        throw new NullPointerException("encodedPathSegment == null");
       }
       String canonicalPathSegment = canonicalize(encodedPathSegment,
           0, encodedPathSegment.length(), PATH_SEGMENT_ENCODE_SET, true, false, false, true);
@@ -845,7 +845,7 @@ public final class HttpUrl {
     }
 
     public Builder encodedPath(String encodedPath) {
-      if (encodedPath == null) throw new IllegalArgumentException("encodedPath == null");
+      if (encodedPath == null) throw new NullPointerException("encodedPath == null");
       if (!encodedPath.startsWith("/")) {
         throw new IllegalArgumentException("unexpected encodedPath: " + encodedPath);
       }
@@ -871,7 +871,7 @@ public final class HttpUrl {
 
     /** Encodes the query parameter using UTF-8 and adds it to this URL's query string. */
     public Builder addQueryParameter(String name, String value) {
-      if (name == null) throw new IllegalArgumentException("name == null");
+      if (name == null) throw new NullPointerException("name == null");
       if (encodedQueryNamesAndValues == null) encodedQueryNamesAndValues = new ArrayList<>();
       encodedQueryNamesAndValues.add(
           canonicalize(name, QUERY_COMPONENT_ENCODE_SET, false, false, true, true));
@@ -883,7 +883,7 @@ public final class HttpUrl {
 
     /** Adds the pre-encoded query parameter to this URL's query string. */
     public Builder addEncodedQueryParameter(String encodedName, String encodedValue) {
-      if (encodedName == null) throw new IllegalArgumentException("encodedName == null");
+      if (encodedName == null) throw new NullPointerException("encodedName == null");
       if (encodedQueryNamesAndValues == null) encodedQueryNamesAndValues = new ArrayList<>();
       encodedQueryNamesAndValues.add(
           canonicalize(encodedName, QUERY_COMPONENT_ENCODE_SET, true, false, true, true));
@@ -906,7 +906,7 @@ public final class HttpUrl {
     }
 
     public Builder removeAllQueryParameters(String name) {
-      if (name == null) throw new IllegalArgumentException("name == null");
+      if (name == null) throw new NullPointerException("name == null");
       if (encodedQueryNamesAndValues == null) return this;
       String nameToRemove = canonicalize(
           name, QUERY_COMPONENT_ENCODE_SET, false, false, true, true);
@@ -915,7 +915,7 @@ public final class HttpUrl {
     }
 
     public Builder removeAllEncodedQueryParameters(String encodedName) {
-      if (encodedName == null) throw new IllegalArgumentException("encodedName == null");
+      if (encodedName == null) throw new NullPointerException("encodedName == null");
       if (encodedQueryNamesAndValues == null) return this;
       removeAllCanonicalQueryParameters(
           canonicalize(encodedName, QUERY_COMPONENT_ENCODE_SET, true, false, true, true));

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -410,7 +410,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
      */
     public Builder connectTimeout(long timeout, TimeUnit unit) {
       if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
-      if (unit == null) throw new IllegalArgumentException("unit == null");
+      if (unit == null) throw new NullPointerException("unit == null");
       long millis = unit.toMillis(timeout);
       if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
       if (millis == 0 && timeout > 0) throw new IllegalArgumentException("Timeout too small.");
@@ -424,7 +424,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
      */
     public Builder readTimeout(long timeout, TimeUnit unit) {
       if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
-      if (unit == null) throw new IllegalArgumentException("unit == null");
+      if (unit == null) throw new NullPointerException("unit == null");
       long millis = unit.toMillis(timeout);
       if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
       if (millis == 0 && timeout > 0) throw new IllegalArgumentException("Timeout too small.");
@@ -438,7 +438,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
      */
     public Builder writeTimeout(long timeout, TimeUnit unit) {
       if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
-      if (unit == null) throw new IllegalArgumentException("unit == null");
+      if (unit == null) throw new NullPointerException("unit == null");
       long millis = unit.toMillis(timeout);
       if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
       if (millis == 0 && timeout > 0) throw new IllegalArgumentException("Timeout too small.");

--- a/okhttp/src/main/java/okhttp3/Request.java
+++ b/okhttp/src/main/java/okhttp3/Request.java
@@ -235,7 +235,7 @@ public final class Request {
         throw new IllegalArgumentException("method " + method + " must not have a request body.");
       }
       if (body == null && HttpMethod.requiresRequestBody(method)) {
-        throw new NullPointerException("method " + method + " must have a request body.");
+        throw new IllegalArgumentException("method " + method + " must have a request body.");
       }
       this.method = method;
       this.body = body;

--- a/okhttp/src/main/java/okhttp3/Request.java
+++ b/okhttp/src/main/java/okhttp3/Request.java
@@ -118,7 +118,7 @@ public final class Request {
     }
 
     public Builder url(HttpUrl url) {
-      if (url == null) throw new IllegalArgumentException("url == null");
+      if (url == null) throw new NullPointerException("url == null");
       this.url = url;
       return this;
     }
@@ -130,7 +130,7 @@ public final class Request {
      * exception by calling {@link HttpUrl#parse}; it returns null for invalid URLs.
      */
     public Builder url(String url) {
-      if (url == null) throw new IllegalArgumentException("url == null");
+      if (url == null) throw new NullPointerException("url == null");
 
       // Silently replace websocket URLs with HTTP URLs.
       if (url.regionMatches(true, 0, "ws:", 0, 3)) {
@@ -151,7 +151,7 @@ public final class Request {
      * https}.
      */
     public Builder url(URL url) {
-      if (url == null) throw new IllegalArgumentException("url == null");
+      if (url == null) throw new NullPointerException("url == null");
       HttpUrl parsed = HttpUrl.get(url);
       if (parsed == null) throw new IllegalArgumentException("unexpected url: " + url);
       return url(parsed);
@@ -229,14 +229,13 @@ public final class Request {
     }
 
     public Builder method(String method, RequestBody body) {
-      if (method == null || method.length() == 0) {
-        throw new IllegalArgumentException("method == null || method.length() == 0");
-      }
+      if (method == null) throw new NullPointerException("method == null");
+      if (method.length() == 0) throw new IllegalArgumentException("method.length() == 0");
       if (body != null && !HttpMethod.permitsRequestBody(method)) {
         throw new IllegalArgumentException("method " + method + " must not have a request body.");
       }
       if (body == null && HttpMethod.requiresRequestBody(method)) {
-        throw new IllegalArgumentException("method " + method + " must have a request body.");
+        throw new NullPointerException("method " + method + " must have a request body.");
       }
       this.method = method;
       this.body = body;


### PR DESCRIPTION
I replaced IAEs with NPEs for null parameter where a null value is prohibited, and updated existing tests.

There are a couple situations where `IllegalArgumentException` is thrown when a value inside a non-null collection parameter is null. For example, `Headers.of(Map<String, String> headers)` (line 186 in `Headers`) checks for null keys and/or values and throws an IAE. I left this as is, specifically because Effective Java tells us to use NPE when a "parameter value is null where prohibited" and use IAE when "non-null parameter value is inappropriate." Since the `Map` parameter itself is non-null and it's value (it's keys and values) is inappropriate, I think this should be kept as an IAE. I used the same reasoning for `Headers.of(String... namesAndValues)`.

Another tricky situation is in `Request.Builder.method(String method, RequestBody body)`, where we had the following check:

```
if (body == null && HttpMethod.requiresRequestBody(method)) {
  throw new IllegalArgumentException("method " + method + " must have a request body.");
}
```

If we stay true to the "[throw NPE] when a parameter value is null where prohibited" rule, then this should be changed to NPE, which I did change.