### PR TITLE
Avoid generating synthetic accessor methods

### DIFF
--- a/okhttp/src/main/java/okhttp3/Cache.java
+++ b/okhttp/src/main/java/okhttp3/Cache.java
@@ -165,11 +165,11 @@ public final class Cache implements Closeable, Flushable {
     }
   };
 
-  private final DiskLruCache cache;
+  final DiskLruCache cache;
 
   /* read and write statistics, all guarded by 'this' */
-  private int writeSuccessCount;
-  private int writeAbortCount;
+  int writeSuccessCount;
+  int writeAbortCount;
   private int networkCount;
   private int hitCount;
   private int requestCount;
@@ -217,7 +217,7 @@ public final class Cache implements Closeable, Flushable {
     return response;
   }
 
-  private CacheRequest put(Response response) {
+  CacheRequest put(Response response) {
     String requestMethod = response.request().method();
 
     if (HttpMethod.invalidatesCache(response.request().method())) {
@@ -254,11 +254,11 @@ public final class Cache implements Closeable, Flushable {
     }
   }
 
-  private void remove(Request request) throws IOException {
+  void remove(Request request) throws IOException {
     cache.remove(urlToKey(request));
   }
 
-  private void update(Response cached, Response network) {
+  void update(Response cached, Response network) {
     Entry entry = new Entry(network);
     DiskLruCache.Snapshot snapshot = ((CacheResponseBody) cached.body()).snapshot;
     DiskLruCache.Editor editor = null;
@@ -398,7 +398,7 @@ public final class Cache implements Closeable, Flushable {
     return cache.isClosed();
   }
 
-  private synchronized void trackResponse(CacheStrategy cacheStrategy) {
+  synchronized void trackResponse(CacheStrategy cacheStrategy) {
     requestCount++;
 
     if (cacheStrategy.networkRequest != null) {
@@ -410,7 +410,7 @@ public final class Cache implements Closeable, Flushable {
     }
   }
 
-  private synchronized void trackConditionalCacheHit() {
+  synchronized void trackConditionalCacheHit() {
     hitCount++;
   }
 
@@ -429,8 +429,8 @@ public final class Cache implements Closeable, Flushable {
   private final class CacheRequestImpl implements CacheRequest {
     private final DiskLruCache.Editor editor;
     private Sink cacheOut;
-    private boolean done;
     private Sink body;
+    boolean done;
 
     public CacheRequestImpl(final DiskLruCache.Editor editor) {
       this.editor = editor;
@@ -720,7 +720,7 @@ public final class Cache implements Closeable, Flushable {
     }
   }
 
-  private static int readInt(BufferedSource source) throws IOException {
+  static int readInt(BufferedSource source) throws IOException {
     try {
       long result = source.readDecimalLong();
       String line = source.readUtf8LineStrict();
@@ -734,7 +734,7 @@ public final class Cache implements Closeable, Flushable {
   }
 
   private static class CacheResponseBody extends ResponseBody {
-    private final DiskLruCache.Snapshot snapshot;
+    final DiskLruCache.Snapshot snapshot;
     private final BufferedSource bodySource;
     private final String contentType;
     private final String contentLength;

--- a/okhttp/src/main/java/okhttp3/Request.java
+++ b/okhttp/src/main/java/okhttp3/Request.java
@@ -25,15 +25,15 @@ import okhttp3.internal.http.HttpMethod;
  * immutable.
  */
 public final class Request {
-  private final HttpUrl url;
-  private final String method;
-  private final Headers headers;
-  private final RequestBody body;
-  private final Object tag;
+  final HttpUrl url;
+  final String method;
+  final Headers headers;
+  final RequestBody body;
+  final Object tag;
 
   private volatile CacheControl cacheControl; // Lazily initialized.
 
-  private Request(Builder builder) {
+  Request(Builder builder) {
     this.url = builder.url;
     this.method = builder.method;
     this.headers = builder.headers.build();
@@ -97,18 +97,18 @@ public final class Request {
   }
 
   public static class Builder {
-    private HttpUrl url;
-    private String method;
-    private Headers.Builder headers;
-    private RequestBody body;
-    private Object tag;
+    HttpUrl url;
+    String method;
+    Headers.Builder headers;
+    RequestBody body;
+    Object tag;
 
     public Builder() {
       this.method = "GET";
       this.headers = new Headers.Builder();
     }
 
-    private Builder(Request request) {
+    Builder(Request request) {
       this.url = request.url;
       this.method = request.method;
       this.body = request.body;

--- a/okhttp/src/main/java/okhttp3/Response.java
+++ b/okhttp/src/main/java/okhttp3/Response.java
@@ -40,22 +40,22 @@ import static okhttp3.internal.http.StatusLine.HTTP_TEMP_REDIRECT;
  * {@link ResponseBody} for an explanation and examples.
  */
 public final class Response implements Closeable {
-  private final Request request;
-  private final Protocol protocol;
-  private final int code;
-  private final String message;
-  private final Handshake handshake;
-  private final Headers headers;
-  private final ResponseBody body;
-  private final Response networkResponse;
-  private final Response cacheResponse;
-  private final Response priorResponse;
-  private final long sentRequestAtMillis;
-  private final long receivedResponseAtMillis;
+  final Request request;
+  final Protocol protocol;
+  final int code;
+  final String message;
+  final Handshake handshake;
+  final Headers headers;
+  final ResponseBody body;
+  final Response networkResponse;
+  final Response cacheResponse;
+  final Response priorResponse;
+  final long sentRequestAtMillis;
+  final long receivedResponseAtMillis;
 
   private volatile CacheControl cacheControl; // Lazily initialized.
 
-  private Response(Builder builder) {
+  Response(Builder builder) {
     this.request = builder.request;
     this.protocol = builder.protocol;
     this.code = builder.code;
@@ -286,24 +286,24 @@ public final class Response implements Closeable {
   }
 
   public static class Builder {
-    private Request request;
-    private Protocol protocol;
-    private int code = -1;
-    private String message;
-    private Handshake handshake;
-    private Headers.Builder headers;
-    private ResponseBody body;
-    private Response networkResponse;
-    private Response cacheResponse;
-    private Response priorResponse;
-    private long sentRequestAtMillis;
-    private long receivedResponseAtMillis;
+    Request request;
+    Protocol protocol;
+    int code = -1;
+    String message;
+    Handshake handshake;
+    Headers.Builder headers;
+    ResponseBody body;
+    Response networkResponse;
+    Response cacheResponse;
+    Response priorResponse;
+    long sentRequestAtMillis;
+    long receivedResponseAtMillis;
 
     public Builder() {
       headers = new Headers.Builder();
     }
 
-    private Builder(Response response) {
+    Builder(Response response) {
       this.request = response.request;
       this.protocol = response.protocol;
       this.code = response.code;


### PR DESCRIPTION
Affected:
- okhttp3.Request
- okhttp3.Response
- okhttp3.Cache