### PR TITLE
Retain response body when web socket returns non-101 response code.

### DIFF
--- a/okhttp-ws-tests/src/test/java/okhttp3/ws/WebSocketRecorder.java
+++ b/okhttp-ws-tests/src/test/java/okhttp3/ws/WebSocketRecorder.java
@@ -38,6 +38,7 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
 
   private final BlockingQueue<Object> events = new LinkedBlockingQueue<>();
   private MessageDelegate delegate;
+  private Response response;
 
   /** Sets a delegate for the next call to {@link #onMessage}. Cleared after invoked. */
   public void setNextMessageDelegate(MessageDelegate delegate) {
@@ -73,6 +74,7 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
 
   @Override public void onFailure(IOException e, Response response) {
     events.add(e);
+    this.response = response;
   }
 
   private Object nextEvent() {
@@ -142,6 +144,12 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
 
   public void assertExhausted() {
     assertTrue("Remaining events: " + events, events.isEmpty());
+  }
+
+  public void assertResponse(int code, String body) throws IOException {
+    assertNotNull(response);
+    assertEquals(code, response.code());
+    assertEquals(body, response.body().string());
   }
 
   private static class Message {

--- a/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
@@ -115,7 +115,6 @@ public final class WebSocketCall {
 
   private void createWebSocket(Response response, WebSocketListener listener) throws IOException {
     if (response.code() != 101) {
-      Util.closeQuietly(response.body());
       throw new ProtocolException("Expected HTTP 101 response but was '"
           + response.code()
           + " "

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -779,7 +779,7 @@ public final class HttpEngine {
         .receivedResponseAtMillis(System.currentTimeMillis())
         .build();
 
-    if (!forWebSocket) {
+    if (!forWebSocket || networkResponse.code() != 101) {
       networkResponse = networkResponse.newBuilder()
           .body(httpStream.openResponseBody(networkResponse))
           .build();


### PR DESCRIPTION
This change also fixes an edge case where a server returns a response
that allows a follow up request. Previously, this would cause an
exception because the body was being ignored.