### PR TITLE
Unblock waiting dispatchers on MockWebServer shutdown.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/Dispatcher.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/Dispatcher.java
@@ -32,4 +32,12 @@ public abstract class Dispatcher {
   public MockResponse peek() {
     return new MockResponse().setSocketPolicy(SocketPolicy.KEEP_OPEN);
   }
+
+  /**
+   * Release any resources held by this dispatcher. Any requests that are currently being dispatched
+   * should return immediately. Responses returned after shutdown will not be transmitted: their
+   * socket connections have already been closed.
+   */
+  public void shutdown() {
+  }
 }

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -350,6 +350,7 @@ public final class MockWebServer implements TestRule {
           Util.closeQuietly(s.next());
           s.remove();
         }
+        dispatcher.shutdown();
         executor.shutdown();
       }
 

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
@@ -382,4 +382,18 @@ public final class MockWebServerTest {
     } catch (ConnectException expected) {
     }
   }
+
+  @Test public void shutdownWhileBlockedDispatching() throws Exception {
+    // Enqueue a request that'll cause MockWebServer to hang on QueueDispatcher.dispatch().
+    HttpURLConnection connection = (HttpURLConnection) server.url("/").url().openConnection();
+    connection.setReadTimeout(500);
+    try {
+      connection.getResponseCode();
+      fail();
+    } catch (SocketTimeoutException expected) {
+    }
+
+    // Shutting down the server should unblock the dispatcher.
+    server.shutdown();
+  }
 }


### PR DESCRIPTION
Closes https://github.com/square/okhttp/issues/2521