### PR TITLE
Don't share the OkHttpClient's Dispatcher in HttpURLConnection.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -3546,6 +3546,23 @@ public final class URLConnectionTest {
     }
   }
 
+  @Test public void callsNotManagedByDispatcher() throws Exception {
+    server.enqueue(new MockResponse()
+        .setBody("abc"));
+
+    Dispatcher dispatcher = urlFactory.client().dispatcher();
+    assertEquals(0, dispatcher.runningCallsCount());
+
+    connection = urlFactory.open(server.url("/").url());
+    assertEquals(0, dispatcher.runningCallsCount());
+
+    connection.connect();
+    assertEquals(0, dispatcher.runningCallsCount());
+
+    assertContent("abc", connection);
+    assertEquals(0, dispatcher.runningCallsCount());
+  }
+
   private void testInstanceFollowsRedirects(String spec) throws Exception {
     URL url = new URL(spec);
     HttpURLConnection urlConnection = urlFactory.open(url);

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.Dispatcher;
 import okhttp3.Handshake;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
@@ -385,6 +386,9 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
     clientBuilder.interceptors().add(UnexpectedException.INTERCEPTOR);
     clientBuilder.networkInterceptors().clear();
     clientBuilder.networkInterceptors().add(networkInterceptor);
+
+    // Use a separate dispatcher so that limits aren't impacted. But use the same executor service!
+    clientBuilder.dispatcher(new Dispatcher(client.dispatcher().executorService()));
 
     // If we're currently not using caches, make sure the engine's client doesn't have one.
     if (!getUseCaches()) {


### PR DESCRIPTION
Any limits enforced here would be awkward because there's an application
thread blocked on the work anyway.

Closes: https://github.com/square/okhttp/issues/2667