### PR TITLE
Add a simple version dynamic table of HPACK to the writer client.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/framed/HpackTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/framed/HpackTest.java
@@ -215,9 +215,6 @@ public class HpackTest {
     bytesIn.writeByte(0x0d); // Literal value (len = 13)
     bytesIn.writeUtf8("custom-header");
 
-    hpackWriter.writeHeaders(headerBlock);
-    assertEquals(bytesIn, bytesOut);
-
     hpackReader.readHeaders();
 
     assertEquals(0, hpackReader.headerCount);
@@ -239,6 +236,8 @@ public class HpackTest {
   }
 
   @Test public void literalHeaderFieldNeverIndexedNewName() throws IOException {
+    List<Header> headerBlock = headerEntries("custom-key", "custom-header");
+
     bytesIn.writeByte(0x10); // Never indexed
     bytesIn.writeByte(0x0a); // Literal name (len = 10)
     bytesIn.writeUtf8("custom-key");
@@ -674,7 +673,7 @@ public class HpackTest {
 
   @Test public void lowercaseHeaderNameBeforeEmit() throws IOException {
     hpackWriter.writeHeaders(Arrays.asList(new Header("FoO", "BaR")));
-    assertBytes(0, 3, 'f', 'o', 'o', 3, 'B', 'a', 'R');
+    assertBytes(0x40, 3, 'f', 'o', 'o', 3, 'B', 'a', 'R');
   }
 
   @Test public void mixedCaseHeaderNameIsMalformed() throws IOException {

--- a/okhttp/src/main/java/okhttp3/internal/framed/Hpack.java
+++ b/okhttp/src/main/java/okhttp3/internal/framed/Hpack.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -367,10 +368,97 @@ final class Hpack {
   }
 
   static final class Writer {
+    private static final byte SEPARATED_TOKEN = ':';
+    private static final int SETTINGS_HEADER_TABLE_SIZE = 4096;
+
     private final Buffer out;
+    private final Map<ByteString, Integer> headerStringToDynamicIndex =
+        new HashMap<ByteString, Integer>();
+
+    private int headerTableSizeSetting;
+    private int maxDynamicTableByteCount;
+    // Visible for testing.
+    Header[] dynamicTable = new Header[8];
+    // Array is populated back to front, so new entries always have lowest index.
+    int nextHeaderIndex = dynamicTable.length - 1;
+    int headerCount = 0;
+    int dynamicTableByteCount = 0;
 
     Writer(Buffer out) {
+      this(SETTINGS_HEADER_TABLE_SIZE, out);
+    }
+
+    Writer(int headerTableSizeSetting, Buffer out) {
+      this.headerTableSizeSetting = headerTableSizeSetting;
+      this.maxDynamicTableByteCount = headerTableSizeSetting;
       this.out = out;
+    }
+
+    ByteString getHeaderString(Header entry) {
+      byte[] ret = new byte[entry.name.size() + 1 + entry.value.size()];
+      System.arraycopy(entry.name.toByteArray(), 0, ret, 0, entry.name.size());
+      ret[entry.name.size()] = SEPARATED_TOKEN;
+      System.arraycopy(entry.value.toByteArray(), 0, ret, entry.name.size() + 1,
+          entry.value.size());
+      return ByteString.of(ret);
+    }
+
+    private void clearDynamicTable() {
+      Arrays.fill(dynamicTable, null);
+      headerStringToDynamicIndex.clear();
+      nextHeaderIndex = dynamicTable.length - 1;
+      headerCount = 0;
+      dynamicTableByteCount = 0;
+    }
+
+    /** Returns the count of entries evicted. */
+    private int evictToRecoverBytes(int bytesToRecover) {
+      int entriesToEvict = 0;
+      if (bytesToRecover > 0) {
+        // determine how many headers need to be evicted.
+        for (int j = dynamicTable.length - 1; j >= nextHeaderIndex && bytesToRecover > 0; j--) {
+          bytesToRecover -= dynamicTable[j].hpackSize;
+          dynamicTableByteCount -= dynamicTable[j].hpackSize;
+          headerCount--;
+          entriesToEvict++;
+        }
+        System.arraycopy(dynamicTable, nextHeaderIndex + 1, dynamicTable,
+            nextHeaderIndex + 1 + entriesToEvict, headerCount);
+        for (Map.Entry<ByteString, Integer> p : headerStringToDynamicIndex.entrySet()) {
+          p.setValue(p.getValue() + entriesToEvict);
+        }
+        nextHeaderIndex += entriesToEvict;
+      }
+      return entriesToEvict;
+    }
+
+    private void insertIntoDynamicTable(Header entry) {
+      int delta = entry.hpackSize;
+
+      // if the new or replacement header is too big, drop all entries.
+      if (delta > maxDynamicTableByteCount) {
+        clearDynamicTable();
+        return;
+      }
+
+      // Evict headers to the required length.
+      int bytesToRecover = (dynamicTableByteCount + delta) - maxDynamicTableByteCount;
+      evictToRecoverBytes(bytesToRecover);
+
+      if (headerCount + 1 > dynamicTable.length) { // Need to grow the dynamic table.
+        Header[] doubled = new Header[dynamicTable.length * 2];
+        System.arraycopy(dynamicTable, 0, doubled, dynamicTable.length, dynamicTable.length);
+        for (Map.Entry<ByteString, Integer> p : headerStringToDynamicIndex.entrySet()) {
+          p.setValue(p.getValue() + dynamicTable.length);
+        }
+        nextHeaderIndex = dynamicTable.length - 1;
+        dynamicTable = doubled;
+      }
+      int index = nextHeaderIndex--;
+      dynamicTable[index] = entry;
+      headerStringToDynamicIndex.put(getHeaderString(entry), index);
+      headerCount++;
+      dynamicTableByteCount += delta;
     }
 
     /** This does not use "never indexed" semantics for sensitive headers. */
@@ -379,15 +467,26 @@ final class Hpack {
       // TODO: implement index tracking
       for (int i = 0, size = headerBlock.size(); i < size; i++) {
         ByteString name = headerBlock.get(i).name.toAsciiLowercase();
+        ByteString value = headerBlock.get(i).value;
         Integer staticIndex = NAME_TO_FIRST_INDEX.get(name);
         if (staticIndex != null) {
           // Literal Header Field without Indexing - Indexed Name.
           writeInt(staticIndex + 1, PREFIX_4_BITS, 0);
-          writeByteString(headerBlock.get(i).value);
+          writeByteString(value);
         } else {
-          out.writeByte(0x00); // Literal Header without Indexing - New Name.
-          writeByteString(name);
-          writeByteString(headerBlock.get(i).value);
+          ByteString headerString = getHeaderString(headerBlock.get(i));
+          Integer dynamicIndex = headerStringToDynamicIndex.get(headerString);
+          if (dynamicIndex != null) {
+            // Indexed Header.
+            writeInt(dynamicTable.length - dynamicIndex + STATIC_HEADER_TABLE.length, PREFIX_7_BITS,
+                0);
+          } else {
+            // Literal Header Field with Incremental Indexing — New Name
+            out.writeByte(0x40);
+            writeByteString(name);
+            writeByteString(value);
+            insertIntoDynamicTable(headerBlock.get(i));
+          }
         }
       }
     }


### PR DESCRIPTION
This will automatically add all the headers into the dynamic table of HPACK if it is not in the static table.

I didn't write new unit test for checking the new added logic, e.g., the eviction of the dynamic table. This is just for a quick review. If the algorithm I used looks good, I'll add them.