### PR TITLE
Add encode for asterisk in form fields.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/FormBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/FormBodyTest.java
@@ -152,7 +152,7 @@ public final class FormBodyTest {
     assertEquals("%27", formEncode(39));
     assertEquals("%28", formEncode(40));
     assertEquals("%29", formEncode(41));
-    assertEquals("*", formEncode(42));
+    assertEquals("%2A", formEncode(42));
     assertEquals("%2B", formEncode(43));
     assertEquals("%2C", formEncode(44));
     assertEquals("-", formEncode(45));

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -285,7 +285,7 @@ public final class HttpUrl {
   static final String QUERY_ENCODE_SET = " \"'<>#";
   static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>#&=";
   static final String QUERY_COMPONENT_ENCODE_SET_URI = "\\^`{|}";
-  static final String FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~";
+  static final String FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~*";
   static final String FRAGMENT_ENCODE_SET = "";
   static final String FRAGMENT_ENCODE_SET_URI = " \"#<>\\^`{|}";
 


### PR DESCRIPTION
According to [RFC3986 point 2.2](https://tools.ietf.org/html/rfc3986#page-12) and [RFC1738 point 2.2](http://www.rfc-editor.org/rfc/rfc1738.txt)

> URIs include components and subcomponents that are delimited by
   characters in the "reserved" set.  These characters are called
   "reserved" because they may (or may not) be defined as delimiters by
   the generic syntax, by each scheme-specific syntax, or by the
   implementation-specific syntax of a URI's dereferencing algorithm.

Although:

> [...] only alphanumerics, the special characters "$-_.+!*'(),", and
   reserved characters used for their reserved purposes may be used
   unencoded within a URL.

Therefore as far as I understood is optional to encode some characters ("$-_.+!*'(),"), therefore following the logic that `HttpUrl.FORM_ENCODE_SET` already includes almost all of this characters, I think it would make sense to be consistent within this convention and thus include the asterisk symbol as well.

Please let me know if you agree with this and if the changes made are fine.
Thank you in advance.