### PR TITLE
Recover from REFUSED_STREAM errors in HTTP/2.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
@@ -38,6 +38,7 @@ public final class MockResponse implements Cloneable {
   private TimeUnit throttlePeriodUnit = TimeUnit.SECONDS;
 
   private SocketPolicy socketPolicy = SocketPolicy.KEEP_OPEN;
+  private int http2ErrorCode = -1;
 
   private long bodyDelayAmount = 0;
   private TimeUnit bodyDelayUnit = TimeUnit.MILLISECONDS;
@@ -202,6 +203,20 @@ public final class MockResponse implements Cloneable {
 
   public MockResponse setSocketPolicy(SocketPolicy socketPolicy) {
     this.socketPolicy = socketPolicy;
+    return this;
+  }
+
+  public int getHttp2ErrorCode() {
+    return http2ErrorCode;
+  }
+
+  /**
+   * Sets the <a href="https://tools.ietf.org/html/rfc7540#section-7">HTTP/2 error code</a> to be
+   * returned when resetting the stream. This is only valid with {@link
+   * SocketPolicy#RESET_STREAM_AT_START}.
+   */
+  public MockResponse setHttp2ErrorCode(int http2ErrorCode) {
+    this.http2ErrorCode = http2ErrorCode;
     return this;
   }
 

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/SocketPolicy.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/SocketPolicy.java
@@ -88,5 +88,11 @@ public enum SocketPolicy {
    * Don't respond to the request but keep the socket open. For testing read response header timeout
    * issue.
    */
-  NO_RESPONSE
+  NO_RESPONSE,
+
+  /**
+   * Fail HTTP/2 requests without processing them by sending an {@linkplain
+   * MockResponse#getHttp2ErrorCode() HTTP/2 error code}.
+   */
+  RESET_STREAM_AT_START
 }

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -631,9 +631,12 @@ public final class URLConnectionTest {
 
     assertContent("this response comes via SSL", connection);
 
-    RecordedRequest request = server.takeRequest();
-    assertEquals("GET /foo HTTP/1.1", request.getRequestLine());
-    assertEquals(TlsVersion.TLS_1_0, request.getTlsVersion());
+    RecordedRequest failHandshakeRequest = server.takeRequest();
+    assertNull(failHandshakeRequest.getRequestLine());
+
+    RecordedRequest fallbackRequest = server.takeRequest();
+    assertEquals("GET /foo HTTP/1.1", fallbackRequest.getRequestLine());
+    assertEquals(TlsVersion.TLS_1_0, fallbackRequest.getTlsVersion());
   }
 
   @Test public void connectViaHttpsWithSSLFallbackFailuresRecorded() throws Exception {

--- a/okhttp/src/main/java/okhttp3/internal/framed/FramedStream.java
+++ b/okhttp/src/main/java/okhttp3/internal/framed/FramedStream.java
@@ -142,7 +142,7 @@ public final class FramedStream {
       readTimeout.exitAndThrowIfTimedOut();
     }
     if (responseHeaders != null) return responseHeaders;
-    throw new IOException("stream was reset: " + errorCode);
+    throw new StreamResetException(errorCode);
   }
 
   /**
@@ -438,7 +438,7 @@ public final class FramedStream {
         throw new IOException("stream closed");
       }
       if (errorCode != null) {
-        throw new IOException("stream was reset: " + errorCode);
+        throw new StreamResetException(errorCode);
       }
     }
   }
@@ -571,7 +571,7 @@ public final class FramedStream {
     } else if (sink.finished) {
       throw new IOException("stream finished");
     } else if (errorCode != null) {
-      throw new IOException("stream was reset: " + errorCode);
+      throw new StreamResetException(errorCode);
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/framed/StreamResetException.java
+++ b/okhttp/src/main/java/okhttp3/internal/framed/StreamResetException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.framed;
+
+import java.io.IOException;
+
+/** Thrown when an HTTP/2 stream is canceled without damage to the socket that carries it. */
+public final class StreamResetException extends IOException {
+  public final ErrorCode errorCode;
+
+  public StreamResetException(ErrorCode errorCode) {
+    super("stream was reset: " + errorCode);
+    this.errorCode = errorCode;
+  }
+}


### PR DESCRIPTION
This implements the following policy:

 - If a REFUSED_STREAM error is received, OkHttp will retry the same stream
   on the same socket 1x.
 - If any other error is received, or an additional REFUSED_STREAM error is
   received, OkHttp will retry on a different route if one exists.

We may want to follow up by going through HTTP/2 error codes and deciding
a per-code retry policy, but this should be good enough for now.

Closes: https://github.com/square/okhttp/issues/2543