### PR TITLE
Be lenient if a character set is 'single-quoted'.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/MediaTypeTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MediaTypeTest.java
@@ -87,6 +87,16 @@ public class MediaTypeTest {
     assertInvalid("text/plain ; a=1");
   }
 
+  @Test public void testDoubleQuotesAreSpecial() throws Exception {
+    MediaType mediaType = MediaType.parse("text/plain;a=\";charset=utf-8;b=\"");
+    assertNull(mediaType.charset());
+  }
+
+  @Test public void testSingleQuotesAreNotSpecial() throws Exception {
+    MediaType mediaType = MediaType.parse("text/plain;a=';charset=utf-8;b='");
+    assertEquals("UTF-8", mediaType.charset().name());
+  }
+
   @Test public void testParseWithSpecialCharacters() throws Exception {
     MediaType mediaType = MediaType.parse(
         "!#$%&'*+-.{|}~/!#$%&'*+-.{|}~; !#$%&'*+-.{|}~=!#$%&'*+-.{|}~");
@@ -135,6 +145,33 @@ public class MediaTypeTest {
       mediaType.charset();
       fail();
     } catch (UnsupportedCharsetException expected) {
+    }
+  }
+
+  /**
+   * This is invalid according to RFC 822. But it's what Chrome does and it avoids a potentially
+   * unpleasant IllegalCharsetNameException.
+   */
+  @Test public void testCharsetNameIsSingleQuoted() throws Exception {
+    MediaType mediaType = MediaType.parse("text/plain;charset='utf-8'");
+    assertEquals("UTF-8", mediaType.charset().name());
+  }
+
+  @Test public void testCharsetNameIsDoubleQuotedAndSingleQuoted() throws Exception {
+    MediaType mediaType = MediaType.parse("text/plain;charset=\"'utf-8'\"");
+    try {
+      mediaType.charset();
+      fail();
+    } catch (IllegalCharsetNameException expected) {
+    }
+  }
+
+  @Test public void testCharsetNameIsDoubleQuotedSingleQuote() throws Exception {
+    MediaType mediaType = MediaType.parse("text/plain;charset=\"'\"");
+    try {
+      mediaType.charset();
+      fail();
+    } catch (IllegalCharsetNameException expected) {
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/MediaType.java
+++ b/okhttp/src/main/java/okhttp3/MediaType.java
@@ -61,9 +61,17 @@ public final class MediaType {
 
       String name = parameter.group(1);
       if (name == null || !name.equalsIgnoreCase("charset")) continue;
-      String charsetParameter = parameter.group(2) != null
-          ? parameter.group(2)  // Value is a token.
-          : parameter.group(3); // Value is a quoted string.
+      String charsetParameter;
+      String token = parameter.group(2);
+      if (token != null) {
+        // If the token is 'single-quoted' it's invalid! But we're lenient and strip the quotes.
+        charsetParameter = (token.startsWith("'") && token.endsWith("'") && token.length() > 2)
+            ? token.substring(1, token.length() - 1)
+            : token;
+      } else {
+        // Value is "double-quoted". That's valid and our regex group already strips the quotes.
+        charsetParameter = parameter.group(3);
+      }
       if (charset != null && !charsetParameter.equalsIgnoreCase(charset)) {
         throw new IllegalArgumentException("Multiple different charsets: " + string);
       }


### PR DESCRIPTION
It's what Chrome does. Firefox and Safari ignore it. I'd love to ignore
it, but in our API that really just means the caller needs to handle an
InvalidCharsetNameException and nobody is expecting that.

Closes: https://github.com/square/okhttp/issues/2677