### PR TITLE
Let SocksProxy use the same definition of localhost as MockWebServer.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/SocksProxy.java
+++ b/okhttp-tests/src/test/java/okhttp3/SocksProxy.java
@@ -160,7 +160,7 @@ public final class SocksProxy {
         String domainName = fromSource.readUtf8(domainNameLength);
         // Resolve HOSTNAME_THAT_ONLY_THE_PROXY_KNOWS to localhost.
         toAddress = domainName.equalsIgnoreCase(HOSTNAME_THAT_ONLY_THE_PROXY_KNOWS)
-            ? InetAddress.getLoopbackAddress()
+            ? InetAddress.getByName("localhost")
             : InetAddress.getByName(domainName);
         break;
 


### PR DESCRIPTION
This fixes SocksProxyTest failing on some systems. The problem was that
MockWebServer is listening on InetAddress.getByName("localhost") but
SocksProxy was trying to connect to InetAddress.getLoopbackAddress().
This is not guaranteed to work, for example on recent AOSP, "localhost"
resolves to 127.0.0.1 (IPv4) but getLoopbackAddress() is ::1 (IPv6).

This CL makes the simplest change to make the two consistent so that
SocksProxyTest passes. In the long run, OkHttp may want to consider
using getLoopbackAddress().getHostName() everywhere instead of hard
coding the hostname "localhost" at all.