### PR TITLE
Okio deadline for HTTP and HTTP2 stream

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -831,7 +831,7 @@ public final class CallTest {
     server.enqueue(new MockResponse());
     server.enqueue(new MockResponse());
 
-    // Call 1: set a deadline on the request body.
+    // Call 1: set a requestDeadline on the request body.
     RequestBody requestBody1 = new RequestBody() {
       @Override public MediaType contentType() {
         return MediaType.parse("text/plain");
@@ -849,7 +849,7 @@ public final class CallTest {
     Response response1 = client.newCall(request1).execute();
     assertEquals(200, response1.code());
 
-    // Call 2: check for the absence of a deadline on the request body.
+    // Call 2: check for the absence of a requestDeadline on the request body.
     RequestBody requestBody2 = new RequestBody() {
       @Override public MediaType contentType() {
         return MediaType.parse("text/plain");
@@ -876,14 +876,14 @@ public final class CallTest {
     server.enqueue(new MockResponse().setBody("abc"));
     server.enqueue(new MockResponse().setBody("def"));
 
-    // Call 1: set a deadline on the response body.
+    // Call 1: set a requestDeadline on the response body.
     Request request1 = new Request.Builder().url(server.url("/")).build();
     Response response1 = client.newCall(request1).execute();
     BufferedSource body1 = response1.body().source();
     assertEquals("abc", body1.readUtf8());
     body1.timeout().deadline(5, TimeUnit.SECONDS);
 
-    // Call 2: check for the absence of a deadline on the request body.
+    // Call 2: check for the absence of a requestDeadline on the request body.
     Request request2 = new Request.Builder().url(server.url("/")).build();
     Response response2 = client.newCall(request2).execute();
     BufferedSource body2 = response2.body().source();

--- a/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
@@ -47,6 +47,7 @@ public final class OkHttpClientTest {
     assertEquals(10_000, client.connectTimeoutMillis());
     assertEquals(10_000, client.readTimeoutMillis());
     assertEquals(10_000, client.writeTimeoutMillis());
+    assertEquals(10_000, client.requestDeadlineMillis());
   }
 
   @Test public void timeoutValidRange() {
@@ -64,6 +65,10 @@ public final class OkHttpClientTest {
     } catch (IllegalArgumentException ignored) {
     }
     try {
+      builder.requestDeadline(1, TimeUnit.NANOSECONDS);
+    } catch (IllegalArgumentException ignored) {
+    }
+    try {
       builder.connectTimeout(365, TimeUnit.DAYS);
     } catch (IllegalArgumentException ignored) {
     }
@@ -73,6 +78,10 @@ public final class OkHttpClientTest {
     }
     try {
       builder.readTimeout(365, TimeUnit.DAYS);
+    } catch (IllegalArgumentException ignored) {
+    }
+    try {
+      builder.requestDeadline(365, TimeUnit.DAYS);
     } catch (IllegalArgumentException ignored) {
     }
   }

--- a/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
@@ -54,34 +54,42 @@ public final class OkHttpClientTest {
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
     try {
       builder.connectTimeout(1, TimeUnit.NANOSECONDS);
+      fail("Connect timeout value is too small and check is not working");
     } catch (IllegalArgumentException ignored) {
     }
     try {
       builder.writeTimeout(1, TimeUnit.NANOSECONDS);
+      fail("Write timeout value is too small and check is not working");
     } catch (IllegalArgumentException ignored) {
     }
     try {
       builder.readTimeout(1, TimeUnit.NANOSECONDS);
+      fail("Read timeout value is too small and check is not working");
     } catch (IllegalArgumentException ignored) {
     }
     try {
       builder.requestDeadline(1, TimeUnit.NANOSECONDS);
+      fail("Request deadline value is too small and check is not working");
     } catch (IllegalArgumentException ignored) {
     }
     try {
       builder.connectTimeout(365, TimeUnit.DAYS);
+      fail("Connect timeout value is too large and check is not working");
     } catch (IllegalArgumentException ignored) {
     }
     try {
       builder.writeTimeout(365, TimeUnit.DAYS);
+      fail("Write timeout value is too large and check is not working");
     } catch (IllegalArgumentException ignored) {
     }
     try {
       builder.readTimeout(365, TimeUnit.DAYS);
+      fail("Read timeout value is too large and check is not working");
     } catch (IllegalArgumentException ignored) {
     }
     try {
       builder.requestDeadline(365, TimeUnit.DAYS);
+      fail("Request deadline value is too large and check is not working");
     } catch (IllegalArgumentException ignored) {
     }
   }

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -199,6 +199,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
   final int connectTimeout;
   final int readTimeout;
   final int writeTimeout;
+  final int requestDeadline;
 
   public OkHttpClient() {
     this(new Builder());
@@ -244,6 +245,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
     this.connectTimeout = builder.connectTimeout;
     this.readTimeout = builder.readTimeout;
     this.writeTimeout = builder.writeTimeout;
+    this.requestDeadline = builder.requestDeadline;
   }
 
   private X509TrustManager systemDefaultTrustManager() {
@@ -285,6 +287,11 @@ public class OkHttpClient implements Cloneable, Call.Factory {
   /** Default write timeout (in milliseconds). */
   public int writeTimeoutMillis() {
     return writeTimeout;
+  }
+
+  /** Default request deadline (in milliseconds). */
+  public int requestDeadlineMillis() {
+    return requestDeadline;
   }
 
   public Proxy proxy() {
@@ -418,6 +425,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
     int connectTimeout;
     int readTimeout;
     int writeTimeout;
+    int requestDeadline;
 
     public Builder() {
       dispatcher = new Dispatcher();
@@ -438,6 +446,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
       connectTimeout = 10_000;
       readTimeout = 10_000;
       writeTimeout = 10_000;
+      requestDeadline = 10_000;
     }
 
     Builder(OkHttpClient okHttpClient) {
@@ -466,6 +475,7 @@ public class OkHttpClient implements Cloneable, Call.Factory {
       this.connectTimeout = okHttpClient.connectTimeout;
       this.readTimeout = okHttpClient.readTimeout;
       this.writeTimeout = okHttpClient.writeTimeout;
+      this.requestDeadline = okHttpClient.requestDeadline;
     }
 
     /**
@@ -508,6 +518,21 @@ public class OkHttpClient implements Cloneable, Call.Factory {
       if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("Timeout too large.");
       if (millis == 0 && timeout > 0) throw new IllegalArgumentException("Timeout too small.");
       writeTimeout = (int) millis;
+      return this;
+    }
+
+    /**
+     * Sets the default requestDeadline for new connections. A value of 0 means no deadline,
+     * otherwise values must be between 1 and {@link Integer#MAX_VALUE} when converted
+     * to milliseconds.
+     */
+    public Builder requestDeadline(long deadline, TimeUnit unit) {
+      if (deadline < 0) throw new IllegalArgumentException("deadline < 0");
+      if (unit == null) throw new NullPointerException("unit == null");
+      long millis = unit.toMillis(deadline);
+      if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException("deadline too large.");
+      if (millis == 0 && deadline > 0) throw new IllegalArgumentException("deadline too small.");
+      requestDeadline = (int) millis;
       return this;
     }
 

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpRequestDeadline.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpRequestDeadline.java
@@ -1,0 +1,23 @@
+package okhttp3.internal.http;
+
+import okio.AsyncTimeout;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+/**
+ * The Okio timeout watchdog will call {@link #timeout} if the timeout is reached. In that case
+ * we close the stream (asynchronously) which will notify the waiting thread
+ */
+public abstract class HttpRequestDeadline extends AsyncTimeout {
+  @Override protected IOException newTimeoutException(IOException cause) {
+    SocketTimeoutException socketTimeoutException = new SocketTimeoutException("Request deadline");
+    if (cause != null) {
+      socketTimeoutException.initCause(cause);
+    }
+    return socketTimeoutException;
+  }
+
+  public void exitAndThrowIfDeadlineIsReached() throws IOException {
+    if (exit()) throw newTimeoutException(null /* cause */);
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -106,6 +106,8 @@ public final class Http2Codec implements HttpCodec {
     stream = connection.newStream(requestHeaders, permitsRequestBody);
     stream.readTimeout().timeout(client.readTimeoutMillis(), TimeUnit.MILLISECONDS);
     stream.writeTimeout().timeout(client.writeTimeoutMillis(), TimeUnit.MILLISECONDS);
+    stream.requestDeadline().deadline(client.requestDeadlineMillis(), TimeUnit.MILLISECONDS);
+    stream.startRequestDeadline();
   }
 
   @Override public void finishRequest() throws IOException {

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
@@ -21,6 +21,7 @@ import java.io.InterruptedIOException;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
+import okhttp3.internal.http.HttpRequestDeadline;
 import okio.AsyncTimeout;
 import okio.Buffer;
 import okio.BufferedSource;
@@ -61,7 +62,7 @@ public final class Http2Stream {
   final FramedDataSink sink;
   private final StreamTimeout readTimeout = new StreamTimeout();
   private final StreamTimeout writeTimeout = new StreamTimeout();
-  private final StreamTimeout requestDeadline = new StreamTimeout();
+  private final Http2RequestDeadline requestDeadline = new Http2RequestDeadline();
 
   /**
    * The reason why this stream was abnormally closed. If there are multiple reasons to abnormally
@@ -603,6 +604,13 @@ public final class Http2Stream {
 
     public void exitAndThrowIfTimedOut() throws IOException {
       if (exit()) throw newTimeoutException(null /* cause */);
+    }
+  }
+
+  private class Http2RequestDeadline extends HttpRequestDeadline {
+    @Override
+    protected void timedOut() {
+      closeLater(ErrorCode.CANCEL);
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
@@ -61,6 +61,7 @@ public final class Http2Stream {
   final FramedDataSink sink;
   private final StreamTimeout readTimeout = new StreamTimeout();
   private final StreamTimeout writeTimeout = new StreamTimeout();
+  private final StreamTimeout requestDeadline = new StreamTimeout();
 
   /**
    * The reason why this stream was abnormally closed. If there are multiple reasons to abnormally
@@ -188,6 +189,14 @@ public final class Http2Stream {
     return writeTimeout;
   }
 
+  public Timeout requestDeadline() {
+    return requestDeadline;
+  }
+
+  public void startRequestDeadline() {
+    requestDeadline.enter();
+  }
+
   /** Returns a source that reads data from the peer. */
   public Source getSource() {
     return source;
@@ -277,6 +286,7 @@ public final class Http2Stream {
     boolean open;
     synchronized (this) {
       this.source.finished = true;
+      requestDeadline.exit();
       open = isOpen();
       notifyAll();
     }


### PR DESCRIPTION
#2191 

Set a deadline timeout for each HTTP2 stream. DeadlineTimeout will start when the request header is written and will stop the moment `Http2Stream#receiveFin()` is triggered. 

This should allow the entire process of the request to be kept within the allocated deadline time.

Edit:
A timeout using the expected deadline duration is created in `Http1Codec` which will ensure that the time duration at which a request is made to getting a response is within the allocated deadline time