### PR TITLE
Keep the cause when sending ConnectException

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -186,7 +186,8 @@ public final class RealConnection extends Http2Connection.Listener implements Co
     try {
       Platform.get().connectSocket(rawSocket, route.socketAddress(), connectTimeout);
     } catch (ConnectException e) {
-      throw new ConnectException("Failed to connect to " + route.socketAddress());
+      throw (ConnectException) new ConnectException("Failed to connect to " + route.socketAddress())
+          .initCause(e);
     }
     source = Okio.buffer(Okio.source(rawSocket));
     sink = Okio.buffer(Okio.sink(rawSocket));


### PR DESCRIPTION
Proposed fix for Issue #2881 

Keep the cause when sending ConnectException