### PR TITLE
Parse authentication headers with wrong order

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
@@ -360,5 +360,51 @@ public final class HeadersTest {
     assertEquals(1, challenges.size());
     assertEquals("Digest", challenges.get(0).scheme());
     assertEquals("myrealm", challenges.get(0).realm());
+
+    // Not strict RFC 2617 header #2
+    headers = new Headers.Builder()
+            .add("WWW-Authenticate", "Digest qop=\"auth\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf\", realm=\"myrealm\", stale=\"FALSE\"").build();
+    challenges = HttpHeaders.parseChallenges(headers, "WWW-Authenticate");
+    assertEquals(1, challenges.size());
+    assertEquals("Digest", challenges.get(0).scheme());
+    assertEquals("myrealm", challenges.get(0).realm());
+
+    // Wrong header
+    headers = new Headers.Builder()
+            .add("WWW-Authenticate", "Digest qop=\"auth\", underrealm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf\", stale=\"FALSE\"").build();
+    challenges = HttpHeaders.parseChallenges(headers, "WWW-Authenticate");
+    assertEquals(0, challenges.size());
+
+    // Not strict RFC 2617 header with some spaces
+    headers = new Headers.Builder()
+            .add("WWW-Authenticate", "Digest qop=\"auth\",    realm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf\", stale=\"FALSE\"").build();
+    challenges = HttpHeaders.parseChallenges(headers, "WWW-Authenticate");
+    assertEquals(1, challenges.size());
+    assertEquals("Digest", challenges.get(0).scheme());
+    assertEquals("myrealm", challenges.get(0).realm());
+
+    // Strict RFC 2617 header with some spaces
+    headers = new Headers.Builder()
+            .add("WWW-Authenticate", "Digest    realm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf\", qop=\"auth\", stale=\"FALSE\"").build();
+    challenges = HttpHeaders.parseChallenges(headers, "WWW-Authenticate");
+    assertEquals(1, challenges.size());
+    assertEquals("Digest", challenges.get(0).scheme());
+    assertEquals("myrealm", challenges.get(0).realm());
+
+    // Not strict RFC 2617 camelcased
+    headers = new Headers.Builder()
+            .add("WWW-Authenticate", "DiGeSt qop=\"auth\", rEaLm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf\", stale=\"FALSE\"").build();
+    challenges = HttpHeaders.parseChallenges(headers, "WWW-Authenticate");
+    assertEquals(1, challenges.size());
+    assertEquals("DiGeSt", challenges.get(0).scheme());
+    assertEquals("myrealm", challenges.get(0).realm());
+
+    // Strict RFC 2617 camelcased
+    headers = new Headers.Builder()
+            .add("WWW-Authenticate", "DIgEsT rEaLm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf\", qop=\"auth\", stale=\"FALSE\"").build();
+    challenges = HttpHeaders.parseChallenges(headers, "WWW-Authenticate");
+    assertEquals(1, challenges.size());
+    assertEquals("DIgEsT", challenges.get(0).scheme());
+    assertEquals("myrealm", challenges.get(0).realm());
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.java
@@ -38,8 +38,7 @@ import static okhttp3.internal.http.StatusLine.HTTP_CONTINUE;
 
 /** Headers and utilities for internal use by OkHttp. */
 public final class HttpHeaders {
-  private static final Pattern AUTHENTICATION_HEADER_PATTERN
-          = Pattern.compile("(.*?) .*?realm=\"(.*?)\"", Pattern.CASE_INSENSITIVE);
+  private static final String AUTHENTICATION_HEADER_PATTERN = "(.*?) +(.*?, *)?realm=\"(.*?)\"";
 
   private HttpHeaders() {
   }
@@ -153,10 +152,11 @@ public final class HttpHeaders {
     // realm-value = quoted-string
     List<Challenge> challenges = new ArrayList<>();
     List<String> authenticationHeaders = responseHeaders.values(challengeHeader);
+    Pattern pattern = Pattern.compile(AUTHENTICATION_HEADER_PATTERN, Pattern.CASE_INSENSITIVE);
     for (String authenticationHeader : authenticationHeaders) {
-      Matcher matcher = AUTHENTICATION_HEADER_PATTERN.matcher(authenticationHeader);
+      Matcher matcher = pattern.matcher(authenticationHeader);
       if (matcher.find()) {
-        challenges.add(new Challenge(matcher.group(1), matcher.group(2)));
+        challenges.add(new Challenge(matcher.group(1), matcher.group(3)));
       }
     }
     return challenges;

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.java
@@ -20,6 +20,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import okhttp3.Challenge;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
@@ -35,6 +38,9 @@ import static okhttp3.internal.http.StatusLine.HTTP_CONTINUE;
 
 /** Headers and utilities for internal use by OkHttp. */
 public final class HttpHeaders {
+  private static final Pattern AUTHENTICATION_HEADER_PATTERN
+          = Pattern.compile("(.*?) .*?realm=\"(.*?)\"", Pattern.CASE_INSENSITIVE);
+
   private HttpHeaders() {
   }
 
@@ -135,47 +141,25 @@ public final class HttpHeaders {
     return result.build();
   }
 
-  /** Parse RFC 2617 challenges. This API is only interested in the scheme name and realm. */
+  /**
+   * Parse RFC 2617 challenges, also wrong ordered ones.
+   * This API is only interested in the scheme name and realm.
+   */
   public static List<Challenge> parseChallenges(Headers responseHeaders, String challengeHeader) {
     // auth-scheme = token
     // auth-param  = token "=" ( token | quoted-string )
     // challenge   = auth-scheme 1*SP 1#auth-param
     // realm       = "realm" "=" realm-value
     // realm-value = quoted-string
-    List<Challenge> result = new ArrayList<>();
-    for (int i = 0, size = responseHeaders.size(); i < size; i++) {
-      if (!challengeHeader.equalsIgnoreCase(responseHeaders.name(i))) {
-        continue;
-      }
-      String value = responseHeaders.value(i);
-      int pos = 0;
-      while (pos < value.length()) {
-        int tokenStart = pos;
-        pos = skipUntil(value, pos, " ");
-
-        String scheme = value.substring(tokenStart, pos).trim();
-        pos = skipWhitespace(value, pos);
-
-        // TODO: This currently only handles schemes with a 'realm' parameter;
-        //       It needs to be fixed to handle any scheme and any parameters
-        //       http://code.google.com/p/android/issues/detail?id=11140
-
-        if (!value.regionMatches(true, pos, "realm=\"", 0, "realm=\"".length())) {
-          break; // Unexpected challenge parameter; give up!
-        }
-
-        pos += "realm=\"".length();
-        int realmStart = pos;
-        pos = skipUntil(value, pos, "\"");
-        String realm = value.substring(realmStart, pos);
-        pos++; // Consume '"' close quote.
-        pos = skipUntil(value, pos, ",");
-        pos++; // Consume ',' comma.
-        pos = skipWhitespace(value, pos);
-        result.add(new Challenge(scheme, realm));
+    List<Challenge> challenges = new ArrayList<>();
+    List<String> authenticationHeaders = responseHeaders.values(challengeHeader);
+    for (String authenticationHeader : authenticationHeaders) {
+      Matcher matcher = AUTHENTICATION_HEADER_PATTERN.matcher(authenticationHeader);
+      if (matcher.find()) {
+        challenges.add(new Challenge(matcher.group(1), matcher.group(2)));
       }
     }
-    return result;
+    return challenges;
   }
 
   public static void receiveHeaders(CookieJar cookieJar, HttpUrl url, Headers headers) {


### PR DESCRIPTION
HttpHeaders.parseChallenges(...) changed to parse also wrong ordered authentication headers.

Authentication headers with wrongly ordered parameters not following RFC 2617 were not recognized.
See: https://github.com/square/okhttp/issues/2780

Probably you can find this usefull. If you are already working on a more feature rich Challenges version just forget the pull request :-)

Thanks for the great library.
regards
Lukas