### PR TITLE
Fix HttpLoggingInterceptor to be cool with newlines.

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -283,7 +283,8 @@ public final class HttpLoggingInterceptor implements Interceptor {
         if (prefix.exhausted()) {
           break;
         }
-        if (Character.isISOControl(prefix.readUtf8CodePoint())) {
+        int codePoint = prefix.readUtf8CodePoint();
+        if (Character.isISOControl(codePoint) && !Character.isWhitespace(codePoint)) {
           return false;
         }
       }

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -597,6 +597,8 @@ public final class HttpLoggingInterceptorTest {
   @Test public void isPlaintext() throws IOException {
     assertTrue(HttpLoggingInterceptor.isPlaintext(new Buffer()));
     assertTrue(HttpLoggingInterceptor.isPlaintext(new Buffer().writeUtf8("abc")));
+    assertTrue(HttpLoggingInterceptor.isPlaintext(new Buffer().writeUtf8("new\r\nlines")));
+    assertTrue(HttpLoggingInterceptor.isPlaintext(new Buffer().writeUtf8("white\t space")));
     assertTrue(HttpLoggingInterceptor.isPlaintext(new Buffer().writeByte(0x80)));
     assertFalse(HttpLoggingInterceptor.isPlaintext(new Buffer().writeByte(0x00)));
     assertFalse(HttpLoggingInterceptor.isPlaintext(new Buffer().writeByte(0xc0)));


### PR DESCRIPTION
Unfortunately our plaintext detector treats \r and \n as non-plaintext
characters, and they're completely fine.

Closes: https://github.com/square/okhttp/issues/2579