### PR TITLE
website only: Update examples to encourage closing the Response (and …

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -78,8 +78,12 @@ String run(String url) throws IOException {
       .url(url)
       .build();
 
-  Response response = client.newCall(request).execute();
-  return response.body().string();
+  try {
+    Response response = client.newCall(request).execute();
+    return response.body().string();
+  } finally {
+    response.close();
+  }
 }
 </pre>
             <h4>Post to a Server</h4>
@@ -97,8 +101,9 @@ String post(String url, String json) throws IOException {
       .url(url)
       .post(body)
       .build();
-  Response response = client.newCall(request).execute();
-  return response.body().string();
+  try (Response response = client.newCall(request).execute()) {
+    return response.body().string();
+  }
 }
 </pre>
 


### PR DESCRIPTION
…and the underlying response body).

People follow example code and the current examples don't explicitly encourage people to use try finally blocks (or try with resources) to close the underlying ResponseBody.

The existing examples don't leak resources because they use they always use `response.body().string();` ... but I think this is subtle and it might be better if the examples use explicit try finally. This is especially important for the cases where the response body not read or sometimes read.