### PR TITLE
Fix Connection sharing across equivalent OkHttpClients

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CertificateChainCleanerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CertificateChainCleanerTest.java
@@ -21,6 +21,10 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.internal.platform.Platform;
 import okhttp3.internal.tls.CertificateChainCleaner;
 import okhttp3.internal.tls.HeldCertificate;
 import org.junit.Test;
@@ -29,6 +33,27 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public final class CertificateChainCleanerTest {
+  @Test public void equals_fromCertificate() throws Exception {
+    HeldCertificate rootA = new HeldCertificate.Builder()
+            .serialNumber("1")
+            .build();
+    HeldCertificate rootB = new HeldCertificate.Builder()
+            .serialNumber("2")
+            .build();
+    assertEquals(
+            CertificateChainCleaner.get(rootA.certificate, rootB.certificate),
+            CertificateChainCleaner.get(rootB.certificate, rootA.certificate));
+  }
+
+  @Test public void equals_fromTrustManager() throws Exception {
+    Platform platform = Platform.get();
+    X509TrustManager x509TrustManager = platform.trustManager(
+            (SSLSocketFactory) SSLSocketFactory.getDefault());
+    assertEquals(
+            CertificateChainCleaner.get(x509TrustManager),
+            CertificateChainCleaner.get(x509TrustManager));
+  }
+
   @Test public void normalizeSingleSelfSignedCertificate() throws Exception {
     HeldCertificate root = new HeldCertificate.Builder()
         .serialNumber("1")

--- a/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
@@ -120,4 +120,12 @@ public final class OkHttpClientTest {
     } catch (IllegalArgumentException expected) {
     }
   }
+
+  @Test
+  public void certificatePinnerEquality() {
+    OkHttpClient clientA = TestUtil.defaultClient();
+    OkHttpClient clientB = TestUtil.defaultClient();
+    assertEquals(clientA.certificatePinner(), clientB.certificatePinner());
+  }
+
 }

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Authenticator;
 import java.net.ConnectException;
+import java.net.CookieManager;
 import java.net.HttpRetryException;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
@@ -594,6 +595,16 @@ public final class URLConnectionTest {
   }
 
   @Test public void connectViaHttpsReusingConnections() throws IOException, InterruptedException {
+    connectViaHttpsReusingConnections(false);
+  }
+
+  @Test public void connectViaHttpsReusingConnections_rebuildClient()
+          throws IOException, InterruptedException {
+    connectViaHttpsReusingConnections(true);
+  }
+
+  private void connectViaHttpsReusingConnections(boolean rebuildClient)
+          throws IOException, InterruptedException {
     server.useHttps(sslClient.socketFactory, false);
     server.enqueue(new MockResponse().setBody("this response comes via HTTPS"));
     server.enqueue(new MockResponse().setBody("another response via HTTPS"));
@@ -602,12 +613,28 @@ public final class URLConnectionTest {
     SSLSocketFactory clientSocketFactory = sslClient.socketFactory;
     RecordingHostnameVerifier hostnameVerifier = new RecordingHostnameVerifier();
 
-    urlFactory.setClient(urlFactory.client().newBuilder()
-        .sslSocketFactory(clientSocketFactory, sslClient.trustManager)
-        .hostnameVerifier(hostnameVerifier)
-        .build());
+    CookieJar cookieJar = new JavaNetCookieJar(new CookieManager());
+    ConnectionPool connectionPool = new ConnectionPool();
+
+    urlFactory.setClient(new OkHttpClient.Builder()
+            .cache(cache)
+            .connectionPool(connectionPool)
+            .cookieJar(cookieJar)
+            .sslSocketFactory(clientSocketFactory, sslClient.trustManager)
+            .hostnameVerifier(hostnameVerifier)
+            .build());
     connection = urlFactory.open(server.url("/").url());
     assertContent("this response comes via HTTPS", connection);
+
+    if (rebuildClient) {
+      urlFactory.setClient(new OkHttpClient.Builder()
+              .cache(cache)
+              .connectionPool(connectionPool)
+              .cookieJar(cookieJar)
+              .sslSocketFactory(clientSocketFactory, sslClient.trustManager)
+              .hostnameVerifier(hostnameVerifier)
+              .build());
+    }
 
     connection = urlFactory.open(server.url("/").url());
     assertContent("another response via HTTPS", connection);

--- a/okhttp/src/main/java/okhttp3/CertificatePinner.java
+++ b/okhttp/src/main/java/okhttp3/CertificatePinner.java
@@ -20,11 +20,15 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import okhttp3.internal.Util;
 import okhttp3.internal.tls.CertificateChainCleaner;
 import okio.ByteString;
+
+import static okhttp3.internal.Util.equal;
 
 /**
  * Constrains which certificates are trusted. Pinning certificates defends against attacks on
@@ -124,12 +128,32 @@ import okio.ByteString;
 public final class CertificatePinner {
   public static final CertificatePinner DEFAULT = new Builder().build();
 
-  private final List<Pin> pins;
+  private final Set<Pin> pins;
   private final CertificateChainCleaner certificateChainCleaner;
 
-  private CertificatePinner(List<Pin> pins, CertificateChainCleaner certificateChainCleaner) {
+  private CertificatePinner(Set<Pin> pins, CertificateChainCleaner certificateChainCleaner) {
     this.pins = pins;
     this.certificateChainCleaner = certificateChainCleaner;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (!(obj instanceof CertificatePinner)) {
+      return false;
+    }
+    CertificatePinner that = (CertificatePinner) obj;
+    return equal(certificateChainCleaner, that.certificateChainCleaner)
+            && pins.equals(that.pins);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (certificateChainCleaner == null) ? 0 : certificateChainCleaner.hashCode();
+    result = 31 * result + pins.hashCode();
+    return result;
   }
 
   /**
@@ -210,9 +234,9 @@ public final class CertificatePinner {
 
   /** Returns a certificate pinner that uses {@code certificateChainCleaner}. */
   CertificatePinner withCertificateChainCleaner(CertificateChainCleaner certificateChainCleaner) {
-    return this.certificateChainCleaner != certificateChainCleaner
-        ? new CertificatePinner(pins, certificateChainCleaner)
-        : this;
+    return equal(this.certificateChainCleaner, certificateChainCleaner)
+        ? this
+        : new CertificatePinner(pins, certificateChainCleaner);
   }
 
   /**
@@ -319,7 +343,7 @@ public final class CertificatePinner {
     }
 
     public CertificatePinner build() {
-      return new CertificatePinner(Util.immutableList(pins), null);
+      return new CertificatePinner(new LinkedHashSet<>(pins), null);
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -239,6 +239,25 @@ class AndroidPlatform extends Platform {
         throw new AssertionError(e);
       }
     }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof AndroidCertificateChainCleaner)) {
+        return false;
+      }
+      AndroidCertificateChainCleaner that = (AndroidCertificateChainCleaner) obj;
+      boolean result = x509TrustManagerExtensions.equals(that.x509TrustManagerExtensions)
+              && checkServerTrusted.equals(that.checkServerTrusted);
+      return result;
+    }
+
+    @Override
+    public int hashCode() {
+      return checkServerTrusted.hashCode() + 31 * x509TrustManagerExtensions.hashCode();
+    }
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/internal/tls/BasicCertificateChainCleaner.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/BasicCertificateChainCleaner.java
@@ -111,4 +111,18 @@ public final class BasicCertificateChainCleaner extends CertificateChainCleaner 
       return false;
     }
   }
+
+  @Override
+  public int hashCode() {
+    return trustRootIndex.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof BasicCertificateChainCleaner)) {
+      return false;
+    }
+    BasicCertificateChainCleaner that = (BasicCertificateChainCleaner) obj;
+    return trustRootIndex.equals(that.trustRootIndex);
+  }
 }


### PR DESCRIPTION
Fix Connection sharing across equivalent OkHttpClients

Fixes https://github.com/square/okhttp/issues/2757

The OkHttpClient(Builder) constructor and both overloads of
OkHttpClient.Builder.sslSocketFactory() set a new CertificateChainCleaner
instance on the OkHttpClient.

Before this CL, CertificateChainCleaner, CertificatePinner and
TrustRootIndex used object rather than value identity semantics. This
caused Address.equals() to not recognize when addresses were equivalent,
which broke connection pooling across OkHttpClient instances.

This CL changes CertificateChainClaner, CertificatePinner and
TrustRootIndex to use value equality by overriding equals() and hashCode().

CertificatePinner.pins and BasicTrustRootIndex.subjectToCaCerts's values
have changed from List to Set because their order shouldn't matter.
This CL uses LinkedHashSet, although HashSet should also work.