### PR TITLE
Cleanup refactoring: Move 3 methods into DelegatingHttpsURLConnection

### DIFF
--- a/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
+++ b/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
@@ -859,18 +859,6 @@ public final class JavaApiConverter {
     @Override public SSLSocketFactory getSSLSocketFactory() {
       throw throwRequestSslAccessException();
     }
-
-    @Override public long getContentLengthLong() {
-      return delegate.getContentLengthLong();
-    }
-
-    @Override public void setFixedLengthStreamingMode(long contentLength) {
-      delegate.setFixedLengthStreamingMode(contentLength);
-    }
-
-    @Override public long getHeaderFieldLong(String field, long defaultValue) {
-      return delegate.getHeaderFieldLong(field, defaultValue);
-    }
   }
 
   private static RuntimeException throwRequestModificationException() {

--- a/okhttp-urlconnection/pom.xml
+++ b/okhttp-urlconnection/pom.xml
@@ -14,6 +14,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>animal-sniffer-annotations</artifactId>
+      <version>${animal.sniffer.version}</version>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>okhttp</artifactId>
       <version>${project.version}</version>

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/DelegatingHttpsURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/DelegatingHttpsURLConnection.java
@@ -32,6 +32,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocketFactory;
 import okhttp3.Handshake;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * Implement an HTTPS connection by delegating to an HTTP connection for everything but the
@@ -146,6 +147,11 @@ abstract class DelegatingHttpsURLConnection extends HttpsURLConnection {
     return delegate.getContentLength();
   }
 
+  @IgnoreJRERequirement // Should only be invoked on Java 7+.
+  @Override public long getContentLengthLong() {
+    return delegate.getContentLengthLong();
+  }
+
   @Override public String getContentType() {
     return delegate.getContentType();
   }
@@ -188,6 +194,11 @@ abstract class DelegatingHttpsURLConnection extends HttpsURLConnection {
 
   @Override public String getHeaderField(String key) {
     return delegate.getHeaderField(key);
+  }
+
+  @IgnoreJRERequirement // Should only be invoked on Java 7+.
+  @Override public long getHeaderFieldLong(String field, long defaultValue) {
+    return delegate.getHeaderFieldLong(field, defaultValue);
   }
 
   @Override public long getHeaderFieldDate(String field, long defaultValue) {
@@ -248,6 +259,11 @@ abstract class DelegatingHttpsURLConnection extends HttpsURLConnection {
 
   @Override public void setDoOutput(boolean newValue) {
     delegate.setDoOutput(newValue);
+  }
+
+  @IgnoreJRERequirement // Should only be invoked on Java 7+.
+  @Override public void setFixedLengthStreamingMode(long contentLength) {
+    delegate.setFixedLengthStreamingMode(contentLength);
   }
 
   @Override public void setIfModifiedSince(long newValue) {

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpsURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpsURLConnection.java
@@ -68,15 +68,4 @@ public final class OkHttpsURLConnection extends DelegatingHttpsURLConnection {
     return delegate.client.sslSocketFactory();
   }
 
-  @Override public long getContentLengthLong() {
-    return delegate.getContentLengthLong();
-  }
-
-  @Override public void setFixedLengthStreamingMode(long contentLength) {
-    delegate.setFixedLengthStreamingMode(contentLength);
-  }
-
-  @Override public long getHeaderFieldLong(String field, long defaultValue) {
-    return delegate.getHeaderFieldLong(field, defaultValue);
-  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <!-- ALPN library targeted to Java 7 -->
     <alpn.jdk7.version>7.1.2.v20141202</alpn.jdk7.version>
     <android.version>4.1.1.4</android.version>
+    <animal.sniffer.version>1.11</animal.sniffer.version>
     <apache.http.version>4.2.2</apache.http.version>
     <bouncycastle.version>1.50</bouncycastle.version>
     <guava.version>16.0</guava.version>
@@ -214,7 +215,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.11</version>
+        <version>${animal.sniffer.version}</version>
         <executions>
           <execution>
             <phase>test</phase>


### PR DESCRIPTION
These three methods were delegating to delegate; their implementation
was duplicated across both subclasses of DelegatingHttpsURLConnection.

This change moves them into the base class in order to
  - avoid duplication
  - separate the responsibility of delegation (base class) from the
    responsibility of change to behavior (subclasses).