### PR TITLE
update Logging Interceptor to log connection failures

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -207,7 +207,13 @@ public final class HttpLoggingInterceptor implements Interceptor {
     }
 
     long startNs = System.nanoTime();
-    Response response = chain.proceed(request);
+    Response response;
+    try {
+      response = chain.proceed(request);
+    } catch (Exception e) {
+      logger.log("<-- Failed to send: " + e);
+      throw e;
+    }
     long tookMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
 
     ResponseBody responseBody = response.body();

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -658,7 +658,7 @@ public final class HttpLoggingInterceptorTest {
 
         applicationLogs
             .assertLogEqual("--> GET " + url + " http/1.1")
-            .assertLogEqual("<-- Failed to send: java.net.UnknownHostException: okhttp-notfound.com")
+            .assertLogMatch("<-- Failed to send: java.net.UnknownHostException: okhttp-notfound.com.*")
             .assertNoMoreLogs();
     }
 

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -16,6 +16,7 @@
 package okhttp3.logging;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -640,6 +641,26 @@ public final class HttpLoggingInterceptorTest {
         .assertLogEqual("<-- END HTTP (binary 9-byte body omitted)")
         .assertNoMoreLogs();
   }
+
+    @Test public void connectFail() throws IOException {
+        setLevel(Level.BASIC);
+        url = new HttpUrl.Builder()
+            .scheme("http")
+            .host("okhttp-notfound.com")
+            .port(80)
+            .build()
+            .resolve("/");
+
+        try {
+            client.newCall(request().build()).execute();
+        } catch (UnknownHostException ignored) {
+        }
+
+        applicationLogs
+            .assertLogEqual("--> GET " + url + " http/1.1")
+            .assertLogEqual("<-- Failed to send: java.net.UnknownHostException: okhttp-notfound.com")
+            .assertNoMoreLogs();
+    }
 
   private Request.Builder request() {
     return new Request.Builder().url(url);


### PR DESCRIPTION
BEFORE

05-06 08:21:41.939 10449-11016/com.blah.blah D/OkHttp: --> GET https://somewhere.com/ http/1.1
05-06 08:22:11.205 10449-11016/com.blah.blah D/libc: [NET] android_getaddrinfofornetcontext+,hn 24(0x736f6c6f2d7175),sn(),hints(known),family 0,flags 1024, proc=com.blah.blah
05-06 08:22:11.207 10449-11016/com.blah.blah D/libc: [NET] android_getaddrinfo_proxy get netid:0
05-06 08:22:11.557 10449-11016/com.blah.blah D/libc: [NET] android_getaddrinfo_proxy-, NODATA

AFTER

05-10 09:10:42.693 17637-19160/com.blah.blah D/OkHttp: --> GET https://somewhere.com/ http/1.1
05-10 09:10:42.697 17637-19160/com.blah.blah D/libc: [NET] android_getaddrinfofornetcontext+,hn 25(0x736f6c6f2d7175),sn(),hints(known),family 0,flags 1024, proc=com.blah.blah
05-10 09:10:42.697 17637-19160/com.blah.blah D/libc: [NET] android_getaddrinfo_proxy get netid:0
05-10 09:10:43.202 17637-19160/com.blah.blah D/libc: [NET] android_getaddrinfo_proxy-, NODATA
05-10 09:10:43.203 17637-19160/com.blah.blah D/OkHttp: <-- Failed to send: java.net.UnknownHostException: Unable to resolve host "somewhere.com": No address associated with hostname
