### PR TITLE
Allow empty close control frames for WebSockets according to rfc6455

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -442,6 +442,17 @@ public final class RealWebSocketTest {
     serverListener.assertClose(1000, "Bye!");
   }
 
+  @Test public void serverCloseWithoutBodyClosesConnection() throws IOException {
+    server.close(0, null);
+
+    client.processNextFrame(); // Read server close, send client close, close connection.
+    assertTrue(clientConnectionClosed);
+    clientListener.assertClose(1005, "");
+
+    server.processNextFrame();
+    serverListener.assertClose(1005, "");
+  }
+
   static final class MemorySocket implements Closeable {
     private final Buffer buffer = new Buffer();
     private boolean closed;

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
@@ -317,7 +317,7 @@ public final class WebSocketRecorder implements WebSocketListener {
         onPong(padload);
       }
 
-      @Override public void onReadClose(int code, String reason) {
+      @Override public void onReadClose(int code, String reason, boolean isEmpty) {
         onClose(code, reason);
       }
     };

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebSocketReader.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebSocketReader.java
@@ -60,7 +60,7 @@ final class WebSocketReader {
     void onReadMessage(ResponseBody body) throws IOException;
     void onReadPing(ByteString buffer);
     void onReadPong(ByteString buffer);
-    void onReadClose(int code, String reason);
+    void onReadClose(int code, String reason, boolean isEmpty);
   }
 
   final boolean isClient;
@@ -199,8 +199,10 @@ final class WebSocketReader {
           code = buffer.readShort();
           reason = buffer.readUtf8();
           validateCloseCode(code, false);
+          frameCallback.onReadClose(code, reason, false);
+        } else {
+          frameCallback.onReadClose(code, reason, true);
         }
-        frameCallback.onReadClose(code, reason);
         closed = true;
         break;
       default:


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/2940
