### PR TITLE
preemptive authentication

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/RecordingOkAuthenticator.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/RecordingOkAuthenticator.java
@@ -51,4 +51,16 @@ public final class RecordingOkAuthenticator implements Authenticator {
         .addHeader(header, credential)
         .build();
   }
+
+  @Override
+  public Request authenticate(Route route, Request request) throws IOException {
+	// TODO Auto-generated method stub
+	return null;
+  }
+
+  @Override
+  public boolean isPreemptive() {
+	// TODO Auto-generated method stub
+	return false;
+  }
 }

--- a/okhttp-tests/src/test/java/okhttp3/internal/RecordingOkAuthenticator.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/RecordingOkAuthenticator.java
@@ -53,7 +53,7 @@ public final class RecordingOkAuthenticator implements Authenticator {
   }
 
   @Override
-  public Request authenticate(Route route, Request request) throws IOException {
+  public Request authenticatePreemptive(Route route, Request request) throws IOException {
 	// TODO Auto-generated method stub
 	return null;
   }

--- a/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
@@ -69,4 +69,16 @@ public final class JavaNetAuthenticator implements Authenticator {
         ? ((InetSocketAddress) proxy.address()).getAddress()
         : InetAddress.getByName(url.host());
   }
+
+  @Override
+  public Request authenticate(Route route, Request request) throws IOException {
+	// TODO Auto-generated method stub
+	return null;
+  }
+
+  @Override
+  public boolean isPreemptive() {
+	// TODO Auto-generated method stub
+	return false;
+  }
 }

--- a/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
@@ -71,7 +71,7 @@ public final class JavaNetAuthenticator implements Authenticator {
   }
 
   @Override
-  public Request authenticate(Route route, Request request) throws IOException {
+  public Request authenticatePreemptive(Route route, Request request) throws IOException {
 	// TODO Auto-generated method stub
 	return null;
   }

--- a/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
@@ -72,13 +72,11 @@ public final class JavaNetAuthenticator implements Authenticator {
 
   @Override
   public Request authenticatePreemptive(Route route, Request request) throws IOException {
-	// TODO Auto-generated method stub
-	return null;
+    return null;
   }
 
   @Override
   public boolean isPreemptive() {
-	// TODO Auto-generated method stub
-	return false;
+    return false;
   }
 }

--- a/okhttp/src/main/java/okhttp3/Authenticator.java
+++ b/okhttp/src/main/java/okhttp3/Authenticator.java
@@ -52,6 +52,16 @@ public interface Authenticator {
     @Override public Request authenticate(Route route, Response response) {
       return null;
     }
+
+	@Override
+	public Request authenticate(Route route, Request request) throws IOException {
+		return null;
+	}
+
+	@Override
+	public boolean isPreemptive() {
+		return false;
+	}
   };
 
   /**
@@ -59,4 +69,8 @@ public interface Authenticator {
    * response}. Returns null if the challenge cannot be satisfied.
    */
   Request authenticate(Route route, Response response) throws IOException;
+  
+  Request authenticate(Route route, Request request) throws IOException;
+  
+  boolean isPreemptive();  
 }

--- a/okhttp/src/main/java/okhttp3/Authenticator.java
+++ b/okhttp/src/main/java/okhttp3/Authenticator.java
@@ -54,7 +54,7 @@ public interface Authenticator {
     }
 
 	@Override
-	public Request authenticate(Route route, Request request) throws IOException {
+	public Request authenticatePreemptive(Route route, Request request) throws IOException {
 		return null;
 	}
 
@@ -70,7 +70,15 @@ public interface Authenticator {
    */
   Request authenticate(Route route, Response response) throws IOException;
   
-  Request authenticate(Route route, Request request) throws IOException;
+  /**
+   * Return a request that is a copy of the original request plus authentication header.
+   * isPreemptive method must return true.
+   * 
+   */
+  Request authenticatePreemptive(Route route, Request request) throws IOException;
   
+  /**
+   *  If preemptive authentication is needed, implement this return true.
+   */
   boolean isPreemptive();  
 }

--- a/okhttp/src/main/java/okhttp3/Authenticator.java
+++ b/okhttp/src/main/java/okhttp3/Authenticator.java
@@ -69,16 +69,16 @@ public interface Authenticator {
    * response}. Returns null if the challenge cannot be satisfied.
    */
   Request authenticate(Route route, Response response) throws IOException;
-  
+
   /**
    * Return a request that is a copy of the original request plus authentication header.
    * isPreemptive method must return true.
-   * 
+   *
    */
   Request authenticatePreemptive(Route route, Request request) throws IOException;
-  
+
   /**
    *  If preemptive authentication is needed, implement this return true.
    */
-  boolean isPreemptive();  
+  boolean isPreemptive();
 }

--- a/okhttp/src/main/java/okhttp3/Authenticator.java
+++ b/okhttp/src/main/java/okhttp3/Authenticator.java
@@ -53,15 +53,15 @@ public interface Authenticator {
       return null;
     }
 
-	@Override
-	public Request authenticatePreemptive(Route route, Request request) throws IOException {
-		return null;
-	}
+    @Override
+    public Request authenticatePreemptive(Route route, Request request) throws IOException {
+      return null;
+    }
 
-	@Override
-	public boolean isPreemptive() {
-		return false;
-	}
+    @Override
+    public boolean isPreemptive() {
+	  return false;
+    }
   };
 
   /**

--- a/okhttp/src/main/java/okhttp3/Authenticator.java
+++ b/okhttp/src/main/java/okhttp3/Authenticator.java
@@ -60,7 +60,7 @@ public interface Authenticator {
 
     @Override
     public boolean isPreemptive() {
-	  return false;
+      return false;
     }
   };
 

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -506,7 +506,7 @@ public final class HttpEngine {
         request = client.proxyAuthenticator().authenticatePreemptive(null, request);
       }
     }
-  
+
     Request.Builder result = request.newBuilder();
 
     if (request.header("Host") == null) {

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 import okhttp3.Address;
+import okhttp3.Authenticator;
 import okhttp3.CertificatePinner;
 import okhttp3.Connection;
 import okhttp3.Cookie;
@@ -499,13 +500,12 @@ public final class HttpEngine {
    * content types the application is interested in.
    */
   private Request networkRequest(Request request) throws IOException {
-    if (!request.isHttps())
-    {
-      if (client.proxyAuthenticator() != null && client.proxyAuthenticator().isPreemptive())
-      {
+    if (!request.isHttps()) {
+      Authenticator authenticator = client.proxyAuthenticator(); 
+      if (authenticator != null && authenticator.isPreemptive()) {
         request = client.proxyAuthenticator().authenticatePreemptive(null, request);
       }
-    }	  
+    }
 	  
     Request.Builder result = request.newBuilder();
 

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -499,6 +499,14 @@ public final class HttpEngine {
    * content types the application is interested in.
    */
   private Request networkRequest(Request request) throws IOException {
+    if (!request.isHttps())
+    {
+      if (client.proxyAuthenticator() != null && client.proxyAuthenticator().isPreemptive())
+      {
+        request = client.proxyAuthenticator().authenticate(null, request);
+      }
+    }	  
+	  
     Request.Builder result = request.newBuilder();
 
     if (request.header("Host") == null) {

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -501,12 +501,12 @@ public final class HttpEngine {
    */
   private Request networkRequest(Request request) throws IOException {
     if (!request.isHttps()) {
-      Authenticator authenticator = client.proxyAuthenticator(); 
+      Authenticator authenticator = client.proxyAuthenticator();
       if (authenticator != null && authenticator.isPreemptive()) {
         request = client.proxyAuthenticator().authenticatePreemptive(null, request);
       }
     }
-	  
+  
     Request.Builder result = request.newBuilder();
 
     if (request.header("Host") == null) {

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -503,7 +503,7 @@ public final class HttpEngine {
     {
       if (client.proxyAuthenticator() != null && client.proxyAuthenticator().isPreemptive())
       {
-        request = client.proxyAuthenticator().authenticate(null, request);
+        request = client.proxyAuthenticator().authenticatePreemptive(null, request);
       }
     }	  
 	  

--- a/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
@@ -242,11 +242,11 @@ public final class RealConnection extends FramedConnection.Listener implements C
     // Make an SSL Tunnel on the first message pair of each SSL + proxy connection.
     Request tunnelRequest = createTunnelRequest();
 
-    Authenticator authenticator = route.address().proxyAuthenticator(); 
+    Authenticator authenticator = route.address().proxyAuthenticator();
     if (authenticator != null && authenticator.isPreemptive()) {
       tunnelRequest = authenticator.authenticatePreemptive(route, tunnelRequest);
     }
-    
+
     HttpUrl url = tunnelRequest.url();
     String requestLine = "CONNECT " + Util.hostHeader(url, true) + " HTTP/1.1";
     while (true) {

--- a/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
@@ -243,7 +243,7 @@ public final class RealConnection extends FramedConnection.Listener implements C
     
     if (route.address().proxyAuthenticator() != null && route.address().proxyAuthenticator().isPreemptive())
     {
-      tunnelRequest = route.address().proxyAuthenticator().authenticate(route, tunnelRequest);
+      tunnelRequest = route.address().proxyAuthenticator().authenticatePreemptive(route, tunnelRequest);
     }
     
     HttpUrl url = tunnelRequest.url();

--- a/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
@@ -240,6 +240,12 @@ public final class RealConnection extends FramedConnection.Listener implements C
   private void createTunnel(int readTimeout, int writeTimeout) throws IOException {
     // Make an SSL Tunnel on the first message pair of each SSL + proxy connection.
     Request tunnelRequest = createTunnelRequest();
+    
+    if (route.address().proxyAuthenticator() != null && route.address().proxyAuthenticator().isPreemptive())
+    {
+      tunnelRequest = route.address().proxyAuthenticator().authenticate(route, tunnelRequest);
+    }
+    
     HttpUrl url = tunnelRequest.url();
     String requestLine = "CONNECT " + Util.hostHeader(url, true) + " HTTP/1.1";
     while (true) {

--- a/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
@@ -31,6 +31,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import okhttp3.Address;
+import okhttp3.Authenticator;
 import okhttp3.CertificatePinner;
 import okhttp3.Connection;
 import okhttp3.ConnectionSpec;
@@ -240,10 +241,10 @@ public final class RealConnection extends FramedConnection.Listener implements C
   private void createTunnel(int readTimeout, int writeTimeout) throws IOException {
     // Make an SSL Tunnel on the first message pair of each SSL + proxy connection.
     Request tunnelRequest = createTunnelRequest();
-    
-    if (route.address().proxyAuthenticator() != null && route.address().proxyAuthenticator().isPreemptive())
-    {
-      tunnelRequest = route.address().proxyAuthenticator().authenticatePreemptive(route, tunnelRequest);
+
+    Authenticator authenticator = route.address().proxyAuthenticator(); 
+    if (authenticator != null && authenticator.isPreemptive()) {
+      tunnelRequest = authenticator.authenticatePreemptive(route, tunnelRequest);
     }
     
     HttpUrl url = tunnelRequest.url();

--- a/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
@@ -38,17 +38,15 @@ public final class Authenticate {
                 .build();
           }
 
-		  @Override
-		  public Request authenticatePreemptive(Route route, Request request) throws IOException {
-			// TODO Auto-generated method stub
-			return null;
-		  }
+          @Override
+          public Request authenticatePreemptive(Route route, Request request) throws IOException {
+            return null;
+          }
 
-		  @Override
-		  public boolean isPreemptive() {
-			// TODO Auto-generated method stub
-			return false;
-		  }
+          @Override
+          public boolean isPreemptive() {
+            return false;
+          }
         })
         .build();
   }

--- a/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
@@ -39,7 +39,7 @@ public final class Authenticate {
           }
 
 		  @Override
-		  public Request authenticate(Route route, Request request) throws IOException {
+		  public Request authenticatePreemptive(Route route, Request request) throws IOException {
 			// TODO Auto-generated method stub
 			return null;
 		  }

--- a/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
@@ -37,6 +37,18 @@ public final class Authenticate {
                 .header("Authorization", credential)
                 .build();
           }
+
+		  @Override
+		  public Request authenticate(Route route, Request request) throws IOException {
+			// TODO Auto-generated method stub
+			return null;
+		  }
+
+		  @Override
+		  public boolean isPreemptive() {
+			// TODO Auto-generated method stub
+			return false;
+		  }
         })
         .build();
   }


### PR DESCRIPTION
Added preemptive authentication methods to the Authenticator interface.

https://github.com/square/okhttp/issues/2435
https://github.com/square/okhttp/issues/2453

Called them in the RealConnection.createTunnel method for the https requests, and HttpEngine.networkRequest for the http requests.

Now my Authenticator looks like this:

`    Authenticator proxyAuthenticator = new Authenticator() {
      public Request authenticate(Route route, Response response) throws IOException {
         // no longer need to implement, as I will not receive a 407 any more
         return null;
      }

      @Override
      public Request authenticatePreemptive(Route route, Request request)
          throws IOException
      {
        String credential = Credentials.basic(user, password);
        return request.newBuilder()
            .header("Proxy-Authorization", credential)
            .build();
      }
      
      @Override
      public boolean isPreemptive()
      {
        return true;
      }
    };`

This works for me. No need for two requests any more, one with 407 response and one with authenticate header.

By the way, even without my preemptive mechanism, if the user/password is wrong, I get 

Exception in thread "main" java.net.ProtocolException: Too many follow-up requests: 21

The exception is not so friendly, maybe you can improve this.