### PR TITLE
Website and Guide only: Add try/finally example (closing Response)

### DIFF
--- a/samples/guide/src/main/java/okhttp3/guide/GetTryFinallyExample.java
+++ b/samples/guide/src/main/java/okhttp3/guide/GetTryFinallyExample.java
@@ -3,7 +3,6 @@ package okhttp3.guide;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.internal.Util;
 
 import java.io.IOException;
 
@@ -24,8 +23,10 @@ public class GetTryFinallyExample {
       response = client.newCall(request).execute();
       return response.body().string();
     } finally {
-      // ensure underlying response resources are closed
-      Util.closeQuietly(response);
+      if (response != null) {
+        // ensure underlying response resources are closed
+        response.close();
+      }
     }
   }
 

--- a/samples/guide/src/main/java/okhttp3/guide/GetTryFinallyExample.java
+++ b/samples/guide/src/main/java/okhttp3/guide/GetTryFinallyExample.java
@@ -1,0 +1,37 @@
+package okhttp3.guide;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.internal.Util;
+
+import java.io.IOException;
+
+/**
+ * Example using try/finally (typically when try with resources is not available).
+ */
+public class GetTryFinallyExample {
+
+  OkHttpClient client = new OkHttpClient();
+
+  String run(String url) throws IOException {
+    Request request = new Request.Builder()
+        .url(url)
+        .build();
+
+    Response response = null;
+    try {
+      response = client.newCall(request).execute();
+      return response.body().string();
+    } finally {
+      // ensure underlying response resources are closed
+      Util.closeQuietly(response);
+    }
+  }
+
+  public static void main(String[] args) throws IOException {
+    GetTryFinallyExample example = new GetTryFinallyExample();
+    String response = example.run("https://raw.github.com/square/okhttp/master/README.md");
+    System.out.println(response);
+  }
+}

--- a/website/index.html
+++ b/website/index.html
@@ -107,6 +107,33 @@ String post(String url, String json) throws IOException {
 }
 </pre>
 
+            <h4>Try/Finally example</h4>
+            <p>This program uses try/finally to ensure underlying resources are closed. <a href="https://raw.github.com/square/okhttp/master/samples/guide/src/main/java/okhttp3/guide/GetTryFinallyExample.java">Full source</a>.
+            <p>The Response must be closed and this can be done in a finally block (ensuring the underlying response body is closed).
+
+            <pre class="prettyprint">
+
+OkHttpClient client = new OkHttpClient();
+
+  String run(String url) throws IOException {
+    Request request = new Request.Builder()
+        .url(url)
+        .build();
+
+    // use Try/Finally block to ensure underlying
+    // response resources are closed
+
+    Response response = null;
+    try {
+      response = client.newCall(request).execute();
+      return response.body().string();
+    } finally {
+      // ensure underlying resources are closed
+      Util.closeQuietly(response);
+    }
+  }
+</pre>
+
             <h3 id="download">Download</h3>
             <p><a href="https://search.maven.org/remote_content?g=com.squareup.okhttp3&a=okhttp&v=LATEST" class="dl version-href">&darr; <span class="version-tag">Latest</span> JAR</a></p>
             <p>You'll also need <a href="http://github.com/square/okio">Okio</a>, which OkHttp

--- a/website/index.html
+++ b/website/index.html
@@ -128,8 +128,10 @@ OkHttpClient client = new OkHttpClient();
       response = client.newCall(request).execute();
       return response.body().string();
     } finally {
-      // ensure underlying resources are closed
-      Util.closeQuietly(response);
+      if (response != null) {
+        // ensure underlying resources are closed
+        response.close();
+      }
     }
   }
 </pre>


### PR DESCRIPTION
Note this example uses `okhttp3.internal.Util.closeQuietly()` ... to close potentially null `Response`.  I'm not sure if you want to encourage that or not.
