### PR TITLE
Fix a major bug in our HPACK encoder.

### DIFF
--- a/okhttp-hpacktests/pom.xml
+++ b/okhttp-hpacktests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.3.0-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-hpacktests</artifactId>

--- a/okhttp/src/main/java/okhttp3/ConnectionSpec.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionSpec.java
@@ -20,8 +20,8 @@ import java.util.List;
 import javax.net.ssl.SSLSocket;
 
 import static okhttp3.internal.Util.concat;
-import static okhttp3.internal.Util.contains;
 import static okhttp3.internal.Util.immutableList;
+import static okhttp3.internal.Util.indexOf;
 import static okhttp3.internal.Util.intersect;
 
 /**
@@ -151,7 +151,7 @@ public final class ConnectionSpec {
 
     // In accordance with https://tools.ietf.org/html/draft-ietf-tls-downgrade-scsv-00
     // the SCSV cipher is added to signal that a protocol fallback has taken place.
-    if (isFallback && contains(sslSocket.getSupportedCipherSuites(), "TLS_FALLBACK_SCSV")) {
+    if (isFallback && indexOf(sslSocket.getSupportedCipherSuites(), "TLS_FALLBACK_SCSV") != -1) {
       cipherSuitesIntersection = concat(cipherSuitesIntersection, "TLS_FALLBACK_SCSV");
     }
 
@@ -200,7 +200,7 @@ public final class ConnectionSpec {
       return false;
     }
     for (String toFind : a) {
-      if (contains(b, toFind)) {
+      if (indexOf(b, toFind) != -1) {
         return true;
       }
     }

--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -314,8 +314,11 @@ public final class Util {
         && e.getMessage().contains("getsockname failed");
   }
 
-  public static boolean contains(String[] array, String value) {
-    return Arrays.asList(array).contains(value);
+  public static <T> int indexOf(T[] array, T value) {
+    for (int i = 0, size = array.length; i < size; i++) {
+      if (equal(array[i], value)) return i;
+    }
+    return -1;
   }
 
   public static String[] concat(String[] array, String value) {


### PR DESCRIPTION
Running the HPACK regression suite shows that in some cases we may
use the wrong dynamic index after the dynamic table has been resized.

This fixes the problem and simplifies the implementation to avoid
maps with Integer values, which were difficult to reason about and
easy to get out-of-sync with the main table.