### PR TITLE
Allow users to provide a custom FileSystem to Cache

### DIFF
--- a/okhttp/src/main/java/okhttp3/Cache.java
+++ b/okhttp/src/main/java/okhttp3/Cache.java
@@ -178,7 +178,7 @@ public final class Cache implements Closeable, Flushable {
     this(directory, maxSize, FileSystem.SYSTEM);
   }
 
-  Cache(File directory, long maxSize, FileSystem fileSystem) {
+  public Cache(File directory, long maxSize, FileSystem fileSystem) {
     this.cache = DiskLruCache.create(fileSystem, directory, VERSION, ENTRY_COUNT, maxSize);
   }
 


### PR DESCRIPTION
Hey y'all,

We wrote an EncryptedSource/EncryptedSink to use in our request cache, and wrote an EncryptedFilesystem that wraps FileSystem.SYSTEM in that layer of encryption.

Let me know if you think there's a better way to encrypt our Request Cache instead!

Andrew