### PR TITLE
Example of using an European National ID card for client auth

### DIFF
--- a/samples/guide/src/main/java/okhttp3/recipes/CustomTrust.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/CustomTrust.java
@@ -171,7 +171,7 @@ public final class CustomTrust {
    * not use custom trusted certificates in production without the blessing of your server's TLS
    * administrator.
    */
-  private X509TrustManager trustManagerForCertificates(InputStream in)
+  static X509TrustManager trustManagerForCertificates(InputStream in)
       throws GeneralSecurityException {
     CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
     Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(in);
@@ -203,7 +203,7 @@ public final class CustomTrust {
     return (X509TrustManager) trustManagers[0];
   }
 
-  private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+  static KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
     try {
       KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
       InputStream in = null; // By convention, 'null' creates an empty key store.

--- a/samples/guide/src/main/java/okhttp3/recipes/OpenScClientAuthentication.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/OpenScClientAuthentication.java
@@ -1,0 +1,83 @@
+package okhttp3.recipes;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import sun.security.pkcs11.SunPKCS11;
+
+/**
+ * Client Authentication using a Smart Card
+ *
+ * OpenSC can be installed from https://github.com/OpenSC/OpenSC/wiki
+ */
+public class OpenScClientAuthentication {
+  String run(String url) throws Exception {
+    char[] password = System.console().readPassword("smartcard password: ");
+    KeyManager[] keyManagers = getKeyManagers(password);
+
+    X509TrustManager trustManager =
+        CustomTrust.trustManagerForCertificates(new FileInputStream("testserver/cert.pem"));
+
+    SSLContext context = SSLContext.getInstance("TLS");
+    context.init(keyManagers, new TrustManager[] { trustManager }, null);
+    SSLSocketFactory socketFactory = context.getSocketFactory();
+
+    OkHttpClient client = new OkHttpClient.Builder().sslSocketFactory(socketFactory, trustManager).build();
+
+    Request request = new Request.Builder()
+        .url(url)
+        .build();
+
+    Response response = client.newCall(request).execute();
+    return response.body().string();
+  }
+
+  public static void main(String[] args) throws Exception {
+    OpenScClientAuthentication example = new OpenScClientAuthentication();
+
+    /*
+     * openssl dhparam -out dhparam.pem 2048
+     * openssl req -x509 -sha256 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365
+     *          -nodes -subj '/O=Company/OU=Department/CN=localhost'
+     *
+     * openssl s_server -verify 20 -key key.pem -cert cert.pem -accept 44330 -no_ssl3
+     *         -dhparam dhparam.pem -www
+     */
+
+    String response = example.run("https://localhost:44330");
+    System.out.println(response);
+  }
+
+  public static KeyManager[] getKeyManagers(char[] password)
+      throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException,
+      UnrecoverableKeyException {
+    String config = "name=OpenSC\nlibrary=/Library/OpenSC/lib/opensc-pkcs11.so\n";
+    SunPKCS11 pkcs11 =
+        new SunPKCS11(new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8)));
+    Security.addProvider(pkcs11);
+
+    KeyStore keystore = KeyStore.getInstance("PKCS11", pkcs11);
+    keystore.load(null, password);
+
+    KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509");
+    kmf.init(keystore, null);
+
+    return kmf.getKeyManagers();
+  }
+}


### PR DESCRIPTION
This example works with the Estonian National ID Card. 

Output from s_server test server

```
Client certificate
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            ...
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: C=EE, O=AS Sertifitseerimiskeskus, CN=ESTEID-SK 2011/emailAddress=pki@sk.ee
        Validity
            Not Before: ...
            Not After : ...
        Subject: C=EE, O=ESTEID, OU=authentication, CN=...
```