### PR TITLE
support httpdns,verify hostname in header(if set) not get in url

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -985,7 +985,8 @@ public final class HttpEngine {
     String host = request.url().host();
     String headerHost = request.header("Host");
     //if host is set in header,then replace host by the value in header(named headerHost).
-    //when using https and httpdns,if get the host from url it will get an Exception (javax.net.ssl.SSLPeerUnverifiedException)
+    //when using https and httpdns,if get the host from url it will get an Exception
+    // (javax.net.ssl.SSLPeerUnverifiedException)
     //what is the httpdns ,see https://www.dnspod.cn/httpdns
     //more see the recipes named HttpDns in okhttp-sample
     if (headerHost != null && !headerHost.equals("")) {

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -981,7 +981,16 @@ public final class HttpEngine {
       certificatePinner = client.certificatePinner();
     }
 
-    return new Address(request.url().host(), request.url().port(), client.dns(),
+    String host = request.url().host();
+    String headerHost = request.header("Host");
+    //if host is set in header,then replace host by the value in header(named headerHost).
+    //when using https and httpdns,if get the host from url it will get an Exception (javax.net.ssl.SSLPeerUnverifiedException)
+    //what is the httpdns ,see https://www.dnspod.cn/httpdns
+    //more see the recipes named HttpDns in okhttp-sample
+    if (headerHost != null && !headerHost.equals("")) {
+      host = headerHost;
+    }
+    return new Address(host, request.url().port(), client.dns(),
         client.socketFactory(), sslSocketFactory, hostnameVerifier, certificatePinner,
         client.proxyAuthenticator(), client.proxy(), client.protocols(),
         client.connectionSpecs(), client.proxySelector());

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -16,56 +16,24 @@
  */
 package okhttp3.internal.http;
 
+import okhttp3.*;
+import okhttp3.internal.Internal;
+import okhttp3.internal.InternalCache;
+import okhttp3.internal.Version;
+import okio.*;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.ProtocolException;
 import java.net.Proxy;
 import java.util.Date;
 import java.util.List;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSocketFactory;
-import okhttp3.Address;
-import okhttp3.CertificatePinner;
-import okhttp3.Connection;
-import okhttp3.Cookie;
-import okhttp3.CookieJar;
-import okhttp3.Headers;
-import okhttp3.HttpUrl;
-import okhttp3.Interceptor;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okhttp3.Route;
-import okhttp3.internal.Internal;
-import okhttp3.internal.InternalCache;
-import okhttp3.internal.Version;
-import okio.Buffer;
-import okio.BufferedSink;
-import okio.BufferedSource;
-import okio.GzipSource;
-import okio.Okio;
-import okio.Sink;
-import okio.Source;
-import okio.Timeout;
 
-import static java.net.HttpURLConnection.HTTP_CLIENT_TIMEOUT;
-import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
-import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
-import static java.net.HttpURLConnection.HTTP_MULT_CHOICE;
-import static java.net.HttpURLConnection.HTTP_NOT_MODIFIED;
-import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
-import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
-import static java.net.HttpURLConnection.HTTP_SEE_OTHER;
-import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static java.net.HttpURLConnection.*;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static okhttp3.internal.Util.closeQuietly;
-import static okhttp3.internal.Util.discard;
-import static okhttp3.internal.Util.hostHeader;
-import static okhttp3.internal.http.StatusLine.HTTP_CONTINUE;
-import static okhttp3.internal.http.StatusLine.HTTP_PERM_REDIRECT;
-import static okhttp3.internal.http.StatusLine.HTTP_TEMP_REDIRECT;
+import static okhttp3.internal.Util.*;
+import static okhttp3.internal.http.StatusLine.*;
 
 /**
  * Handles a single HTTP request/response pair. Each HTTP engine follows this lifecycle: <ol> <li>It
@@ -983,10 +951,11 @@ public final class HttpEngine {
 
     String host = request.url().host();
     String headerHost = request.header("Host");
-    //if host is set in header,then replace host by the value in header(named headerHost).
-    //when using https and httpdns,if get the host from url it will get an Exception (javax.net.ssl.SSLPeerUnverifiedException)
-    //what is the httpdns ,see https://www.dnspod.cn/httpdns
-    //more see the recipes named HttpDns in okhttp-sample
+    // if host is set in header,then replace host by the value in header(named headerHost).
+    // when using https and httpdns
+    // if get the host from url it will get an Exception (javax.net.ssl.SSLPeerUnverifiedException)
+    // what is the httpdns ,see https://www.dnspod.cn/httpdns
+    // more see the recipes named HttpDns in okhttp-sample
     if (headerHost != null && !headerHost.equals("")) {
       host = headerHost;
     }

--- a/samples/guide/src/main/java/okhttp3/recipes/HttpDns.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/HttpDns.java
@@ -11,11 +11,10 @@ import java.io.IOException;
  * using httpdns ,not using localdns sample
  * Created by lizhangqu on 16/4/12.
  */
-public class HttpDns {
-    public static void main(String[] args) throws IOException {
-
-        OkHttpClient okHttpClient = new OkHttpClient.Builder().addInterceptor(new HttpDnsInterceptor()).build();
-
+public final class HttpDns {
+    public void run() throws Exception {
+        OkHttpClient okHttpClient = new OkHttpClient.Builder()
+                .addInterceptor(new HttpDnsInterceptor()).build();
 
         Request request = new Request.Builder()
                 .url(HttpDnsInterceptor.BAIDU_URL)
@@ -25,6 +24,10 @@ public class HttpDns {
         Response execute = okHttpClient.newCall(request).execute();
 
         System.out.println(execute.body().string());
+    }
+
+    public static void main(String... args) throws Exception {
+        new HttpDns().run();
     }
 
     static class HttpDnsInterceptor implements Interceptor {

--- a/samples/guide/src/main/java/okhttp3/recipes/HttpDns.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/HttpDns.java
@@ -1,0 +1,48 @@
+package okhttp3.recipes;
+
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * using httpdns ,not using localdns sample
+ * Created by lizhangqu on 16/4/12.
+ */
+public class HttpDns {
+    public static void main(String[] args) throws IOException {
+
+        OkHttpClient okHttpClient = new OkHttpClient.Builder().addInterceptor(new HttpDnsInterceptor()).build();
+
+
+        Request request = new Request.Builder()
+                .url(HttpDnsInterceptor.BAIDU_URL)
+                .get()
+                .build();
+
+        Response execute = okHttpClient.newCall(request).execute();
+
+        System.out.println(execute.body().string());
+    }
+
+    static class HttpDnsInterceptor implements Interceptor {
+        public static final String BAIDU_URL = "https://www.baidu.com";
+        public static final String BAIDU_DOMAIN = "www.baidu.com";
+        public static final String BAIDU_IP = "220.181.112.244";
+
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            Request orignalRequest = chain.request();
+            Request newRequest = orignalRequest.newBuilder()
+                    //set Host
+                    .header("Host", BAIDU_DOMAIN)
+                    //replace domain in url with ip,the ip get from httpdns,this is a mock ip
+                    .url(orignalRequest.url().toString().replace(BAIDU_DOMAIN, BAIDU_IP))
+                    .build();
+            Response response = chain.proceed(newRequest);
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
If host is set in header,then replace host by the value in header(named headerHost).
When using https and httpdns,if get the host from url it will get an Exception (javax.net.ssl.SSLPeerUnverifiedException).
What is the httpdns ,see https://www.dnspod.cn/httpdns.
See more in recipes named HttpDns in okhttp-sample.