### PR TITLE
updates junit version to v4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <okio.version>1.6.0</okio.version>
 
     <!-- Test Dependencies -->
-    <junit.version>4.11</junit.version>
+    <junit.version>4.12</junit.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
When including MockWebServer as 'compile' into my Android build instead of 'testCompile' there are dependency conflicts when using a different version of JUnit in testCompile and compile:

`Error:Conflict with dependency 'junit:junit'. Resolved versions for app (4.11) and test app (4.12) differ. See http://g.co/androidstudio/app-test-app-conflict for details.`

Was there a reason for keeping JUnit 4.11 that I'm not aware of?