### PR TITLE
Make logging more consistent throughout OkHttp.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/internal/framed/FramedServer.java
+++ b/mockwebserver/src/main/java/okhttp3/internal/framed/FramedServer.java
@@ -35,6 +35,8 @@ import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
 
+import static okhttp3.internal.Platform.INFO;
+
 /** A basic SPDY/HTTP_2 server that serves the contents of a local directory. */
 public final class FramedServer extends FramedConnection.Listener {
   static final Logger logger = Logger.getLogger(FramedServer.class.getName());
@@ -116,7 +118,7 @@ public final class FramedServer extends FramedConnection.Listener {
         send404(stream, path);
       }
     } catch (IOException e) {
-      System.out.println(e.getMessage());
+      Platform.get().log(INFO, "Failure serving FramedStream: " + e.getMessage(), null);
     }
   }
 

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -35,6 +35,8 @@ import okhttp3.internal.http.HttpEngine;
 import okio.Buffer;
 import okio.BufferedSource;
 
+import static okhttp3.internal.Platform.INFO;
+
 /**
  * An OkHttp interceptor which logs request and response information. Can be applied as an
  * {@linkplain OkHttpClient#interceptors() application interceptor} or as a {@linkplain
@@ -107,7 +109,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
     /** A {@link Logger} defaults output appropriate for the current platform. */
     Logger DEFAULT = new Logger() {
       @Override public void log(String message) {
-        Platform.get().log(message);
+        Platform.get().log(INFO, message, null);
       }
     };
   }

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
 import javax.net.ServerSocketFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
@@ -80,7 +81,6 @@ import org.junit.rules.Timeout;
 
 import static java.net.CookiePolicy.ACCEPT_ORIGINAL_SERVER;
 import static okhttp3.TestUtil.defaultClient;
-import static okhttp3.internal.Internal.logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -100,6 +100,7 @@ public final class CallTest {
   private TestLogHandler logHandler = new TestLogHandler();
   private Cache cache = new Cache(new File("/cache/"), Integer.MAX_VALUE, fileSystem);
   private ServerSocket nullServer;
+  private Logger logger = Logger.getLogger(OkHttpClient.class.getName());
 
   @Before public void setUp() throws Exception {
     logger.addHandler(logHandler);

--- a/okhttp-urlconnection/src/main/java/okhttp3/JavaNetCookieJar.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/JavaNetCookieJar.java
@@ -22,9 +22,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import okhttp3.internal.Internal;
+import okhttp3.internal.Platform;
 
-import static java.util.logging.Level.WARNING;
+import static okhttp3.internal.Platform.WARN;
 import static okhttp3.internal.Util.delimiterOffset;
 import static okhttp3.internal.Util.trimSubstring;
 
@@ -46,7 +46,7 @@ public final class JavaNetCookieJar implements CookieJar {
       try {
         cookieHandler.put(url.uri(), multimap);
       } catch (IOException e) {
-        Internal.logger.log(WARNING, "Saving cookies failed for " + url.resolve("/..."), e);
+        Platform.get().log(WARN, "Saving cookies failed for " + url.resolve("/..."), e);
       }
     }
   }
@@ -58,7 +58,7 @@ public final class JavaNetCookieJar implements CookieJar {
     try {
       cookieHeaders = cookieHandler.get(url.uri(), headers);
     } catch (IOException e) {
-      Internal.logger.log(WARNING, "Loading cookies failed for " + url.resolve("/..."), e);
+      Platform.get().log(WARN, "Loading cookies failed for " + url.resolve("/..."), e);
       return Collections.emptyList();
     }
 

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/HttpURLConnectionImpl.java
@@ -68,6 +68,8 @@ import okhttp3.internal.http.StreamAllocation;
 import okio.BufferedSink;
 import okio.Sink;
 
+import static okhttp3.internal.Platform.WARN;
+
 /**
  * This implementation uses HttpEngine to send requests and receive responses. This class may use
  * multiple HttpEngines to follow redirects, authentication retries, etc. to retrieve the final
@@ -562,7 +564,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       //
       // Some implementations send a malformed HTTP header when faced with
       // such requests, we respect the spec and ignore the header.
-      Platform.get().logW("Ignoring header " + field + " because its value was null.");
+      Platform.get().log(WARN, "Ignoring header " + field + " because its value was null.", null);
       return;
     }
 
@@ -596,7 +598,7 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       //
       // Some implementations send a malformed HTTP header when faced with
       // such requests, we respect the spec and ignore the header.
-      Platform.get().logW("Ignoring header " + field + " because its value was null.");
+      Platform.get().log(WARN, "Ignoring header " + field + " because its value was null.", null);
       return;
     }
 

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -26,12 +26,13 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import okhttp3.internal.Internal;
+import okhttp3.internal.Platform;
 import okhttp3.internal.RouteDatabase;
 import okhttp3.internal.Util;
 import okhttp3.internal.http.StreamAllocation;
 import okhttp3.internal.io.RealConnection;
 
+import static okhttp3.internal.Platform.WARN;
 import static okhttp3.internal.Util.closeQuietly;
 
 /**
@@ -245,8 +246,8 @@ public final class ConnectionPool {
       }
 
       // We've discovered a leaked allocation. This is an application bug.
-      Internal.logger.warning("A connection to " + connection.route().address().url()
-          + " was leaked. Did you forget to close a response body?");
+      Platform.get().log(WARN, "A connection to " + connection.route().address().url()
+          + " was leaked. Did you forget to close a response body?", null);
       references.remove(i);
       connection.noNewStreams = true;
 

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -17,14 +17,14 @@ package okhttp3;
 
 import java.io.IOException;
 import java.net.ProtocolException;
-import java.util.logging.Level;
 import okhttp3.internal.NamedRunnable;
+import okhttp3.internal.Platform;
 import okhttp3.internal.http.HttpEngine;
 import okhttp3.internal.http.RequestException;
 import okhttp3.internal.http.RouteException;
 import okhttp3.internal.http.StreamAllocation;
 
-import static okhttp3.internal.Internal.logger;
+import static okhttp3.internal.Platform.INFO;
 import static okhttp3.internal.http.HttpEngine.MAX_FOLLOW_UPS;
 
 final class RealCall implements Call {
@@ -135,7 +135,7 @@ final class RealCall implements Call {
       } catch (IOException e) {
         if (signalledCallback) {
           // Do not signal the callback twice!
-          logger.log(Level.INFO, "Callback failure for " + toLoggableString(), e);
+          Platform.get().log(INFO, "Callback failure for " + toLoggableString(), e);
         } else {
           responseCallback.onFailure(RealCall.this, e);
         }

--- a/okhttp/src/main/java/okhttp3/internal/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/AndroidPlatform.java
@@ -110,14 +110,17 @@ class AndroidPlatform extends Platform {
     return alpnResult != null ? new String(alpnResult, Util.UTF_8) : null;
   }
 
-  @Override public void log(String message) {
+  @Override public void log(int level, String message, Throwable t) {
+    int logLevel = level == WARN ? Log.WARN : Log.DEBUG;
+    if (t != null) message = message + '\n' + Log.getStackTraceString(t);
+
     // Split by line, then ensure each line can fit into Log's maximum length.
     for (int i = 0, length = message.length(); i < length; i++) {
       int newline = message.indexOf('\n', i);
       newline = newline != -1 ? newline : length;
       do {
         int end = Math.min(newline, i + MAX_LOG_LENGTH);
-        Log.d("OkHttp", message.substring(i, end));
+        Log.println(logLevel, "OkHttp", message.substring(i, end));
         i = end;
       } while (i < newline);
     }

--- a/okhttp/src/main/java/okhttp3/internal/DiskLruCache.java
+++ b/okhttp/src/main/java/okhttp3/internal/DiskLruCache.java
@@ -41,6 +41,8 @@ import okio.Sink;
 import okio.Source;
 import okio.Timeout;
 
+import static okhttp3.internal.Platform.WARN;
+
 /**
  * A cache that uses a bounded amount of space on a filesystem. Each cache entry has a string key
  * and a fixed number of values. Each key must match the regex <strong>[a-z0-9_-]{1,64}</strong>.
@@ -227,8 +229,8 @@ public final class DiskLruCache implements Closeable, Flushable {
         initialized = true;
         return;
       } catch (IOException journalIsCorrupt) {
-        Platform.get().logW("DiskLruCache " + directory + " is corrupt: "
-            + journalIsCorrupt.getMessage() + ", removing");
+        Platform.get().log(WARN, "DiskLruCache " + directory + " is corrupt: "
+            + journalIsCorrupt.getMessage() + ", removing", journalIsCorrupt);
         delete();
         closed = false;
       }

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -17,7 +17,6 @@ package okhttp3.internal;
 
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
-import java.util.logging.Logger;
 import javax.net.ssl.SSLSocket;
 import okhttp3.Address;
 import okhttp3.Call;
@@ -35,7 +34,6 @@ import okhttp3.internal.io.RealConnection;
  * packages. The only implementation of this interface is in {@link OkHttpClient}.
  */
 public abstract class Internal {
-  public static final Logger logger = Logger.getLogger(OkHttpClient.class.getName());
 
   public static void initializeInstanceForTests() {
     // Needed in tests to ensure that the instance is actually pointing to something.

--- a/okhttp/src/main/java/okhttp3/internal/JdkWithJettyBootPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/JdkWithJettyBootPlatform.java
@@ -20,11 +20,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.List;
-import java.util.logging.Level;
 import javax.net.ssl.SSLSocket;
 import okhttp3.Protocol;
-
-import static okhttp3.internal.Internal.logger;
 
 /**
  * OpenJDK 7 or OpenJDK 8 with {@code org.mortbay.jetty.alpn/alpn-boot} in the boot class path.
@@ -71,8 +68,8 @@ class JdkWithJettyBootPlatform extends Platform {
       JettyNegoProvider provider =
           (JettyNegoProvider) Proxy.getInvocationHandler(getMethod.invoke(null, socket));
       if (!provider.unsupported && provider.selected == null) {
-        logger.log(Level.INFO, "ALPN callback dropped: SPDY and HTTP/2 are disabled. "
-            + "Is alpn-boot on the boot class path?");
+        Platform.get().log(INFO, "ALPN callback dropped: SPDY and HTTP/2 are disabled. "
+            + "Is alpn-boot on the boot class path?", null);
         return null;
       }
       return provider.unsupported ? null : provider.selected;

--- a/okhttp/src/main/java/okhttp3/internal/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/Platform.java
@@ -22,9 +22,12 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
+import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okio.Buffer;
 
@@ -65,6 +68,9 @@ import okio.Buffer;
  */
 public class Platform {
   private static final Platform PLATFORM = findPlatform();
+  public static final int INFO = 4;
+  public static final int WARN = 5;
+  private static final Logger logger = Logger.getLogger(OkHttpClient.class.getName());
 
   public static Platform get() {
     return PLATFORM;
@@ -73,10 +79,6 @@ public class Platform {
   /** Prefix used on custom headers. */
   public String getPrefix() {
     return "OkHttp";
-  }
-
-  public void logW(String warning) {
-    System.out.println(warning);
   }
 
   public X509TrustManager trustManager(SSLSocketFactory sslSocketFactory) {
@@ -119,8 +121,9 @@ public class Platform {
     socket.connect(address, connectTimeout);
   }
 
-  public void log(String message) {
-    System.out.println(message);
+  public void log(int level, String message, Throwable t) {
+    Level logLevel = level == WARN ? Level.WARNING : Level.INFO;
+    logger.log(logLevel, message, t);
   }
 
   public boolean isCleartextTrafficPermitted() {

--- a/okhttp/src/main/java/okhttp3/internal/framed/FramedConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/framed/FramedConnection.java
@@ -30,9 +30,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import okhttp3.Protocol;
 import okhttp3.internal.NamedRunnable;
+import okhttp3.internal.Platform;
 import okhttp3.internal.Util;
 import okio.Buffer;
 import okio.BufferedSink;
@@ -40,7 +40,7 @@ import okio.BufferedSource;
 import okio.ByteString;
 import okio.Okio;
 
-import static okhttp3.internal.Internal.logger;
+import static okhttp3.internal.Platform.INFO;
 import static okhttp3.internal.framed.Settings.DEFAULT_INITIAL_WINDOW_SIZE;
 
 /**
@@ -678,7 +678,7 @@ public final class FramedConnection implements Closeable {
               try {
                 listener.onStream(newStream);
               } catch (IOException e) {
-                logger.log(Level.INFO, "FramedConnection.Listener failure for " + hostname, e);
+                Platform.get().log(INFO, "FramedConnection.Listener failure for " + hostname, e);
                 try {
                   newStream.close(ErrorCode.PROTOCOL_ERROR);
                 } catch (IOException ignored) {


### PR DESCRIPTION
Avoid using System.out.

Use the best logging implementation on the host platform. On Java this is
java.util.logging. On Android it's Android.util.Log.

Closes https://github.com/square/okhttp/issues/2505