### PR TITLE
New non-blocking API for websockets.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/NewWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/NewWebSocketTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import java.io.IOException;
+import java.net.ProtocolException;
+import java.util.Random;
+import java.util.logging.Logger;
+import okhttp3.internal.tls.SslClient;
+import okhttp3.internal.ws.NewWebSocketRecorder;
+import okhttp3.internal.ws.RealNewWebSocket;
+import okhttp3.internal.ws.WebSocketRecorder;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.ByteString;
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static okhttp3.TestUtil.defaultClient;
+import static okhttp3.WebSocket.TEXT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public final class NewWebSocketTest {
+  @Rule public final MockWebServer webServer = new MockWebServer();
+
+  private final SslClient sslClient = SslClient.localhost();
+  private final NewWebSocketRecorder clientListener = new NewWebSocketRecorder("client");
+  private final WebSocketRecorder serverListener = new WebSocketRecorder("server");
+  private final Random random = new Random(0);
+  private OkHttpClient client = defaultClient().newBuilder()
+      .addInterceptor(new Interceptor() {
+        @Override public Response intercept(Chain chain) throws IOException {
+          Response response = chain.proceed(chain.request());
+          assertNotNull(response.body()); // Ensure application interceptors never see a null body.
+          return response;
+        }
+      })
+      .build();
+
+  @After public void tearDown() {
+    clientListener.assertExhausted();
+  }
+
+  @Test public void textMessage() throws IOException {
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+    NewWebSocket client = enqueueClientWebSocket();
+
+    clientListener.assertOpen();
+    serverListener.assertOpen();
+
+    client.send("Hello, WebSockets!");
+    serverListener.assertTextMessage("Hello, WebSockets!");
+  }
+
+  @Test public void binaryMessage() throws IOException {
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+    RealNewWebSocket client = enqueueClientWebSocket();
+
+    clientListener.assertOpen();
+    serverListener.assertOpen();
+
+    client.send(ByteString.encodeUtf8("Hello!"));
+    serverListener.assertBinaryMessage(new byte[] {'H', 'e', 'l', 'l', 'o', '!'});
+  }
+
+  @Test public void nullStringThrows() throws IOException {
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+    RealNewWebSocket client = enqueueClientWebSocket();
+
+    clientListener.assertOpen();
+    try {
+      client.send((String) null);
+      fail();
+    } catch (NullPointerException e) {
+      assertEquals("text == null", e.getMessage());
+    }
+  }
+
+  @Test public void nullByteStringThrows() throws IOException {
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+    RealNewWebSocket client = enqueueClientWebSocket();
+
+    clientListener.assertOpen();
+    try {
+      client.send((ByteString) null);
+      fail();
+    } catch (NullPointerException e) {
+      assertEquals("bytes == null", e.getMessage());
+    }
+  }
+
+  @Test public void serverMessage() throws IOException {
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+    enqueueClientWebSocket();
+
+    clientListener.assertOpen();
+    WebSocket server = serverListener.assertOpen();
+
+    server.message(RequestBody.create(TEXT, "Hello, WebSockets!"));
+    clientListener.assertTextMessage("Hello, WebSockets!");
+  }
+
+  @Test public void throwingOnOpenFailsImmediately() {
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+
+    final RuntimeException e = new RuntimeException();
+    clientListener.setNextEventDelegate(new NewWebSocket.Listener() {
+      @Override public void onOpen(NewWebSocket webSocket, Response response) {
+        throw e;
+      }
+    });
+    enqueueClientWebSocket();
+
+    serverListener.assertOpen();
+    serverListener.assertExhausted();
+    clientListener.assertFailure(e);
+  }
+
+  @Ignore("AsyncCall currently lets runtime exceptions propagate.")
+  @Test public void throwingOnFailLogs() throws InterruptedException {
+    TestLogHandler logs = new TestLogHandler();
+    Logger logger = Logger.getLogger(OkHttpClient.class.getName());
+    logger.addHandler(logs);
+
+    webServer.enqueue(new MockResponse().setResponseCode(200).setBody("Body"));
+
+    final RuntimeException e = new RuntimeException();
+    clientListener.setNextEventDelegate(new NewWebSocket.Listener() {
+      @Override public void onFailure(NewWebSocket webSocket, Throwable t, Response response) {
+        throw e;
+      }
+    });
+
+    enqueueClientWebSocket();
+
+    assertEquals("", logs.take());
+    logger.removeHandler(logs);
+  }
+
+  @Test public void throwingOnMessageClosesImmediatelyAndFails() throws IOException {
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+    enqueueClientWebSocket();
+
+    clientListener.assertOpen();
+    WebSocket server = serverListener.assertOpen();
+
+    final RuntimeException e = new RuntimeException();
+    clientListener.setNextEventDelegate(new NewWebSocket.Listener() {
+      @Override public void onMessage(NewWebSocket webSocket, String text) {
+        throw e;
+      }
+    });
+
+    server.message(RequestBody.create(TEXT, "Hello, WebSockets!"));
+    clientListener.assertFailure(e);
+    serverListener.assertExhausted();
+  }
+
+  @Test public void throwingOnClosingClosesImmediatelyAndFails() throws IOException {
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+    enqueueClientWebSocket();
+
+    clientListener.assertOpen();
+    WebSocket server = serverListener.assertOpen();
+
+    final RuntimeException e = new RuntimeException();
+    clientListener.setNextEventDelegate(new NewWebSocket.Listener() {
+      @Override public void onClosing(NewWebSocket webSocket, int code, String reason) {
+        throw e;
+      }
+    });
+
+    server.close(1000, "bye");
+    clientListener.assertFailure(e);
+    serverListener.assertExhausted();
+  }
+
+  @Test public void non101RetainsBody() throws IOException {
+    webServer.enqueue(new MockResponse().setResponseCode(200).setBody("Body"));
+    enqueueClientWebSocket();
+
+    clientListener.assertFailure(200, "Body", ProtocolException.class,
+        "Expected HTTP 101 response but was '200 OK'");
+  }
+
+  @Test public void notFound() throws IOException {
+    webServer.enqueue(new MockResponse().setStatus("HTTP/1.1 404 Not Found"));
+    enqueueClientWebSocket();
+
+    clientListener.assertFailure(404, null, ProtocolException.class,
+        "Expected HTTP 101 response but was '404 Not Found'");
+  }
+
+  @Test public void clientTimeoutClosesBody() throws IOException {
+    webServer.enqueue(new MockResponse().setResponseCode(408));
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+    RealNewWebSocket client = enqueueClientWebSocket();
+
+    clientListener.assertOpen();
+    WebSocket server = serverListener.assertOpen();
+
+    client.send("abc");
+    serverListener.assertTextMessage("abc");
+
+    server.message(RequestBody.create(TEXT, "def"));
+    clientListener.assertTextMessage("def");
+  }
+
+  @Test public void missingConnectionHeader() throws IOException {
+    webServer.enqueue(new MockResponse()
+        .setResponseCode(101)
+        .setHeader("Upgrade", "websocket")
+        .setHeader("Sec-WebSocket-Accept", "ujmZX4KXZqjwy6vi1aQFH5p4Ygk="));
+    enqueueClientWebSocket();
+
+    clientListener.assertFailure(101, null, ProtocolException.class,
+        "Expected 'Connection' header value 'Upgrade' but was 'null'");
+  }
+
+  @Test public void wrongConnectionHeader() throws IOException {
+    webServer.enqueue(new MockResponse()
+        .setResponseCode(101)
+        .setHeader("Upgrade", "websocket")
+        .setHeader("Connection", "Downgrade")
+        .setHeader("Sec-WebSocket-Accept", "ujmZX4KXZqjwy6vi1aQFH5p4Ygk="));
+    enqueueClientWebSocket();
+
+    clientListener.assertFailure(101, null, ProtocolException.class,
+        "Expected 'Connection' header value 'Upgrade' but was 'Downgrade'");
+  }
+
+  @Test public void missingUpgradeHeader() throws IOException {
+    webServer.enqueue(new MockResponse()
+        .setResponseCode(101)
+        .setHeader("Connection", "Upgrade")
+        .setHeader("Sec-WebSocket-Accept", "ujmZX4KXZqjwy6vi1aQFH5p4Ygk="));
+    enqueueClientWebSocket();
+
+    clientListener.assertFailure(101, null, ProtocolException.class,
+        "Expected 'Upgrade' header value 'websocket' but was 'null'");
+  }
+
+  @Test public void wrongUpgradeHeader() throws IOException {
+    webServer.enqueue(new MockResponse()
+        .setResponseCode(101)
+        .setHeader("Connection", "Upgrade")
+        .setHeader("Upgrade", "Pepsi")
+        .setHeader("Sec-WebSocket-Accept", "ujmZX4KXZqjwy6vi1aQFH5p4Ygk="));
+    enqueueClientWebSocket();
+
+    clientListener.assertFailure(101, null, ProtocolException.class,
+        "Expected 'Upgrade' header value 'websocket' but was 'Pepsi'");
+  }
+
+  @Test public void missingMagicHeader() throws IOException {
+    webServer.enqueue(new MockResponse()
+        .setResponseCode(101)
+        .setHeader("Connection", "Upgrade")
+        .setHeader("Upgrade", "websocket"));
+    enqueueClientWebSocket();
+
+    clientListener.assertFailure(101, null, ProtocolException.class,
+        "Expected 'Sec-WebSocket-Accept' header value 'ujmZX4KXZqjwy6vi1aQFH5p4Ygk=' but was 'null'");
+  }
+
+  @Test public void wrongMagicHeader() throws IOException {
+    webServer.enqueue(new MockResponse()
+        .setResponseCode(101)
+        .setHeader("Connection", "Upgrade")
+        .setHeader("Upgrade", "websocket")
+        .setHeader("Sec-WebSocket-Accept", "magic"));
+    enqueueClientWebSocket();
+
+    clientListener.assertFailure(101, null, ProtocolException.class,
+        "Expected 'Sec-WebSocket-Accept' header value 'ujmZX4KXZqjwy6vi1aQFH5p4Ygk=' but was 'magic'");
+  }
+
+  @Test public void wsScheme() throws IOException {
+    websocketScheme("ws");
+  }
+
+  @Test public void wsUppercaseScheme() throws IOException {
+    websocketScheme("WS");
+  }
+
+  @Test public void wssScheme() throws IOException {
+    webServer.useHttps(sslClient.socketFactory, false);
+    client = client.newBuilder()
+        .sslSocketFactory(sslClient.socketFactory, sslClient.trustManager)
+        .hostnameVerifier(new RecordingHostnameVerifier())
+        .build();
+
+    websocketScheme("wss");
+  }
+
+  @Test public void httpsScheme() throws IOException {
+    webServer.useHttps(sslClient.socketFactory, false);
+    client = client.newBuilder()
+        .sslSocketFactory(sslClient.socketFactory, sslClient.trustManager)
+        .hostnameVerifier(new RecordingHostnameVerifier())
+        .build();
+
+    websocketScheme("https");
+  }
+
+  private void websocketScheme(String scheme) throws IOException {
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+
+    Request request = new Request.Builder()
+        .url(scheme + "://" + webServer.getHostName() + ":" + webServer.getPort() + "/")
+        .build();
+
+    RealNewWebSocket webSocket = enqueueClientWebSocket(request);
+    clientListener.assertOpen();
+    serverListener.assertOpen();
+
+    webSocket.send("abc");
+    serverListener.assertTextMessage("abc");
+  }
+
+  private RealNewWebSocket enqueueClientWebSocket() {
+    return enqueueClientWebSocket(new Request.Builder().get().url(webServer.url("/")).build());
+  }
+
+  private RealNewWebSocket enqueueClientWebSocket(Request request) {
+    RealNewWebSocket webSocket = new RealNewWebSocket(client, request, clientListener, random);
+    webSocket.connnect();
+    return webSocket;
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/NewWebSocketRecorder.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/NewWebSocketRecorder.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.ws;
+
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import okhttp3.NewWebSocket;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.WebSocket;
+import okhttp3.internal.Util;
+import okhttp3.internal.platform.Platform;
+import okio.ByteString;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public final class NewWebSocketRecorder extends NewWebSocket.Listener {
+  private final String name;
+  private final BlockingQueue<Object> events = new LinkedBlockingQueue<>();
+  private NewWebSocket.Listener delegate;
+
+  public NewWebSocketRecorder(String name) {
+    this.name = name;
+  }
+
+  /** Sets a delegate for handling the next callback to this listener. Cleared after invoked. */
+  public void setNextEventDelegate(NewWebSocket.Listener delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public void onOpen(NewWebSocket webSocket, Response response) {
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onOpen", null);
+
+    NewWebSocket.Listener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onOpen(webSocket, response);
+    } else {
+      events.add(new Open(webSocket, response));
+    }
+  }
+
+  @Override public void onMessage(NewWebSocket webSocket, ByteString bytes) {
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onMessage", null);
+
+    NewWebSocket.Listener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onMessage(webSocket, bytes);
+    } else {
+      Message event = new Message(bytes);
+      events.add(event);
+    }
+  }
+
+  @Override public void onMessage(NewWebSocket webSocket, String text) {
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onMessage", null);
+
+    NewWebSocket.Listener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onMessage(webSocket, text);
+    } else {
+      Message event = new Message(text);
+      events.add(event);
+    }
+  }
+
+  @Override public void onClosing(NewWebSocket webSocket, int code, String reason) {
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onClose " + code, null);
+
+    NewWebSocket.Listener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onClosing(webSocket, code, reason);
+    } else {
+      events.add(new Closing(code, reason));
+    }
+  }
+
+  @Override public void onClosed(NewWebSocket webSocket, int code, String reason) {
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onClose " + code, null);
+
+    NewWebSocket.Listener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onClosed(webSocket, code, reason);
+    } else {
+      events.add(new Closed(code, reason));
+    }
+  }
+
+  @Override public void onFailure(NewWebSocket webSocket, Throwable t, Response response)  {
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onFailure", t);
+
+    NewWebSocket.Listener delegate = this.delegate;
+    if (delegate != null) {
+      this.delegate = null;
+      delegate.onFailure(webSocket, t, response);
+    } else {
+      events.add(new Failure(t, response));
+    }
+  }
+
+  private Object nextEvent() {
+    try {
+      Object event = events.poll(10, TimeUnit.SECONDS);
+      if (event == null) {
+        throw new AssertionError("Timed out waiting for event.");
+      }
+      return event;
+    } catch (InterruptedException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  public void assertTextMessage(String payload) {
+    Object actual = nextEvent();
+    assertEquals(new Message(payload), actual);
+  }
+
+  public void assertBinaryMessage(byte[] payload) {
+    Object actual = nextEvent();
+    assertEquals(new Message(ByteString.of(payload)), actual);
+  }
+
+  public void assertPong(ByteString payload) {
+    Object actual = nextEvent();
+    assertEquals(new Pong(payload), actual);
+  }
+
+  public void assertClose(int code, String reason) {
+    Object actual = nextEvent();
+    assertEquals(new Closing(code, reason), actual);
+  }
+
+  public void assertExhausted() {
+    assertTrue("Remaining events: " + events, events.isEmpty());
+  }
+
+  public NewWebSocket assertOpen() {
+    Object event = nextEvent();
+    if (!(event instanceof Open)) {
+      throw new AssertionError("Expected Open but was " + event);
+    }
+    return ((Open) event).webSocket;
+  }
+
+  public void assertFailure(Throwable t) {
+    Object event = nextEvent();
+    if (!(event instanceof Failure)) {
+      throw new AssertionError("Expected Failure but was " + event);
+    }
+    Failure failure = (Failure) event;
+    assertNull(failure.response);
+    assertSame(t, failure.t);
+  }
+
+  public void assertFailure(Class<? extends IOException> cls, String message) {
+    Object event = nextEvent();
+    if (!(event instanceof Failure)) {
+      throw new AssertionError("Expected Failure but was " + event);
+    }
+    Failure failure = (Failure) event;
+    assertNull(failure.response);
+    assertEquals(cls, failure.t.getClass());
+    assertEquals(message, failure.t.getMessage());
+  }
+
+  public void assertFailure(int code, String body, Class<? extends IOException> cls, String message)
+      throws IOException {
+    Object event = nextEvent();
+    if (!(event instanceof Failure)) {
+      throw new AssertionError("Expected Failure but was " + event);
+    }
+    Failure failure = (Failure) event;
+    assertEquals(code, failure.response.code());
+    if (body != null) {
+      assertEquals(body, failure.responseBody);
+    }
+    assertEquals(cls, failure.t.getClass());
+    assertEquals(message, failure.t.getMessage());
+  }
+
+  static final class Open {
+    final NewWebSocket webSocket;
+    final Response response;
+
+    Open(NewWebSocket webSocket, Response response) {
+      this.webSocket = webSocket;
+      this.response = response;
+    }
+
+    @Override public String toString() {
+      return "Open[" + response + "]";
+    }
+  }
+
+  static final class Failure {
+    final Throwable t;
+    final Response response;
+    final String responseBody;
+
+    Failure(Throwable t, Response response) {
+      this.t = t;
+      this.response = response;
+      String responseBody = null;
+      if (response != null) {
+        try {
+          responseBody = response.body().string();
+        } catch (IOException ignored) {
+        }
+      }
+      this.responseBody = responseBody;
+    }
+
+    @Override public String toString() {
+      if (response == null) {
+        return "Failure[" + t + "]";
+      }
+      return "Failure[" + response + "]";
+    }
+  }
+
+  static final class Message {
+    public final ByteString bytes;
+    public final String string;
+
+    public Message(ByteString bytes) {
+      this.bytes = bytes;
+      this.string = null;
+    }
+
+    public Message(String string) {
+      this.bytes = null;
+      this.string = string;
+    }
+
+    @Override public String toString() {
+      return "Message[" + (bytes != null ? bytes : string) + "]";
+    }
+
+    @Override public int hashCode() {
+      return (bytes != null ? bytes : string).hashCode();
+    }
+
+    @Override public boolean equals(Object other) {
+      return other instanceof Message
+          && Util.equal(((Message) other).bytes, bytes)
+          && Util.equal(((Message) other).string, string);
+    }
+  }
+
+  static final class Pong {
+    public final ByteString payload;
+
+    Pong(ByteString payload) {
+      this.payload = payload;
+    }
+
+    @Override public String toString() {
+      return "Pong[" + payload + "]";
+    }
+
+    @Override public int hashCode() {
+      return payload.hashCode();
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (obj instanceof Pong) {
+        Pong other = (Pong) obj;
+        return payload == null ? other.payload == null : payload.equals(other.payload);
+      }
+      return false;
+    }
+  }
+
+  static final class Closing {
+    public final int code;
+    public final String reason;
+
+    Closing(int code, String reason) {
+      this.code = code;
+      this.reason = reason;
+    }
+
+    @Override public String toString() {
+      return "Closing[" + code + " " + reason + "]";
+    }
+
+    @Override public int hashCode() {
+      return code * 37 + reason.hashCode();
+    }
+
+    @Override public boolean equals(Object other) {
+      return other instanceof Closing
+          && ((Closing) other).code == code
+          && ((Closing) other).reason.equals(reason);
+    }
+  }
+
+  static final class Closed {
+    public final int code;
+    public final String reason;
+
+    Closed(int code, String reason) {
+      this.code = code;
+      this.reason = reason;
+    }
+
+    @Override public String toString() {
+      return "Closed[" + code + " " + reason + "]";
+    }
+
+    @Override public int hashCode() {
+      return code * 37 + reason.hashCode();
+    }
+
+    @Override public boolean equals(Object other) {
+      return other instanceof Closed
+          && ((Closed) other).code == code
+          && ((Closed) other).reason.equals(reason);
+    }
+  }
+
+  /** Expose this recorder as a frame callback and shim in "ping" events. */
+  WebSocketReader.FrameCallback asFrameCallback() {
+    return new WebSocketReader.FrameCallback() {
+      @Override public void onReadMessage(ResponseBody body) throws IOException {
+        if (body.contentType().equals(WebSocket.TEXT)) {
+          String text = body.source().readUtf8();
+          onMessage(null, text);
+        } else if (body.contentType().equals(WebSocket.BINARY)) {
+          ByteString bytes = body.source().readByteString();
+          onMessage(null, bytes);
+        } else {
+          throw new IllegalArgumentException();
+        }
+      }
+
+      @Override public void onReadPing(ByteString payload) {
+        events.add(new Ping(payload));
+      }
+
+      @Override public void onReadPong(ByteString padload) {
+      }
+
+      @Override public void onReadClose(int code, String reason) {
+        onClosing(null, code, reason);
+      }
+    };
+  }
+
+  void assertPing(ByteString payload) {
+    Object actual = nextEvent();
+    assertEquals(new Ping(payload), actual);
+  }
+
+  static final class Ping {
+    public final ByteString buffer;
+
+    Ping(ByteString buffer) {
+      this.buffer = buffer;
+    }
+
+    @Override public String toString() {
+      return "Ping[" + buffer + "]";
+    }
+
+    @Override public int hashCode() {
+      return buffer.hashCode();
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (obj instanceof Ping) {
+        Ping other = (Ping) obj;
+        return buffer == null ? other.buffer == null : buffer.equals(other.buffer);
+      }
+      return false;
+    }
+  }
+}

--- a/okhttp/src/main/java/okhttp3/NewWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/NewWebSocket.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import okio.ByteString;
+
+/**
+ * A non-blocking interface to a web socket. Use the {@linkplain NewWebSocket.Factory factory} to
+ * create instances; usually this is {@link OkHttpClient}.
+ *
+ * <h3>Web Socket Lifecycle</h3>
+ *
+ * Upon normal operation each web socket progresses through a sequence of states:
+ *
+ * <ul>
+ *   <li><strong>Connecting:</strong> the initial state of each web socket. Messages may be enqueued
+ *       but they won't be transmitted until the web socket is open.
+ *   <li><strong>Open:</strong> the web socket has been accepted by the remote peer and is fully
+ *       operational. Messages in either direction are enqueued for immediate transmission.
+ *   <li><strong>Closing:</strong> one of the peers on the web socket has initiated a graceful
+ *       shutdown. The web socket will continue to transmit already-enqueued messages but will
+ *       refuse to enqueue new ones.
+ *   <li><strong>Closed:</strong> the web socket has transmitted all of its messages and has
+ *       received all messages from the peer.
+ * </ul>
+ *
+ * Web sockets may fail due to HTTP upgrade problems, connectivity problems, or if either peer
+ * chooses to short-circuit the graceful shutdown process:
+ *
+ * <ul>
+ *   <li><strong>Canceled:</strong> the web socket connection failed. Messages that were
+ *       successfully enqueued by either peer may not have been transmitted to the other.
+ * </ul>
+ *
+ * Note that the state progression is independent for each peer. Arriving at a gracefully-closed
+ * state indicates that a peer has sent all of its outgoing messages and received all of its
+ * incoming messages. But it does not guarantee that the other peer will successfully receive all of
+ * its incoming messages.
+ */
+public interface NewWebSocket {
+  /** Returns the original request that initiated this web socket. */
+  Request request();
+
+  /**
+   * Returns the size in bytes of all messages enqueued to be transmitted to the server. This
+   * doesn't include framing overhead. It also doesn't include any bytes buffered by the operating
+   * system or network intermediaries. This method returns 0 if no messages are waiting
+   * in the queue. If may return a nonzero value after the web socket has been canceled; this
+   * indicates that enqueued messages were not transmitted.
+   */
+  long queueSize();
+
+  /**
+   * Attempts to enqueue {@code text} to be UTF-8 encoded and sent as a the data of a text (type
+   * {@code 0x1}) message.
+   *
+   * <p>This method returns true if the message was enqueued. Messages that would overflow the
+   * outgoing message buffer will be rejected and trigger a {@linkplain #close graceful shutdown} of
+   * this web socket. This method returns false in that case, and in any other case where this
+   * web socket is closing, closed, or canceled.
+   *
+   * <p>This method returns immediately.
+   */
+  boolean send(String text);
+
+  /**
+   * Attempts to enqueue {@code bytes} to be sent as a the data of a binary (type {@code 0x2})
+   * message.
+   *
+   * <p>This method returns true if the message was enqueued. Messages that would overflow the
+   * outgoing message buffer will be rejected and trigger a {@linkplain #close graceful shutdown} of
+   * this web socket. This method returns false in that case, and in any other case where this
+   * web socket is closing, closed, or canceled.
+   *
+   * <p>This method returns immediately.
+   */
+  boolean send(ByteString bytes);
+
+  /**
+   * Attempts to initiate a graceful shutdown of this web socket. Any already-enqueued messages will
+   * be transmitted before the close message is sent but subsequent calls to {@link #send} will
+   * return false and their messages will not be enqueued.
+   *
+   * <p>This returns true if a graceful shutdown was initiated by this call. It returns false and if
+   * a graceful shutdown was already underway or if the web socket is already closed or canceled.
+   *
+   * @param code Status code as defined by <a
+   * href="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a> or {@code 0}.
+   * @param reason Reason for shutting down or {@code null}.
+   */
+  boolean close(int code, String reason);
+
+  /**
+   * Immediately and violently release resources held by this web socket, discarding any enqueued
+   * messages. This does nothing if the web socket has already been closed or canceled.
+   */
+  void cancel();
+
+  interface Factory {
+    NewWebSocket newWebSocket(Request request, Listener listener);
+  }
+
+  abstract class Listener {
+    /**
+     * Invoked when a web socket has been accepted by the remote peer and may begin transmitting
+     * messages.
+     */
+    public void onOpen(NewWebSocket webSocket, Response response) {
+    }
+
+    /** Invoked when a text (type {@code 0x1}) message has been received. */
+    public void onMessage(NewWebSocket webSocket, String text) {
+    }
+
+    /** Invoked when a binary (type {@code 0x2}) message has been received. */
+    public void onMessage(NewWebSocket webSocket, ByteString bytes) {
+    }
+
+    /** Invoked when the peer has indicated that no more incoming messages will be transmitted. */
+    public void onClosing(NewWebSocket webSocket, int code, String reason) {
+    }
+
+    /**
+     * Invoked when both peers have indicated that no more messages will be transmitted and the
+     * connection has been successfully released. No further calls to this listener will be made.
+     */
+    public void onClosed(NewWebSocket webSocket, int code, String reason) {
+    }
+
+    /**
+     * Invoked when a web socket has been closed due to an error reading from or writing to the
+     * network. Both outgoing and incoming messages may have been lost. No further calls to this
+     * listener will be made.
+     */
+    public void onFailure(NewWebSocket webSocket, Throwable t, Response response) {
+    }
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -19,11 +19,13 @@ import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 import javax.net.ssl.SSLSocket;
 import okhttp3.Address;
+import okhttp3.Call;
 import okhttp3.ConnectionPool;
 import okhttp3.ConnectionSpec;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import okhttp3.internal.cache.InternalCache;
 import okhttp3.internal.connection.RealConnection;
 import okhttp3.internal.connection.RouteDatabase;
@@ -62,4 +64,8 @@ public abstract class Internal {
 
   public abstract HttpUrl getHttpUrlChecked(String url)
       throws MalformedURLException, UnknownHostException;
+
+  public abstract StreamAllocation streamAllocation(Call call);
+
+  public abstract Call newWebSocketCall(OkHttpClient client, Request request);
 }


### PR DESCRIPTION
Currently this uses a placholder name, NewWebSocket. I'd like to get this
reviewed, expand it to cover MockWebServer's needs, and then I'll delete
the current blocking API.

Still undecided is which APIs to add - if any - to expose the state of the
web socket.

https://github.com/square/okhttp/issues/2902