### PR TITLE
Corrected javadoc of the Cookie persistent() method

### DIFF
--- a/okhttp/src/main/java/okhttp3/Cookie.java
+++ b/okhttp/src/main/java/okhttp3/Cookie.java
@@ -100,7 +100,7 @@ public final class Cookie {
     return value;
   }
 
-  /** Returns true if this cookie expires at the end of the current session. */
+  /** Returns true if this cookie does not expire at the end of the current session. */
   public boolean persistent() {
     return persistent;
   }


### PR DESCRIPTION
It was claiming that returns true if the cookie expires and the end of the session and really is the opposite behavior.