### PR TITLE
Unconditional FileNotFoundException for response code >= 400 violates…

### DIFF
--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
@@ -17,7 +17,6 @@
 
 package okhttp3.internal.huc;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
@@ -246,14 +246,6 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
 
     HttpEngine response = getResponse();
 
-    // if the requested file does not exist, throw an exception formerly the
-    // Error page from the server was returned if the requested file was
-    // text/html this has changed to return FileNotFoundException for all
-    // file types
-    if (getResponseCode() >= HTTP_BAD_REQUEST) {
-      throw new FileNotFoundException(url.toString());
-    }
-
     return response.getResponse().body().byteStream();
   }
 


### PR DESCRIPTION
… RFC7231.

6.5.  Client Error 4xx

   The 4xx (Client Error) class of status code indicates that the client
   seems to have erred.  Except when responding to a HEAD request, the
   server SHOULD send a representation containing an explanation of the
   error situation, and whether it is a temporary or permanent
   condition.  These status codes are applicable to any request method.
   **User agents SHOULD display any included representation to the user.**

6.6.  Server Error 5xx

   The 5xx (Server Error) class of status code indicates that the server
   is aware that it has erred or is incapable of performing the
   requested method.  Except when responding to a HEAD request, the
   server SHOULD send a representation containing an explanation of the
   error situation, and whether it is a temporary or permanent
   condition.  **A user agent SHOULD display any included representation
   to the user.**  These response codes are applicable to any request
   method.