### PR TITLE
Fix logging-interceptor Javadoc typo

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -90,7 +90,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
      * Content-Length: 3
      *
      * Hi?
-     * --> END GET
+     * --> END POST
      *
      * <-- 200 OK (22ms)
      * Content-Type: plain/text


### PR DESCRIPTION
Minor fix for a typo in the Javadoc for the `HttpLoggingInterceptor.Level` enum