### PR TITLE
Permit network interceptors to rewrite the host header.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
@@ -56,6 +56,7 @@ public final class HeadersTest {
         .url("http://square.com/")
         .header("Connection", "upgrade")
         .header("Upgrade", "websocket")
+        .header("Host", "square.com")
         .build();
     List<Header> expected = headerEntries(
         ":method", "GET",

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -130,7 +130,10 @@ public final class Http2Codec implements HttpCodec {
     List<Header> result = new ArrayList<>(headers.size() + 4);
     result.add(new Header(TARGET_METHOD, request.method()));
     result.add(new Header(TARGET_PATH, RequestLine.requestPath(request.url())));
-    result.add(new Header(TARGET_AUTHORITY, Util.hostHeader(request.url(), false))); // Optional.
+    String host = request.header("Host");
+    if (host != null) {
+      result.add(new Header(TARGET_AUTHORITY, host)); // Optional.
+    }
     result.add(new Header(TARGET_SCHEME, request.url().scheme()));
 
     for (int i = 0, size = headers.size(); i < size; i++) {


### PR DESCRIPTION
This makes it possible to do domain fronting.

Closes https://github.com/square/okhttp/issues/3103