### PR TITLE
Adds utility to create a MockResponse from resource file

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
@@ -15,6 +15,8 @@
  */
 package okhttp3.mockwebserver;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -22,6 +24,7 @@ import okhttp3.Headers;
 import okhttp3.internal.Internal;
 import okhttp3.internal.http2.Settings;
 import okhttp3.ws.WebSocketListener;
+import okio.Okio;
 import okio.Buffer;
 
 /** A scripted response to be replayed by the mock web server. */
@@ -299,5 +302,20 @@ public final class MockResponse implements Cloneable {
 
   @Override public String toString() {
     return status;
+  }
+
+  /**
+   * Creates a MockResponse with body from a resource file on the classpath, e.g. a file relative
+   * to 'src/test/resources'.
+   */
+  public static MockResponse fromResource(String file, Class<?> clz) throws IOException {
+    return from(clz.getResourceAsStream(file));
+  }
+
+  public static MockResponse from(InputStream inputStream) {
+    return new MockResponse()
+      .setBody(
+        Okio.buffer(Okio.source(inputStream)).buffer()
+      );
   }
 }


### PR DESCRIPTION
Hi guys,

noticed that I am writing the following code over and over again in various test cases.

Usually, we have static files in ``src/test/resources`` that we use to create mock responses. Maybe it's helpful to have that utility in the library.

wdyt? better naming? should there be a test for the two methods?

cheers! 🌙 