### PR TITLE
Begin to fold together parts of RealCall and HttpEngine.

### DIFF
--- a/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
+++ b/okhttp-ws/src/main/java/okhttp3/ws/WebSocketCall.java
@@ -105,7 +105,8 @@ public final class WebSocketCall {
       }
     };
     // TODO call.enqueue(responseCallback, true);
-    Internal.instance.callEnqueue(call, responseCallback, true);
+    Internal.instance.setCallWebSocket(call);
+    call.enqueue(responseCallback);
   }
 
   /** Cancels the request, if possible. Requests that are already complete cannot be canceled. */

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -110,11 +110,6 @@ public class OkHttpClient implements Cloneable, Call.Factory {
         return connectionPool.routeDatabase;
       }
 
-      @Override
-      public void callEnqueue(Call call, Callback responseCallback, boolean forWebSocket) {
-        ((RealCall) call).enqueue(responseCallback, forWebSocket);
-      }
-
       @Override public StreamAllocation callEngineGetStreamAllocation(Call call) {
         return ((RealCall) call).engine.streamAllocation;
       }
@@ -127,6 +122,10 @@ public class OkHttpClient implements Cloneable, Call.Factory {
       @Override public HttpUrl getHttpUrlChecked(String url)
           throws MalformedURLException, UnknownHostException {
         return HttpUrl.getChecked(url);
+      }
+
+      @Override public void setCallWebSocket(Call call) {
+        ((RealCall) call).setForWebSocket();
       }
     };
   }

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -20,7 +20,6 @@ import java.net.UnknownHostException;
 import javax.net.ssl.SSLSocket;
 import okhttp3.Address;
 import okhttp3.Call;
-import okhttp3.Callback;
 import okhttp3.ConnectionPool;
 import okhttp3.ConnectionSpec;
 import okhttp3.Headers;
@@ -65,8 +64,7 @@ public abstract class Internal {
   public abstract HttpUrl getHttpUrlChecked(String url)
       throws MalformedURLException, UnknownHostException;
 
-  // TODO delete the following when web sockets move into the main package.
-  public abstract void callEnqueue(Call call, Callback responseCallback, boolean forWebSocket);
-
   public abstract StreamAllocation callEngineGetStreamAllocation(Call call);
+
+  public abstract void setCallWebSocket(Call call);
 }

--- a/okhttp/src/main/java/okhttp3/internal/http/RouteException.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RouteException.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Method;
  * An exception thrown to indicate a problem connecting via a single Route. Multiple attempts may
  * have been made with alternative protocols, none of which were successful.
  */
-public final class RouteException extends Exception {
+public final class RouteException extends RuntimeException {
   private static final Method addSuppressedExceptionMethod;
 
   static {

--- a/okhttp/src/main/java/okhttp3/internal/http/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/StreamAllocation.java
@@ -87,8 +87,7 @@ public final class StreamAllocation {
   }
 
   public HttpStream newStream(int connectTimeout, int readTimeout, int writeTimeout,
-      boolean connectionRetryEnabled, boolean doExtensiveHealthChecks)
-      throws RouteException, IOException {
+      boolean connectionRetryEnabled, boolean doExtensiveHealthChecks) throws IOException {
     try {
       RealConnection resultConnection = findHealthyConnection(connectTimeout, readTimeout,
           writeTimeout, connectionRetryEnabled, doExtensiveHealthChecks);
@@ -118,7 +117,7 @@ public final class StreamAllocation {
    */
   private RealConnection findHealthyConnection(int connectTimeout, int readTimeout,
       int writeTimeout, boolean connectionRetryEnabled, boolean doExtensiveHealthChecks)
-      throws IOException, RouteException {
+      throws IOException {
     while (true) {
       RealConnection candidate = findConnection(connectTimeout, readTimeout, writeTimeout,
           connectionRetryEnabled);
@@ -146,7 +145,7 @@ public final class StreamAllocation {
    * then the pool, finally building a new connection.
    */
   private RealConnection findConnection(int connectTimeout, int readTimeout, int writeTimeout,
-      boolean connectionRetryEnabled) throws IOException, RouteException {
+      boolean connectionRetryEnabled) throws IOException {
     Route selectedRoute;
     synchronized (connectionPool) {
       if (released) throw new IllegalStateException("released");

--- a/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/io/RealConnection.java
@@ -90,7 +90,7 @@ public final class RealConnection extends FramedConnection.Listener implements C
   }
 
   public void connect(int connectTimeout, int readTimeout, int writeTimeout,
-      List<ConnectionSpec> connectionSpecs, boolean connectionRetryEnabled) throws RouteException {
+      List<ConnectionSpec> connectionSpecs, boolean connectionRetryEnabled) {
     if (protocol != null) throw new IllegalStateException("already connected");
 
     RouteException routeException = null;


### PR DESCRIPTION
Previously we had an awkward, arbitrary separation because RealCall contained
the stuff that wasn't in HttpURLConnection, and HttpEngine contained everything
that was shared.

It was also awkward because HttpEngine could be interrupted in various parts
of the HttpURLConnection flow: after connecting, while transmitting the request
body, etc. With this change we no longer need to handle API calls while we're
in these intermediate states, which means we can reduce the scope of certain
things from fields to local variables.

There's still a way to go here but this is more easy wins.