### PR TITLE
throw ConnectException in connection phase

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/AndroidPlatform.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.security.cert.Certificate;
@@ -59,12 +60,16 @@ class AndroidPlatform extends Platform {
     try {
       socket.connect(address, connectTimeout);
     } catch (AssertionError e) {
-      if (Util.isAndroidGetsocknameError(e)) throw new IOException(e);
+      if (Util.isAndroidGetsocknameError(e)) {
+          ConnectException connectException = new ConnectException(e.getMessage());
+          connectException.initCause(e);
+          throw connectException;
+      }
       throw e;
     } catch (SecurityException e) {
       // Before android 4.3, socket.connect could throw a SecurityException
       // if opening a socket resulted in an EACCES error.
-      IOException ioException = new IOException("Exception in connect");
+      IOException ioException = new ConnectException("Exception in connect");
       ioException.initCause(e);
       throw ioException;
     }

--- a/okhttp/src/main/java/okhttp3/internal/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/AndroidPlatform.java
@@ -61,17 +61,21 @@ class AndroidPlatform extends Platform {
       socket.connect(address, connectTimeout);
     } catch (AssertionError e) {
       if (Util.isAndroidGetsocknameError(e)) {
-          ConnectException connectException = new ConnectException(e.getMessage());
-          connectException.initCause(e);
-          throw connectException;
+        ConnectException connectException = new ConnectException(e.getMessage());
+        connectException.initCause(e);
+        throw connectException;
       }
       throw e;
     } catch (SecurityException e) {
       // Before android 4.3, socket.connect could throw a SecurityException
       // if opening a socket resulted in an EACCES error.
-      IOException ioException = new ConnectException("Exception in connect");
-      ioException.initCause(e);
-      throw ioException;
+      IOException connectException = new ConnectException("Exception in connect");
+      connectException.initCause(e);
+      throw connectException;
+    } catch (IOException e) {
+      IOException connectException = new ConnectException(e.getMessage());
+      connectException.initCause(e);
+      throw connectException;
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/Platform.java
@@ -18,6 +18,7 @@ package okhttp3.internal;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.ArrayList;
@@ -121,7 +122,13 @@ public class Platform {
 
   public void connectSocket(Socket socket, InetSocketAddress address,
       int connectTimeout) throws IOException {
-    socket.connect(address, connectTimeout);
+    try {
+      socket.connect(address, connectTimeout);
+    } catch (IOException e) {
+      ConnectException connectException = new ConnectException(e.getMessage());
+      connectException.initCause(e);
+      throw e;
+    }
   }
 
   public void log(int level, String message, Throwable t) {


### PR DESCRIPTION
In many cases it is important to detect whether the sent request is failed because of connection error or not.

For example, In a payment application. When we send a payment request to our servers if we get a connection error it is not necessary to attempt for reversing the payment request but in other cases we need to do a reverse phase.

okhttp throws `IOException` for both kind of connection errors or other kind of errors such as "Socket Read/Write Timeout"; So it is not possible to detect whether it is connection error or something like socket read error. 

In order to fix this problem I made some changes in `AndroidPlatform` & `Platform` class for throwing `ConnectException` in connection phase.