### PR TITLE
Connection coalescing - feature/help wanted

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
@@ -1,0 +1,100 @@
+package okhttp3;
+
+import java.io.IOException;
+import java.util.List;
+import okhttp3.coalescing.ConnectionInterceptor;
+import okhttp3.coalescing.ConnectionTarget;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConnectionCoalescingTest {
+  private OkHttpClient client;
+  private ConnectionTarget target = new ConnectionTarget();
+
+  @Before
+  public void setup() {
+    client = new OkHttpClient.Builder().addInterceptor(new ConnectionInterceptor(target)).build();
+  }
+
+  @Test
+  public void testManualConnectionCoalescing() throws IOException {
+    // test that a specific domain can be routed through another API
+    // useful for connection coalescing or domain fronting
+    // TODO use a real example through google.com if possible
+
+    target.addTarget("pbs.twimg.com", "api.twitter.com");
+
+    Response pbsResponse =
+        execute("https://pbs.twimg.com/profile_background_images/481546505468145664/a59ZFvIP.jpeg");
+
+    assertEquals(200, pbsResponse.code());
+    assertEquals("pbs.twimg.com", pbsResponse.request().header("Host"));
+    // not supported without internal support or more work in interceptor
+    //assertEquals("pbs.twimg.com", pbsResponse.request().url().host());
+    assertEquals(Protocol.HTTP_2, pbsResponse.protocol());
+
+    assertEquals("api.twitter.com",
+        client.connectionPool().liveConnections().get(0).route().socketAddress().getHostName());
+  }
+
+  @Test
+  public void testManualCoalescing() throws IOException {
+    // example that could be best practice for many APIs
+    // send all known owned targets to a single host
+
+    target.addTarget("*.twimg.com", "twitter.com");
+    target.addTarget("*.twitter.com", "twitter.com");
+
+    Response pbsResponse =
+        execute("https://pbs.twimg.com/profile_background_images/481546505468145664/a59ZFvIP.jpeg");
+    Response apiResponse = execute("https://api.twitter.com/robots.txt");
+
+    assertEquals(200, pbsResponse.code());
+    assertEquals("pbs.twimg.com", pbsResponse.request().header("Host"));
+    // not supported without internal support or more work in interceptor
+    //assertEquals("pbs.twimg.com", pbsResponse.request().url().host());
+    assertEquals(Protocol.HTTP_2, pbsResponse.protocol());
+
+    assertEquals(200, apiResponse.code());
+    assertEquals("api.twitter.com", apiResponse.request().header("Host"));
+    // not supported without internal support or more work in interceptor
+    //assertEquals("api.twitter.com", apiResponse.request().url().host());
+    assertEquals(Protocol.HTTP_2, apiResponse.protocol());
+
+    List<Connection> connections = client.connectionPool().liveConnections();
+    assertEquals(1, connections.size());
+    assertEquals("twitter.com", connections.get(0).route().socketAddress().getHostName());
+  }
+
+  @Test
+  public void testAutoCoalescing() throws IOException {
+    // https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/
+    // IP + subjectAlternativeName
+
+    target.setAutoCoalescing(true);
+
+    Response twitterResponse = execute("https://twitter.com/robots.txt");
+    Response wwwResponse = execute("https://www.twitter.com/robots.txt");
+
+    assertEquals(200, twitterResponse.code());
+    //assertEquals("twitter.com", twitterResponse.request().header("Host"));
+    assertEquals("twitter.com", twitterResponse.request().url().host());
+    assertEquals(Protocol.HTTP_2, twitterResponse.protocol());
+
+    assertEquals(200, wwwResponse.code());
+    assertEquals("www.twitter.com", wwwResponse.request().header("Host"));
+    // not supported without internal support or more work in interceptor
+    //assertEquals("api.twitter.com", wwwResponse.request().url().host());
+    assertEquals(Protocol.HTTP_2, wwwResponse.protocol());
+
+    List<Connection> connections = client.connectionPool().liveConnections();
+    assertEquals(1, connections.size());
+    assertEquals("twitter.com", connections.get(0).route().socketAddress().getHostName());
+  }
+
+  private Response execute(String url) throws IOException {
+    return client.newCall(new Request.Builder().url(url).build()).execute();
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/coalescing/ConnectionInterceptor.java
+++ b/okhttp-tests/src/test/java/okhttp3/coalescing/ConnectionInterceptor.java
@@ -1,0 +1,98 @@
+package okhttp3.coalescing;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import okhttp3.Connection;
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class ConnectionInterceptor implements Interceptor {
+  private ConnectionTarget connectionTarget;
+
+  public ConnectionInterceptor(ConnectionTarget connectionTarget) {
+    this.connectionTarget = connectionTarget;
+  }
+
+  @Override public Response intercept(Chain chain) throws IOException {
+    Request request = chain.request();
+
+    request = remapRequest(chain, request);
+
+    Response response = chain.proceed(request);
+
+    return response;
+  }
+
+  private Request remapRequest(Chain chain, Request request) throws IOException {
+    HttpUrl destinationUrl = request.url();
+
+    OkHttpClient client = chain.client();
+    List<Connection> connections = client.connectionPool().liveConnections();
+
+    String urlHost = destinationUrl.host();
+
+    List<InetAddress> urlDns = null;
+
+    String targetHost = connectionTarget.getTarget(urlHost);
+    if (targetHost != null) {
+      HttpUrl targetUrl = destinationUrl.newBuilder().host(targetHost).build();
+      return request.newBuilder().url(targetUrl).header("Host", urlHost).build();
+    } else if (connectionTarget.isAutoCoalescing()) {
+      for (Connection con : connections) {
+        List<String> supportedHosts = con.getSupportedHosts();
+
+        String connectionHost = con.route().socketAddress().getHostName();
+        List<InetAddress> connectionDns = null;
+
+        System.out.println(connectionHost + " " + supportedHosts);
+
+        for (String host: supportedHosts) {
+          if (ConnectionTarget.matches(host, urlHost)) {
+            if (connectionDns == null) {
+              connectionDns = dnsLookup(client, connectionHost);
+              System.out.println(connectionHost + " " + connectionDns);
+            }
+
+            if (urlDns == null) {
+              urlDns = dnsLookup(client, urlHost);
+              System.out.println(urlHost + " " + urlDns);
+            }
+
+            if (matchesDns(connectionDns, urlDns)) {
+              HttpUrl targetUrl = destinationUrl.newBuilder().host(connectionHost).build();
+              return request.newBuilder().url(targetUrl).header("Host", urlHost).build();
+            }
+          }
+        }
+      }
+    }
+
+    return request;
+  }
+
+  private boolean matchesDns(List<InetAddress> connectionDns, List<InetAddress> urlDns) {
+    for (InetAddress c: connectionDns) {
+      for (InetAddress u: urlDns) {
+        if (c.getHostAddress().equals(u.getHostAddress())) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private List<InetAddress> dnsLookup(OkHttpClient client, String urlHost) throws IOException {
+    // TODO caching
+    try {
+      return client.dns().lookup(urlHost);
+    } catch (UnknownHostException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/coalescing/ConnectionTarget.java
+++ b/okhttp-tests/src/test/java/okhttp3/coalescing/ConnectionTarget.java
@@ -1,0 +1,48 @@
+package okhttp3.coalescing;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ConnectionTarget {
+  private Map<String, String> configuredTargets = new LinkedHashMap<>();
+  private boolean autoCoalescing;
+
+  public ConnectionTarget() {
+  }
+
+  public void addTarget(String destination, String target) {
+    configuredTargets.put(destination, target);
+  }
+
+  public String getTarget(String host) {
+    for (Map.Entry<String, String> e : configuredTargets.entrySet()) {
+      if (matches(e.getKey(), host)) {
+        return e.getValue();
+      }
+    }
+
+    return null;
+  }
+
+  public static boolean matches(String key, String host) {
+    if (key.equals(host)) {
+      return true;
+    }
+
+    if (key.startsWith("*.")) {
+      String parentHost = key.substring(2);
+
+      return parentHost.equals(host) || host.endsWith("." + parentHost);
+    }
+
+    return false;
+  }
+
+  public void setAutoCoalescing(boolean autoCoalescing) {
+    this.autoCoalescing = autoCoalescing;
+  }
+
+  public boolean isAutoCoalescing() {
+    return autoCoalescing;
+  }
+}

--- a/okhttp/src/main/java/okhttp3/Connection.java
+++ b/okhttp/src/main/java/okhttp3/Connection.java
@@ -17,6 +17,7 @@
 package okhttp3;
 
 import java.net.Socket;
+import java.util.List;
 
 /**
  * The sockets and streams of an HTTP, HTTPS, or HTTPS+HTTP/2 connection. May be used for multiple
@@ -90,4 +91,6 @@ public interface Connection {
    * using {@link Protocol#HTTP_1_0}.
    */
   Protocol protocol();
+
+  List<String> getSupportedHosts();
 }

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -278,4 +278,8 @@ public final class ConnectionPool {
 
     return references.size();
   }
+
+  public List<Connection> liveConnections() {
+    return new ArrayList<Connection>(connections);
+  }
 }

--- a/okhttp/src/main/java/okhttp3/Interceptor.java
+++ b/okhttp/src/main/java/okhttp3/Interceptor.java
@@ -31,5 +31,7 @@ public interface Interceptor {
     Response proceed(Request request) throws IOException;
 
     Connection connection();
+
+    OkHttpClient client();
   }
 }

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -175,7 +175,7 @@ final class RealCall implements Call {
     interceptors.add(new CallServerInterceptor(forWebSocket));
 
     Interceptor.Chain chain = new RealInterceptorChain(
-        interceptors, null, null, null, 0, originalRequest);
+        interceptors, null, null, null, 0, originalRequest, client);
     return chain.proceed(originalRequest);
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -104,10 +104,15 @@ public final class RealConnection extends Http2Connection.Listener implements Co
 
   /** Nanotime timestamp when {@code allocations.size()} reached zero. */
   public long idleAtNanos = Long.MAX_VALUE;
+  private List<String> supportedHosts;
 
   public RealConnection(ConnectionPool connectionPool, Route route) {
     this.connectionPool = connectionPool;
     this.route = route;
+  }
+
+  @Override public List<String> getSupportedHosts() {
+    return supportedHosts;
   }
 
   public static RealConnection testConnection(
@@ -275,6 +280,9 @@ public final class RealConnection extends Http2Connection.Listener implements Co
             + "\n    DN: " + cert.getSubjectDN().getName()
             + "\n    subjectAltNames: " + OkHostnameVerifier.allSubjectAltNames(cert));
       }
+
+      X509Certificate cert = (X509Certificate) unverifiedHandshake.peerCertificates().get(0);
+      supportedHosts = OkHostnameVerifier.allSubjectAltNames(cert);
 
       // Check that the certificate pinner is satisfied by the certificates presented.
       address.certificatePinner().check(address.url().host(),

--- a/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.java
@@ -20,6 +20,7 @@ import java.util.List;
 import okhttp3.Connection;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.internal.connection.StreamAllocation;
@@ -35,16 +36,18 @@ public final class RealInterceptorChain implements Interceptor.Chain {
   private final Connection connection;
   private final int index;
   private final Request request;
+  private OkHttpClient client;
   private int calls;
 
   public RealInterceptorChain(List<Interceptor> interceptors, StreamAllocation streamAllocation,
-      HttpCodec httpCodec, Connection connection, int index, Request request) {
+      HttpCodec httpCodec, Connection connection, int index, Request request, OkHttpClient client) {
     this.interceptors = interceptors;
     this.connection = connection;
     this.streamAllocation = streamAllocation;
     this.httpCodec = httpCodec;
     this.index = index;
     this.request = request;
+    this.client = client;
   }
 
   @Override public Connection connection() {
@@ -87,7 +90,7 @@ public final class RealInterceptorChain implements Interceptor.Chain {
 
     // Call the next interceptor in the chain.
     RealInterceptorChain next = new RealInterceptorChain(
-        interceptors, streamAllocation, httpCodec, connection, index + 1, request);
+        interceptors, streamAllocation, httpCodec, connection, index + 1, request, client);
     Interceptor interceptor = interceptors.get(index);
     Response response = interceptor.intercept(next);
 
@@ -108,5 +111,9 @@ public final class RealInterceptorChain implements Interceptor.Chain {
   private boolean sameConnection(HttpUrl url) {
     return url.host().equals(connection.route().address().url().host())
         && url.port() == connection.route().address().url().port();
+  }
+
+  @Override public OkHttpClient client() {
+    return client;
   }
 }

--- a/samples/guide/src/main/java/okhttp3/recipes/ConfigureTimeouts.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/ConfigureTimeouts.java
@@ -27,7 +27,7 @@ public final class ConfigureTimeouts {
     client = new OkHttpClient.Builder()
         .connectTimeout(10, TimeUnit.SECONDS)
         .writeTimeout(10, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(100, TimeUnit.MILLISECONDS)
         .build();
   }
 


### PR DESCRIPTION
Was playing around with implementing Connection Coalescing as described here.  DNS and subject alternative name match.

https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/

Also allowed for manual configs e.g. for 1st party domains.

a few questions

1) Is this a useful feature for okhttp3, potentially moved from an interceptor into OkHttpClient?
2) Are there ways to access the subject alternative names from the ConnectionPool? without code changes, or are those code changes appropriate?
