### PR TITLE
Redact the full url in AsyncCall thread name.

### DIFF
--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -96,7 +96,7 @@ final class RealCall implements Call {
     private final boolean forWebSocket;
 
     private AsyncCall(Callback responseCallback, boolean forWebSocket) {
-      super("OkHttp %s", originalRequest.url().toString());
+      super("OkHttp %s", redactedUrl().toString());
       this.responseCallback = responseCallback;
       this.forWebSocket = forWebSocket;
     }
@@ -151,8 +151,11 @@ final class RealCall implements Call {
    */
   private String toLoggableString() {
     String string = canceled ? "canceled call" : "call";
-    HttpUrl redactedUrl = originalRequest.url().resolve("/...");
-    return string + " to " + redactedUrl;
+    return string + " to " + redactedUrl();
+  }
+
+  HttpUrl redactedUrl() {
+    return originalRequest.url().resolve("/...");
   }
 
   private Response getResponseWithInterceptorChain(boolean forWebSocket) throws IOException {


### PR DESCRIPTION
We don't want to accidentally leak sensitive information that may be
embedded in the url.

For #2481.