### PR TITLE
document support for SNI in OpenJDK

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/Platform.java
@@ -43,6 +43,8 @@ import static okhttp3.internal.Internal.logger;
  *
  * <p>Supported on Android 2.3+.
  *
+ * Supported on OpenJDK 7+
+ *
  * <h3>Session Tickets</h3>
  *
  * <p>Supported on Android 2.3+.


### PR DESCRIPTION
I looked into adding via SSLParameters, but I think okhttp already uses the correct path to make this work.  Can you confirm?

Do you know of a test server to check against?

Java 7

```
$ $(/usr/libexec/java_home -v 1.7)/bin/java -Djavax.net.debug=ssl:handshake -jar okcurl/target/okcurl-3.3.0-SNAPSHOT-jar-with-dependencies.jar -k https://testssl-valid-r2i2.disig.sk/index.en.html | grep -e server_name -e Hello
*** ClientHello, TLSv1
Extension server_name, server_name: [host_name: testssl-valid-r2i2.disig.sk]
*** ServerHello, TLSv1
Extension server_name, server_name:
*** ServerHelloDone
```

Java 8

```
$ $(/usr/libexec/java_home -v 1.8)/bin/java -Djavax.net.debug=ssl:handshake -jar okcurl/target/okcurl-3.3.0-SNAPSHOT-jar-with-dependencies.jar -k https://testssl-valid-r2i2.disig.sk/index.en.html | grep -e server_name -e Hello
*** ClientHello, TLSv1.2
Extension server_name, server_name: [type=host_name (0), value=testssl-valid-r2i2.disig.sk]
*** ServerHello, TLSv1.2
Extension server_name, server_name:
*** ServerHelloDone
```