### PR TITLE
Use TestUtil.defaultClient in more tests.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -827,7 +827,7 @@ public final class CallTest {
 
   /** https://github.com/square/okhttp/issues/1801 */
   @Test public void asyncCallEngineInitialized() throws Exception {
-    OkHttpClient c = new OkHttpClient.Builder()
+    OkHttpClient c = defaultClient().newBuilder()
         .addInterceptor(new Interceptor() {
           @Override public Response intercept(Chain chain) throws IOException {
             throw new IOException();
@@ -2586,7 +2586,7 @@ public final class CallTest {
     server.enqueue(new MockResponse()
         .setBody("This gets leaked."));
 
-    client = new OkHttpClient.Builder()
+    client = defaultClient().newBuilder()
         .connectionPool(new ConnectionPool(0, 10, TimeUnit.MILLISECONDS))
         .build();
 
@@ -2615,7 +2615,7 @@ public final class CallTest {
     server.enqueue(new MockResponse()
         .setBody("This gets leaked."));
 
-    client = new OkHttpClient.Builder()
+    client = defaultClient().newBuilder()
         .connectionPool(new ConnectionPool(0, 10, TimeUnit.MILLISECONDS))
         .build();
 

--- a/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
@@ -15,9 +15,11 @@
  */
 package okhttp3;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLException;
 import okhttp3.internal.tls.SslClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -294,6 +296,8 @@ public final class ConnectionReuseTest {
    * them after the redirect has completed. This forces a connection to not be reused where it would
    * be otherwise.
    *
+   * <p>This test leaks a response body by not closing it.
+   *
    * https://github.com/square/okhttp/issues/2409
    */
   @Test public void connectionsAreNotReusedIfNetworkInterceptorInterferes() throws Exception {
@@ -316,8 +320,9 @@ public final class ConnectionReuseTest {
     Request request = new Request.Builder()
         .url(server.url("/"))
         .build();
+    Call call = client.newCall(request);
     try {
-      client.newCall(request).execute();
+      call.execute();
       fail();
     } catch (IllegalStateException expected) {
       assertTrue(expected.getMessage().startsWith("Closing the body of"));

--- a/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -26,7 +27,7 @@ public final class DispatcherTest {
   RecordingExecutor executor = new RecordingExecutor();
   RecordingCallback callback = new RecordingCallback();
   Dispatcher dispatcher = new Dispatcher(executor);
-  OkHttpClient client = new OkHttpClient.Builder()
+  OkHttpClient client = defaultClient().newBuilder()
       .dispatcher(dispatcher)
       .build();
 

--- a/okhttp-tests/src/test/java/okhttp3/SocksProxyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/SocksProxyTest.java
@@ -28,6 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.assertEquals;
 
 public final class SocksProxyTest {
@@ -48,7 +49,7 @@ public final class SocksProxyTest {
     server.enqueue(new MockResponse().setBody("abc"));
     server.enqueue(new MockResponse().setBody("def"));
 
-    OkHttpClient client = new OkHttpClient.Builder()
+    OkHttpClient client = defaultClient().newBuilder()
         .proxy(socksProxy.proxy())
         .build();
 
@@ -77,7 +78,7 @@ public final class SocksProxyTest {
       }
     };
 
-    OkHttpClient client = new OkHttpClient.Builder()
+    OkHttpClient client = defaultClient().newBuilder()
         .proxySelector(proxySelector)
         .build();
 
@@ -92,7 +93,7 @@ public final class SocksProxyTest {
     // This testcase will fail if the target is resolved locally instead of through the proxy.
     server.enqueue(new MockResponse().setBody("abc"));
 
-    OkHttpClient client = new OkHttpClient.Builder()
+    OkHttpClient client = defaultClient().newBuilder()
         .proxy(socksProxy.proxy())
         .build();
 

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -326,7 +326,7 @@ public final class URLConnectionTest {
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
 
-    urlFactory = new OkUrlFactory(new OkHttpClient.Builder()
+    urlFactory = new OkUrlFactory(defaultClient().newBuilder()
         .dns(new DoubleInetAddressDns())
         .build());
     HttpURLConnection connection = urlFactory.open(server.url("/").url());

--- a/okhttp-tests/src/test/java/okhttp3/WebSocketCallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/WebSocketCallTest.java
@@ -34,6 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.WebSocket.BINARY;
 import static okhttp3.WebSocket.TEXT;
 import static org.junit.Assert.assertEquals;
@@ -48,7 +49,7 @@ public final class WebSocketCallTest {
   private final WebSocketRecorder clientListener = new WebSocketRecorder("client");
   private final WebSocketRecorder serverListener = new WebSocketRecorder("server");
   private final Random random = new Random(0);
-  private OkHttpClient client = new OkHttpClient.Builder()
+  private OkHttpClient client = defaultClient().newBuilder()
       .addInterceptor(new Interceptor() {
         @Override public Response intercept(Chain chain) throws IOException {
           Response response = chain.proceed(chain.request());

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/DisconnectTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/DisconnectTest.java
@@ -34,6 +34,7 @@ import okio.Buffer;
 import org.junit.Before;
 import org.junit.Test;
 
+import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.fail;
 
 public final class DisconnectTest {
@@ -56,7 +57,7 @@ public final class DisconnectTest {
             return serverSocket;
           }
         });
-    client = new OkHttpClient.Builder()
+    client = defaultClient().newBuilder()
         .socketFactory(new DelegatingSocketFactory(SocketFactory.getDefault()) {
           @Override protected Socket configureSocket(Socket socket) throws IOException {
             socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
@@ -113,7 +114,7 @@ public final class DisconnectTest {
     } catch (IOException expected) {
     }
 
-    connection.disconnect();
+    responseBody.close();
   }
 
   private void disconnectLater(final HttpURLConnection connection, final int delayMillis) {

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/ThreadInterruptTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/ThreadInterruptTest.java
@@ -35,6 +35,7 @@ import okio.Buffer;
 import org.junit.Before;
 import org.junit.Test;
 
+import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.fail;
 
 public final class ThreadInterruptTest {
@@ -58,7 +59,7 @@ public final class ThreadInterruptTest {
             return serverSocket;
           }
         });
-    client = new OkHttpClient.Builder()
+    client = defaultClient().newBuilder()
         .socketFactory(new DelegatingSocketFactory(SocketFactory.getDefault()) {
           @Override
           protected Socket configureSocket(Socket socket) throws IOException {
@@ -116,7 +117,7 @@ public final class ThreadInterruptTest {
     } catch (InterruptedIOException expected) {
     }
 
-    connection.disconnect();
+    responseBody.close();
   }
 
   private void interruptLater(final int delayMillis) {

--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
@@ -16,8 +16,8 @@
 package okhttp3.internal.tls;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.security.GeneralSecurityException;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.security.auth.x500.X500Principal;
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -160,7 +161,7 @@ public final class ClientAuthTest {
     try {
       call.execute();
       fail();
-    } catch (ConnectException expected) {
+    } catch (SSLHandshakeException expected) {
     }
   }
 
@@ -181,7 +182,7 @@ public final class ClientAuthTest {
     try {
       call.execute();
       fail();
-    } catch (ConnectException expected) {
+    } catch (SSLHandshakeException expected) {
     }
   }
 
@@ -194,7 +195,7 @@ public final class ClientAuthTest {
     }
 
     SslClient sslClient = sslClientBuilder.build();
-    return new OkHttpClient.Builder()
+    return defaultClient().newBuilder()
         .sslSocketFactory(sslClient.socketFactory, sslClient.trustManager)
         .build();
   }


### PR DESCRIPTION
The client it returns is less susceptible to environment-specific flakiness.
I suspect that some of our tests that pass locally and fail in continuous
integration may be due to such environment-specific behaviors.