### PR TITLE
RFC: frameLogger

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/FrameLogTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/FrameLogTest.java
@@ -31,57 +31,57 @@ import static okhttp3.internal.http2.Http2.TYPE_HEADERS;
 import static okhttp3.internal.http2.Http2.TYPE_PING;
 import static okhttp3.internal.http2.Http2.TYPE_PUSH_PROMISE;
 import static okhttp3.internal.http2.Http2.TYPE_SETTINGS;
-import static okhttp3.internal.http2.Http2.frameLog;
+import static okhttp3.internal.http2.Http2.frameLogFormat;
 import static org.junit.Assert.assertEquals;
 
 public final class FrameLogTest {
   /** Real stream traffic applied to the log format. */
   @Test public void exampleStream() {
     assertEquals(">> 0x00000000     5 SETTINGS      ",
-        frameLog(false, 0, 5, TYPE_SETTINGS, FLAG_NONE));
+        frameLogFormat(false, 0, 5, TYPE_SETTINGS, FLAG_NONE));
     assertEquals(">> 0x00000003   100 HEADERS       END_HEADERS",
-        frameLog(false, 3, 100, TYPE_HEADERS, FLAG_END_HEADERS));
+        frameLogFormat(false, 3, 100, TYPE_HEADERS, FLAG_END_HEADERS));
     assertEquals(">> 0x00000003     0 DATA          END_STREAM",
-        frameLog(false, 3, 0, TYPE_DATA, FLAG_END_STREAM));
+        frameLogFormat(false, 3, 0, TYPE_DATA, FLAG_END_STREAM));
     assertEquals("<< 0x00000000    15 SETTINGS      ",
-        frameLog(true, 0, 15, TYPE_SETTINGS, FLAG_NONE));
+        frameLogFormat(true, 0, 15, TYPE_SETTINGS, FLAG_NONE));
     assertEquals(">> 0x00000000     0 SETTINGS      ACK",
-        frameLog(false, 0, 0, TYPE_SETTINGS, FLAG_ACK));
+        frameLogFormat(false, 0, 0, TYPE_SETTINGS, FLAG_ACK));
     assertEquals("<< 0x00000000     0 SETTINGS      ACK",
-        frameLog(true, 0, 0, TYPE_SETTINGS, FLAG_ACK));
+        frameLogFormat(true, 0, 0, TYPE_SETTINGS, FLAG_ACK));
     assertEquals("<< 0x00000003    22 HEADERS       END_HEADERS",
-        frameLog(true, 3, 22, TYPE_HEADERS, FLAG_END_HEADERS));
+        frameLogFormat(true, 3, 22, TYPE_HEADERS, FLAG_END_HEADERS));
     assertEquals("<< 0x00000003   226 DATA          END_STREAM",
-        frameLog(true, 3, 226, TYPE_DATA, FLAG_END_STREAM));
+        frameLogFormat(true, 3, 226, TYPE_DATA, FLAG_END_STREAM));
     assertEquals(">> 0x00000000     8 GOAWAY        ",
-        frameLog(false, 0, 8, TYPE_GOAWAY, FLAG_NONE));
+        frameLogFormat(false, 0, 8, TYPE_GOAWAY, FLAG_NONE));
   }
 
   @Test public void flagOverlapOn0x1() {
     assertEquals("<< 0x00000000     0 SETTINGS      ACK",
-        frameLog(true, 0, 0, TYPE_SETTINGS, (byte) 0x1));
+        frameLogFormat(true, 0, 0, TYPE_SETTINGS, (byte) 0x1));
     assertEquals("<< 0x00000000     8 PING          ACK",
-        frameLog(true, 0, 8, TYPE_PING, (byte) 0x1));
+        frameLogFormat(true, 0, 8, TYPE_PING, (byte) 0x1));
     assertEquals("<< 0x00000003     0 HEADERS       END_STREAM",
-        frameLog(true, 3, 0, TYPE_HEADERS, (byte) 0x1));
+        frameLogFormat(true, 3, 0, TYPE_HEADERS, (byte) 0x1));
     assertEquals("<< 0x00000003     0 DATA          END_STREAM",
-        frameLog(true, 3, 0, TYPE_DATA, (byte) 0x1));
+        frameLogFormat(true, 3, 0, TYPE_DATA, (byte) 0x1));
   }
 
   @Test public void flagOverlapOn0x4() {
     assertEquals("<< 0x00000003 10000 HEADERS       END_HEADERS",
-        frameLog(true, 3, 10000, TYPE_HEADERS, (byte) 0x4));
+        frameLogFormat(true, 3, 10000, TYPE_HEADERS, (byte) 0x4));
     assertEquals("<< 0x00000003 10000 CONTINUATION  END_HEADERS",
-        frameLog(true, 3, 10000, TYPE_CONTINUATION, (byte) 0x4));
+        frameLogFormat(true, 3, 10000, TYPE_CONTINUATION, (byte) 0x4));
     assertEquals("<< 0x00000004 10000 PUSH_PROMISE  END_PUSH_PROMISE",
-        frameLog(true, 4, 10000, TYPE_PUSH_PROMISE, (byte) 0x4));
+        frameLogFormat(true, 4, 10000, TYPE_PUSH_PROMISE, (byte) 0x4));
   }
 
   @Test public void flagOverlapOn0x20() {
     assertEquals("<< 0x00000003 10000 HEADERS       PRIORITY",
-        frameLog(true, 3, 10000, TYPE_HEADERS, (byte) 0x20));
+        frameLogFormat(true, 3, 10000, TYPE_HEADERS, (byte) 0x20));
     assertEquals("<< 0x00000003 10000 DATA          COMPRESSED",
-        frameLog(true, 3, 10000, TYPE_DATA, (byte) 0x20));
+        frameLogFormat(true, 3, 10000, TYPE_DATA, (byte) 0x20));
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/internal/http2/FrameLogger.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/FrameLogger.java
@@ -1,0 +1,6 @@
+package okhttp3.internal.http2;
+
+// TODO better mechanism, just for testing and discussion
+public interface FrameLogger {
+    void frameLog(boolean inbound, int streamId, int length, byte type, byte flags);
+}

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Writer.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Writer.java
@@ -18,7 +18,6 @@ package okhttp3.internal.http2;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Logger;
 import okio.Buffer;
 import okio.BufferedSink;
 
@@ -39,13 +38,10 @@ import static okhttp3.internal.http2.Http2.TYPE_PUSH_PROMISE;
 import static okhttp3.internal.http2.Http2.TYPE_RST_STREAM;
 import static okhttp3.internal.http2.Http2.TYPE_SETTINGS;
 import static okhttp3.internal.http2.Http2.TYPE_WINDOW_UPDATE;
-import static okhttp3.internal.http2.Http2.frameLog;
 import static okhttp3.internal.http2.Http2.illegalArgument;
 
 /** Writes HTTP/2 transport frames. */
 final class Http2Writer implements Closeable {
-  private static final Logger logger = Logger.getLogger(Http2.class.getName());
-
   private final BufferedSink sink;
   private final boolean client;
   private final Buffer hpackBuffer;
@@ -65,8 +61,8 @@ final class Http2Writer implements Closeable {
   public synchronized void connectionPreface() throws IOException {
     if (closed) throw new IOException("closed");
     if (!client) return; // Nothing to write; servers don't send connection headers!
-    if (logger.isLoggable(FINE)) {
-      logger.fine(format(">> CONNECTION %s", CONNECTION_PREFACE.hex()));
+    if (Http2.logger.isLoggable(FINE)) {
+        Http2.logger.fine(format(">> CONNECTION %s", CONNECTION_PREFACE.hex()));
     }
     sink.write(CONNECTION_PREFACE.toByteArray());
     sink.flush();
@@ -263,7 +259,7 @@ final class Http2Writer implements Closeable {
   }
 
   public void frameHeader(int streamId, int length, byte type, byte flags) throws IOException {
-    if (logger.isLoggable(FINE)) logger.fine(frameLog(false, streamId, length, type, flags));
+    Http2.frameLog(false, streamId, length, type, flags);
     if (length > maxFrameSize) {
       throw illegalArgument("FRAME_SIZE_ERROR length > %d: %d", maxFrameSize, length);
     }


### PR DESCRIPTION
I'd like to be able to customise how to deal with frame events.  But logging to string is a bit restrictive.

Putting this up as a dreadful strawman to see if there is any prevailing thoughts here?