### PR TITLE
Always pass a host to NetworkSecurityPolicy.isCleartextTrafficPermitted

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -1063,7 +1063,7 @@ public final class CallTest {
       client.newCall(request).execute();
       fail();
     } catch (UnknownServiceException expected) {
-      assertTrue(expected.getMessage().contains("CLEARTEXT communication not supported"));
+      assertEquals("CLEARTEXT communication not enabled for client", expected.getMessage());
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -65,16 +65,10 @@ public class OkHttpClient implements Cloneable, Call.Factory {
   private static final List<Protocol> DEFAULT_PROTOCOLS = Util.immutableList(
       Protocol.HTTP_2, Protocol.SPDY_3, Protocol.HTTP_1_1);
 
-  private static final List<ConnectionSpec> DEFAULT_CONNECTION_SPECS;
+  private static final List<ConnectionSpec> DEFAULT_CONNECTION_SPECS = Util.immutableList(
+      ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS, ConnectionSpec.CLEARTEXT);
 
   static {
-    List<ConnectionSpec> connSpecs = new ArrayList<>(Arrays.asList(ConnectionSpec.MODERN_TLS,
-        ConnectionSpec.COMPATIBLE_TLS));
-    if (Platform.get().isCleartextTrafficPermitted()) {
-      connSpecs.add(ConnectionSpec.CLEARTEXT);
-    }
-    DEFAULT_CONNECTION_SPECS = Util.immutableList(connSpecs);
-
     Internal.instance = new Internal() {
       @Override public void addLenient(Headers.Builder builder, String line) {
         builder.addLenient(line);

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -93,10 +93,16 @@ public final class RealConnection extends FramedConnection.Listener implements C
     RouteException routeException = null;
     ConnectionSpecSelector connectionSpecSelector = new ConnectionSpecSelector(connectionSpecs);
 
-    if (route.address().sslSocketFactory() == null
-        && !connectionSpecs.contains(ConnectionSpec.CLEARTEXT)) {
-      throw new RouteException(new UnknownServiceException(
-          "CLEARTEXT communication not supported: " + connectionSpecs));
+    if (route.address().sslSocketFactory() == null) {
+      if (!connectionSpecs.contains(ConnectionSpec.CLEARTEXT)) {
+        throw new RouteException(new UnknownServiceException(
+            "CLEARTEXT communication not enabled for client"));
+      }
+      String host = route.address().url().host();
+      if (!Platform.get().isCleartextTrafficPermitted(host)) {
+        throw new RouteException(new UnknownServiceException(
+            "CLEARTEXT communication to " + host + " not permitted by network security policy"));
+      }
     }
 
     while (protocol == null) {

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -132,20 +132,17 @@ class AndroidPlatform extends Platform {
     }
   }
 
-  @Override public boolean isCleartextTrafficPermitted() {
+  @Override public boolean isCleartextTrafficPermitted(String hostname) {
     try {
       Class<?> networkPolicyClass = Class.forName("android.security.NetworkSecurityPolicy");
       Method getInstanceMethod = networkPolicyClass.getMethod("getInstance");
       Object networkSecurityPolicy = getInstanceMethod.invoke(null);
       Method isCleartextTrafficPermittedMethod = networkPolicyClass
-          .getMethod("isCleartextTrafficPermitted");
-      boolean cleartextPermitted = (boolean) isCleartextTrafficPermittedMethod
-          .invoke(networkSecurityPolicy);
-      return cleartextPermitted;
-    } catch (ClassNotFoundException e) {
-      return super.isCleartextTrafficPermitted();
-    } catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException
-        | InvocationTargetException e) {
+          .getMethod("isCleartextTrafficPermitted", String.class);
+      return (boolean) isCleartextTrafficPermittedMethod.invoke(networkSecurityPolicy, hostname);
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      return super.isCleartextTrafficPermitted(hostname);
+    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
       throw new AssertionError();
     }
   }

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -129,7 +129,7 @@ public class Platform {
     logger.log(logLevel, message, t);
   }
 
-  public boolean isCleartextTrafficPermitted() {
+  public boolean isCleartextTrafficPermitted(String hostname) {
     return true;
   }
 


### PR DESCRIPTION
Previously we were misinterpretting which hosts this method applied to.
Suppose an Android app was configured to require TLS for bank.com and
not for any other address. The NetworkSecurityPolicy.isCleartextTrafficPermitted()
method would return false because cleartext traffic wasn't universally
permitted. And OkHttp would incorrectly forbid cleartext communication
to other hosts like puppies.com.

Closes: https://github.com/square/okhttp/issues/2640