### PR TITLE
Fix CertificatePinner javadoc to use a Builder

### DIFF
--- a/okhttp/src/main/java/okhttp3/CertificatePinner.java
+++ b/okhttp/src/main/java/okhttp3/CertificatePinner.java
@@ -50,8 +50,9 @@ import okio.ByteString;
  *     CertificatePinner certificatePinner = new CertificatePinner.Builder()
  *         .add(hostname, "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
  *         .build();
- *     OkHttpClient client = new OkHttpClient();
- *     client.setCertificatePinner(certificatePinner);
+ *     OkHttpClient client = OkHttpClient.Builder()
+ *         .certificatePinner(certificatePinner)
+ *         .build();
  *
  *     Request request = new Request.Builder()
  *         .url("https://" + hostname)


### PR DESCRIPTION
The provided example wouldn't compile because OkHttpClient doesn't have
a `setCertificatePinner()` method.