### PR TITLE
Allow Cache-Control durations to be longs

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CacheControlTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheControlTest.java
@@ -190,4 +190,11 @@ public final class CacheControlTest {
         .build();
     assertEquals(4, cacheControl.maxAgeSeconds());
   }
+
+  @Test public void longNanosecondsOkay() {
+    CacheControl cacheControl = new CacheControl.Builder()
+        .maxAge(100000000000L, TimeUnit.NANOSECONDS)
+        .build();
+    assertEquals(100, cacheControl.maxAgeSeconds());
+  }
 }

--- a/okhttp/src/main/java/okhttp3/CacheControl.java
+++ b/okhttp/src/main/java/okhttp3/CacheControl.java
@@ -290,7 +290,7 @@ public final class CacheControl {
      * @param maxAge a non-negative integer. This is stored and transmitted with {@link
      * TimeUnit#SECONDS} precision; finer precision will be lost.
      */
-    public Builder maxAge(int maxAge, TimeUnit timeUnit) {
+    public Builder maxAge(long maxAge, TimeUnit timeUnit) {
       if (maxAge < 0) throw new IllegalArgumentException("maxAge < 0: " + maxAge);
       long maxAgeSecondsLong = timeUnit.toSeconds(maxAge);
       this.maxAgeSeconds = maxAgeSecondsLong > Integer.MAX_VALUE
@@ -306,7 +306,7 @@ public final class CacheControl {
      * @param maxStale a non-negative integer. This is stored and transmitted with {@link
      * TimeUnit#SECONDS} precision; finer precision will be lost.
      */
-    public Builder maxStale(int maxStale, TimeUnit timeUnit) {
+    public Builder maxStale(long maxStale, TimeUnit timeUnit) {
       if (maxStale < 0) throw new IllegalArgumentException("maxStale < 0: " + maxStale);
       long maxStaleSecondsLong = timeUnit.toSeconds(maxStale);
       this.maxStaleSeconds = maxStaleSecondsLong > Integer.MAX_VALUE
@@ -323,7 +323,7 @@ public final class CacheControl {
      * @param minFresh a non-negative integer. This is stored and transmitted with {@link
      * TimeUnit#SECONDS} precision; finer precision will be lost.
      */
-    public Builder minFresh(int minFresh, TimeUnit timeUnit) {
+    public Builder minFresh(long minFresh, TimeUnit timeUnit) {
       if (minFresh < 0) throw new IllegalArgumentException("minFresh < 0: " + minFresh);
       long minFreshSecondsLong = timeUnit.toSeconds(minFresh);
       this.minFreshSeconds = minFreshSecondsLong > Integer.MAX_VALUE


### PR DESCRIPTION
Sometimes, when providing a Cache-Control duration in milliseconds or a smaller unit, you want to be able to specify something greater than `INT_MAX`. This patch enables that, without affecting the code which clamps the final result to `INT_MAX` seconds.