### PR TITLE
Don't crash reading non-ASCII characters from the server or the cache.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/framed/HttpOverSpdyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/framed/HttpOverSpdyTest.java
@@ -678,6 +678,20 @@ public abstract class HttpOverSpdyTest {
     }
   }
 
+  @Test public void nonAsciiResponseHeader() throws Exception {
+    server.enqueue(new MockResponse()
+        .addHeaderLenient("Alpha", "α")
+        .addHeaderLenient("β", "Beta"));
+
+    Call call = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    Response response = call.execute();
+
+    assertEquals("α", response.header("Alpha"));
+    assertEquals("Beta", response.header("β"));
+  }
+
   public Buffer gzip(String bytes) throws IOException {
     Buffer bytesOut = new Buffer();
     BufferedSink sink = Okio.buffer(new GzipSink(bytesOut));

--- a/okhttp/src/main/java/okhttp3/internal/http/Http2xStream.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/Http2xStream.java
@@ -28,6 +28,7 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.internal.Internal;
 import okhttp3.internal.Util;
 import okhttp3.internal.framed.ErrorCode;
 import okhttp3.internal.framed.FramedConnection;
@@ -233,7 +234,7 @@ public final class Http2xStream implements HttpStream {
         } else if (name.equals(VERSION)) {
           version = value;
         } else if (!SPDY_3_SKIPPED_RESPONSE_HEADERS.contains(name)) {
-          headersBuilder.add(name.utf8(), value);
+          Internal.instance.addLenient(headersBuilder, name.utf8(), value);
         }
         start = end + 1;
       }
@@ -260,7 +261,7 @@ public final class Http2xStream implements HttpStream {
       if (name.equals(RESPONSE_STATUS)) {
         status = value;
       } else if (!HTTP_2_SKIPPED_RESPONSE_HEADERS.contains(name)) {
-        headersBuilder.add(name.utf8(), value);
+        Internal.instance.addLenient(headersBuilder, name.utf8(), value);
       }
     }
     if (status == null) throw new ProtocolException("Expected ':status' header not present");

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpEngine.java
@@ -892,7 +892,7 @@ public final class HttpEngine {
         continue; // Drop 100-level freshness warnings.
       }
       if (!OkHeaders.isEndToEnd(fieldName) || networkHeaders.get(fieldName) == null) {
-        result.add(fieldName, value);
+        Internal.instance.addLenient(result, fieldName, value);
       }
     }
 
@@ -902,7 +902,7 @@ public final class HttpEngine {
         continue; // Ignore content-length headers of validating responses.
       }
       if (OkHeaders.isEndToEnd(fieldName)) {
-        result.add(fieldName, networkHeaders.value(i));
+        Internal.instance.addLenient(result, fieldName, networkHeaders.value(i));
       }
     }
 


### PR DESCRIPTION
This doesn't completely support ISO-8859-1 headers; instead they will most likely
be mangled when they are decoded as UTF-8. If we decide we absolutely must support
ISO-8859-1 here we can do that in another change. (I'm not currently enthusiastic
about this idea.)

But this does prevent OkHttp from crashing when it encounters non-ASCII characters
in headers for HTTP/2, SPDY, and cached responses.

Closes: https://github.com/square/okhttp/issues/1998