### PR TITLE
Fix a regression in authenticating HTTP proxies.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -1596,15 +1596,16 @@ public final class URLConnectionTest {
         .setBody("Please authenticate.");
     server.enqueue(pleaseAuthenticate);
 
-    urlFactory.setClient(urlFactory.client().newBuilder()
-        .authenticator(new JavaNetAuthenticator())
-        .build());
     if (proxy) {
       urlFactory.setClient(urlFactory.client().newBuilder()
           .proxy(server.toProxyAddress())
+          .proxyAuthenticator(new JavaNetAuthenticator())
           .build());
-      connection = urlFactory.open(new URL("http://android.com"));
+      connection = urlFactory.open(new URL("http://android.com/"));
     } else {
+      urlFactory.setClient(urlFactory.client().newBuilder()
+          .authenticator(new JavaNetAuthenticator())
+          .build());
       connection = urlFactory.open(server.url("/").url());
     }
     assertEquals(responseCode, connection.getResponseCode());

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -891,7 +891,8 @@ public final class HttpEngine {
         if (selectedProxy.type() != Proxy.Type.HTTP) {
           throw new ProtocolException("Received HTTP_PROXY_AUTH (407) code while not using proxy");
         }
-        // fall-through
+        return client.proxyAuthenticator().authenticate(route, userResponse);
+
       case HTTP_UNAUTHORIZED:
         return client.authenticator().authenticate(route, userResponse);
 


### PR DESCRIPTION
We were using the regular authenticator, not the proxy authenticator.

Closes: https://github.com/square/okhttp/issues/2414