### PR TITLE
Add hook to gather network metrics

### DIFF
--- a/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
+++ b/okhttp-urlconnection/src/main/java/com/squareup/okhttp/internal/huc/HttpURLConnectionImpl.java
@@ -230,7 +230,18 @@ public class HttpURLConnectionImpl extends HttpURLConnection {
       throw new ProtocolException("This protocol does not support input");
     }
 
-    HttpEngine response = getResponse();
+    final long startTimeMs = System.currentTimeMillis();
+    HttpEngine response;
+    boolean exceptionThrown = true;
+    int responseCode = 0;
+    try {
+      response = getResponse();
+      responseCode = getResponseCode();
+      exceptionThrown = false;
+    } finally {
+      final long timeDeltaMs = System.currentTimeMillis() - startTimeMs;
+      Platform.get().maybeLogHttpEvent(method, timeDeltaMs, responseCode, exceptionThrown);
+    }
 
     // if the requested file does not exist, throw an exception formerly the
     // Error page from the server was returned if the requested file was

--- a/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
+++ b/okhttp/src/main/java/com/squareup/okhttp/internal/Platform.java
@@ -100,6 +100,11 @@ public class Platform {
     socket.connect(address, connectTimeout);
   }
 
+  /** Maybe log the http latency, method and response code if enabled */
+  public void maybeLogHttpEvent(final String method, long timeDeltaMs, int responseCode,
+      boolean exceptionThrown) {
+  }
+
   /** Attempt to match the host runtime to a capable Platform implementation. */
   private static Platform findPlatform() {
     // Attempt to find Android 2.3+ APIs.


### PR DESCRIPTION
If enabled, send an event log for each http
request with latency, http status code and
if an exception was thrown.

The idea here is to instrument each  http connection
so that statistically significant data can be gathered
from all consumers about underlying network health.

It should be minimally intrusive when disabled, and
emit a single event log per connection.

Android is using an older version ok2.5 thus the ancient version request.
