### PR TITLE
Don't fallback to no proxy after all configured proxies have failed.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -2514,7 +2514,8 @@ public final class CallTest {
     // Enable a misconfigured proxy selector to guarantee that the request is retried.
     client = client.newBuilder()
         .proxySelector(new FakeProxySelector()
-            .addProxy(server2.toProxyAddress()))
+            .addProxy(server2.toProxyAddress())
+            .addProxy(Proxy.NO_PROXY))
         .build();
     server2.shutdown();
 

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -310,7 +310,8 @@ public final class URLConnectionTest {
     // Use a misconfigured proxy to guarantee that the request is retried.
     urlFactory.setClient(urlFactory.client().newBuilder()
         .proxySelector(new FakeProxySelector()
-            .addProxy(server2.toProxyAddress()))
+            .addProxy(server2.toProxyAddress())
+            .addProxy(Proxy.NO_PROXY))
         .build());
     server2.shutdown();
 

--- a/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteSelectorTest.java
@@ -206,12 +206,7 @@ public final class RouteSelectorTest {
     assertRoute(routeSelector.next(), address, proxyB, dns.address(0), proxyBPort);
     dns.assertRequests(proxyBHost);
 
-    // Finally try the only IP address of the origin server.
-    assertTrue(routeSelector.hasNext());
-    dns.addresses(makeFakeAddresses(253, 1));
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.address(0), uriPort);
-    dns.assertRequests(uriHost);
-
+    // No more proxies to try.
     assertFalse(routeSelector.hasNext());
   }
 
@@ -259,11 +254,6 @@ public final class RouteSelectorTest {
     assertRoute(routeSelector.next(), address, proxyA, dns.address(0), proxyAPort);
     dns.assertRequests(proxyAHost);
 
-    assertTrue(routeSelector.hasNext());
-    dns.addresses(makeFakeAddresses(254, 1));
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.address(0), uriPort);
-    dns.assertRequests(uriHost);
-
     assertFalse(routeSelector.hasNext());
   }
 
@@ -285,12 +275,7 @@ public final class RouteSelectorTest {
     dns.assertRequests(proxyBHost);
     assertRoute(routeSelector.next(), address, proxyB, dns.address(1), proxyBPort);
 
-    // Origin
-    dns.addresses(makeFakeAddresses(253, 2));
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.address(0), uriPort);
-    dns.assertRequests(uriHost);
-    assertRoute(routeSelector.next(), address, NO_PROXY, dns.address(1), uriPort);
-
+    // No more proxies to attempt.
     assertFalse(routeSelector.hasNext());
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
@@ -28,6 +28,7 @@ import java.util.NoSuchElementException;
 import okhttp3.Address;
 import okhttp3.HttpUrl;
 import okhttp3.Route;
+import okhttp3.internal.Util;
 
 /**
  * Selects routes to connect to an origin server. Each connection requires a choice of proxy server,
@@ -111,14 +112,11 @@ public final class RouteSelector {
       // If the user specifies a proxy, try that and only that.
       proxies = Collections.singletonList(proxy);
     } else {
-      // Try each of the ProxySelector choices until one connection succeeds. If none succeed
-      // then we'll try a direct connection below.
-      proxies = new ArrayList<>();
-      List<Proxy> selectedProxies = address.proxySelector().select(url.uri());
-      if (selectedProxies != null) proxies.addAll(selectedProxies);
-      // Finally try a direct connection. We only try it once!
-      proxies.removeAll(Collections.singleton(Proxy.NO_PROXY));
-      proxies.add(Proxy.NO_PROXY);
+      // Try each of the ProxySelector choices until one connection succeeds.
+      List<Proxy> proxiesOrNull = address.proxySelector().select(url.uri());
+      proxies = proxiesOrNull != null && !proxiesOrNull.isEmpty()
+          ? Util.immutableList(proxiesOrNull)
+          : Util.immutableList(Proxy.NO_PROXY);
     }
     nextProxyIndex = 0;
   }


### PR DESCRIPTION
Falling back to no proxy causes problems, particularly when the proxy is
adding some value.

Closes: https://github.com/square/okhttp/issues/2525