### PR TITLE
Web socket API and implementation improvements.

### DIFF
--- a/okhttp-tests/src/main/java/okhttp3/AutobahnTester.java
+++ b/okhttp-tests/src/main/java/okhttp3/AutobahnTester.java
@@ -62,7 +62,7 @@ public final class AutobahnTester {
     }
   }
 
-  private void runTest(final long number, final long count) throws IOException {
+  private void runTest(final long number, final long count) {
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicLong startNanos = new AtomicLong();
     newWebSocket("/runCase?case=" + number + "&agent=okhttp") //
@@ -105,8 +105,8 @@ public final class AutobahnTester {
             latch.countDown();
           }
 
-          @Override public void onFailure(IOException e, Response response) {
-            e.printStackTrace(System.out);
+          @Override public void onFailure(Throwable t, Response response) {
+            t.printStackTrace(System.out);
             latch.countDown();
           }
         });
@@ -126,7 +126,7 @@ public final class AutobahnTester {
   private long getTestCount() throws IOException {
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicLong countRef = new AtomicLong();
-    final AtomicReference<IOException> failureRef = new AtomicReference<>();
+    final AtomicReference<Throwable> failureRef = new AtomicReference<>();
     newWebSocket("/getCaseCount").enqueue(new WebSocketListener() {
       @Override public void onOpen(WebSocket webSocket, Response response) {
       }
@@ -143,8 +143,8 @@ public final class AutobahnTester {
         latch.countDown();
       }
 
-      @Override public void onFailure(IOException e, Response response) {
-        failureRef.set(e);
+      @Override public void onFailure(Throwable t, Response response) {
+        failureRef.set(t);
         latch.countDown();
       }
     });
@@ -155,9 +155,9 @@ public final class AutobahnTester {
     } catch (InterruptedException e) {
       throw new AssertionError();
     }
-    IOException failure = failureRef.get();
+    Throwable failure = failureRef.get();
     if (failure != null) {
-      throw failure;
+      throw new RuntimeException(failure);
     }
     return countRef.get();
   }
@@ -178,7 +178,7 @@ public final class AutobahnTester {
         latch.countDown();
       }
 
-      @Override public void onFailure(IOException e, Response response) {
+      @Override public void onFailure(Throwable t, Response response) {
         latch.countDown();
       }
     });

--- a/okhttp-tests/src/test/java/okhttp3/TestLogHandler.java
+++ b/okhttp-tests/src/test/java/okhttp3/TestLogHandler.java
@@ -15,38 +15,38 @@
  */
 package okhttp3;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
-import java.util.logging.SimpleFormatter;
 
 /**
  * A log handler that records which log messages were published so that a calling test can make
  * assertions about them.
  */
 public final class TestLogHandler extends Handler {
-  private final List<String> logs = new ArrayList<>();
+  private final BlockingQueue<String> logs = new LinkedBlockingQueue<>();
 
-  @Override public synchronized void publish(LogRecord logRecord) {
+  @Override public void publish(LogRecord logRecord) {
     if (getFormatter() == null) {
       logs.add(logRecord.getLevel() + ": " + logRecord.getMessage());
     } else {
       logs.add(getFormatter().format(logRecord));
     }
-    notifyAll();
   }
 
   @Override public void flush() {
   }
 
-  @Override public void close() throws SecurityException {
+  @Override public void close() {
   }
 
-  public synchronized String take() throws InterruptedException {
-    while (logs.isEmpty()) {
-      wait();
+  public String take() throws InterruptedException {
+    String message = logs.poll(10, TimeUnit.SECONDS);
+    if (message == null) {
+      throw new AssertionError("Timed out waiting for log message.");
     }
-    return logs.remove(0);
+    return message;
   }
 }

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/EmptyWebSocketListener.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/EmptyWebSocketListener.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.ws;
+
+import java.io.IOException;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.Buffer;
+
+public class EmptyWebSocketListener implements WebSocketListener {
+  @Override public void onOpen(WebSocket webSocket, Response response) {
+  }
+
+  @Override public void onMessage(ResponseBody message) throws IOException {
+  }
+
+  @Override public void onPong(Buffer payload) {
+  }
+
+  @Override public void onClose(int code, String reason) {
+  }
+
+  @Override public void onFailure(Throwable t, Response response) {
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -21,7 +21,10 @@ import java.net.ProtocolException;
 import java.util.Random;
 import java.util.concurrent.Executor;
 import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
 import okhttp3.RequestBody;
+import okhttp3.Response;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
@@ -34,7 +37,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static okhttp3.WebSocket.BINARY;
 import static okhttp3.WebSocket.TEXT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -52,34 +54,39 @@ public final class RealWebSocketTest {
   private boolean clientConnectionCloseThrows;
   private boolean clientConnectionClosed;
   private final MemorySocket client2Server = new MemorySocket();
-  private final WebSocketRecorder clientListener = new WebSocketRecorder();
+  private final WebSocketRecorder clientListener = new WebSocketRecorder("client");
 
   private final Executor serverExecutor = new SynchronousExecutor();
   private RealWebSocket server;
   private boolean serverConnectionClosed;
   private final MemorySocket server2client = new MemorySocket();
-  private final WebSocketRecorder serverListener = new WebSocketRecorder();
+  private final WebSocketRecorder serverListener = new WebSocketRecorder("server");
 
   @Before public void setUp() {
     Random random = new Random(0);
     String url = "http://example.com/websocket";
+    Response response = new Response.Builder()
+        .code(101)
+        .request(new Request.Builder().url(url).build())
+        .protocol(Protocol.HTTP_1_1)
+        .build();
 
     client = new RealWebSocket(true, server2client.source(), client2Server.sink(), random,
-        clientExecutor, clientListener, url) {
-      @Override protected void close() throws IOException {
+        clientExecutor, clientListener, response, url) {
+      @Override protected void shutdown() {
         if (clientConnectionClosed) {
           throw new AssertionError("Already closed");
         }
         clientConnectionClosed = true;
 
         if (clientConnectionCloseThrows) {
-          throw new IOException("Oops!");
+          throw new RuntimeException("Oops!");
         }
       }
     };
     server = new RealWebSocket(false, client2Server.source(), server2client.sink(), random,
-        serverExecutor, serverListener, url) {
-      @Override protected void close() throws IOException {
+        serverExecutor, serverListener, response, url) {
+      @Override protected void shutdown() {
         if (serverConnectionClosed) {
           throw new AssertionError("Already closed");
         }
@@ -91,48 +98,6 @@ public final class RealWebSocketTest {
   @After public void tearDown() {
     clientListener.assertExhausted();
     serverListener.assertExhausted();
-  }
-
-  @Test public void nullMessageThrows() throws IOException {
-    try {
-      client.sendMessage(null);
-      fail();
-    } catch (NullPointerException e) {
-      assertEquals("message == null", e.getMessage());
-    }
-  }
-
-  @Test public void textMessage() throws IOException {
-    client.sendMessage(RequestBody.create(TEXT, "Hello!"));
-    server.readMessage();
-    serverListener.assertTextMessage("Hello!");
-  }
-
-  @Test public void binaryMessage() throws IOException {
-    client.sendMessage(RequestBody.create(BINARY, "Hello!"));
-    server.readMessage();
-    serverListener.assertBinaryMessage(new byte[] {'H', 'e', 'l', 'l', 'o', '!'});
-  }
-
-  @Test public void missingContentTypeThrows() throws IOException {
-    try {
-      client.sendMessage(RequestBody.create(null, "Hey!"));
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertEquals("Message content type was null. Must use WebSocket.TEXT or WebSocket.BINARY.",
-          e.getMessage());
-    }
-  }
-
-  @Test public void unknownContentTypeThrows() throws IOException {
-    try {
-      client.sendMessage(RequestBody.create(MediaType.parse("text/plain"), "Hey!"));
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertEquals(
-          "Unknown message content type: text/plain. Must use WebSocket.TEXT or WebSocket.BINARY.",
-          e.getMessage());
-    }
   }
 
   @Test public void streamingMessage() throws IOException {
@@ -148,11 +113,11 @@ public final class RealWebSocketTest {
       }
     };
     client.sendMessage(message);
-    server.readMessage();
+    server.processNextFrame();
     serverListener.assertTextMessage("Hello!");
   }
 
-  @Test public void streamingMessageCanInterleavePing() throws IOException, InterruptedException {
+  @Test public void streamingMessageCanInterleavePing() throws IOException {
     RequestBody message = new RequestBody() {
       @Override public MediaType contentType() {
         return TEXT;
@@ -167,30 +132,30 @@ public final class RealWebSocketTest {
     };
 
     client.sendMessage(message);
-    server.readMessage();
+    server.processNextFrame();
     serverListener.assertTextMessage("Hello!");
-    client.readMessage();
+    client.processNextFrame();
     clientListener.assertPong(new Buffer().writeUtf8("Pong?"));
   }
 
-  @Test public void pingWritesPong() throws IOException, InterruptedException {
+  @Test public void pingWritesPong() throws IOException {
     client.sendPing(new Buffer().writeUtf8("Hello!"));
-    server.readMessage(); // Read the ping, write the pong.
-    client.readMessage(); // Read the pong.
+    server.processNextFrame(); // Read the ping, write the pong.
+    client.processNextFrame(); // Read the pong.
     clientListener.assertPong(new Buffer().writeUtf8("Hello!"));
   }
 
   @Test public void unsolicitedPong() throws IOException {
     client.sendPong(new Buffer().writeUtf8("Hello!"));
-    server.readMessage();
+    server.processNextFrame();
     serverListener.assertPong(new Buffer().writeUtf8("Hello!"));
   }
 
   @Test public void close() throws IOException {
     client.close(1000, "Hello!");
-    assertFalse(server.readMessage()); // This will trigger a close response.
+    assertFalse(server.processNextFrame()); // This will trigger a close response.
     serverListener.assertClose(1000, "Hello!");
-    assertFalse(client.readMessage());
+    assertFalse(client.processNextFrame());
     clientListener.assertClose(1000, "Hello!");
   }
 
@@ -267,7 +232,7 @@ public final class RealWebSocketTest {
 
   @Test public void serverCloseThenWritingPingThrows() throws IOException {
     server.close(1000, "Hello!");
-    client.readMessage();
+    client.processNextFrame();
     clientListener.assertClose(1000, "Hello!");
 
     try {
@@ -280,7 +245,7 @@ public final class RealWebSocketTest {
 
   @Test public void serverCloseThenWritingMessageThrows() throws IOException {
     server.close(1000, "Hello!");
-    client.readMessage();
+    client.processNextFrame();
     clientListener.assertClose(1000, "Hello!");
 
     try {
@@ -293,7 +258,7 @@ public final class RealWebSocketTest {
 
   @Test public void serverCloseThenWritingCloseThrows() throws IOException {
     server.close(1000, "Hello!");
-    client.readMessage();
+    client.processNextFrame();
     clientListener.assertClose(1000, "Hello!");
 
     try {
@@ -315,7 +280,7 @@ public final class RealWebSocketTest {
         sink.writeUtf8("Hel").flush();
 
         server.close(1000, "Hello!");
-        client.readMessage();
+        client.processNextFrame();
         clientListener.assertClose(1000, "Hello!");
 
         try {
@@ -338,10 +303,10 @@ public final class RealWebSocketTest {
   @Test public void clientCloseClosesConnection() throws IOException {
     client.close(1000, "Hello!");
     assertFalse(clientConnectionClosed);
-    server.readMessage(); // Read client close, send server close.
+    server.processNextFrame(); // Read client close, send server close.
     serverListener.assertClose(1000, "Hello!");
 
-    client.readMessage(); // Read server close, close connection.
+    client.processNextFrame(); // Read server close, close connection.
     assertTrue(clientConnectionClosed);
     clientListener.assertClose(1000, "Hello!");
   }
@@ -349,11 +314,11 @@ public final class RealWebSocketTest {
   @Test public void serverCloseClosesConnection() throws IOException {
     server.close(1000, "Hello!");
 
-    client.readMessage(); // Read server close, send client close, close connection.
+    client.processNextFrame(); // Read server close, send client close, close connection.
     assertTrue(clientConnectionClosed);
     clientListener.assertClose(1000, "Hello!");
 
-    server.readMessage();
+    server.processNextFrame();
     serverListener.assertClose(1000, "Hello!");
   }
 
@@ -363,11 +328,11 @@ public final class RealWebSocketTest {
     client.close(1000, "Hi!");
     assertFalse(clientConnectionClosed);
 
-    client.readMessage(); // Read close, close connection close.
+    client.processNextFrame(); // Read close, close connection close.
     assertTrue(clientConnectionClosed);
     clientListener.assertClose(1000, "Hello!");
 
-    server.readMessage();
+    server.processNextFrame();
     serverListener.assertClose(1000, "Hi!");
 
     serverListener.assertExhausted(); // Client should not have sent second close.
@@ -377,21 +342,38 @@ public final class RealWebSocketTest {
   @Test public void serverCloseBreaksReadMessageLoop() throws IOException {
     server.sendMessage(RequestBody.create(TEXT, "Hello!"));
     server.close(1000, "Bye!");
-    assertTrue(client.readMessage());
+    assertTrue(client.processNextFrame());
     clientListener.assertTextMessage("Hello!");
-    assertFalse(client.readMessage());
+    assertFalse(client.processNextFrame());
     clientListener.assertClose(1000, "Bye!");
   }
 
-  @Test public void protocolErrorBeforeCloseSendsClose() throws IOException {
+  @Test public void protocolErrorBeforeCloseSendsClose() {
     server2client.raw().write(ByteString.decodeHex("0a00")); // Invalid non-final ping frame.
 
-    client.readMessage(); // Detects error, send close, close connection.
+    client.processNextFrame(); // Detects error, send close, close connection.
     assertTrue(clientConnectionClosed);
     clientListener.assertFailure(ProtocolException.class, "Control frames must be final.");
 
-    server.readMessage();
+    server.processNextFrame();
     serverListener.assertClose(1002, "");
+  }
+
+  @Test public void protocolErrorInCloseResponseClosesConnection() throws IOException {
+    client.close(1000, "Hello");
+    assertFalse(clientConnectionClosed); // Not closed until close reply is received.
+
+    // Manually write an invalid masked close frame.
+    server2client.raw().write(ByteString.decodeHex("888760b420bb635c68de0cd84f"));
+
+    client.processNextFrame(); // Detects error, closes connection immediately since close already sent.
+    assertTrue(clientConnectionClosed);
+    clientListener.assertFailure(ProtocolException.class, "Server-sent frames must not be masked.");
+
+    server.processNextFrame();
+    serverListener.assertClose(1000, "Hello");
+
+    serverListener.assertExhausted(); // Client should not have sent second close.
   }
 
   @Test public void protocolErrorAfterCloseDoesNotSendClose() throws IOException {
@@ -399,11 +381,11 @@ public final class RealWebSocketTest {
     assertFalse(clientConnectionClosed); // Not closed until close reply is received.
     server2client.raw().write(ByteString.decodeHex("0a00")); // Invalid non-final ping frame.
 
-    client.readMessage(); // Detects error, closes connection immediately since close already sent.
+    client.processNextFrame(); // Detects error, closes connection immediately since close already sent.
     assertTrue(clientConnectionClosed);
     clientListener.assertFailure(ProtocolException.class, "Control frames must be final.");
 
-    server.readMessage();
+    server.processNextFrame();
     serverListener.assertClose(1000, "Hello!");
 
     serverListener.assertExhausted(); // Client should not have sent second close.
@@ -420,7 +402,7 @@ public final class RealWebSocketTest {
     assertTrue(clientConnectionClosed);
   }
 
-  @Test public void closeMessageAndConnectionCloseThrowingDoesNotMaskOriginal() throws IOException {
+  @Test public void closeMessageAndConnectionCloseThrowingDoesNotMaskOriginal() {
     client2Server.close();
     clientConnectionCloseThrows = true;
 
@@ -437,11 +419,11 @@ public final class RealWebSocketTest {
     clientConnectionCloseThrows = true;
 
     server.close(1000, "Bye!");
-    client.readMessage();
+    client.processNextFrame();
     assertTrue(clientConnectionClosed);
     clientListener.assertClose(1000, "Bye!");
 
-    server.readMessage();
+    server.processNextFrame();
     serverListener.assertClose(1000, "Bye!");
   }
 
@@ -468,7 +450,7 @@ public final class RealWebSocketTest {
           return Timeout.NONE;
         }
 
-        @Override public void close() throws IOException {
+        @Override public void close() {
           closed = true;
         }
       });
@@ -481,14 +463,14 @@ public final class RealWebSocketTest {
           buffer.write(source, byteCount);
         }
 
-        @Override public void flush() throws IOException {
+        @Override public void flush() {
         }
 
         @Override public Timeout timeout() {
           return Timeout.NONE;
         }
 
-        @Override public void close() throws IOException {
+        @Override public void close() {
           closed = true;
         }
       });

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
@@ -24,35 +24,49 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
+import okhttp3.internal.platform.Platform;
 import okio.Buffer;
 
 import static okhttp3.WebSocket.BINARY;
 import static okhttp3.WebSocket.TEXT;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-public final class WebSocketRecorder implements WebSocketReader.FrameCallback, WebSocketListener {
-  public interface MessageDelegate {
-    void onMessage(ResponseBody message) throws IOException;
+public final class WebSocketRecorder implements WebSocketListener {
+  private final String name;
+  private final BlockingQueue<Object> events = new LinkedBlockingQueue<>();
+  private WebSocketListener delegate;
+
+  public WebSocketRecorder(String name) {
+    this.name = name;
   }
 
-  private final BlockingQueue<Object> events = new LinkedBlockingQueue<>();
-  private MessageDelegate delegate;
-  private Response response;
-
-  /** Sets a delegate for the next call to {@link #onMessage}. Cleared after invoked. */
-  public void setNextMessageDelegate(MessageDelegate delegate) {
+  /** Sets a delegate for handling the next callback to this listener. Cleared after invoked. */
+  public void setNextEventDelegate(WebSocketListener delegate) {
     this.delegate = delegate;
   }
 
   @Override public void onOpen(WebSocket webSocket, Response response) {
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onOpen", null);
+
+    WebSocketListener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onOpen(webSocket, response);
+    } else {
+      events.add(new Open(webSocket, response));
+    }
   }
 
   @Override public void onMessage(ResponseBody message) throws IOException {
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onMessage", null);
+
+    WebSocketListener delegate = this.delegate;
     if (delegate != null) {
+      this.delegate = null;
       delegate.onMessage(message);
-      delegate = null;
     } else {
       Message event = new Message(message.contentType());
       message.source().readAll(event.buffer);
@@ -61,28 +75,47 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
     }
   }
 
-  @Override public void onPing(Buffer buffer) {
-    events.add(new Ping(buffer));
-  }
-
   @Override public void onPong(Buffer buffer) {
-    events.add(new Pong(buffer));
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onPong", null);
+
+    WebSocketListener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onPong(buffer);
+    } else {
+      events.add(new Pong(buffer));
+    }
   }
 
   @Override public void onClose(int code, String reason) {
-    events.add(new Close(code, reason));
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onClose " + code, null);
+
+    WebSocketListener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onClose(code, reason);
+    } else {
+      events.add(new Close(code, reason));
+    }
   }
 
-  @Override public void onFailure(IOException e, Response response) {
-    events.add(e);
-    this.response = response;
+  @Override public void onFailure(Throwable t, Response response) {
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onFailure", t);
+
+    WebSocketListener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onFailure(t, response);
+    } else {
+      events.add(new Failure(t, response));
+    }
   }
 
   private Object nextEvent() {
     try {
       Object event = events.poll(10, TimeUnit.SECONDS);
       if (event == null) {
-        throw new AssertionError("Timed out.");
+        throw new AssertionError("Timed out waiting for event.");
       }
       return event;
     } catch (InterruptedException e) {
@@ -90,67 +123,107 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
     }
   }
 
-  public void assertTextMessage(String payload) throws IOException {
+  public void assertTextMessage(String payload) {
     Message message = new Message(TEXT);
     message.buffer.writeUtf8(payload);
     Object actual = nextEvent();
-    if (actual instanceof IOException) {
-      throw (IOException) actual;
-    }
     assertEquals(message, actual);
   }
 
-  public void assertBinaryMessage(byte[] payload) throws IOException {
+  public void assertBinaryMessage(byte[] payload) {
     Message message = new Message(BINARY);
     message.buffer.write(payload);
     Object actual = nextEvent();
-    if (actual instanceof IOException) {
-      throw (IOException) actual;
-    }
     assertEquals(message, actual);
   }
 
-  public void assertPing(Buffer payload) throws IOException {
+  public void assertPong(Buffer payload) {
     Object actual = nextEvent();
-    if (actual instanceof IOException) {
-      throw (IOException) actual;
-    }
-    assertEquals(new Ping(payload), actual);
-  }
-
-  public void assertPong(Buffer payload) throws IOException {
-    Object actual = nextEvent();
-    if (actual instanceof IOException) {
-      throw (IOException) actual;
-    }
     assertEquals(new Pong(payload), actual);
   }
 
-  public void assertClose(int code, String reason) throws IOException {
+  public void assertClose(int code, String reason) {
     Object actual = nextEvent();
-    if (actual instanceof IOException) {
-      throw (IOException) actual;
-    }
     assertEquals(new Close(code, reason), actual);
-  }
-
-  public void assertFailure(Class<? extends IOException> cls, String message) {
-    Object event = nextEvent();
-    String errorMessage =
-        "Expected [" + cls.getName() + ": " + message + "] but was [" + event + "].";
-    assertNotNull(errorMessage, event);
-    assertEquals(errorMessage, cls, event.getClass());
-    assertEquals(errorMessage, cls.cast(event).getMessage(), message);
   }
 
   public void assertExhausted() {
     assertTrue("Remaining events: " + events, events.isEmpty());
   }
 
-  public void assertResponse(int code, String body) throws IOException {
-    assertNotNull(response);
-    assertEquals(code, response.code());
-    assertEquals(body, response.body().string());
+  public WebSocket assertOpen() {
+    Object event = nextEvent();
+    if (!(event instanceof Open)) {
+      throw new AssertionError("Expected Open but was " + event);
+    }
+    return ((Open) event).webSocket;
+  }
+
+  public void assertFailure(Throwable t) {
+    Object event = nextEvent();
+    if (!(event instanceof Failure)) {
+      throw new AssertionError("Expected Failure but was " + event);
+    }
+    Failure failure = (Failure) event;
+    assertNull(failure.response);
+    assertSame(t, failure.t);
+  }
+
+  public void assertFailure(Class<? extends IOException> cls, String message) {
+    Object event = nextEvent();
+    if (!(event instanceof Failure)) {
+      throw new AssertionError("Expected Failure but was " + event);
+    }
+    Failure failure = (Failure) event;
+    assertNull(failure.response);
+    assertEquals(cls, failure.t.getClass());
+    assertEquals(message, failure.t.getMessage());
+  }
+
+  public void assertFailure(int code, String body, Class<? extends IOException> cls, String message)
+      throws IOException {
+    Object event = nextEvent();
+    if (!(event instanceof Failure)) {
+      throw new AssertionError("Expected Failure but was " + event);
+    }
+    Failure failure = (Failure) event;
+    assertEquals(code, failure.response.code());
+    if (body != null) {
+      assertEquals(body, failure.response.body().string());
+    }
+    assertEquals(cls, failure.t.getClass());
+    assertEquals(message, failure.t.getMessage());
+  }
+
+  static final class Open {
+    final WebSocket webSocket;
+    final Response response;
+
+    Open(WebSocket webSocket, Response response) {
+      this.webSocket = webSocket;
+      this.response = response;
+    }
+
+    @Override public String toString() {
+      return "Open[" + response + "]";
+    }
+  }
+
+  static final class Failure {
+    final Throwable t;
+    final Response response;
+
+    Failure(Throwable t, Response response) {
+      this.t = t;
+      this.response = response;
+    }
+
+    @Override public String toString() {
+      if (response == null) {
+        return "Failure[" + t + "]";
+      }
+      return "Failure[" + response + "]";
+    }
   }
 
   static final class Message {
@@ -173,30 +246,6 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
       if (obj instanceof Message) {
         Message other = (Message) obj;
         return mediaType.equals(other.mediaType) && buffer.equals(other.buffer);
-      }
-      return false;
-    }
-  }
-
-  static final class Ping {
-    public final Buffer buffer;
-
-    Ping(Buffer buffer) {
-      this.buffer = buffer;
-    }
-
-    @Override public String toString() {
-      return "Ping[" + buffer + "]";
-    }
-
-    @Override public int hashCode() {
-      return buffer.hashCode();
-    }
-
-    @Override public boolean equals(Object obj) {
-      if (obj instanceof Ping) {
-        Ping other = (Ping) obj;
-        return buffer == null ? other.buffer == null : buffer.equals(other.buffer);
       }
       return false;
     }
@@ -247,6 +296,56 @@ public final class WebSocketRecorder implements WebSocketReader.FrameCallback, W
       if (obj instanceof Close) {
         Close other = (Close) obj;
         return code == other.code && reason.equals(other.reason);
+      }
+      return false;
+    }
+  }
+
+  /** Expose this recorder as a frame callback and shim in "ping" events. */
+  WebSocketReader.FrameCallback asFrameCallback() {
+    return new WebSocketReader.FrameCallback() {
+      @Override public void onReadMessage(ResponseBody body) throws IOException {
+        onMessage(body);
+      }
+
+      @Override public void onReadPing(Buffer buffer) {
+        events.add(new Ping(buffer));
+      }
+
+      @Override public void onReadPong(Buffer buffer) {
+        onPong(buffer);
+      }
+
+      @Override public void onReadClose(int code, String reason) {
+        onClose(code, reason);
+      }
+    };
+  }
+
+  void assertPing(Buffer payload) {
+    Object actual = nextEvent();
+    assertEquals(new Ping(payload), actual);
+  }
+
+  static final class Ping {
+    public final Buffer buffer;
+
+    Ping(Buffer buffer) {
+      this.buffer = buffer;
+    }
+
+    @Override public String toString() {
+      return "Ping[" + buffer + "]";
+    }
+
+    @Override public int hashCode() {
+      return buffer.hashCode();
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (obj instanceof Ping) {
+        Ping other = (Ping) obj;
+        return buffer == null ? other.buffer == null : buffer.equals(other.buffer);
       }
       return false;
     }

--- a/okhttp/src/main/java/okhttp3/WebSocketListener.java
+++ b/okhttp/src/main/java/okhttp3/WebSocketListener.java
@@ -18,25 +18,32 @@ package okhttp3;
 import java.io.IOException;
 import okio.Buffer;
 
-/** Listener for server-initiated messages on a connected {@link WebSocket}. */
+/**
+ * Listener for server-initiated messages on a connected {@link WebSocket}. All callbacks will be
+ * called on a single thread.
+ *
+ * <h2>Lifecycle Rules</h2>
+ * <ul>
+ * <li>Either {@link #onOpen} or {@link #onFailure} will be called first depending on if the web
+ * socket was successfully opened or if there was an error connecting to the server or parsing its
+ * response.</li>
+ * <li>After {@link #onOpen} is called, {@link #onFailure} can be called at any time. No more
+ * callbacks will follow a call to {@link #onFailure}.</li>
+ * <li>After {@link #onOpen} is called, {@link #onMessage} and {@link #onPong} will be called for
+ * each message and pong frame, respectively. Note: {@link #onPong} may be called while {@link
+ * #onMessage} is reading the message because pong frames may interleave in the message body.</li>
+ * <li>After {@link #onOpen} is called, {@link #onClose} may be called once. No calls to {@link
+ * #onMessage} or {@link #onPong} will follow a call to {@link #onClose}.</li>
+ * <li>{@link #onFailure} will be called if any of the other callbacks throws an exception.</li>
+ * </ul>
+ */
 public interface WebSocketListener {
   /**
-   * Called when the request has successfully been upgraded to a web socket. This method is called
-   * on the message reading thread to allow setting up any state before the {@linkplain #onMessage
-   * message}, {@linkplain #onPong pong}, and {@link #onClose close} callbacks start.
-   *
-   * <p><b>Do not</b> use this callback to write to the web socket. Start a new thread or use
-   * another thread in your application.
+   * Called when the request has successfully been upgraded to a web socket. <b>Do not</b> use this
+   * callback to write to the web socket. Start a new thread or use another thread in your
+   * application.
    */
   void onOpen(WebSocket webSocket, Response response);
-
-  /**
-   * Called when the transport or protocol layer of this web socket errors during communication.
-   *
-   * @param response Present when the failure is a direct result of the response (e.g., failed
-   * upgrade, non-101 response code, etc.). {@code null} otherwise.
-   */
-  void onFailure(IOException e, Response response);
 
   /**
    * Called when a server message is received. The {@code type} indicates whether the {@code
@@ -53,17 +60,31 @@ public interface WebSocketListener {
 
   /**
    * Called when a server pong is received. This is usually a result of calling {@link
-   * WebSocket#sendPing(Buffer)} but might also be unsolicited.
+   * WebSocket#sendPing(Buffer)} but might also be unsolicited directly from the server.
    */
   void onPong(Buffer payload);
 
   /**
    * Called when the server sends a close message. This may have been initiated from a call to
    * {@link WebSocket#close(int, String) close()} or as an unprompted message from the server.
+   * If you did not explicitly call {@link WebSocket#close(int, String) close()}, you do not need
+   * to do so in response to this callback. A matching close frame is automatically sent back to
+   * the server.
    *
    * @param code The <a href="http://tools.ietf.org/html/rfc6455#section-7.4.1">RFC-compliant</a>
    * status code.
    * @param reason Reason for close or an empty string.
    */
   void onClose(int code, String reason);
+
+  /**
+   * Called when the transport or protocol layer of this web socket errors during communication, or
+   * when another listener callback throws an exception. If the web socket was successfully
+   * {@linkplain #onOpen opened} before this callback, it will have been closed automatically and
+   * future interactions with it will throw {@link IOException}.
+   *
+   * @param response Non-null when the failure is because of an unexpected HTTP response (e.g.,
+   * failed upgrade, non-101 response code, etc.).
+   */
+  void onFailure(Throwable t, Response response);
 }

--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -463,4 +463,11 @@ public final class Util {
     }
     return charset;
   }
+
+  /** Re-throws {@code t} if it is a fatal exception which should not be handled. */
+  public static void throwIfFatal(Throwable t) {
+    if (t instanceof VirtualMachineError) throw (VirtualMachineError) t;
+    if (t instanceof ThreadDeath) throw (ThreadDeath) t;
+    if (t instanceof LinkageError) throw (LinkageError) t;
+  }
 }

--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
@@ -91,10 +91,6 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
     return canceled;
   }
 
-  public boolean isForWebSocket() {
-    return forWebSocket;
-  }
-
   public void setCallStackTrace(Object callStackTrace) {
     this.callStackTrace = callStackTrace;
   }

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebSocketWriter.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebSocketWriter.java
@@ -108,8 +108,11 @@ final class WebSocketWriter {
     }
 
     synchronized (this) {
-      writeControlFrameSynchronized(OPCODE_CONTROL_CLOSE, payload);
-      writerClosed = true;
+      try {
+        writeControlFrameSynchronized(OPCODE_CONTROL_CLOSE, payload);
+      } finally {
+        writerClosed = true;
+      }
     }
   }
 
@@ -149,7 +152,7 @@ final class WebSocketWriter {
       }
     }
 
-    sink.emit();
+    sink.flush();
   }
 
   /**

--- a/samples/guide/src/main/java/okhttp3/recipes/WebSocketEcho.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/WebSocketEcho.java
@@ -67,8 +67,8 @@ public final class WebSocketEcho implements WebSocketListener {
     writeExecutor.shutdown();
   }
 
-  @Override public void onFailure(IOException e, Response response) {
-    e.printStackTrace();
+  @Override public void onFailure(Throwable t, Response response) {
+    t.printStackTrace();
     writeExecutor.shutdown();
   }
 


### PR DESCRIPTION
* onFailure callback's exception type widened to Throwable. This allows runtime exceptions from other callbacks to be passed along.
* Ensure the connection is closed properly for all failures.
* Fix and document the threading inside RealWebSocket. This ensures the listener is always called on the same thread and replies always happen from the correct thread.

Closes #2455. Closes #1701.