### PR TITLE
PROPFIND redirects should maintain request body

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -1503,17 +1503,21 @@ public final class CallTest {
     assertEquals("Hello", request2.getBody().readUtf8());
   }
 
-  @Test public void propfindRedirectsToPropfind() throws Exception {
+  @Test public void propfindRedirectsToPropfindAndMaintainsRequestBody() throws Exception {
+    // given
     server.enqueue(new MockResponse()
         .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
         .addHeader("Location: /page2")
         .setBody("This page has moved!"));
     server.enqueue(new MockResponse().setBody("Page 2"));
 
+    // when
     Response response = client.newCall(new Request.Builder()
         .url(server.url("/page1"))
         .method("PROPFIND", RequestBody.create(MediaType.parse("text/plain"), "Request Body"))
         .build()).execute();
+
+    // then
     assertEquals("Page 2", response.body().string());
 
     RecordedRequest page1 = server.takeRequest();
@@ -1522,6 +1526,7 @@ public final class CallTest {
 
     RecordedRequest page2 = server.takeRequest();
     assertEquals("PROPFIND /page2 HTTP/1.1", page2.getRequestLine());
+    assertEquals("Request Body", page2.getBody().readUtf8());
   }
 
   @Test public void responseCookies() throws Exception {

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpMethod.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpMethod.java
@@ -41,6 +41,10 @@ public final class HttpMethod {
         || method.equals("LOCK");     // (WebDAV) body: create lock, without body: refresh lock
   }
 
+  public static boolean redirectsWithBody(String method) {
+    return method.equals("PROPFIND"); // (WebDAV) redirects should also maintain the request body
+  }
+
   public static boolean redirectsToGet(String method) {
     // All requests but PROPFIND should redirect to a GET request.
     return !method.equals("PROPFIND");


### PR DESCRIPTION
the fact that all redirects strip the request body is somewhat unusual.
In WEBDAV the body contains restrictions such as the depth of how much
data you want to receive. Stripping this off will produce an unlimited
request with unlimited depth (where the initial request had depth 1).

* havent checked other WEBDAV methods though whether they require similar
  treatment.