### PR TITLE
Allow HTAB in header values.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
@@ -75,10 +75,12 @@ public final class HeadersTest {
         .add("foo: bar")
         .add(" foo: baz") // Name leading whitespace is trimmed.
         .add("foo : bak") // Name trailing whitespace is trimmed.
+        .add("\tkey\t:\tvalue\t") // '\t' also counts as whitespace
         .add("ping:  pong  ") // Value whitespace is trimmed.
         .add("kit:kat") // Space after colon is not required.
         .build();
     assertEquals(Arrays.asList("bar", "baz", "bak"), headers.values("foo"));
+    assertEquals(Arrays.asList("value"), headers.values("key"));
     assertEquals(Arrays.asList("pong"), headers.values("ping"));
     assertEquals(Arrays.asList("kat"), headers.values("kit"));
   }

--- a/okhttp-tests/src/test/java/okhttp3/RequestTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/RequestTest.java
@@ -198,11 +198,20 @@ public final class RequestTest {
     }
   }
 
+  @Test public void headerAllowsTabOnlyInValues() throws Exception {
+    Request.Builder builder = new Request.Builder();
+    builder.header("key", "sample\tvalue");
+    try {
+      builder.header("sample\tkey", "value");
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   @Test public void headerForbidsControlCharacters() throws Exception {
     assertForbiddenHeader("\u0000");
     assertForbiddenHeader("\r");
     assertForbiddenHeader("\n");
-    assertForbiddenHeader("\t");
     assertForbiddenHeader("\u001f");
     assertForbiddenHeader("\u007f");
     assertForbiddenHeader("\u0080");

--- a/okhttp/src/main/java/okhttp3/Headers.java
+++ b/okhttp/src/main/java/okhttp3/Headers.java
@@ -316,7 +316,7 @@ public final class Headers {
       if (value == null) throw new NullPointerException("value == null");
       for (int i = 0, length = value.length(); i < length; i++) {
         char c = value.charAt(i);
-        if (c <= '\u001f' || c >= '\u007f') {
+        if ((c <= '\u001f' && c != '\u0009' /* htab */) || c >= '\u007f') {
           throw new IllegalArgumentException(Util.format(
               "Unexpected char %#04x at %d in %s value: %s", (int) c, i, name, value));
         }


### PR DESCRIPTION
RFC 7230 section 3.2 allows HTAB ('\t', '\u0009') inside header
values as long as there is not more than one in a row:
  https://tools.ietf.org/html/rfc7230#section-3.2

Before this CL, OkHttp previously disallowed HTAB in header values.
This CL changes behavior to allow any number of consecutive HTABs
inside a header value; this is more permissive than the RFC, but
is consistent with how OkHttp currently treats space characters
(' ', '\u0020').