### PR TITLE
Guard allocation changes by the connection pool lock.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
@@ -81,8 +81,10 @@ public final class ConnectionPoolTest {
     pool.cleanupRunning = true; // Prevent the cleanup runnable from being started.
 
     RealConnection c1 = newConnection(pool, routeA1, 50L);
-    StreamAllocation streamAllocation = new StreamAllocation(pool, addressA);
-    streamAllocation.acquire(c1);
+    synchronized (pool) {
+      StreamAllocation streamAllocation = new StreamAllocation(pool, addressA);
+      streamAllocation.acquire(c1);
+    }
 
     // Running at time 50, the pool returns that nothing can be evicted until time 150.
     assertEquals(100L, pool.cleanup(50L));
@@ -172,8 +174,10 @@ public final class ConnectionPoolTest {
 
   /** Use a helper method so there's no hidden reference remaining on the stack. */
   private void allocateAndLeakAllocation(ConnectionPool pool, RealConnection connection) {
-    StreamAllocation leak = new StreamAllocation(pool, connection.route().address());
-    leak.acquire(connection);
+    synchronized (pool) {
+      StreamAllocation leak = new StreamAllocation(pool, connection.route().address());
+      leak.acquire(connection);
+    }
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -182,9 +182,9 @@ public final class StreamAllocation {
       }
     }
     RealConnection newConnection = new RealConnection(selectedRoute);
-    acquire(newConnection);
 
     synchronized (connectionPool) {
+      acquire(newConnection);
       Internal.instance.put(connectionPool, newConnection);
       this.connection = newConnection;
       if (canceled) throw new IOException("Canceled");
@@ -317,6 +317,7 @@ public final class StreamAllocation {
    * {@link #release} on the same connection.
    */
   public void acquire(RealConnection connection) {
+    assert (Thread.holdsLock(connectionPool));
     connection.allocations.add(new WeakReference<>(this));
   }
 


### PR DESCRIPTION
As suggested here: https://github.com/square/okhttp/pull/2597/files