### PR TITLE
Don't crash when a stream hasn't been closed.

### DIFF
--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -292,7 +292,7 @@ final class RealCall implements Call {
         throw new ProtocolException("Too many follow-up requests: " + followUpCount);
       }
 
-      if (!engine.sameConnection(followUp.url())) {
+      if (!engine.sameConnection(followUp.url()) || streamAllocation.stream() != null) {
         streamAllocation.release();
         streamAllocation = null;
       }


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/2409