### PR TITLE
Rename HttpURLConnectionImpl to OkHttpURLConnection.

### DIFF
--- a/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
+++ b/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
@@ -44,6 +44,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.internal.Internal;
 import okhttp3.internal.JavaNetHeaders;
+import okhttp3.internal.Platform;
 import okhttp3.internal.Util;
 import okhttp3.internal.http.CacheRequest;
 import okhttp3.internal.http.HttpMethod;
@@ -58,6 +59,12 @@ import okio.Sink;
  */
 public final class JavaApiConverter {
   private static final RequestBody EMPTY_REQUEST_BODY = RequestBody.create(null, new byte[0]);
+
+  /** Synthetic response header: the local time when the request was sent. */
+  private static final String SENT_MILLIS = Platform.get().getPrefix() + "-Sent-Millis";
+
+  /** Synthetic response header: the local time when the response was received. */
+  private static final String RECEIVED_MILLIS = Platform.get().getPrefix() + "-Received-Millis";
 
   private JavaApiConverter() {
   }
@@ -397,8 +404,8 @@ public final class JavaApiConverter {
 
   private static Headers withSyntheticHeaders(Response okResponse) {
     return okResponse.headers().newBuilder()
-        .add(OkHeaders.SENT_MILLIS, Long.toString(okResponse.sentRequestAtMillis()))
-        .add(OkHeaders.RECEIVED_MILLIS, Long.toString(okResponse.receivedResponseAtMillis()))
+        .add(SENT_MILLIS, Long.toString(okResponse.sentRequestAtMillis()))
+        .add(RECEIVED_MILLIS, Long.toString(okResponse.receivedResponseAtMillis()))
         .build();
   }
 
@@ -448,11 +455,11 @@ public final class JavaApiConverter {
         continue;
       }
       if (okResponseBuilder != null && javaHeader.getValue().size() == 1) {
-        if (name.equals(OkHeaders.SENT_MILLIS)) {
+        if (name.equals(SENT_MILLIS)) {
           okResponseBuilder.sentRequestAtMillis(Long.valueOf(javaHeader.getValue().get(0)));
           continue;
         }
-        if (name.equals(OkHeaders.RECEIVED_MILLIS)) {
+        if (name.equals(RECEIVED_MILLIS)) {
           okResponseBuilder.receivedResponseAtMillis(Long.valueOf(javaHeader.getValue().get(0)));
           continue;
         }

--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
@@ -2102,11 +2102,11 @@ public final class ResponseCacheTest {
 
     // Use the platform's HTTP stack.
     URLConnection connection = server.url("/").url().openConnection();
-    assertFalse(connection instanceof HttpURLConnectionImpl);
+    assertFalse(connection instanceof OkHttpURLConnection);
     assertEquals("A", readAscii(connection));
 
     URLConnection connection2 = server.url("/").url().openConnection();
-    assertFalse(connection2 instanceof HttpURLConnectionImpl);
+    assertFalse(connection2 instanceof OkHttpURLConnection);
     assertEquals("A", readAscii(connection2));
   }
 
@@ -2126,11 +2126,11 @@ public final class ResponseCacheTest {
 
     // Use the platform's HTTP stack.
     URLConnection connection = server.url("/").url().openConnection();
-    assertFalse(connection instanceof HttpURLConnectionImpl);
+    assertFalse(connection instanceof OkHttpURLConnection);
     assertEquals("A", readAscii(connection));
 
     URLConnection connection2 = server.url("/").url().openConnection();
-    assertFalse(connection2 instanceof HttpURLConnectionImpl);
+    assertFalse(connection2 instanceof OkHttpURLConnection);
     assertEquals("B", readAscii(connection2));
   }
 
@@ -2150,12 +2150,12 @@ public final class ResponseCacheTest {
 
     // Use the platform's HTTP stack.
     URLConnection connection = server.url("/").url().openConnection();
-    assertFalse(connection instanceof HttpURLConnectionImpl);
+    assertFalse(connection instanceof OkHttpURLConnection);
     connection.setRequestProperty("Accept-Language", "en-US");
     assertEquals("A", readAscii(connection));
 
     URLConnection connection2 = server.url("/").url().openConnection();
-    assertFalse(connection2 instanceof HttpURLConnectionImpl);
+    assertFalse(connection2 instanceof OkHttpURLConnection);
     assertEquals("B", readAscii(connection2));
   }
 
@@ -2175,11 +2175,11 @@ public final class ResponseCacheTest {
 
     // Use the platform's HTTP stack.
     URLConnection connection = server.url("/").url().openConnection();
-    assertFalse(connection instanceof HttpURLConnectionImpl);
+    assertFalse(connection instanceof OkHttpURLConnection);
     assertEquals("A", readAscii(connection));
 
     URLConnection connection2 = server.url("/").url().openConnection();
-    assertFalse(connection2 instanceof HttpURLConnectionImpl);
+    assertFalse(connection2 instanceof OkHttpURLConnection);
     assertEquals("B", readAscii(connection2));
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -85,7 +85,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.internal.Util.UTF_8;
-import static okhttp3.internal.http.OkHeaders.SELECTED_PROTOCOL;
+import static okhttp3.internal.huc.OkHttpURLConnection.SELECTED_PROTOCOL;
 import static okhttp3.internal.http.StatusLine.HTTP_PERM_REDIRECT;
 import static okhttp3.internal.http.StatusLine.HTTP_TEMP_REDIRECT;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;

--- a/okhttp-urlconnection/src/main/java/okhttp3/OkUrlFactory.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/OkUrlFactory.java
@@ -22,8 +22,8 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 import okhttp3.internal.URLFilter;
-import okhttp3.internal.huc.HttpURLConnectionImpl;
-import okhttp3.internal.huc.HttpsURLConnectionImpl;
+import okhttp3.internal.huc.OkHttpURLConnection;
+import okhttp3.internal.huc.OkHttpsURLConnection;
 
 /**
  * @deprecated OkHttp will be dropping its ability to be used with {@link HttpURLConnection} in an
@@ -69,8 +69,8 @@ public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
         .proxy(proxy)
         .build();
 
-    if (protocol.equals("http")) return new HttpURLConnectionImpl(url, copy, urlFilter);
-    if (protocol.equals("https")) return new HttpsURLConnectionImpl(url, copy, urlFilter);
+    if (protocol.equals("http")) return new OkHttpURLConnection(url, copy, urlFilter);
+    if (protocol.equals("https")) return new OkHttpsURLConnection(url, copy, urlFilter);
     throw new IllegalArgumentException("Unexpected protocol: " + protocol);
   }
 

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpsURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpsURLConnection.java
@@ -23,18 +23,18 @@ import okhttp3.Handshake;
 import okhttp3.OkHttpClient;
 import okhttp3.internal.URLFilter;
 
-public final class HttpsURLConnectionImpl extends DelegatingHttpsURLConnection {
-  private final HttpURLConnectionImpl delegate;
+public final class OkHttpsURLConnection extends DelegatingHttpsURLConnection {
+  private final OkHttpURLConnection delegate;
 
-  public HttpsURLConnectionImpl(URL url, OkHttpClient client) {
-    this(new HttpURLConnectionImpl(url, client));
+  public OkHttpsURLConnection(URL url, OkHttpClient client) {
+    this(new OkHttpURLConnection(url, client));
   }
 
-  public HttpsURLConnectionImpl(URL url, OkHttpClient client, URLFilter filter) {
-    this(new HttpURLConnectionImpl(url, client, filter));
+  public OkHttpsURLConnection(URL url, OkHttpClient client, URLFilter filter) {
+    this(new OkHttpURLConnection(url, client, filter));
   }
 
-  public HttpsURLConnectionImpl(HttpURLConnectionImpl delegate) {
+  public OkHttpsURLConnection(OkHttpURLConnection delegate) {
     super(delegate);
     this.delegate = delegate;
   }

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OutputStreamRequestBody.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OutputStreamRequestBody.java
@@ -30,7 +30,7 @@ import okio.Timeout;
  * In either case the bytes of the body aren't known until the caller writes them to the output
  * stream.
  */
-public abstract class OutputStreamRequestBody extends RequestBody {
+abstract class OutputStreamRequestBody extends RequestBody {
   private Timeout timeout;
   private long expectedContentLength;
   private OutputStream outputStream;

--- a/okhttp-urlconnection/src/test/java/okhttp3/OkUrlFactoryTest.java
+++ b/okhttp-urlconnection/src/test/java/okhttp3/OkUrlFactoryTest.java
@@ -12,7 +12,7 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HttpsURLConnection;
 import okhttp3.internal.URLFilter;
-import okhttp3.internal.http.OkHeaders;
+import okhttp3.internal.huc.OkHttpURLConnection;
 import okhttp3.internal.io.InMemoryFileSystem;
 import okhttp3.internal.tls.SslClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -219,7 +219,7 @@ public class OkUrlFactoryTest {
   }
 
   private void assertResponseHeader(HttpURLConnection connection, String expected) {
-    assertEquals(expected, connection.getHeaderField(OkHeaders.RESPONSE_SOURCE));
+    assertEquals(expected, connection.getHeaderField(OkHttpURLConnection.RESPONSE_SOURCE));
   }
 
   private void assertResponseCode(HttpURLConnection connection, int expected) throws IOException {

--- a/okhttp/src/main/java/okhttp3/Cache.java
+++ b/okhttp/src/main/java/okhttp3/Cache.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import okhttp3.internal.DiskLruCache;
 import okhttp3.internal.InternalCache;
+import okhttp3.internal.Platform;
 import okhttp3.internal.Util;
 import okhttp3.internal.http.CacheRequest;
 import okhttp3.internal.http.CacheStrategy;
@@ -470,6 +471,12 @@ public final class Cache implements Closeable, Flushable {
   }
 
   private static final class Entry {
+    /** Synthetic response header: the local time when the request was sent. */
+    private static final String SENT_MILLIS = Platform.get().getPrefix() + "-Sent-Millis";
+
+    /** Synthetic response header: the local time when the response was received. */
+    private static final String RECEIVED_MILLIS = Platform.get().getPrefix() + "-Received-Millis";
+
     private final String url;
     private final Headers varyHeaders;
     private final String requestMethod;
@@ -550,10 +557,10 @@ public final class Cache implements Closeable, Flushable {
         for (int i = 0; i < responseHeaderLineCount; i++) {
           responseHeadersBuilder.addLenient(source.readUtf8LineStrict());
         }
-        String sendRequestMillisString = responseHeadersBuilder.get(OkHeaders.SENT_MILLIS);
-        String receivedResponseMillisString = responseHeadersBuilder.get(OkHeaders.RECEIVED_MILLIS);
-        responseHeadersBuilder.removeAll(OkHeaders.SENT_MILLIS);
-        responseHeadersBuilder.removeAll(OkHeaders.RECEIVED_MILLIS);
+        String sendRequestMillisString = responseHeadersBuilder.get(SENT_MILLIS);
+        String receivedResponseMillisString = responseHeadersBuilder.get(RECEIVED_MILLIS);
+        responseHeadersBuilder.removeAll(SENT_MILLIS);
+        responseHeadersBuilder.removeAll(RECEIVED_MILLIS);
         sentRequestMillis = sendRequestMillisString != null
             ? Long.parseLong(sendRequestMillisString)
             : 0L;
@@ -622,11 +629,11 @@ public final class Cache implements Closeable, Flushable {
             .writeUtf8(responseHeaders.value(i))
             .writeByte('\n');
       }
-      sink.writeUtf8(OkHeaders.SENT_MILLIS)
+      sink.writeUtf8(SENT_MILLIS)
           .writeUtf8(": ")
           .writeDecimalLong(sentRequestMillis)
           .writeByte('\n');
-      sink.writeUtf8(OkHeaders.RECEIVED_MILLIS)
+      sink.writeUtf8(RECEIVED_MILLIS)
           .writeUtf8(": ")
           .writeDecimalLong(receivedResponseMillis)
           .writeByte('\n');

--- a/okhttp/src/main/java/okhttp3/internal/http/OkHeaders.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/OkHeaders.java
@@ -22,37 +22,13 @@ import java.util.Set;
 import java.util.TreeSet;
 import okhttp3.Challenge;
 import okhttp3.Headers;
-import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.internal.Platform;
 
 import static okhttp3.internal.Util.equal;
 
 /** Headers and utilities for internal use by OkHttp. */
 public final class OkHeaders {
-
-  static final String PREFIX = Platform.get().getPrefix();
-
-  /**
-   * Synthetic response header: the local time when the request was sent.
-   */
-  public static final String SENT_MILLIS = PREFIX + "-Sent-Millis";
-
-  /**
-   * Synthetic response header: the local time when the response was received.
-   */
-  public static final String RECEIVED_MILLIS = PREFIX + "-Received-Millis";
-
-  /**
-   * Synthetic response header: the selected {@link Protocol protocol} ("spdy/3.1", "http/1.1",
-   * etc).
-   */
-  public static final String SELECTED_PROTOCOL = PREFIX + "-Selected-Protocol";
-
-  /** Synthetic response header: the location from which the response was loaded. */
-  public static final String RESPONSE_SOURCE = PREFIX + "-Response-Source";
-
   private OkHeaders() {
   }
 


### PR DESCRIPTION
This is an internal class so nobody should see the name. But having a
completely different name will make it much easier to diagnose future
stacktraces because the internal implementation has changed so much
recently.

Also share fewer internal details with the rest of OkHttp. In particular
remove the OkHttp-Selected-Protocol and OkHttp-Response-Source headers
from the core.