### PR TITLE
Check for MockWebServer shutdown result across the tests

### DIFF
--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/CustomDispatcherTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/CustomDispatcherTest.java
@@ -26,12 +26,13 @@ import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CustomDispatcherTest {
   private MockWebServer mockWebServer = new MockWebServer();
 
   @After public void tearDown() throws Exception {
-    mockWebServer.shutdown();
+    assertTrue("Server failed to shutdown.", mockWebServer.shutdown());
   }
 
   @Test public void simpleDispatch() throws Exception {

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
@@ -336,17 +336,17 @@ public final class MockWebServerTest {
 
   @Test public void shutdownWithoutStart() throws IOException {
     MockWebServer server = new MockWebServer();
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
   }
 
   @Test public void shutdownWithoutEnqueue() throws IOException {
     MockWebServer server = new MockWebServer();
     server.start();
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
   }
 
   @After public void tearDown() throws IOException {
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
   }
 
   @Test public void portImplicitlyStarts() throws IOException {
@@ -364,7 +364,7 @@ public final class MockWebServerTest {
   @Test public void differentInstancesGetDifferentPorts() throws IOException {
     MockWebServer other = new MockWebServer();
     assertNotEquals(server.getPort(), other.getPort());
-    other.shutdown();
+    assertTrue("Server failed to shutdown.", other.shutdown());
   }
 
   @Test public void statementStartsAndStops() throws Throwable {
@@ -397,6 +397,6 @@ public final class MockWebServerTest {
     }
 
     // Shutting down the server should unblock the dispatcher.
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
   }
 }

--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/CacheAdapterTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/CacheAdapterTest.java
@@ -73,7 +73,7 @@ public class CacheAdapterTest {
     if (connection != null) {
       connection.disconnect();
     }
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
   }
 
   @Test public void get_httpGet() throws Exception {

--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
@@ -222,7 +222,8 @@ public final class ResponseCacheTest {
     } else {
       assertNull(Integer.toString(responseCode), cached);
     }
-    server.shutdown(); // tearDown() isn't sufficient; this test starts multiple servers
+    // tearDown() isn't sufficient; this test starts multiple servers
+    assertTrue("Server failed to shutdown.", server.shutdown());
   }
 
   @Test public void responseCachingAndInputStreamSkipWithFixedLength() throws IOException {

--- a/okhttp-apache/src/test/java/okhttp3/apache/OkApacheClientTest.java
+++ b/okhttp-apache/src/test/java/okhttp3/apache/OkApacheClientTest.java
@@ -29,6 +29,7 @@ import static okhttp3.internal.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class OkApacheClientTest {
   private MockWebServer server;
@@ -41,7 +42,7 @@ public class OkApacheClientTest {
   }
 
   @After public void tearDown() throws IOException {
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
   }
 
   @Test public void success() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -199,7 +199,8 @@ public final class CacheTest {
     } else {
       assertNull(Integer.toString(responseCode), cached);
     }
-    server.shutdown(); // tearDown() isn't sufficient; this test starts multiple servers
+    // tearDown() isn't sufficient; this test starts multiple servers
+    assertTrue("Server failed to shutdown.", server.shutdown());
   }
 
   @Test public void responseCachingAndInputStreamSkipWithFixedLength() throws IOException {

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -2430,7 +2430,7 @@ public final class CallTest {
   }
 
   @Test public void connectFails() throws Exception {
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
 
     executeSynchronously("/")
         .assertFailure(IOException.class);
@@ -2444,7 +2444,7 @@ public final class CallTest {
         .proxySelector(new FakeProxySelector()
             .addProxy(server2.toProxyAddress()))
         .build();
-    server2.shutdown();
+    assertTrue("Server failed to shutdown.", server2.shutdown());
 
     Request request = new Request.Builder()
         .url(server.url("/"))

--- a/okhttp-tests/src/test/java/okhttp3/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/InterceptorTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class InterceptorTest {
@@ -52,7 +53,7 @@ public final class InterceptorTest {
   private RecordingCallback callback = new RecordingCallback();
 
   @Test public void applicationInterceptorsCanShortCircuitResponses() throws Exception {
-    server.shutdown(); // Accept no connections.
+    assertTrue("Server failed to shutdown.", server.shutdown()); // Accept no connections.
 
     Request request = new Request.Builder()
         .url("https://localhost:1/")

--- a/okhttp-tests/src/test/java/okhttp3/SocksProxyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/SocksProxyTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public final class SocksProxyTest {
   private final SocksProxy socksProxy = new SocksProxy();
@@ -40,7 +41,7 @@ public final class SocksProxyTest {
   }
 
   @After public void tearDown() throws Exception {
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
     socksProxy.shutdown();
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -281,7 +281,7 @@ public final class URLConnectionTest {
 
   @Test public void connectRetriesUntilConnectedOrFailed() throws Exception {
     URL url = server.url("/foo").url();
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
 
     connection = urlFactory.open(url);
     try {
@@ -311,7 +311,7 @@ public final class URLConnectionTest {
         .proxySelector(new FakeProxySelector()
             .addProxy(server2.toProxyAddress()))
         .build());
-    server2.shutdown();
+    assertTrue("Server failed to shutdown.", server2.shutdown());
 
     connection = urlFactory.open(server.url("/def").url());
     connection.setDoOutput(true);
@@ -2661,7 +2661,7 @@ public final class URLConnectionTest {
     connection1.setReadTimeout(100);
     InputStream input = connection1.getInputStream();
     assertEquals("ABC", readAscii(input, Integer.MAX_VALUE));
-    server.shutdown();
+    assertTrue("Server failed to shutdown.", server.shutdown());
     try {
       HttpURLConnection connection2 = urlFactory.open(server.url("").url());
       connection2.setReadTimeout(100);

--- a/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
@@ -206,7 +206,9 @@ public final class UrlConnectionCacheTest {
     } else {
       assertNull(Integer.toString(responseCode), cached);
     }
-    server.shutdown(); // tearDown() isn't sufficient; this test starts multiple servers
+
+    // tearDown() isn't sufficient; this test starts multiple servers
+    assertTrue("Server failed to shutdown.", server.shutdown());
   }
 
   @Test public void responseCachingAndInputStreamSkipWithFixedLength() throws IOException {


### PR DESCRIPTION
#2742 

Check that the MockWebServer is shutdown successfully across the tests to prevent port leakage