### PR TITLE
WIP: Changes to help reason about how idle time works

### DIFF
--- a/okhttp/src/main/java/com/squareup/okhttp/internal/http/StreamAllocation.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/http/StreamAllocation.java
@@ -173,9 +173,9 @@ public final class StreamAllocation {
 
     Route route = routeSelector.next();
     RealConnection newConnection = new RealConnection(route);
-    acquire(newConnection);
 
     synchronized (connectionPool) {
+      acquire(newConnection);
       Internal.instance.put(connectionPool, newConnection);
       this.connection = newConnection;
       if (canceled) throw new IOException("Canceled");
@@ -298,8 +298,9 @@ public final class StreamAllocation {
    * {@link #release} on the same connection.
    */
   public void acquire(RealConnection connection) {
+    assert (Thread.holdsLock(connectionPool));
     connection.allocations.add(new WeakReference<>(this));
-  }
+ }
 
   /** Remove this allocation from the connection's list of allocations. */
   private void release(RealConnection connection) {

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/io/RealConnection.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/io/RealConnection.java
@@ -81,9 +81,13 @@ public final class RealConnection implements Connection {
   public int streamCount;
   public BufferedSource source;
   public BufferedSink sink;
+
+  // State guarded by the owning connectionPool.
   public final List<Reference<StreamAllocation>> allocations = new ArrayList<>();
   public boolean noNewStreams;
-  public long idleAtNanos = Long.MAX_VALUE;
+  // The time the connection became idle. Only valid if allocations.isEmpty(). All reads must check
+  // allocations.isEmpty(), all modifications to allocations must set this if allocations.isEmpty().
+  public long idleAtNanos;
 
   public RealConnection(Route route) {
     this.route = route;

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,10 @@
     <okio.version>1.6.0</okio.version>
     <!-- ALPN library targeted to Java 7 -->
     <alpn.jdk7.version>7.1.2.v20141202</alpn.jdk7.version>
-    <!-- ALPN library targeted to Java 8 update 25. -->
-    <alpn.jdk8.version>8.1.2.v20141202</alpn.jdk8.version>
+    <!-- ALPN library targeted to Java 8 update 71 - 74 -->
+    <!-- alpn.jdk8.version>8.1.7.v20160121</alpn.jdk8.version-->
+    <!-- ALPN library targeted to Java 8 update 45 -->
+    <alpn.jdk8.version>8.1.3.v20150130</alpn.jdk8.version>
     <bouncycastle.version>1.50</bouncycastle.version>
     <gson.version>2.2.3</gson.version>
     <apache.http.version>4.2.2</apache.http.version>


### PR DESCRIPTION
Jesse,

This is *not* intended for submission and is against branch 2.7: I want to check a few things with you. I found the ConnectionPool / StreamAllocation / RealConnection arrangement in 2.7 hard to reason about. Apparently there is a bug in the OkHttp on N (~2.5) due to the use of Long.MAX_VALUE to initialize the old equivalent of idleAtNanos.

The arithmetic to work out whether a connection was idle would fail if System.nanoTime() returned a value > 0 and < keepAliveNanos. Generally I think the use of any absolute "can never happen" or "in far future" timestamp is probably bogus when dealing with nanoTime(): no guarantees about sign or magnitude, only really useful for elapsed time or ordering comparisons.

I _believe_ that bug has gone away with subsequent commits which now check whether but I found it hard to prove to myself. This change includes additional docs and assertions. Do you agree with them?

It's possible that streamCount should also be guarded by the connection pool monitor, though that's not currently the case.

Not sure if an equivalent change would transfer to OkHttp 3: a lot of it looks similar.

(Ignore the pom.xml change too)