### PR TITLE
Add javadoc for cache call in the builder

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -551,6 +551,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocketCall.Fact
       this.cache = null;
     }
 
+    /** Sets the response cache to be used to read and write cached responses. */
     public Builder cache(Cache cache) {
       this.cache = cache;
       this.internalCache = null;


### PR DESCRIPTION
Title says it all! I copied over the docs from `setInternalCache()` as I figured it was an accurate description for this call. 