### PR TITLE
Add ability to specify X509TrustManager via builder

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -181,7 +181,9 @@ public class OkHttpClient implements Cloneable, Call.Factory {
       }
     }
     if (sslSocketFactory != null && builder.trustRootIndex == null) {
-      X509TrustManager trustManager = Platform.get().trustManager(sslSocketFactory);
+      X509TrustManager trustManager = builder.x509TrustManager == null
+          ? Platform.get().trustManager(sslSocketFactory)
+          : builder.x509TrustManager;
       if (trustManager == null) {
         throw new IllegalStateException("Unable to extract the trust manager on " + Platform.get()
             + ", sslSocketFactory is " + sslSocketFactory.getClass());
@@ -353,6 +355,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
     int connectTimeout;
     int readTimeout;
     int writeTimeout;
+    X509TrustManager x509TrustManager;
 
     public Builder() {
       dispatcher = new Dispatcher();
@@ -711,6 +714,11 @@ public class OkHttpClient implements Cloneable, Call.Factory {
 
     public Builder addNetworkInterceptor(Interceptor interceptor) {
       networkInterceptors.add(interceptor);
+      return this;
+    }
+
+    public Builder x509TrustManager(X509TrustManager x509TrustManager) {
+      this.x509TrustManager = x509TrustManager;
       return this;
     }
 


### PR DESCRIPTION
Addresses #2323.

This is WIP and so on. Initially I though that interface will be needed, but since trust manager required at `OkHttpClient` creation time, we can accept it right in the builder.

Also, allows user to save some reflection calls if they have direct reference to the trust manager.

Probably this is totally not the direction you would like to go, so feel free to close.

---
BTW, maybe better to allow user pass `Platform` implementation? This will open so many possibilities to support any kind of environment without modifying the library.