### PR TITLE
Don't recover connection when request method is not GET

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
@@ -209,6 +209,9 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
     // We can't send the request body again.
     if (!routeException && userRequest.body() instanceof UnrepeatableRequestBody) return false;
 
+    // Don't recover connection when request method is not GET.
+    if (!routeException && !userRequest.method().equals("GET")) return false;
+
     // This exception is fatal.
     if (!isRecoverable(e, routeException)) return false;
 


### PR DESCRIPTION
This may cause client send POST request to server twice, or leave an exception after send POST request to server.