### PR TITLE
IllegalArgumentException

### DIFF
--- a/okhttp/src/main/java/okhttp3/Request.java
+++ b/okhttp/src/main/java/okhttp3/Request.java
@@ -232,8 +232,11 @@ public final class Request {
       if (body != null && !HttpMethod.permitsRequestBody(method)) {
         throw new IllegalArgumentException("method " + method + " must not have a request body.");
       }
-      if (body == null && HttpMethod.requiresRequestBody(method)) {
-        throw new IllegalArgumentException("method " + method + " must have a request body.");
+      // if (body == null && HttpMethod.requiresRequestBody(method)) {
+      //   throw new IllegalArgumentException("method " + method + " must have a request body.");
+      // }
+      if (body == null && HttpMethod.permitsRequestBody(method)) {
+        body = RequestBody.create(null, Util.EMPTY_BYTE_ARRAY);
       }
       this.method = method;
       this.body = body;


### PR DESCRIPTION
Unhandled exception java.lang.IllegalArgumentException: method POST must have a request body.