### PR TITLE
Fix a test to not require a fallback IP address.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -2533,9 +2533,8 @@ public final class URLConnectionTest {
    * https://code.google.com/p/android/issues/detail?id=41576
    */
   @Test public void sameConnectionRedirectAndReuse() throws Exception {
-    // TODO(jwilson): this behavior shouldn't rely on having another IP address to attempt.
     urlFactory.setClient(urlFactory.client().newBuilder()
-        .dns(new DoubleInetAddressDns())
+        .dns(new SingleInetAddressDns())
         .build());
     server.enqueue(new MockResponse()
         .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)


### PR DESCRIPTION
This might be an unexpected upside of the migration to the Call API.

Closes: https://github.com/square/okhttp/issues/2178