### PR TITLE
Confirm that HTTP/2 failure recovery is decent.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -858,11 +858,16 @@ public final class MockWebServer implements TestRule, Closeable {
       RecordedRequest request = readRequest(stream);
       requestCount.incrementAndGet();
       requestQueue.add(request);
+
       MockResponse response;
       try {
         response = dispatcher.dispatch(request);
       } catch (InterruptedException e) {
         throw new AssertionError(e);
+      }
+      if (response.getSocketPolicy() == DISCONNECT_AFTER_REQUEST) {
+        socket.close();
+        return;
       }
       writeResponse(stream, response);
       if (logger.isLoggable(Level.INFO)) {

--- a/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
@@ -154,10 +154,12 @@ public final class RecordedResponse {
     return this;
   }
 
-  public RecordedResponse assertFailureMatches(String pattern) {
+  public RecordedResponse assertFailureMatches(String... patterns) {
     assertNotNull(failure);
-    assertTrue(failure.getMessage(), failure.getMessage().matches(pattern));
-    return this;
+    for (String pattern : patterns) {
+      if (failure.getMessage().matches(pattern)) return this;
+    }
+    throw new AssertionError(failure.getMessage());
   }
 
   public RecordedResponse assertSentRequestAtMillis(long minimum, long maximum) {


### PR DESCRIPTION
This was fixed recently but we didn't update the corresponding test case. This
updates the test and adds a few more to confirm that HTTP/2 failure recovery
works as it should.

Closes: https://github.com/square/okhttp/issues/578