### PR TITLE
Accommodate tunneling proxies that close the connection after an auth challenge.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -24,6 +24,7 @@ import java.net.HttpCookie;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.ProtocolException;
 import java.net.Proxy;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
@@ -2229,7 +2230,6 @@ public final class CallTest {
    * OkHttp has a bug where a `Connection: close` response header is not honored when establishing
    * a TLS tunnel. https://github.com/square/okhttp/issues/2426
    */
-  @Ignore("currently broken")
   @Test public void proxyAuthenticateOnConnectWithConnectionClose() throws Exception {
     server.useHttps(sslContext.getSocketFactory(), true);
     server.setProtocols(Collections.singletonList(Protocol.HTTP_1_1));
@@ -2264,6 +2264,33 @@ public final class CallTest {
 
     // GET reuses the connection from the second connect.
     assertEquals(1, server.takeRequest().getSequenceNumber());
+  }
+
+  @Test public void tooManyProxyAuthFailuresWithConnectionClose() throws IOException {
+    server.useHttps(sslContext.getSocketFactory(), true);
+    server.setProtocols(Collections.singletonList(Protocol.HTTP_1_1));
+    for (int i = 0; i < 21; i++) {
+      server.enqueue(new MockResponse()
+          .setResponseCode(407)
+          .addHeader("Proxy-Authenticate: Basic realm=\"localhost\"")
+          .addHeader("Connection: close"));
+    }
+
+    client = client.newBuilder()
+        .sslSocketFactory(sslContext.getSocketFactory())
+        .proxy(server.toProxyAddress())
+        .proxyAuthenticator(new RecordingOkAuthenticator("password"))
+        .hostnameVerifier(new RecordingHostnameVerifier())
+        .build();
+
+    Request request = new Request.Builder()
+        .url("https://android.com/foo")
+        .build();
+    try {
+      client.newCall(request).execute();
+      fail();
+    } catch (ProtocolException expected) {
+    }
   }
 
   /**


### PR DESCRIPTION
A fix for #2426. This was mainly a rejiggering of the existing connection code.