### PR TITLE
fix NPE with okcurl insecure mode

### DIFF
--- a/okcurl/src/main/java/okhttp3/curl/Main.java
+++ b/okcurl/src/main/java/okhttp3/curl/Main.java
@@ -251,7 +251,7 @@ public class Main extends HelpOption implements Runnable {
         }
 
         @Override public X509Certificate[] getAcceptedIssuers() {
-          return null;
+          return new X509Certificate[0];
         }
       };
       context.init(null, new TrustManager[] {permissive}, null);


### PR DESCRIPTION
Before:

```
$ okcurl/target/okcurl-3.3.0-SNAPSHOT-jar-with-dependencies.jar -k https://www.howsmyssl.com/a/check
Exception in thread "main" java.lang.NullPointerException
	at okhttp3.internal.tls.TrustRootIndex$BasicTrustRootIndex.<init>(TrustRootIndex.java:90)
	at okhttp3.internal.tls.TrustRootIndex.get(TrustRootIndex.java:48)
	at okhttp3.internal.tls.TrustRootIndex.get(TrustRootIndex.java:43)
	at okhttp3.internal.tls.CertificateChainCleaner.get(CertificateChainCleaner.java:56)
	at okhttp3.OkHttpClient$Builder.sslSocketFactory(OkHttpClient.java:554)
	at okhttp3.curl.Main.createClient(Main.java:180)
	at okhttp3.curl.Main.run(Main.java:141)
	at okhttp3.curl.Main.main(Main.java:66)
```