### PR TITLE
Minor memory optimization for Util.immutableList

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteSelectorTest.java
@@ -24,7 +24,6 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 import javax.net.SocketFactory;
@@ -72,7 +71,7 @@ public final class RouteSelectorTest {
   private HostnameVerifier hostnameVerifier;
 
   private final Authenticator authenticator = Authenticator.NONE;
-  private final List<Protocol> protocols = Arrays.asList(Protocol.HTTP_1_1);
+  private final List<Protocol> protocols = Util.immutableList(Protocol.HTTP_1_1);
   private final FakeDns dns = new FakeDns();
   private final RecordingProxySelector proxySelector = new RecordingProxySelector();
   private RouteDatabase routeDatabase = new RouteDatabase();

--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -226,11 +226,16 @@ public final class Util {
 
   /** Returns an immutable copy of {@code list}. */
   public static <T> List<T> immutableList(List<T> list) {
+    if (list.isEmpty()) return Collections.emptyList();
+    if (list.size() == 1) return Collections.singletonList(list.get(0));
     return Collections.unmodifiableList(new ArrayList<>(list));
   }
 
   /** Returns an immutable list containing {@code elements}. */
+  @SafeVarargs
   public static <T> List<T> immutableList(T... elements) {
+    if (elements.length == 0) return Collections.emptyList();
+    if (elements.length == 1) return Collections.singletonList(elements[0]);
     return Collections.unmodifiableList(Arrays.asList(elements.clone()));
   }
 


### PR DESCRIPTION
I didn't doing any kind of formal analysis, but simply running the tests showed that several calls to Utils.immutableList yielded either the empty list instance or a singleton list, instead of allocating an ArrayList + UnmodifiedList.

Definitely a micro-optimization, but seems harmless at worst.