### PR TITLE
split out platform and test them based on active profile

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/Jdk9PlatformTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/Jdk9PlatformTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import org.junit.Test;
+
+import static okhttp3.internal.PlatformTest.getPlatform;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
+
+public class Jdk9PlatformTest {
+  @Test
+  public void buildsWhenJdk9() {
+    assumeTrue(getPlatform().equals("jdk9"));
+
+    assertNotNull(Jdk9Platform.buildIfSupported());
+  }
+
+  @Test
+  public void findsAlpnMethods() {
+    assumeTrue(getPlatform().equals("jdk9"));
+
+    Jdk9Platform platform = Jdk9Platform.buildIfSupported();
+
+    assertEquals("getApplicationProtocol", platform.getProtocolMethod.getName());
+    assertEquals("setApplicationProtocols", platform.setProtocolMethod.getName());
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/internal/JdkWithJettyBootPlatformTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/JdkWithJettyBootPlatformTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import org.junit.Test;
+
+import static okhttp3.internal.PlatformTest.getPlatform;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
+
+public class JdkWithJettyBootPlatformTest {
+  @Test
+  public void testBuildsWithJettyBoot() {
+    assumeTrue(getPlatform().equals("jdk-with-jetty-boot"));
+
+    assertNotNull(JdkWithJettyBootPlatform.buildIfSupported());
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/internal/PlatformTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/PlatformTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import org.junit.Test;
+
+public class PlatformTest {
+  @Test
+  public void alwaysBuilds() {
+    new Platform();
+  }
+
+  public static String getPlatform() {
+    return System.getProperty("okhttp.platform", "platform");
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/AndroidPlatform.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import android.util.Log;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.List;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
+import okhttp3.Protocol;
+
+/** Android 2.3 or better. */
+class AndroidPlatform extends Platform {
+  private static final int MAX_LOG_LENGTH = 4000;
+
+  private final Class<?> sslParametersClass;
+  private final OptionalMethod<Socket> setUseSessionTickets;
+  private final OptionalMethod<Socket> setHostname;
+
+  // Non-null on Android 5.0+.
+  private final OptionalMethod<Socket> getAlpnSelectedProtocol;
+  private final OptionalMethod<Socket> setAlpnProtocols;
+
+  public AndroidPlatform(Class<?> sslParametersClass, OptionalMethod<Socket> setUseSessionTickets,
+      OptionalMethod<Socket> setHostname, OptionalMethod<Socket> getAlpnSelectedProtocol,
+      OptionalMethod<Socket> setAlpnProtocols) {
+    this.sslParametersClass = sslParametersClass;
+    this.setUseSessionTickets = setUseSessionTickets;
+    this.setHostname = setHostname;
+    this.getAlpnSelectedProtocol = getAlpnSelectedProtocol;
+    this.setAlpnProtocols = setAlpnProtocols;
+  }
+
+  @Override public void connectSocket(Socket socket, InetSocketAddress address,
+      int connectTimeout) throws IOException {
+    try {
+      socket.connect(address, connectTimeout);
+    } catch (AssertionError e) {
+      if (Util.isAndroidGetsocknameError(e)) throw new IOException(e);
+      throw e;
+    } catch (SecurityException e) {
+      // Before android 4.3, socket.connect could throw a SecurityException
+      // if opening a socket resulted in an EACCES error.
+      IOException ioException = new IOException("Exception in connect");
+      ioException.initCause(e);
+      throw ioException;
+    }
+  }
+
+  @Override public X509TrustManager trustManager(SSLSocketFactory sslSocketFactory) {
+    Object context = readFieldOrNull(sslSocketFactory, sslParametersClass, "sslParameters");
+    if (context == null) {
+      // If that didn't work, try the Google Play Services SSL provider before giving up. This
+      // must be loaded by the SSLSocketFactory's class loader.
+      try {
+        Class<?> gmsSslParametersClass = Class.forName(
+            "com.google.android.gms.org.conscrypt.SSLParametersImpl", false,
+            sslSocketFactory.getClass().getClassLoader());
+        context = readFieldOrNull(sslSocketFactory, gmsSslParametersClass, "sslParameters");
+      } catch (ClassNotFoundException e) {
+        return super.trustManager(sslSocketFactory);
+      }
+    }
+
+    X509TrustManager x509TrustManager = readFieldOrNull(
+        context, X509TrustManager.class, "x509TrustManager");
+    if (x509TrustManager != null) return x509TrustManager;
+
+    return readFieldOrNull(context, X509TrustManager.class, "trustManager");
+  }
+
+  @Override public void configureTlsExtensions(
+      SSLSocket sslSocket, String hostname, List<Protocol> protocols) {
+    // Enable SNI and session tickets.
+    if (hostname != null) {
+      setUseSessionTickets.invokeOptionalWithoutCheckedException(sslSocket, true);
+      setHostname.invokeOptionalWithoutCheckedException(sslSocket, hostname);
+    }
+
+    // Enable ALPN.
+    if (setAlpnProtocols != null && setAlpnProtocols.isSupported(sslSocket)) {
+      Object[] parameters = {concatLengthPrefixed(protocols)};
+      setAlpnProtocols.invokeWithoutCheckedException(sslSocket, parameters);
+    }
+  }
+
+  @Override public String getSelectedProtocol(SSLSocket socket) {
+    if (getAlpnSelectedProtocol == null) return null;
+    if (!getAlpnSelectedProtocol.isSupported(socket)) return null;
+
+    byte[] alpnResult = (byte[]) getAlpnSelectedProtocol.invokeWithoutCheckedException(socket);
+    return alpnResult != null ? new String(alpnResult, Util.UTF_8) : null;
+  }
+
+  @Override public void log(String message) {
+    // Split by line, then ensure each line can fit into Log's maximum length.
+    for (int i = 0, length = message.length(); i < length; i++) {
+      int newline = message.indexOf('\n', i);
+      newline = newline != -1 ? newline : length;
+      do {
+        int end = Math.min(newline, i + MAX_LOG_LENGTH);
+        Log.d("OkHttp", message.substring(i, end));
+        i = end;
+      } while (i < newline);
+    }
+  }
+
+  @Override public boolean isCleartextTrafficPermitted() {
+    try {
+      Class<?> networkPolicyClass = Class.forName("android.security.NetworkSecurityPolicy");
+      Method getInstanceMethod = networkPolicyClass.getMethod("getInstance");
+      Object networkSecurityPolicy = getInstanceMethod.invoke(null);
+      Method isCleartextTrafficPermittedMethod = networkPolicyClass
+          .getMethod("isCleartextTrafficPermitted");
+      boolean cleartextPermitted = (boolean) isCleartextTrafficPermittedMethod
+          .invoke(networkSecurityPolicy);
+      return cleartextPermitted;
+    } catch (ClassNotFoundException e) {
+      return super.isCleartextTrafficPermitted();
+    } catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException
+        | InvocationTargetException e) {
+      throw new AssertionError();
+    }
+  }
+
+  public static Platform buildIfSupported() {
+    // Attempt to find Android 2.3+ APIs.
+    try {
+      Class<?> sslParametersClass;
+      try {
+        sslParametersClass = Class.forName("com.android.org.conscrypt.SSLParametersImpl");
+      } catch (ClassNotFoundException e) {
+        // Older platform before being unbundled.
+        sslParametersClass = Class.forName(
+            "org.apache.harmony.xnet.provider.jsse.SSLParametersImpl");
+      }
+
+      OptionalMethod<Socket> setUseSessionTickets = new OptionalMethod<>(
+          null, "setUseSessionTickets", boolean.class);
+      OptionalMethod<Socket> setHostname = new OptionalMethod<>(
+          null, "setHostname", String.class);
+      OptionalMethod<Socket> getAlpnSelectedProtocol = null;
+      OptionalMethod<Socket> setAlpnProtocols = null;
+
+      // Attempt to find Android 5.0+ APIs.
+      try {
+        Class.forName("android.net.Network"); // Arbitrary class added in Android 5.0.
+        getAlpnSelectedProtocol = new OptionalMethod<>(byte[].class, "getAlpnSelectedProtocol");
+        setAlpnProtocols = new OptionalMethod<>(null, "setAlpnProtocols", byte[].class);
+      } catch (ClassNotFoundException ignored) {
+      }
+
+      return new AndroidPlatform(sslParametersClass, setUseSessionTickets, setHostname,
+          getAlpnSelectedProtocol, setAlpnProtocols);
+    } catch (ClassNotFoundException ignored) {
+      // This isn't an Android runtime.
+    }
+
+    return null;
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/Jdk9Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/Jdk9Platform.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import okhttp3.Protocol;
+
+/**
+ * OpenJDK 9+.
+ */
+final class Jdk9Platform extends Platform {
+  final Method setProtocolMethod;
+  final Method getProtocolMethod;
+
+  public Jdk9Platform(Method setProtocolMethod, Method getProtocolMethod) {
+    this.setProtocolMethod = setProtocolMethod;
+    this.getProtocolMethod = getProtocolMethod;
+  }
+
+  @Override
+  public void configureTlsExtensions(SSLSocket sslSocket, String hostname,
+                                     List<Protocol> protocols) {
+    try {
+      SSLParameters sslParameters = sslSocket.getSSLParameters();
+
+      List<String> names = alpnProtocolNames(protocols);
+
+      setProtocolMethod.invoke(sslParameters,
+          new Object[]{names.toArray(new String[names.size()])});
+
+      sslSocket.setSSLParameters(sslParameters);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new AssertionError();
+    }
+  }
+
+  @Override
+  public String getSelectedProtocol(SSLSocket socket) {
+    try {
+      String protocol = (String) getProtocolMethod.invoke(socket);
+
+      // SSLSocket.getApplicationProtocol returns "" if application protocols values will not
+      // be used. Observed if you didn't specify SSLParameters.setApplicationProtocols
+      if (protocol == null || protocol.equals("")) {
+        return null;
+      }
+
+      return protocol;
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new AssertionError();
+    }
+  }
+
+  public static Jdk9Platform buildIfSupported() {
+    // Find JDK 9 new methods
+    try {
+      Method setProtocolMethod =
+          SSLParameters.class.getMethod("setApplicationProtocols", String[].class);
+      Method getProtocolMethod = SSLSocket.class.getMethod("getApplicationProtocol");
+
+      return new Jdk9Platform(setProtocolMethod, getProtocolMethod);
+    } catch (NoSuchMethodException ignored) {
+      // pre JDK 9
+    }
+
+    return null;
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/JdkWithJettyBootPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/JdkWithJettyBootPlatform.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.logging.Level;
+import javax.net.ssl.SSLSocket;
+import okhttp3.Protocol;
+
+import static okhttp3.internal.Internal.logger;
+
+/**
+ * OpenJDK 7 or OpenJDK 8 with {@code org.mortbay.jetty.alpn/alpn-boot} in the boot class path.
+ */
+class JdkWithJettyBootPlatform extends Platform {
+  private final Method putMethod;
+  private final Method getMethod;
+  private final Method removeMethod;
+  private final Class<?> clientProviderClass;
+  private final Class<?> serverProviderClass;
+
+  public JdkWithJettyBootPlatform(Method putMethod, Method getMethod, Method removeMethod,
+      Class<?> clientProviderClass, Class<?> serverProviderClass) {
+    this.putMethod = putMethod;
+    this.getMethod = getMethod;
+    this.removeMethod = removeMethod;
+    this.clientProviderClass = clientProviderClass;
+    this.serverProviderClass = serverProviderClass;
+  }
+
+  @Override public void configureTlsExtensions(
+      SSLSocket sslSocket, String hostname, List<Protocol> protocols) {
+    List<String> names = alpnProtocolNames(protocols);
+
+    try {
+      Object provider = Proxy.newProxyInstance(Platform.class.getClassLoader(),
+          new Class[] {clientProviderClass, serverProviderClass}, new JettyNegoProvider(names));
+      putMethod.invoke(null, sslSocket, provider);
+    } catch (InvocationTargetException | IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @Override public void afterHandshake(SSLSocket sslSocket) {
+    try {
+      removeMethod.invoke(null, sslSocket);
+    } catch (IllegalAccessException | InvocationTargetException ignored) {
+      throw new AssertionError();
+    }
+  }
+
+  @Override public String getSelectedProtocol(SSLSocket socket) {
+    try {
+      JettyNegoProvider provider =
+          (JettyNegoProvider) Proxy.getInvocationHandler(getMethod.invoke(null, socket));
+      if (!provider.unsupported && provider.selected == null) {
+        logger.log(Level.INFO, "ALPN callback dropped: SPDY and HTTP/2 are disabled. "
+            + "Is alpn-boot on the boot class path?");
+        return null;
+      }
+      return provider.unsupported ? null : provider.selected;
+    } catch (InvocationTargetException | IllegalAccessException e) {
+      throw new AssertionError();
+    }
+  }
+
+  public static Platform buildIfSupported() {
+    // Find Jetty's ALPN extension for OpenJDK.
+    try {
+      String negoClassName = "org.eclipse.jetty.alpn.ALPN";
+      Class<?> negoClass = Class.forName(negoClassName);
+      Class<?> providerClass = Class.forName(negoClassName + "$Provider");
+      Class<?> clientProviderClass = Class.forName(negoClassName + "$ClientProvider");
+      Class<?> serverProviderClass = Class.forName(negoClassName + "$ServerProvider");
+      Method putMethod = negoClass.getMethod("put", SSLSocket.class, providerClass);
+      Method getMethod = negoClass.getMethod("get", SSLSocket.class);
+      Method removeMethod = negoClass.getMethod("remove", SSLSocket.class);
+      return new JdkWithJettyBootPlatform(
+          putMethod, getMethod, removeMethod, clientProviderClass, serverProviderClass);
+    } catch (ClassNotFoundException | NoSuchMethodException ignored) {
+    }
+
+    return null;
+  }
+
+  /**
+   * Handle the methods of ALPN's ClientProvider and ServerProvider without a compile-time
+   * dependency on those interfaces.
+   */
+  private static class JettyNegoProvider implements InvocationHandler {
+    /** This peer's supported protocols. */
+    private final List<String> protocols;
+    /** Set when remote peer notifies ALPN is unsupported. */
+    private boolean unsupported;
+    /** The protocol the server selected. */
+    private String selected;
+
+    public JettyNegoProvider(List<String> protocols) {
+      this.protocols = protocols;
+    }
+
+    @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      String methodName = method.getName();
+      Class<?> returnType = method.getReturnType();
+      if (args == null) {
+        args = Util.EMPTY_STRING_ARRAY;
+      }
+      if (methodName.equals("supports") && boolean.class == returnType) {
+        return true; // ALPN is supported.
+      } else if (methodName.equals("unsupported") && void.class == returnType) {
+        this.unsupported = true; // Peer doesn't support ALPN.
+        return null;
+      } else if (methodName.equals("protocols") && args.length == 0) {
+        return protocols; // Client advertises these protocols.
+      } else if ((methodName.equals("selectProtocol") || methodName.equals("select"))
+          && String.class == returnType && args.length == 1 && args[0] instanceof List) {
+        List<String> peerProtocols = (List) args[0];
+        // Pick the first known protocol the peer advertises.
+        for (int i = 0, size = peerProtocols.size(); i < size; i++) {
+          if (protocols.contains(peerProtocols.get(i))) {
+            return selected = peerProtocols.get(i);
+          }
+        }
+        return selected = protocols.get(0); // On no intersection, try peer's first protocol.
+      } else if ((methodName.equals("protocolSelected") || methodName.equals("selected"))
+          && args.length == 1) {
+        this.selected = (String) args[0]; // Server selected this protocol.
+        return null;
+      } else {
+        return method.invoke(this, args);
+      }
+    }
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/Platform.java
@@ -16,26 +16,17 @@
  */
 package okhttp3.internal;
 
-import android.util.Log;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Protocol;
 import okio.Buffer;
-
-import static okhttp3.internal.Internal.logger;
 
 /**
  * Access to platform-specific features.
@@ -148,336 +139,26 @@ public class Platform {
 
   /** Attempt to match the host runtime to a capable Platform implementation. */
   private static Platform findPlatform() {
-    // Attempt to find Android 2.3+ APIs.
-    try {
-      Class<?> sslParametersClass;
-      try {
-        sslParametersClass = Class.forName("com.android.org.conscrypt.SSLParametersImpl");
-      } catch (ClassNotFoundException e) {
-        // Older platform before being unbundled.
-        sslParametersClass = Class.forName(
-            "org.apache.harmony.xnet.provider.jsse.SSLParametersImpl");
-      }
+    Platform android = AndroidPlatform.buildIfSupported();
 
-      OptionalMethod<Socket> setUseSessionTickets = new OptionalMethod<>(
-          null, "setUseSessionTickets", boolean.class);
-      OptionalMethod<Socket> setHostname = new OptionalMethod<>(
-          null, "setHostname", String.class);
-      OptionalMethod<Socket> getAlpnSelectedProtocol = null;
-      OptionalMethod<Socket> setAlpnProtocols = null;
-
-      // Attempt to find Android 5.0+ APIs.
-      try {
-        Class.forName("android.net.Network"); // Arbitrary class added in Android 5.0.
-        getAlpnSelectedProtocol = new OptionalMethod<>(byte[].class, "getAlpnSelectedProtocol");
-        setAlpnProtocols = new OptionalMethod<>(null, "setAlpnProtocols", byte[].class);
-      } catch (ClassNotFoundException ignored) {
-      }
-
-      return new Android(sslParametersClass, setUseSessionTickets, setHostname,
-          getAlpnSelectedProtocol, setAlpnProtocols);
-    } catch (ClassNotFoundException ignored) {
-      // This isn't an Android runtime.
+    if (android != null) {
+      return android;
     }
 
+    Platform jdk9 = Jdk9Platform.buildIfSupported();
 
-    // Find JDK 9 new methods
-    try {
-      Method setProtocolMethod =
-          SSLParameters.class.getMethod("setApplicationProtocols", String[].class);
-      Method getProtocolMethod = SSLSocket.class.getMethod("getApplicationProtocol");
-
-      return new Jdk9Platform(setProtocolMethod, getProtocolMethod);
-    } catch (NoSuchMethodException ignored) {
-      // pre JDK 9
+    if (jdk9 != null) {
+      return jdk9;
     }
 
-    // Find Jetty's ALPN extension for OpenJDK.
-    try {
-      String negoClassName = "org.eclipse.jetty.alpn.ALPN";
-      Class<?> negoClass = Class.forName(negoClassName);
-      Class<?> providerClass = Class.forName(negoClassName + "$Provider");
-      Class<?> clientProviderClass = Class.forName(negoClassName + "$ClientProvider");
-      Class<?> serverProviderClass = Class.forName(negoClassName + "$ServerProvider");
-      Method putMethod = negoClass.getMethod("put", SSLSocket.class, providerClass);
-      Method getMethod = negoClass.getMethod("get", SSLSocket.class);
-      Method removeMethod = negoClass.getMethod("remove", SSLSocket.class);
-      return new JdkWithJettyBootPlatform(
-          putMethod, getMethod, removeMethod, clientProviderClass, serverProviderClass);
-    } catch (ClassNotFoundException | NoSuchMethodException ignored) {
+    Platform jdkWithJettyBoot = JdkWithJettyBootPlatform.buildIfSupported();
+
+    if (jdkWithJettyBoot != null) {
+      return jdkWithJettyBoot;
     }
 
     // Probably an Oracle JDK like OpenJDK.
     return new Platform();
-  }
-
-  /** Android 2.3 or better. */
-  private static class Android extends Platform {
-    private static final int MAX_LOG_LENGTH = 4000;
-
-    private final Class<?> sslParametersClass;
-    private final OptionalMethod<Socket> setUseSessionTickets;
-    private final OptionalMethod<Socket> setHostname;
-
-    // Non-null on Android 5.0+.
-    private final OptionalMethod<Socket> getAlpnSelectedProtocol;
-    private final OptionalMethod<Socket> setAlpnProtocols;
-
-    public Android(Class<?> sslParametersClass, OptionalMethod<Socket> setUseSessionTickets,
-        OptionalMethod<Socket> setHostname, OptionalMethod<Socket> getAlpnSelectedProtocol,
-        OptionalMethod<Socket> setAlpnProtocols) {
-      this.sslParametersClass = sslParametersClass;
-      this.setUseSessionTickets = setUseSessionTickets;
-      this.setHostname = setHostname;
-      this.getAlpnSelectedProtocol = getAlpnSelectedProtocol;
-      this.setAlpnProtocols = setAlpnProtocols;
-    }
-
-    @Override public void connectSocket(Socket socket, InetSocketAddress address,
-        int connectTimeout) throws IOException {
-      try {
-        socket.connect(address, connectTimeout);
-      } catch (AssertionError e) {
-        if (Util.isAndroidGetsocknameError(e)) throw new IOException(e);
-        throw e;
-      } catch (SecurityException e) {
-        // Before android 4.3, socket.connect could throw a SecurityException
-        // if opening a socket resulted in an EACCES error.
-        IOException ioException = new IOException("Exception in connect");
-        ioException.initCause(e);
-        throw ioException;
-      }
-    }
-
-    @Override public X509TrustManager trustManager(SSLSocketFactory sslSocketFactory) {
-      Object context = readFieldOrNull(sslSocketFactory, sslParametersClass, "sslParameters");
-      if (context == null) {
-        // If that didn't work, try the Google Play Services SSL provider before giving up. This
-        // must be loaded by the SSLSocketFactory's class loader.
-        try {
-          Class<?> gmsSslParametersClass = Class.forName(
-              "com.google.android.gms.org.conscrypt.SSLParametersImpl", false,
-              sslSocketFactory.getClass().getClassLoader());
-          context = readFieldOrNull(sslSocketFactory, gmsSslParametersClass, "sslParameters");
-        } catch (ClassNotFoundException e) {
-          return super.trustManager(sslSocketFactory);
-        }
-      }
-
-      X509TrustManager x509TrustManager = readFieldOrNull(
-          context, X509TrustManager.class, "x509TrustManager");
-      if (x509TrustManager != null) return x509TrustManager;
-
-      return readFieldOrNull(context, X509TrustManager.class, "trustManager");
-    }
-
-    @Override public void configureTlsExtensions(
-        SSLSocket sslSocket, String hostname, List<Protocol> protocols) {
-      // Enable SNI and session tickets.
-      if (hostname != null) {
-        setUseSessionTickets.invokeOptionalWithoutCheckedException(sslSocket, true);
-        setHostname.invokeOptionalWithoutCheckedException(sslSocket, hostname);
-      }
-
-      // Enable ALPN.
-      if (setAlpnProtocols != null && setAlpnProtocols.isSupported(sslSocket)) {
-        Object[] parameters = {concatLengthPrefixed(protocols)};
-        setAlpnProtocols.invokeWithoutCheckedException(sslSocket, parameters);
-      }
-    }
-
-    @Override public String getSelectedProtocol(SSLSocket socket) {
-      if (getAlpnSelectedProtocol == null) return null;
-      if (!getAlpnSelectedProtocol.isSupported(socket)) return null;
-
-      byte[] alpnResult = (byte[]) getAlpnSelectedProtocol.invokeWithoutCheckedException(socket);
-      return alpnResult != null ? new String(alpnResult, Util.UTF_8) : null;
-    }
-
-    @Override public void log(String message) {
-      // Split by line, then ensure each line can fit into Log's maximum length.
-      for (int i = 0, length = message.length(); i < length; i++) {
-        int newline = message.indexOf('\n', i);
-        newline = newline != -1 ? newline : length;
-        do {
-          int end = Math.min(newline, i + MAX_LOG_LENGTH);
-          Log.d("OkHttp", message.substring(i, end));
-          i = end;
-        } while (i < newline);
-      }
-    }
-
-    @Override public boolean isCleartextTrafficPermitted() {
-      try {
-        Class<?> networkPolicyClass = Class.forName("android.security.NetworkSecurityPolicy");
-        Method getInstanceMethod = networkPolicyClass.getMethod("getInstance");
-        Object networkSecurityPolicy = getInstanceMethod.invoke(null);
-        Method isCleartextTrafficPermittedMethod = networkPolicyClass
-            .getMethod("isCleartextTrafficPermitted");
-        boolean cleartextPermitted = (boolean) isCleartextTrafficPermittedMethod
-            .invoke(networkSecurityPolicy);
-        return cleartextPermitted;
-      } catch (ClassNotFoundException e) {
-        return super.isCleartextTrafficPermitted();
-      } catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException
-          | InvocationTargetException e) {
-        throw new AssertionError();
-      }
-    }
-
-  }
-
-  /**
-   * OpenJDK 9+.
-   */
-  private static final class Jdk9Platform extends Platform {
-    private final Method setProtocolMethod;
-    private final Method getProtocolMethod;
-
-    public Jdk9Platform(Method setProtocolMethod, Method getProtocolMethod) {
-      this.setProtocolMethod = setProtocolMethod;
-      this.getProtocolMethod = getProtocolMethod;
-    }
-
-    @Override
-    public void configureTlsExtensions(SSLSocket sslSocket, String hostname,
-                                       List<Protocol> protocols) {
-      try {
-        SSLParameters sslParameters = sslSocket.getSSLParameters();
-
-        List<String> names = alpnProtocolNames(protocols);
-
-        setProtocolMethod.invoke(sslParameters,
-            new Object[]{names.toArray(new String[names.size()])});
-
-        sslSocket.setSSLParameters(sslParameters);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        throw new AssertionError();
-      }
-    }
-
-    @Override
-    public String getSelectedProtocol(SSLSocket socket) {
-      try {
-        String protocol = (String) getProtocolMethod.invoke(socket);
-
-        // SSLSocket.getApplicationProtocol returns "" if application protocols values will not
-        // be used. Observed if you didn't specify SSLParameters.setApplicationProtocols
-        if (protocol == null || protocol.equals("")) {
-          return null;
-        }
-
-        return protocol;
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        throw new AssertionError();
-      }
-    }
-  }
-
-
-  /**
-   * OpenJDK 7+ with {@code org.mortbay.jetty.alpn/alpn-boot} in the boot class path.
-   */
-  private static class JdkWithJettyBootPlatform extends Platform {
-    private final Method putMethod;
-    private final Method getMethod;
-    private final Method removeMethod;
-    private final Class<?> clientProviderClass;
-    private final Class<?> serverProviderClass;
-
-    public JdkWithJettyBootPlatform(Method putMethod, Method getMethod, Method removeMethod,
-        Class<?> clientProviderClass, Class<?> serverProviderClass) {
-      this.putMethod = putMethod;
-      this.getMethod = getMethod;
-      this.removeMethod = removeMethod;
-      this.clientProviderClass = clientProviderClass;
-      this.serverProviderClass = serverProviderClass;
-    }
-
-    @Override public void configureTlsExtensions(
-        SSLSocket sslSocket, String hostname, List<Protocol> protocols) {
-      List<String> names = alpnProtocolNames(protocols);
-
-      try {
-        Object provider = Proxy.newProxyInstance(Platform.class.getClassLoader(),
-            new Class[] {clientProviderClass, serverProviderClass}, new JettyNegoProvider(names));
-        putMethod.invoke(null, sslSocket, provider);
-      } catch (InvocationTargetException | IllegalAccessException e) {
-        throw new AssertionError(e);
-      }
-    }
-
-    @Override public void afterHandshake(SSLSocket sslSocket) {
-      try {
-        removeMethod.invoke(null, sslSocket);
-      } catch (IllegalAccessException | InvocationTargetException ignored) {
-        throw new AssertionError();
-      }
-    }
-
-    @Override public String getSelectedProtocol(SSLSocket socket) {
-      try {
-        JettyNegoProvider provider =
-            (JettyNegoProvider) Proxy.getInvocationHandler(getMethod.invoke(null, socket));
-        if (!provider.unsupported && provider.selected == null) {
-          logger.log(Level.INFO, "ALPN callback dropped: SPDY and HTTP/2 are disabled. "
-              + "Is alpn-boot on the boot class path?");
-          return null;
-        }
-        return provider.unsupported ? null : provider.selected;
-      } catch (InvocationTargetException | IllegalAccessException e) {
-        throw new AssertionError();
-      }
-    }
-  }
-
-  /**
-   * Handle the methods of ALPN's ClientProvider and ServerProvider without a compile-time
-   * dependency on those interfaces.
-   */
-  private static class JettyNegoProvider implements InvocationHandler {
-    /** This peer's supported protocols. */
-    private final List<String> protocols;
-    /** Set when remote peer notifies ALPN is unsupported. */
-    private boolean unsupported;
-    /** The protocol the server selected. */
-    private String selected;
-
-    public JettyNegoProvider(List<String> protocols) {
-      this.protocols = protocols;
-    }
-
-    @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-      String methodName = method.getName();
-      Class<?> returnType = method.getReturnType();
-      if (args == null) {
-        args = Util.EMPTY_STRING_ARRAY;
-      }
-      if (methodName.equals("supports") && boolean.class == returnType) {
-        return true; // ALPN is supported.
-      } else if (methodName.equals("unsupported") && void.class == returnType) {
-        this.unsupported = true; // Peer doesn't support ALPN.
-        return null;
-      } else if (methodName.equals("protocols") && args.length == 0) {
-        return protocols; // Client advertises these protocols.
-      } else if ((methodName.equals("selectProtocol") || methodName.equals("select"))
-          && String.class == returnType && args.length == 1 && args[0] instanceof List) {
-        List<String> peerProtocols = (List) args[0];
-        // Pick the first known protocol the peer advertises.
-        for (int i = 0, size = peerProtocols.size(); i < size; i++) {
-          if (protocols.contains(peerProtocols.get(i))) {
-            return selected = peerProtocols.get(i);
-          }
-        }
-        return selected = protocols.get(0); // On no intersection, try peer's first protocol.
-      } else if ((methodName.equals("protocolSelected") || methodName.equals("selected"))
-          && args.length == 1) {
-        this.selected = (String) args[0]; // Server selected this protocol.
-        return null;
-      } else {
-        return method.invoke(this, args);
-      }
-    }
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
 
     <!-- Test Dependencies -->
     <junit.version>4.12</junit.version>
+
+    <!-- platform test mode -->
+    <okhttp.platform>platform</okhttp.platform>
   </properties>
 
   <scm>
@@ -142,6 +145,9 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.17</version>
           <configuration>
+            <systemPropertyVariables>
+              <okhttp.platform>${okhttp.platform}</okhttp.platform>
+            </systemPropertyVariables>
             <properties>
               <!--
                 Configure a listener for enforcing that no uncaught exceptions issue from OkHttp
@@ -240,6 +246,7 @@
         <bootclasspathPrefix>
           ${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.jdk7.version}/alpn-boot-${alpn.jdk7.version}.jar
         </bootclasspathPrefix>
+        <okhttp.platform>jdk-with-jetty-boot</okhttp.platform>
       </properties>
       <build>
         <pluginManagement>
@@ -271,6 +278,7 @@
         <bootclasspathPrefix>
           ${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.jdk8.version}/alpn-boot-${alpn.jdk8.version}.jar
         </bootclasspathPrefix>
+        <okhttp.platform>jdk-with-jetty-boot</okhttp.platform>
       </properties>
       <build>
         <pluginManagement>
@@ -296,9 +304,11 @@
     <profile>
       <id>jdk9</id>
       <activation>
-        <jdk>9</jdk>
+        <jdk>1.9</jdk>
       </activation>
-      <!-- Not currently used, but visible in Intellij etc -->
+      <properties>
+        <okhttp.platform>jdk9</okhttp.platform>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Want to be able to add some tests for JDK 9, but only run when we have a profile active.

Also fix a bug with JDK 9 profile activation.