### PR TITLE
Bundle for okcurl and local launcher

### DIFF
--- a/okcurl/README.md
+++ b/okcurl/README.md
@@ -5,3 +5,28 @@ _A curl for the next-generation web._
 
 OkCurl is an OkHttp-backed curl clone which allows you to test OkHttp's HTTP engine (including
 SPDY and HTTP/2) against web servers.
+
+    $ ./okcurl/okcurl --frames https://graph.facebook.com/robots.txt
+    << 0x00000000    30 SETTINGS      
+    >> 0x00000000     0 SETTINGS      ACK
+    << 0x00000000     4 WINDOW_UPDATE 
+    >> CONNECTION 505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
+    >> 0x00000000     6 SETTINGS      
+    >> 0x00000000     4 WINDOW_UPDATE 
+    >> 0x00000003    76 HEADERS       END_STREAM|END_HEADERS
+    << 0x00000000    34 GOAWAY        
+    >> CONNECTION 505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
+    >> 0x00000000     6 SETTINGS      
+    >> 0x00000000     4 WINDOW_UPDATE 
+    >> 0x00000003    76 HEADERS       END_STREAM|END_HEADERS
+    << 0x00000000    30 SETTINGS      
+    >> 0x00000000     0 SETTINGS      ACK
+    << 0x00000000     4 WINDOW_UPDATE 
+    << 0x00000000     0 SETTINGS      ACK
+    << 0x00000003     4 WINDOW_UPDATE 
+    << 0x00000003   173 HEADERS       END_HEADERS
+    << 0x00000003    26 DATA          END_STREAM
+    User-agent: *
+    Disallow: /
+    >> 0x00000000     8 GOAWAY        
+    

--- a/okcurl/okcurl
+++ b/okcurl/okcurl
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+codesha() {
+  find ./*/pom.xml ./*/src -type f | sort | xargs shasum | shasum | cut -f 1 -d ' '
+}
+
+SHA=$(codesha)
+
+if [ ! -f "./okcurl/target/cached-$SHA.jar" ]; then
+  mvn -pl okcurl -am -DskipTests clean package dependency:copy-dependencies
+  mv ./okcurl/target/okcurl-*SNAPSHOT.jar "./okcurl/target/cached-$SHA.jar"
+fi
+
+JAVA_CMD=java
+BCP=
+
+if [ -x /usr/libexec/java_home ]; then
+  JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
+
+  if [ $? -eq 0 ]; then
+    JAVA_CMD="$JAVA_HOME/bin/java"
+    ALPN=$(ls ./okcurl/target/alpn/alpn-boot-*.jar)
+    BCP="-Xbootclasspath/p:$ALPN"
+  fi
+fi
+
+MAIN_JAR=$(ls "./okcurl/target/cached-$SHA.jar")
+$JAVA_CMD "$BCP" -classpath "$MAIN_JAR:okcurl/target/dependency/*" okhttp3.curl.Main "$@"
+

--- a/okcurl/okcurl
+++ b/okcurl/okcurl
@@ -2,6 +2,9 @@
 
 set -e
 
+# Rebuild only if something that could change the behaviour has changed
+# otherwise reuse the jar we built last time
+
 codesha() {
   find ./*/pom.xml ./*/src -type f | sort | xargs shasum | shasum | cut -f 1 -d ' '
 }
@@ -15,6 +18,9 @@ fi
 
 JAVA_CMD=java
 BCP=
+
+# If we are on OSX, then hunt down JDK 1.8 so we can use ALPN
+# n.b. may still fail if an older version of JDK 1.8 is used
 
 if [ -x /usr/libexec/java_home ]; then
   JAVA_HOME=$(/usr/libexec/java_home -v 1.8)

--- a/okcurl/pom.xml
+++ b/okcurl/pom.xml
@@ -55,6 +55,34 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.mortbay.jetty.alpn</groupId>
+                  <artifactId>alpn-boot</artifactId>
+                  <version>8.1.7.v20160121</version>
+                  <type>jar</type>
+                  <overWrite>false</overWrite>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/alpn</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptorRefs>
@@ -68,10 +96,37 @@
         </configuration>
         <executions>
           <execution>
+            <id>uberjar</id>
             <phase>package</phase>
             <goals>
               <goal>single</goal>
             </goals>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+              <archive>
+                <manifest>
+                  <mainClass>okhttp3.curl.Main</mainClass>
+                </manifest>
+              </archive>
+            </configuration>
+          </execution>
+          <execution>
+            <id>bundle</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptor>src/main/assembly/bundle.xml</descriptor>
+              <archive>
+                <manifest>
+                  <mainClass>okhttp3.curl.Main</mainClass>
+                </manifest>
+              </archive>
+              <tarLongFileMode>gnu</tarLongFileMode>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/okcurl/src/main/assembly/bundle.xml
+++ b/okcurl/src/main/assembly/bundle.xml
@@ -1,0 +1,35 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>bundle</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>lib</outputDirectory>
+      <scope>runtime</scope>
+    </dependencySet>
+  </dependencySets>
+  <fileSets>
+    <fileSet>
+      <includes>
+        <include>README.md</include>
+        <include>LICENSE</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>src/main/scripts</directory>
+      <outputDirectory>bin</outputDirectory>
+      <includes>
+        <include>okcurl</include>
+      </includes>
+      <lineEnding>unix</lineEnding>
+      <fileMode>0755</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>target/alpn</directory>
+      <outputDirectory>alpn</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/okcurl/src/main/scripts/okcurl
+++ b/okcurl/src/main/scripts/okcurl
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+JAVA_CMD=java
+INSTALLDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+if [ -x /usr/libexec/java_home ]; then
+  JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
+
+  if [ $? -eq 0 ]; then
+    JAVA_CMD="$JAVA_HOME/bin/java"
+    ALPN=$(ls $INSTALLDIR/alpn/alpn-boot-*.jar)
+    BCP="-Xbootclasspath/p:$ALPN"
+  fi
+fi
+
+$JAVA_CMD $BCP -classpath $INSTALLDIR/lib/\* okhttp3.curl.Main "$@"


### PR DESCRIPTION
Support for running okcurl locally with a single command from a git checkout.

n.b. This script is currently designed around OSX, e.g. finds JDK8 and if found includes the alpn bootclasspath.

Also builds a bundle including the alpn-boot, which is suitable for Homebrew e.g. https://github.com/yschimke/homebrew-tap/blob/okcurl/okcurl.rb

    brew install yschimke/okcurl 