### PR TITLE
Reduce memory requirements for MockWebServerTest.disconnectHalfway().

### DIFF
--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
@@ -281,6 +281,9 @@ public final class MockWebServerTest {
 
   @Test public void disconnectRequestHalfway() throws IOException {
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_DURING_REQUEST_BODY));
+    // Limit the size of the request body that the server holds in memory to an arbitrary
+    // 3.5 MBytes so this test can pass on devices with little memory.
+    server.setBodyLimit(7 * 512 * 1024);
 
     HttpURLConnection connection = (HttpURLConnection) server.url("/").url().openConnection();
     connection.setRequestMethod("POST");


### PR DESCRIPTION
MockWebServer.readRequest() was accumulating the request body (1 GByte)
into an unbounded buffer held in memory. This caused the test to fail
with an OutOfMemoryError on low-memory devices. Due to the OOME, not
even a stacktrace was available.

This CL introduces setBodyLimit() to limit the amount of data held in
memory. Note that this is similar to the call to setBodyLimit(0) that
already exists in URLConnectionTest.veryLargeFixedLengthRequest().