### PR TITLE
ConnectException in MockWebServer if no connection preface is received for HTTP2 from a client

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -19,6 +19,7 @@ package okhttp3.mockwebserver;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ProtocolException;
@@ -850,6 +851,11 @@ public final class MockWebServer implements TestRule {
     private FramedSocketHandler(Socket socket, Protocol protocol) {
       this.socket = socket;
       this.protocol = protocol;
+    }
+
+    @Override
+    public void connectionFailed() throws IOException {
+      throw new ConnectException("HTTP2 connection preface is not sent by client");
     }
 
     @Override public void onStream(Http2Stream stream) throws IOException {


### PR DESCRIPTION
#2474

A ConnectionException will be thrown in the MockWebServer if it does not receive a connection preface from it's client when a HTTP2 connection is established.
