### PR TITLE
Provide capability to capture the Call stack trace on leaked connections.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/TestLogHandler.java
+++ b/okhttp-tests/src/test/java/okhttp3/TestLogHandler.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
+import java.util.logging.SimpleFormatter;
 
 /**
  * A log handler that records which log messages were published so that a calling test can make
@@ -28,7 +29,11 @@ public final class TestLogHandler extends Handler {
   private final List<String> logs = new ArrayList<>();
 
   @Override public synchronized void publish(LogRecord logRecord) {
-    logs.add(logRecord.getLevel() + ": " + logRecord.getMessage());
+    if (getFormatter() == null) {
+      logs.add(logRecord.getLevel() + ": " + logRecord.getMessage());
+    } else {
+      logs.add(getFormatter().format(logRecord));
+    }
     notifyAll();
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/TestUtil.java
+++ b/okhttp-tests/src/test/java/okhttp3/TestUtil.java
@@ -43,4 +43,15 @@ public final class TestUtil {
     Arrays.fill(array, c);
     return new String(array);
   }
+
+  /**
+   * See FinalizationTester for discussion on how to best trigger GC in tests.
+   * https://android.googlesource.com/platform/libcore/+/master/support/src/test/java/libcore/
+   * java/lang/ref/FinalizationTester.java
+   */
+  public static void awaitGarbageCollection() throws InterruptedException {
+    Runtime.getRuntime().gc();
+    Thread.sleep(100);
+    System.runFinalization();
+  }
 }

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -1549,6 +1549,7 @@ public final class URLConnectionTest {
     outputStream.write(body.getBytes("UTF-8"));
     outputStream.close();
     assertEquals(200, connection.getResponseCode());
+    connection.getInputStream().close();
 
     RecordedRequest recordedRequest1 = server.takeRequest();
     assertEquals("POST", recordedRequest1.getMethod());
@@ -2399,6 +2400,7 @@ public final class URLConnectionTest {
 
     assertEquals(408, connection.getResponseCode());
     assertEquals(1, server.getRequestCount());
+    connection.getErrorStream().close();
   }
 
   @Test public void readTimeouts() throws IOException {

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -33,7 +33,6 @@ import okhttp3.internal.connection.StreamAllocation;
 import okhttp3.internal.platform.Platform;
 
 import static okhttp3.internal.Util.closeQuietly;
-import static okhttp3.internal.platform.Platform.WARN;
 
 /**
  * Manages reuse of HTTP and HTTP/2 connections for reduced network latency. HTTP requests that
@@ -246,8 +245,12 @@ public final class ConnectionPool {
       }
 
       // We've discovered a leaked allocation. This is an application bug.
-      Platform.get().log(WARN, "A connection to " + connection.route().address().url()
-          + " was leaked. Did you forget to close a response body?", null);
+      StreamAllocation.StreamAllocationReference streamAllocRef =
+          (StreamAllocation.StreamAllocationReference) reference;
+      String message = "A connection to " + connection.route().address().url()
+          + " was leaked. Did you forget to close a response body?";
+      Platform.get().logCloseableLeak(message, streamAllocRef.callStackTrace);
+
       references.remove(i);
       connection.noNewStreams = true;
 

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -55,6 +55,7 @@ final class RealCall implements Call {
       if (executed) throw new IllegalStateException("Already Executed");
       executed = true;
     }
+    captureCallStackTrace();
     try {
       client.dispatcher().executed(this);
       Response result = getResponseWithInterceptorChain();
@@ -63,6 +64,11 @@ final class RealCall implements Call {
     } finally {
       client.dispatcher().finished(this);
     }
+  }
+
+  private void captureCallStackTrace() {
+    Object callStackTrace = Platform.get().getStackTraceForCloseable("response.body().close()");
+    retryAndFollowUpInterceptor.setCallStackTrace(callStackTrace);
   }
 
   synchronized void setForWebSocket() {
@@ -75,6 +81,7 @@ final class RealCall implements Call {
       if (executed) throw new IllegalStateException("Already Executed");
       executed = true;
     }
+    captureCallStackTrace();
     client.dispatcher().enqueue(new AsyncCall(responseCallback));
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -45,6 +45,8 @@ class AndroidPlatform extends Platform {
   private final OptionalMethod<Socket> getAlpnSelectedProtocol;
   private final OptionalMethod<Socket> setAlpnProtocols;
 
+  private final CloseGuard closeGuard = CloseGuard.get();
+
   public AndroidPlatform(Class<?> sslParametersClass, OptionalMethod<Socket> setUseSessionTickets,
       OptionalMethod<Socket> setHostname, OptionalMethod<Socket> getAlpnSelectedProtocol,
       OptionalMethod<Socket> setAlpnProtocols) {
@@ -129,6 +131,18 @@ class AndroidPlatform extends Platform {
         Log.println(logLevel, "OkHttp", message.substring(i, end));
         i = end;
       } while (i < newline);
+    }
+  }
+
+  @Override public Object getStackTraceForCloseable(String closer) {
+    return closeGuard.createAndOpen(closer);
+  }
+
+  @Override public void logCloseableLeak(String message, Object stackTrace) {
+    boolean reported = closeGuard.warnIfOpen(stackTrace);
+    if (!reported) {
+      // Unable to report via CloseGuard. As a last-ditch effort, send it to the logger.
+      log(WARN, message, null);
     }
   }
 
@@ -224,6 +238,65 @@ class AndroidPlatform extends Platform {
       } catch (IllegalAccessException e) {
         throw new AssertionError(e);
       }
+    }
+  }
+
+  /**
+   * Provides access to the internal dalvik.system.CloseGuard class. Android uses this in
+   * combination with android.os.StrictMode to report on leaked java.io.Closeable's. Available since
+   * Android API 11.
+   */
+  static final class CloseGuard {
+    private final Method getMethod;
+    private final Method openMethod;
+    private final Method warnIfOpenMethod;
+
+    CloseGuard(Method getMethod, Method openMethod, Method warnIfOpenMethod) {
+      this.getMethod = getMethod;
+      this.openMethod = openMethod;
+      this.warnIfOpenMethod = warnIfOpenMethod;
+    }
+
+    Object createAndOpen(String closer) {
+      if (getMethod != null) {
+        try {
+          Object closeGuardInstance = getMethod.invoke(null);
+          openMethod.invoke(closeGuardInstance, closer);
+          return closeGuardInstance;
+        } catch (Exception ignored) {
+        }
+      }
+      return null;
+    }
+
+    boolean warnIfOpen(Object closeGuardInstance) {
+      boolean reported = false;
+      if (closeGuardInstance != null) {
+        try {
+          warnIfOpenMethod.invoke(closeGuardInstance);
+          reported = true;
+        } catch (Exception ignored) {
+        }
+      }
+      return reported;
+    }
+
+    static CloseGuard get() {
+      Method getMethod;
+      Method openMethod;
+      Method warnIfOpenMethod;
+
+      try {
+        Class<?> closeGuardClass = Class.forName("dalvik.system.CloseGuard");
+        getMethod = closeGuardClass.getMethod("get");
+        openMethod = closeGuardClass.getMethod("open", String.class);
+        warnIfOpenMethod = closeGuardClass.getMethod("warnIfOpen");
+      } catch (Exception ignored) {
+        getMethod = null;
+        openMethod = null;
+        warnIfOpenMethod = null;
+      }
+      return new CloseGuard(getMethod, openMethod, warnIfOpenMethod);
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -133,6 +133,26 @@ public class Platform {
     return true;
   }
 
+  /**
+   * Returns an object that holds a stack trace created at the moment this method is executed. This
+   * should be used specifically for {@link java.io.Closeable} objects and in conjunction with
+   * {@link #logCloseableLeak(String, Object)}.
+   */
+  public Object getStackTraceForCloseable(String closer) {
+    if (logger.isLoggable(Level.FINE)) {
+      return new Throwable(closer); // These are expensive to allocate.
+    }
+    return null;
+  }
+
+  public void logCloseableLeak(String message, Object stackTrace) {
+    if (stackTrace == null) {
+      message += " To see where this was allocated, set the OkHttpClient logger level to FINE: "
+          + "Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);";
+    }
+    log(WARN, message, (Throwable) stackTrace);
+  }
+
   public static List<String> alpnProtocolNames(List<Protocol> protocols) {
     List<String> names = new ArrayList<>(protocols.size());
     for (int i = 0, size = protocols.size(); i < size; i++) {


### PR DESCRIPTION
Also plugged some leaks discovered after running the tests with this
change in place.

https://github.com/square/okhttp/issues/2127