### PR TITLE
Always prefer the server's returned response body.

### DIFF
--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/ResponseCacheTest.java
@@ -908,7 +908,7 @@ public final class ResponseCacheTest {
     URL url = server.url("/").url();
 
     assertEquals("A", readAscii(openConnection(url)));
-    assertEquals("A", readAscii(openConnection(url)));
+    assertEquals("B", readAscii(openConnection(url)));
   }
 
   @Test public void clientSideNoStore() throws Exception {

--- a/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
@@ -803,7 +803,7 @@ public final class UrlConnectionCacheTest {
     URL url = server.url("/").url();
 
     assertEquals("A", readAscii(urlFactory.open(url)));
-    assertEquals("A", readAscii(urlFactory.open(url)));
+    assertEquals("B", readAscii(urlFactory.open(url)));
   }
 
   @Test public void nonIdentityEncodingAndConditionalCache() throws Exception {


### PR DESCRIPTION
Previously we would prefer the cached response if it had a newer
Last-Modified date.

Closes: https://github.com/square/okhttp/issues/2886