### PR TITLE
Avoid sending empty HTTP/2 data frames when there is no request body.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -31,7 +31,6 @@ import okhttp3.internal.Internal;
 import okhttp3.internal.Util;
 import okhttp3.internal.connection.StreamAllocation;
 import okhttp3.internal.http.HttpCodec;
-import okhttp3.internal.http.HttpMethod;
 import okhttp3.internal.http.RealResponseBody;
 import okhttp3.internal.http.RequestLine;
 import okhttp3.internal.http.StatusLine;
@@ -101,9 +100,9 @@ public final class Http2Codec implements HttpCodec {
   @Override public void writeRequestHeaders(Request request) throws IOException {
     if (stream != null) return;
 
-    boolean permitsRequestBody = HttpMethod.permitsRequestBody(request.method());
+    boolean hasRequestBody = request.body() != null;
     List<Header> requestHeaders = http2HeadersList(request);
-    stream = connection.newStream(requestHeaders, permitsRequestBody);
+    stream = connection.newStream(requestHeaders, hasRequestBody);
     stream.readTimeout().timeout(client.readTimeoutMillis(), TimeUnit.MILLISECONDS);
     stream.writeTimeout().timeout(client.writeTimeoutMillis(), TimeUnit.MILLISECONDS);
   }


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/2892