### PR TITLE
Gracefully recover from a failure to rebuild the DiskLruCache journal.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/FaultyFileSystem.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/FaultyFileSystem.java
@@ -30,6 +30,7 @@ public final class FaultyFileSystem implements FileSystem {
   private final FileSystem delegate;
   private final Set<File> writeFaults = new LinkedHashSet<>();
   private final Set<File> deleteFaults = new LinkedHashSet<>();
+  private final Set<File> renameFaults = new LinkedHashSet<>();
 
   public FaultyFileSystem(FileSystem delegate) {
     this.delegate = delegate;
@@ -48,6 +49,14 @@ public final class FaultyFileSystem implements FileSystem {
       deleteFaults.add(file);
     } else {
       deleteFaults.remove(file);
+    }
+  }
+
+  public void setFaultyRename(File file, boolean faulty) {
+    if (faulty) {
+      renameFaults.add(file);
+    } else {
+      renameFaults.remove(file);
     }
   }
 
@@ -77,6 +86,7 @@ public final class FaultyFileSystem implements FileSystem {
   }
 
   @Override public void rename(File from, File to) throws IOException {
+    if (renameFaults.contains(from) || renameFaults.contains(to)) throw new IOException("boom!");
     delegate.rename(from, to);
   }
 


### PR DESCRIPTION
I think I have something functional, but it's dependent on the answer to this question: if the rebuild fails, should we attempt to re-open the journal writer?

For now I said 'no' and treated the rebuild action as an atomic operation. That means writes are not allowed so we don't leak files. Reads are allowed and same with removals. If an entry is removed while in this state, and the cache is then closed, on a subsequent open the metadata will be inaccurate. To cope with this, an entry will be removed if we discover it's cache files are missing.