### PR TITLE
Support 'Expect: 100-continue' as a request header.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/internal/http2/Http2Server.java
+++ b/mockwebserver/src/main/java/okhttp3/internal/http2/Http2Server.java
@@ -126,7 +126,7 @@ public final class Http2Server extends Http2Connection.Listener {
         new Header(":version", "HTTP/1.1"),
         new Header("content-type", "text/plain")
     );
-    stream.reply(responseHeaders, true);
+    stream.sendResponseHeaders(responseHeaders, true);
     BufferedSink out = Okio.buffer(stream.getSink());
     out.writeUtf8("Not found: " + path);
     out.close();
@@ -138,7 +138,7 @@ public final class Http2Server extends Http2Connection.Listener {
         new Header(":version", "HTTP/1.1"),
         new Header("content-type", "text/html; charset=UTF-8")
     );
-    stream.reply(responseHeaders, true);
+    stream.sendResponseHeaders(responseHeaders, true);
     BufferedSink out = Okio.buffer(stream.getSink());
     for (File file : files) {
       String target = file.isDirectory() ? (file.getName() + "/") : file.getName();
@@ -153,7 +153,7 @@ public final class Http2Server extends Http2Connection.Listener {
         new Header(":version", "HTTP/1.1"),
         new Header("content-type", contentType(file))
     );
-    stream.reply(responseHeaders, true);
+    stream.sendResponseHeaders(responseHeaders, true);
     Source source = Okio.source(file);
     try {
       BufferedSink out = Okio.buffer(stream.getSink());

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/SocketPolicy.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/SocketPolicy.java
@@ -97,5 +97,12 @@ public enum SocketPolicy {
    * Fail HTTP/2 requests without processing them by sending an {@linkplain
    * MockResponse#getHttp2ErrorCode() HTTP/2 error code}.
    */
-  RESET_STREAM_AT_START
+  RESET_STREAM_AT_START,
+
+  /**
+   * Transmit a {@code HTTP/1.1 100 Continue} response before reading the HTTP request body.
+   * Typically this response is sent when a client makes a request with the header {@code
+   * Expect: 100-continue}.
+   */
+  EXPECT_CONTINUE
 }

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -156,6 +156,10 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
         return connectionPool.routeDatabase;
       }
 
+      @Override public int code(Response.Builder responseBuilder) {
+        return responseBuilder.code;
+      }
+
       @Override
       public void apply(ConnectionSpec tlsConfiguration, SSLSocket sslSocket, boolean isFallback) {
         tlsConfiguration.apply(sslSocket, isFallback);

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -26,6 +26,7 @@ import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Response;
 import okhttp3.internal.cache.InternalCache;
 import okhttp3.internal.connection.RealConnection;
 import okhttp3.internal.connection.RouteDatabase;
@@ -58,6 +59,8 @@ public abstract class Internal {
   public abstract boolean connectionBecameIdle(ConnectionPool pool, RealConnection connection);
 
   public abstract RouteDatabase routeDatabase(ConnectionPool connectionPool);
+
+  public abstract int code(Response.Builder responseBuilder);
 
   public abstract void apply(ConnectionSpec tlsConfiguration, SSLSocket sslSocket,
       boolean isFallback);

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -294,7 +294,9 @@ public final class RealConnection extends Http2Connection.Listener implements Co
       sink.timeout().timeout(writeTimeout, MILLISECONDS);
       tunnelConnection.writeRequest(tunnelRequest.headers(), requestLine);
       tunnelConnection.finishRequest();
-      Response response = tunnelConnection.readResponse().request(tunnelRequest).build();
+      Response response = tunnelConnection.readResponseHeaders(false)
+          .request(tunnelRequest)
+          .build();
       // The response body from a CONNECT should be empty, but if it is not then we should consume
       // it before proceeding.
       long contentLength = HttpHeaders.contentLength(response);

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
@@ -42,16 +42,32 @@ public final class CallServerInterceptor implements Interceptor {
     long sentRequestMillis = System.currentTimeMillis();
     httpCodec.writeRequestHeaders(request);
 
+    Response.Builder responseBuilder = null;
     if (HttpMethod.permitsRequestBody(request.method()) && request.body() != null) {
-      Sink requestBodyOut = httpCodec.createRequestBody(request, request.body().contentLength());
-      BufferedSink bufferedRequestBody = Okio.buffer(requestBodyOut);
-      request.body().writeTo(bufferedRequestBody);
-      bufferedRequestBody.close();
+      // If there's a "Expect: 100-continue" header on the request, wait for a "HTTP/1.1 100
+      // Continue" response before transmitting the request body. If we don't get that, return what
+      // we did get (such as a 4xx response) without ever transmitting the request body.
+      if ("100-continue".equalsIgnoreCase(request.header("Expect"))) {
+        httpCodec.flushRequest();
+        responseBuilder = httpCodec.readResponseHeaders(true);
+      }
+
+      // Write the request body, unless an "Expect: 100-continue" expectation failed.
+      if (responseBuilder == null) {
+        Sink requestBodyOut = httpCodec.createRequestBody(request, request.body().contentLength());
+        BufferedSink bufferedRequestBody = Okio.buffer(requestBodyOut);
+        request.body().writeTo(bufferedRequestBody);
+        bufferedRequestBody.close();
+      }
     }
 
     httpCodec.finishRequest();
 
-    Response response = httpCodec.readResponseHeaders()
+    if (responseBuilder == null) {
+      responseBuilder = httpCodec.readResponseHeaders(false);
+    }
+
+    Response response = responseBuilder
         .request(request)
         .handshake(streamAllocation.connection().handshake())
         .sentRequestAtMillis(sentRequestMillis)

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpCodec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpCodec.java
@@ -37,10 +37,18 @@ public interface HttpCodec {
   void writeRequestHeaders(Request request) throws IOException;
 
   /** Flush the request to the underlying socket. */
+  void flushRequest() throws IOException;
+
+  /** Flush the request to the underlying socket and signal no more bytes will be transmitted. */
   void finishRequest() throws IOException;
 
-  /** Read and return response headers. */
-  Response.Builder readResponseHeaders() throws IOException;
+  /**
+   * Parses bytes of a response header from an HTTP transport.
+   *
+   * @param expectContinue true to return null if this is an intermediate response with a "100"
+   *     response code. Otherwise this method never returns null.
+   */
+  Response.Builder readResponseHeaders(boolean expectContinue) throws IOException;
 
   /** Returns a stream that reads the response body. */
   ResponseBody openResponseBody(Response response) throws IOException;

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
@@ -55,7 +55,7 @@ import static okhttp3.internal.http.StatusLine.HTTP_CONTINUE;
  *     <li>Open a sink to write the request body. Either {@linkplain #newFixedLengthSink
  *         fixed-length} or {@link #newChunkedSink chunked}.
  *     <li>Write to and then close that sink.
- *     <li>{@linkplain #readResponse Read response headers}.
+ *     <li>{@linkplain #readResponseHeaders Read response headers}.
  *     <li>Open a source to read the response body. Either {@linkplain #newFixedLengthSource
  *         fixed-length}, {@linkplain #newChunkedSource chunked} or {@linkplain
  *         #newUnknownLengthSource unknown length}.
@@ -128,10 +128,6 @@ public final class Http1Codec implements HttpCodec {
     writeRequest(request.headers(), requestLine);
   }
 
-  @Override public Response.Builder readResponseHeaders() throws IOException {
-    return readResponse();
-  }
-
   @Override public ResponseBody openResponseBody(Response response) throws IOException {
     Source source = getTransferStream(response);
     return new RealResponseBody(response.headers(), Okio.buffer(source));
@@ -162,6 +158,10 @@ public final class Http1Codec implements HttpCodec {
     return state == STATE_CLOSED;
   }
 
+  @Override public void flushRequest() throws IOException {
+    sink.flush();
+  }
+
   @Override public void finishRequest() throws IOException {
     sink.flush();
   }
@@ -180,27 +180,26 @@ public final class Http1Codec implements HttpCodec {
     state = STATE_OPEN_REQUEST_BODY;
   }
 
-  /** Parses bytes of a response header from an HTTP transport. */
-  public Response.Builder readResponse() throws IOException {
+  @Override public Response.Builder readResponseHeaders(boolean expectContinue) throws IOException {
     if (state != STATE_OPEN_REQUEST_BODY && state != STATE_READ_RESPONSE_HEADERS) {
       throw new IllegalStateException("state: " + state);
     }
 
     try {
-      while (true) {
-        StatusLine statusLine = StatusLine.parse(source.readUtf8LineStrict());
+      StatusLine statusLine = StatusLine.parse(source.readUtf8LineStrict());
 
-        Response.Builder responseBuilder = new Response.Builder()
-            .protocol(statusLine.protocol)
-            .code(statusLine.code)
-            .message(statusLine.message)
-            .headers(readHeaders());
+      Response.Builder responseBuilder = new Response.Builder()
+          .protocol(statusLine.protocol)
+          .code(statusLine.code)
+          .message(statusLine.message)
+          .headers(readHeaders());
 
-        if (statusLine.code != HTTP_CONTINUE) {
-          state = STATE_OPEN_RESPONSE_BODY;
-          return responseBuilder;
-        }
+      if (expectContinue && statusLine.code == HTTP_CONTINUE) {
+        return null;
       }
+
+      state = STATE_OPEN_RESPONSE_BODY;
+      return responseBuilder;
     } catch (EOFException e) {
       // Provide more context if the server ends the stream before sending a response.
       IOException exception = new IOException("unexpected end of stream on " + streamAllocation);

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -865,8 +865,8 @@ public final class Http2Connection implements Closeable {
 
     /**
      * Handle a new stream from this connection's peer. Implementations should respond by either
-     * {@linkplain Http2Stream#reply replying to the stream} or {@linkplain Http2Stream#close
-     * closing it}. This response does not need to be synchronous.
+     * {@linkplain Http2Stream#sendResponseHeaders replying to the stream} or {@linkplain
+     * Http2Stream#close closing it}. This response does not need to be synchronous.
      */
     public abstract void onStream(Http2Stream stream) throws IOException;
 

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
@@ -51,11 +51,14 @@ public final class Http2Stream {
   final int id;
   final Http2Connection connection;
 
-  /** Headers sent by the stream initiator. Immutable and non null. */
+  /** Request headers. Immutable and non null. */
   private final List<Header> requestHeaders;
 
-  /** Headers sent in the stream reply. Null if reply is either not sent or not sent yet. */
+  /** Response headers yet to be {@linkplain #takeResponseHeaders taken}. */
   private List<Header> responseHeaders;
+
+  /** True if response headers have been sent or received. */
+  private boolean hasResponseHeaders;
 
   private final FramedDataSource source;
   final FramedDataSink sink;
@@ -106,7 +109,7 @@ public final class Http2Stream {
     }
     if ((source.finished || source.closed)
         && (sink.finished || sink.closed)
-        && responseHeaders != null) {
+        && hasResponseHeaders) {
       return false;
     }
     return true;
@@ -127,10 +130,14 @@ public final class Http2Stream {
   }
 
   /**
-   * Returns the stream's response headers, blocking if necessary if they have not been received
-   * yet.
+   * Removes and returns the stream's received response headers, blocking if necessary until headers
+   * have been received. If the returned list contains multiple blocks of headers the blocks will be
+   * delimited by 'null'.
    */
-  public synchronized List<Header> getResponseHeaders() throws IOException {
+  public synchronized List<Header> takeResponseHeaders() throws IOException {
+    if (!isLocallyInitiated()) {
+      throw new IllegalStateException("servers cannot read response headers");
+    }
     readTimeout.enter();
     try {
       while (responseHeaders == null && errorCode == null) {
@@ -139,7 +146,11 @@ public final class Http2Stream {
     } finally {
       readTimeout.exitAndThrowIfTimedOut();
     }
-    if (responseHeaders != null) return responseHeaders;
+    List<Header> result = responseHeaders;
+    if (result != null) {
+      responseHeaders = null;
+      return result;
+    }
     throw new StreamResetException(errorCode);
   }
 
@@ -157,17 +168,14 @@ public final class Http2Stream {
    * @param out true to create an output stream that we can use to send data to the remote peer.
    * Corresponds to {@code FLAG_FIN}.
    */
-  public void reply(List<Header> responseHeaders, boolean out) throws IOException {
+  public void sendResponseHeaders(List<Header> responseHeaders, boolean out) throws IOException {
     assert (!Thread.holdsLock(Http2Stream.this));
+    if (responseHeaders == null) {
+      throw new NullPointerException("responseHeaders == null");
+    }
     boolean outFinished = false;
     synchronized (this) {
-      if (responseHeaders == null) {
-        throw new NullPointerException("responseHeaders == null");
-      }
-      if (this.responseHeaders != null) {
-        throw new IllegalStateException("reply already sent");
-      }
-      this.responseHeaders = responseHeaders;
+      this.hasResponseHeaders = true;
       if (!out) {
         this.sink.finished = true;
         outFinished = true;
@@ -196,12 +204,12 @@ public final class Http2Stream {
   /**
    * Returns a sink that can be used to write data to the peer.
    *
-   * @throws IllegalStateException if this stream was initiated by the peer and a {@link #reply} has
-   * not yet been sent.
+   * @throws IllegalStateException if this stream was initiated by the peer and a {@link
+   * #sendResponseHeaders} has not yet been sent.
    */
   public Sink getSink() {
     synchronized (this) {
-      if (responseHeaders == null && !isLocallyInitiated()) {
+      if (!hasResponseHeaders && !isLocallyInitiated()) {
         throw new IllegalStateException("reply before requesting the sink");
       }
     }
@@ -251,6 +259,7 @@ public final class Http2Stream {
     assert (!Thread.holdsLock(Http2Stream.this));
     boolean open = true;
     synchronized (this) {
+      hasResponseHeaders = true;
       if (responseHeaders == null) {
         responseHeaders = headers;
         open = isOpen();
@@ -258,6 +267,7 @@ public final class Http2Stream {
       } else {
         List<Header> newHeaders = new ArrayList<>();
         newHeaders.addAll(responseHeaders);
+        newHeaders.add(null); // Delimit separate blocks of headers with null.
         newHeaders.addAll(headers);
         this.responseHeaders = newHeaders;
       }
@@ -320,8 +330,7 @@ public final class Http2Stream {
       this.maxByteCount = maxByteCount;
     }
 
-    @Override public long read(Buffer sink, long byteCount)
-        throws IOException {
+    @Override public long read(Buffer sink, long byteCount) throws IOException {
       if (byteCount < 0) throw new IllegalArgumentException("byteCount < 0: " + byteCount);
 
       long read;


### PR DESCRIPTION
This will stall reading the response body until the server returns
an intermediate '100 Continue' response.

Closes: https://github.com/square/okhttp/issues/675