### PR TITLE
Do not disable TLSv1.3 by default

### DIFF
--- a/okhttp/src/main/java/okhttp3/ConnectionSpec.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionSpec.java
@@ -31,7 +31,7 @@ import static okhttp3.internal.Util.intersect;
  * connection.
  *
  * <p>The TLS versions configured in a connection spec are only be used if they are also enabled in
- * the SSL socket. For example, if an SSL socket does not have TLS 1.2 enabled, it will not be used
+ * the SSL socket. For example, if an SSL socket does not have TLS 1.3 enabled, it will not be used
  * even if it is present on the connection spec. The same policy also applies to cipher suites.
  *
  * <p>Use {@link Builder#allEnabledTlsVersions()} and {@link Builder#allEnabledCipherSuites} to
@@ -67,7 +67,7 @@ public final class ConnectionSpec {
   /** A modern TLS connection with extensions like SNI and ALPN available. */
   public static final ConnectionSpec MODERN_TLS = new Builder(true)
       .cipherSuites(APPROVED_CIPHER_SUITES)
-      .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0)
+      .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0)
       .supportsTlsExtensions(true)
       .build();
 

--- a/okhttp/src/main/java/okhttp3/TlsVersion.java
+++ b/okhttp/src/main/java/okhttp3/TlsVersion.java
@@ -20,6 +20,7 @@ package okhttp3;
  * javax.net.ssl.SSLSocket#setEnabledProtocols}.
  */
 public enum TlsVersion {
+  TLS_1_3("TLSv1.3"), // 2016.
   TLS_1_2("TLSv1.2"), // 2008.
   TLS_1_1("TLSv1.1"), // 2006.
   TLS_1_0("TLSv1"),   // 1999.
@@ -34,6 +35,8 @@ public enum TlsVersion {
 
   public static TlsVersion forJavaName(String javaName) {
     switch (javaName) {
+      case "TLSv1.3":
+        return TLS_1_3;
       case "TLSv1.2":
         return TLS_1_2;
       case "TLSv1.1":


### PR DESCRIPTION
This adjusts TLS protocol selection logic to leave TLSv1.3 enabled if
it's enabled in the underlying TLS stack. Prior to this change,
TLSv1.3 was disabled unless the user of okhttp explicitly enabled it
via a custom ConnectionSpec.

Fixes #2867