### PR TITLE
Fail the HTTP/2 connection if first frame isn't SETTINGS.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/MockHttp2Peer.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/MockHttp2Peer.java
@@ -171,7 +171,7 @@ public final class MockHttp2Peer implements Closeable {
       } else {
         // read a frame
         InFrame inFrame = new InFrame(i, reader);
-        reader.nextFrame(inFrame);
+        reader.nextFrame(false, inFrame);
         inFrames.add(inFrame);
       }
     }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -562,10 +562,8 @@ public final class Http2Connection implements Closeable {
       ErrorCode connectionErrorCode = ErrorCode.INTERNAL_ERROR;
       ErrorCode streamErrorCode = ErrorCode.INTERNAL_ERROR;
       try {
-        if (!client) {
-          reader.readConnectionPreface();
-        }
-        while (reader.nextFrame(this)) {
+        reader.readConnectionPreface(this);
+        while (reader.nextFrame(false, this)) {
         }
         connectionErrorCode = ErrorCode.NO_ERROR;
         streamErrorCode = ErrorCode.CANCEL;


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/2474