### PR TITLE
NetworkSecurityPolicy based ConnectionSpec setup

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -65,10 +65,16 @@ public class OkHttpClient implements Cloneable, Call.Factory {
   private static final List<Protocol> DEFAULT_PROTOCOLS = Util.immutableList(
       Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1);
 
-  private static final List<ConnectionSpec> DEFAULT_CONNECTION_SPECS = Util.immutableList(
-      ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS, ConnectionSpec.CLEARTEXT);
+  private static final List<ConnectionSpec> DEFAULT_CONNECTION_SPECS;
 
   static {
+    List<ConnectionSpec> connSpecs = new ArrayList<>(Arrays.asList(ConnectionSpec.MODERN_TLS,
+        ConnectionSpec.COMPATIBLE_TLS));
+    if (Platform.get().isCleartextTrafficPermitted()) {
+      connSpecs.add(ConnectionSpec.CLEARTEXT);
+    }
+    DEFAULT_CONNECTION_SPECS = Util.immutableList(connSpecs);
+
     Internal.instance = new Internal() {
       @Override public void addLenient(Headers.Builder builder, String line) {
         builder.addLenient(line);

--- a/okhttp/src/main/java/okhttp3/internal/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/Platform.java
@@ -67,6 +67,10 @@ import static okhttp3.internal.Internal.logger;
  *
  * <p>Supported on Android 2.3+ and OpenJDK 7+. There are no public APIs to recover the trust
  * manager that was used to create an {@link SSLSocketFactory}.
+ *
+ * <h3>Android Cleartext Permit Detection</h3>
+ *
+ * <p>Supported on Android 6.0+ via {@code NetworkSecurityPolicy}.
  */
 public class Platform {
   private static final Platform PLATFORM = findPlatform();

--- a/okhttp/src/main/java/okhttp3/internal/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/Platform.java
@@ -317,9 +317,10 @@ public class Platform {
         boolean cleartextPermitted = (boolean) isCleartextTrafficPermittedMethod
             .invoke(networkSecurityPolicy);
         return cleartextPermitted;
-      } catch (ClassNotFoundException | NoSuchMethodException e) {
+      } catch (ClassNotFoundException e) {
         return super.isCleartextTrafficPermitted();
-      } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      } catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException
+          | InvocationTargetException e) {
         throw new AssertionError();
       }
     }

--- a/okhttp/src/main/java/okhttp3/internal/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/Platform.java
@@ -128,6 +128,10 @@ public class Platform {
     System.out.println(message);
   }
 
+  public boolean isCleartextTrafficPermitted() {
+    return true;
+  }
+
   public static List<String> alpnProtocolNames(List<Protocol> protocols) {
     List<String> names = new ArrayList<>(protocols.size());
     for (int i = 0, size = protocols.size(); i < size; i++) {
@@ -298,6 +302,24 @@ public class Platform {
         } while (i < newline);
       }
     }
+
+    @Override public boolean isCleartextTrafficPermitted() {
+      try {
+        Class<?> networkPolicyClass = Class.forName("android.security.NetworkSecurityPolicy");
+        Method getInstanceMethod = networkPolicyClass.getMethod("getInstance");
+        Object networkSecurityPolicy = getInstanceMethod.invoke(null);
+        Method isCleartextTrafficPermittedMethod = networkPolicyClass
+            .getMethod("isCleartextTrafficPermitted");
+        boolean cleartextPermitted = (boolean) isCleartextTrafficPermittedMethod
+            .invoke(networkSecurityPolicy);
+        return cleartextPermitted;
+      } catch (ClassNotFoundException | NoSuchMethodException e) {
+        return super.isCleartextTrafficPermitted();
+      } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+        throw new AssertionError();
+      }
+    }
+
   }
 
   /**


### PR DESCRIPTION
I've added a `isCleartextTrafficPermitted` method to `Platform` which determines whether the device permits cleartext. For Android the call is delegated to [`NetworkSecurityPolicy`](https://developer.android.com/reference/android/security/NetworkSecurityPolicy.html). `OkHttpClient`'s default `ConnectionSpec`s are then setup accordingly. See #2513 for more info.

I've signed the CLA. Please review and pull.

Thanks,
Venil Noronha