### PR TITLE
Make HTTP/2's DISCONNECT_AT_END more graceful.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -877,6 +877,11 @@ public final class MockWebServer implements TestRule, Closeable {
         logger.info(MockWebServer.this + " received request: " + request
             + " and responded: " + response + " protocol is " + protocol.toString());
       }
+
+      if (response.getSocketPolicy() == DISCONNECT_AT_END) {
+        Http2Connection connection = stream.getConnection();
+        connection.shutdown(ErrorCode.NO_ERROR);
+      }
     }
 
     private RecordedRequest readRequest(Http2Stream stream) throws IOException {

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/SocketPolicy.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/SocketPolicy.java
@@ -37,7 +37,10 @@ public enum SocketPolicy {
   KEEP_OPEN,
 
   /**
-   * Close the socket after the response. This is the default HTTP/1.0 behavior.
+   * Close the socket after the response. This is the default HTTP/1.0 behavior. For HTTP/2
+   * connections, this sends a <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY
+   * frame</a> immediately after the response and will close the connection when the client's socket
+   * is exhausted.
    *
    * <p>See {@link SocketPolicy} for reasons why this can cause test flakiness and how to avoid it.
    */

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -366,7 +366,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
     }
 
     if (http2Connection != null) {
-      return true; // TODO: check framedConnection.shutdown.
+      return !http2Connection.isShutdown();
     }
 
     if (doExtensiveChecks) {

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -390,7 +390,8 @@ public final class Http2Connection implements Closeable {
         shutdown = true;
         lastGoodStreamId = this.lastGoodStreamId;
       }
-      // TODO: propagate exception message into debugData
+      // TODO: propagate exception message into debugData.
+      // TODO: configure a timeout on the reader so that it doesn’t block forever.
       writer.goAway(lastGoodStreamId, statusCode, Util.EMPTY_BYTE_ARRAY);
     }
   }
@@ -493,6 +494,10 @@ public final class Http2Connection implements Closeable {
         writer.settings(settings);
       }
     }
+  }
+
+  public synchronized boolean isShutdown() {
+    return shutdown;
   }
 
   public static class Builder {


### PR DESCRIPTION
Rather than immediately and violently closing the HTTP/2 stream,
we initiate the shutdown sequence for a graceful disconnect.

This fixes StreamAllocation to avoid creating new streams on
shutdown connections. That behavior is not well tested, however.
That will come by integrating dave-r12's PR:

See https://github.com/square/okhttp/pull/2889