### PR TITLE
Use web socket close codes 1005 and 1006 correctly.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -400,6 +400,12 @@ public final class RealWebSocketTest {
     serverListener.assertExhausted(); // Client should not have sent second close.
   }
 
+  @Test public void networkErrorReportedAsCloseNotFailure() {
+    server2client.close();
+    client.processNextFrame();
+    clientListener.assertClose(1006, "");
+  }
+
   @Test public void closeThrowingClosesConnection() {
     client2Server.close();
 

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketReaderTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketReaderTest.java
@@ -343,7 +343,7 @@ public final class WebSocketReaderTest {
   @Test public void emptyCloseCallsCallback() throws IOException {
     data.write(ByteString.decodeHex("8800")); // Empty close
     clientReader.processNextFrame();
-    callback.assertClose(1000, "");
+    callback.assertClose(1005, "");
   }
 
   @Test public void closeLengthOfOneThrows() throws IOException {

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebSocketProtocol.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebSocketProtocol.java
@@ -15,6 +15,7 @@
  */
 package okhttp3.internal.ws;
 
+import java.io.IOException;
 import java.net.ProtocolException;
 
 public final class WebSocketProtocol {
@@ -83,6 +84,15 @@ public final class WebSocketProtocol {
    * length.
    */
   static final int PAYLOAD_LONG = 127;
+
+  /** Used when an unchecked exception was thrown in a listener. */
+  static final int CLOSE_CLIENT_GOING_AWAY = 1001;
+  /** Used when a {@link ProtocolException} was thrown by the reader or writer. */
+  static final int CLOSE_PROTOCOL_EXCEPTION = 1002;
+  /** Used when an empty close frame was received (i.e., without a status code). */
+  static final int CLOSE_NO_STATUS_CODE = 1005;
+  /** Used when a non-{@link ProtocolException} {@link IOException} was thrown by the reader. */
+  static final int CLOSE_ABNORMAL_TERMINATION = 1006;
 
   static void toggleMask(byte[] buffer, long byteCount, byte[] key, long frameBytesRead) {
     int keyLength = key.length;

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebSocketReader.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebSocketReader.java
@@ -36,6 +36,7 @@ import static okhttp3.internal.ws.WebSocketProtocol.B0_FLAG_RSV3;
 import static okhttp3.internal.ws.WebSocketProtocol.B0_MASK_OPCODE;
 import static okhttp3.internal.ws.WebSocketProtocol.B1_FLAG_MASK;
 import static okhttp3.internal.ws.WebSocketProtocol.B1_MASK_LENGTH;
+import static okhttp3.internal.ws.WebSocketProtocol.CLOSE_NO_STATUS_CODE;
 import static okhttp3.internal.ws.WebSocketProtocol.OPCODE_BINARY;
 import static okhttp3.internal.ws.WebSocketProtocol.OPCODE_CONTINUATION;
 import static okhttp3.internal.ws.WebSocketProtocol.OPCODE_CONTROL_CLOSE;
@@ -189,7 +190,7 @@ final class WebSocketReader {
         frameCallback.onReadPong(buffer.readByteString());
         break;
       case OPCODE_CONTROL_CLOSE:
-        int code = 1000;
+        int code = CLOSE_NO_STATUS_CODE;
         String reason = "";
         long bufferSize = buffer.size();
         if (bufferSize == 1) {


### PR DESCRIPTION
These are used for an close frame that does not specify a status code and for when a network error occurs while trying to read data, respectively.

Closes #2696.