### PR TITLE
Fix RealConnection to guard allocationLimit by connectionPool.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -190,7 +190,7 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
         // Promote the HTTP streams into web socket streams.
         StreamAllocation streamAllocation = Internal.instance.streamAllocation(call);
         streamAllocation.noNewStreams(); // Prevent connection pooling!
-        Streams streams = new ClientStreams(streamAllocation);
+        Streams streams = streamAllocation.connection().newWebSocketStreams(streamAllocation);
 
         // Process all web socket messages.
         try {
@@ -566,19 +566,6 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
       this.client = client;
       this.source = source;
       this.sink = sink;
-    }
-  }
-
-  static final class ClientStreams extends Streams {
-    private final StreamAllocation streamAllocation;
-
-    ClientStreams(StreamAllocation streamAllocation) {
-      super(true, streamAllocation.connection().source, streamAllocation.connection().sink);
-      this.streamAllocation = streamAllocation;
-    }
-
-    @Override public void close() {
-      streamAllocation.streamFinished(true, streamAllocation.codec());
     }
   }
 


### PR DESCRIPTION
I'm working towards making OkHttp limit itself to a single HTTP/2 connection
to a single host. In this work I found we're not sufficiently safe on
allocationLimit - connections are added to the pool when this is 0, and
the value is updated without any synchronization.

This change also reduces the visibility of some connection fields in
RealConnection and organizes the fields into two sets: those that are
immutable after connect and those that are guarded by connectionPool.

https://github.com/square/okhttp/issues/373