### PR TITLE
Automatically ping the peer on a user-specified interval.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -676,7 +676,8 @@ public final class MockWebServer implements TestRule, Closeable {
     RealWebSocket webSocket = new RealWebSocket(fancyRequest,
         response.getWebSocketListener(), new SecureRandom());
     response.getWebSocketListener().onOpen(webSocket, fancyResponse);
-    webSocket.initReaderAndWriter(streams);
+    String name = "MockWebServer WebSocket " + request.getPath();
+    webSocket.initReaderAndWriter(name, 0, streams);
     webSocket.loopReader();
 
     // Even if messages are no longer being read we need to wait for the connection close signal.

--- a/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
@@ -42,11 +42,12 @@ public final class OkHttpClientTest {
     ResponseCache.setDefault(DEFAULT_RESPONSE_CACHE);
   }
 
-  @Test public void timeoutDefaults() {
+  @Test public void durationDefaults() {
     OkHttpClient client = defaultClient();
     assertEquals(10_000, client.connectTimeoutMillis());
     assertEquals(10_000, client.readTimeoutMillis());
     assertEquals(10_000, client.writeTimeoutMillis());
+    assertEquals(0, client.pingIntervalMillis());
   }
 
   @Test public void timeoutValidRange() {


### PR DESCRIPTION
This changes RealWebSocket from using a shared ThreadPoolExecutor to
using a private ScheduledExecutorService. This make some of the code
simpler but it means that applications will hold 1 writer thread for
each websocket, even if it is mostly not writing.

Testing automatic pings is awkward. This refactors much of
RealWebSocketTest to make it more natural to reinitialize the
configuration.