### PR TITLE
Add support for dynamic table size changes to HPACK Encoder.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/framed/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/framed/Http2ConnectionTest.java
@@ -138,20 +138,18 @@ public final class Http2ConnectionTest {
     assertEquals(3368, stream.bytesLeftInWriteWindow);
   }
 
-  @Test
-  @Ignore("Working through making this work with the new HPACK encoder.")
-  public void peerHttp2ServerZerosCompressionTable() throws Exception {
+  @Test public void peerHttp2ServerZerosCompressionTable() throws Exception {
     boolean client = false; // Peer is server, so we are client.
     Settings settings = new Settings();
     settings.set(HEADER_TABLE_SIZE, PERSIST_VALUE, 0);
 
     FramedConnection connection = sendHttp2SettingsAndCheckForAck(client, settings);
 
-    // verify the peer's settings were read and applied.
+    // Verify the peer's settings were read and applied.
     assertEquals(0, connection.peerSettings.getHeaderTableSize());
-    Http2.Reader frameReader = (Http2.Reader) connection.readerRunnable.frameReader;
-    assertEquals(0, frameReader.hpackReader.maxDynamicTableByteCount());
-    // TODO: when supported, check the frameWriter's compression table is unaffected.
+    Http2.Writer frameWriter = (Http2.Writer) connection.frameWriter;
+    assertEquals(0, frameWriter.hpackWriter.dynamicTableByteCount);
+    assertEquals(0, frameWriter.hpackWriter.headerTableSizeSetting);
   }
 
   @Test public void peerHttp2ClientDisablesPush() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/internal/framed/Http2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/framed/Http2Test.java
@@ -629,7 +629,7 @@ public class Http2Test {
 
     Http2.Writer writer = new Http2.Writer(new Buffer(), true);
 
-    writer.ackSettings(new Settings().set(Settings.MAX_FRAME_SIZE, 0, newMaxFrameSize));
+    writer.applyAndAckSettings(new Settings().set(Settings.MAX_FRAME_SIZE, 0, newMaxFrameSize));
 
     assertEquals(newMaxFrameSize, writer.maxDataLength());
     writer.frameHeader(0, newMaxFrameSize, Http2.TYPE_DATA, FLAG_NONE);

--- a/okhttp/src/main/java/okhttp3/internal/framed/FrameWriter.java
+++ b/okhttp/src/main/java/okhttp3/internal/framed/FrameWriter.java
@@ -25,8 +25,8 @@ public interface FrameWriter extends Closeable {
   /** HTTP/2 only. */
   void connectionPreface() throws IOException;
 
-  /** Informs the peer that we've applied its latest settings. */
-  void ackSettings(Settings peerSettings) throws IOException;
+  /** Applies {@code peerSettings} and then sends a settings ACK. */
+  void applyAndAckSettings(Settings peerSettings) throws IOException;
 
   /**
    * HTTP/2 only. Send a push promise header block.

--- a/okhttp/src/main/java/okhttp3/internal/framed/FramedConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/framed/FramedConnection.java
@@ -700,7 +700,7 @@ public final class FramedConnection implements Closeable {
         if (clearPrevious) peerSettings.clear();
         peerSettings.merge(newSettings);
         if (getProtocol() == Protocol.HTTP_2) {
-          ackSettingsLater(newSettings);
+          applyAndAckSettings(newSettings);
         }
         int peerInitialWindowSize = peerSettings.getInitialWindowSize(DEFAULT_INITIAL_WINDOW_SIZE);
         if (peerInitialWindowSize != -1 && peerInitialWindowSize != priorWriteWindowSize) {
@@ -728,11 +728,11 @@ public final class FramedConnection implements Closeable {
       }
     }
 
-    private void ackSettingsLater(final Settings peerSettings) {
+    private void applyAndAckSettings(final Settings peerSettings) {
       executor.execute(new NamedRunnable("OkHttp %s ACK Settings", hostname) {
         @Override public void execute() {
           try {
-            frameWriter.ackSettings(peerSettings);
+            frameWriter.applyAndAckSettings(peerSettings);
           } catch (IOException ignored) {
           }
         }

--- a/okhttp/src/main/java/okhttp3/internal/framed/Spdy3.java
+++ b/okhttp/src/main/java/okhttp3/internal/framed/Spdy3.java
@@ -301,7 +301,7 @@ public final class Spdy3 implements Variant {
       headerBlockOut = Okio.buffer(new DeflaterSink(headerBlockBuffer, deflater));
     }
 
-    @Override public void ackSettings(Settings peerSettings) {
+    @Override public void applyAndAckSettings(Settings peerSettings) {
       // Do nothing: no ACK for SPDY/3 settings.
     }
 


### PR DESCRIPTION
This is a first pass, and based on:

- https://tools.ietf.org/html/rfc7541#section-4.2
- https://lists.w3.org/Archives/Public/ietf-http-wg/2015OctDec/0088.html
- https://chromium.googlesource.com/chromium/src/+/master/net/spdy/hpack/hpack_encoder.cc

As it turns out, I had some trouble testing this in practice. nginx for example doesn't expose an option to change the default value.