### PR TITLE
Further constrain when we recover from failed routes.

### DIFF
--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
@@ -490,7 +490,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       throw toThrow;
     } catch (RouteException e) {
       // The attempt to connect via a route failed. The request will not have been sent.
-      HttpEngine retryEngine = httpEngine.recover(e.getLastConnectException());
+      HttpEngine retryEngine = httpEngine.recover(e.getLastConnectException(), true);
       if (retryEngine != null) {
         releaseConnection = false;
         httpEngine = retryEngine;
@@ -503,7 +503,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       throw toThrow;
     } catch (IOException e) {
       // An attempt to communicate with a server failed. The request may have been sent.
-      HttpEngine retryEngine = httpEngine.recover(e);
+      HttpEngine retryEngine = httpEngine.recover(e, false);
       if (retryEngine != null) {
         releaseConnection = false;
         httpEngine = retryEngine;

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -245,7 +245,7 @@ final class RealCall implements Call {
         throw e.getCause();
       } catch (RouteException e) {
         // The attempt to connect via a route failed. The request will not have been sent.
-        HttpEngine retryEngine = engine.recover(e.getLastConnectException(), null);
+        HttpEngine retryEngine = engine.recover(e.getLastConnectException(), true, null);
         if (retryEngine != null) {
           releaseConnection = false;
           engine = retryEngine;
@@ -255,7 +255,7 @@ final class RealCall implements Call {
         throw e.getLastConnectException();
       } catch (IOException e) {
         // An attempt to communicate with a server failed. The request may have been sent.
-        HttpEngine retryEngine = engine.recover(e, null);
+        HttpEngine retryEngine = engine.recover(e, false, null);
         if (retryEngine != null) {
           releaseConnection = false;
           engine = retryEngine;

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -185,7 +185,7 @@ public final class HttpEngine {
    * @throws RouteException if the was a problem during connection via a specific route. Sometimes
    * recoverable. See {@link #recover}.
    * @throws IOException if there was a problem while making a request. Sometimes recoverable. See
-   * {@link #recover(IOException)}.
+   * {@link #recover(IOException, boolean)}.
    */
   public void sendRequest() throws RequestException, RouteException, IOException {
     if (cacheStrategy != null) return; // Already sent.
@@ -349,8 +349,8 @@ public final class HttpEngine {
    * engine that should be used for the retry if {@code e} is recoverable, or null if the failure is
    * permanent. Requests with a body can only be recovered if the body is buffered.
    */
-  public HttpEngine recover(IOException e, Sink requestBodyOut) {
-    if (!streamAllocation.recover(e, requestBodyOut)) {
+  public HttpEngine recover(IOException e, boolean routeException, Sink requestBodyOut) {
+    if (!streamAllocation.recover(e, routeException, requestBodyOut)) {
       return null;
     }
 
@@ -365,8 +365,8 @@ public final class HttpEngine {
         forWebSocket, streamAllocation, (RetryableSink) requestBodyOut, priorResponse);
   }
 
-  public HttpEngine recover(IOException e) {
-    return recover(e, requestBodyOut);
+  public HttpEngine recover(IOException e, boolean routeException) {
+    return recover(e, routeException, requestBodyOut);
   }
 
   private void maybeCache() throws IOException {


### PR DESCRIPTION
Don't recover if we encounter a read timeout after sending the request, but
do recover if we encounter a timeout building a connection.

See https://github.com/square/okhttp/issues/2394