### PR TITLE
animal sniffer update for Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <!-- ALPN library targeted to Java 7 -->
     <alpn.jdk7.version>7.1.2.v20141202</alpn.jdk7.version>
     <android.version>4.1.1.4</android.version>
-    <animal.sniffer.version>1.11</animal.sniffer.version>
+    <animal.sniffer.version>1.15</animal.sniffer.version>
     <apache.http.version>4.2.2</apache.http.version>
     <bouncycastle.version>1.50</bouncycastle.version>
     <guava.version>16.0</guava.version>


### PR DESCRIPTION
Fails when maven run with Java 9

```
[INFO] --- animal-sniffer-maven-plugin:1.11:check (default) @ okhttp ---
[INFO] Checking unresolved references to org.codehaus.mojo.signature:java16:1.1
[ERROR] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:57: Undefined reference: java.nio.ByteBuffer java.nio.ByteBuffer.limit(int)
[ERROR] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:67: Undefined reference: java.nio.ByteBuffer java.nio.ByteBuffer.clear()
[ERROR] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:67: Undefined reference: java.nio.ByteBuffer java.nio.ByteBuffer.clear()
[ERROR] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:83: Undefined reference: java.nio.ByteBuffer java.nio.ByteBuffer.limit(int)
[ERROR] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:92: Undefined reference: java.nio.ByteBuffer java.nio.ByteBuffer.clear()
[ERROR] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:92: Undefined reference: java.nio.ByteBuffer java.nio.ByteBuffer.clear()
```

After update

```
[INFO] --- animal-sniffer-maven-plugin:1.15:check (default) @ okhttp ---
[INFO] Checking unresolved references to org.codehaus.mojo.signature:java16:1.1
[INFO] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:57: Covariant return type change detected: java.nio.Buffer java.nio.ByteBuffer.limit(int) has been changed to java.nio.ByteBuffer java.nio.ByteBuffer.limit(int)
[INFO] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:67: Covariant return type change detected: java.nio.Buffer java.nio.ByteBuffer.clear() has been changed to java.nio.ByteBuffer java.nio.ByteBuffer.clear()
[INFO] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:67: Covariant return type change detected: java.nio.Buffer java.nio.ByteBuffer.clear() has been changed to java.nio.ByteBuffer java.nio.ByteBuffer.clear()
[INFO] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:83: Covariant return type change detected: java.nio.Buffer java.nio.ByteBuffer.limit(int) has been changed to java.nio.ByteBuffer java.nio.ByteBuffer.limit(int)
[INFO] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:92: Covariant return type change detected: java.nio.Buffer java.nio.ByteBuffer.clear() has been changed to java.nio.ByteBuffer java.nio.ByteBuffer.clear()
[INFO] /Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/cache2/FileOperator.java:92: Covariant return type change detected: java.nio.Buffer java.nio.ByteBuffer.clear() has been changed to java.nio.ByteBuffer java.nio.ByteBuffer.clear()
```