### PR TITLE
Prefer Executor.execute() over Executor.submit().

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -301,7 +301,7 @@ public final class Http2Connection implements Closeable {
   }
 
   void writeSynResetLater(final int streamId, final ErrorCode errorCode) {
-    executor.submit(new NamedRunnable("OkHttp %s stream %d", hostname, streamId) {
+    executor.execute(new NamedRunnable("OkHttp %s stream %d", hostname, streamId) {
       @Override public void execute() {
         try {
           writeSynReset(streamId, errorCode);


### PR DESCRIPTION
I fixed most of these 2 years ago when it was problematic, but I missed
one.