### PR TITLE
Be more liberal adding headers to the HPACK encoder dynamic table.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/Header.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Header.java
@@ -21,6 +21,7 @@ import okio.ByteString;
 /** HTTP header: the name is an ASCII string, but the value can be UTF-8. */
 public final class Header {
   // Special header names defined in HTTP/2 spec.
+  public static final ByteString PSEUDO_PREFIX = ByteString.encodeUtf8(":");
   public static final ByteString RESPONSE_STATUS = ByteString.encodeUtf8(":status");
   public static final ByteString TARGET_METHOD = ByteString.encodeUtf8(":method");
   public static final ByteString TARGET_PATH = ByteString.encodeUtf8(":path");


### PR DESCRIPTION
Previously, if a header name was in the static table we'd avoid adding it
to the dynamic table. Since most common headers are in the static table,
we were missing the chance to save on bytes sent.