### PR TITLE
Use Socket instead of Closeable for compatibility.

### DIFF
--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -16,8 +16,8 @@
  */
 package okhttp3;
 
-import java.io.Closeable;
 import java.lang.ref.Reference;
+import java.net.Socket;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -130,7 +130,7 @@ public final class ConnectionPool {
    * Replaces the connection held by {@code streamAllocation} with a shared connection if possible.
    * This recovers when multiple multiplexed connections are created concurrently.
    */
-  Closeable deduplicate(Address address, StreamAllocation streamAllocation) {
+  Socket deduplicate(Address address, StreamAllocation streamAllocation) {
     assert (Thread.holdsLock(this));
     for (RealConnection connection : connections) {
       if (connection.isEligible(address)

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -15,10 +15,10 @@
  */
 package okhttp3;
 
-import java.io.Closeable;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.ProxySelector;
+import java.net.Socket;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -149,7 +149,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
         return pool.get(address, streamAllocation);
       }
 
-      @Override public Closeable deduplicate(
+      @Override public Socket deduplicate(
           ConnectionPool pool, Address address, StreamAllocation streamAllocation) {
         return pool.deduplicate(address, streamAllocation);
       }

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -15,8 +15,8 @@
  */
 package okhttp3.internal;
 
-import java.io.Closeable;
 import java.net.MalformedURLException;
+import java.net.Socket;
 import java.net.UnknownHostException;
 import javax.net.ssl.SSLSocket;
 import okhttp3.Address;
@@ -55,7 +55,7 @@ public abstract class Internal {
   public abstract RealConnection get(
       ConnectionPool pool, Address address, StreamAllocation streamAllocation);
 
-  public abstract Closeable deduplicate(
+  public abstract Socket deduplicate(
       ConnectionPool pool, Address address, StreamAllocation streamAllocation);
 
   public abstract void put(ConnectionPool pool, RealConnection connection);

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -15,10 +15,10 @@
  */
 package okhttp3.internal.connection;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.net.Socket;
 import okhttp3.Address;
 import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
@@ -186,7 +186,7 @@ public final class StreamAllocation {
     result.connect(connectTimeout, readTimeout, writeTimeout, connectionRetryEnabled);
     routeDatabase().connected(result.route());
 
-    Closeable closeable = null;
+    Socket socket = null;
     synchronized (connectionPool) {
       // Pool the connection.
       Internal.instance.put(connectionPool, result);
@@ -194,17 +194,17 @@ public final class StreamAllocation {
       // If another multiplexed connection to the same address was created concurrently, then
       // release this connection and acquire that one.
       if (result.isMultiplexed()) {
-        closeable = Internal.instance.deduplicate(connectionPool, address, this);
+        socket = Internal.instance.deduplicate(connectionPool, address, this);
         result = connection;
       }
     }
-    closeQuietly(closeable);
+    closeQuietly(socket);
 
     return result;
   }
 
   public void streamFinished(boolean noNewStreams, HttpCodec codec) {
-    Closeable closeable;
+    Socket socket;
     synchronized (connectionPool) {
       if (codec == null || codec != this.codec) {
         throw new IllegalStateException("expected " + this.codec + " but was " + codec);
@@ -212,9 +212,9 @@ public final class StreamAllocation {
       if (!noNewStreams) {
         connection.successCount++;
       }
-      closeable = deallocate(noNewStreams, false, true);
+      socket = deallocate(noNewStreams, false, true);
     }
-    closeQuietly(closeable);
+    closeQuietly(socket);
   }
 
   public HttpCodec codec() {
@@ -232,20 +232,20 @@ public final class StreamAllocation {
   }
 
   public void release() {
-    Closeable closeable;
+    Socket socket;
     synchronized (connectionPool) {
-      closeable = deallocate(false, true, false);
+      socket = deallocate(false, true, false);
     }
-    closeQuietly(closeable);
+    closeQuietly(socket);
   }
 
   /** Forbid new streams from being created on the connection that hosts this allocation. */
   public void noNewStreams() {
-    Closeable closeable;
+    Socket socket;
     synchronized (connectionPool) {
-      closeable = deallocate(true, false, false);
+      socket = deallocate(true, false, false);
     }
-    closeQuietly(closeable);
+    closeQuietly(socket);
   }
 
   /**
@@ -255,7 +255,7 @@ public final class StreamAllocation {
    * <p>Returns a closeable that the caller should pass to {@link Util#closeQuietly} upon completion
    * of the synchronized block. (We don't do I/O while synchronized on the connection pool.)
    */
-  private Closeable deallocate(boolean noNewStreams, boolean released, boolean streamFinished) {
+  private Socket deallocate(boolean noNewStreams, boolean released, boolean streamFinished) {
     assert (Thread.holdsLock(connectionPool));
 
     if (streamFinished) {
@@ -264,7 +264,7 @@ public final class StreamAllocation {
     if (released) {
       this.released = true;
     }
-    Closeable closeable = null;
+    Socket socket = null;
     if (connection != null) {
       if (noNewStreams) {
         connection.noNewStreams = true;
@@ -274,13 +274,13 @@ public final class StreamAllocation {
         if (connection.allocations.isEmpty()) {
           connection.idleAtNanos = System.nanoTime();
           if (Internal.instance.connectionBecameIdle(connectionPool, connection)) {
-            closeable = connection.socket();
+            socket = connection.socket();
           }
         }
         connection = null;
       }
     }
-    return closeable;
+    return socket;
   }
 
   public void cancel() {
@@ -299,7 +299,7 @@ public final class StreamAllocation {
   }
 
   public void streamFailed(IOException e) {
-    Closeable closeable;
+    Socket socket;
     boolean noNewStreams = false;
 
     synchronized (connectionPool) {
@@ -326,10 +326,10 @@ public final class StreamAllocation {
           route = null;
         }
       }
-      closeable = deallocate(noNewStreams, false, true);
+      socket = deallocate(noNewStreams, false, true);
     }
 
-    closeQuietly(closeable);
+    closeQuietly(socket);
   }
 
   /**
@@ -364,19 +364,19 @@ public final class StreamAllocation {
    * <p>Returns a closeable that the caller should pass to {@link Util#closeQuietly} upon completion
    * of the synchronized block. (We don't do I/O while synchronized on the connection pool.)
    */
-  public Closeable releaseAndAcquire(RealConnection newConnection) {
+  public Socket releaseAndAcquire(RealConnection newConnection) {
     assert (Thread.holdsLock(connectionPool));
     if (codec != null || connection.allocations.size() != 1) throw new IllegalStateException();
 
     // Release the old connection.
     Reference<StreamAllocation> onlyAllocation = connection.allocations.get(0);
-    Closeable closeable = deallocate(true, false, false);
+    Socket socket = deallocate(true, false, false);
 
     // Acquire the new connection.
     this.connection = newConnection;
     newConnection.allocations.add(onlyAllocation);
 
-    return closeable;
+    return socket;
   }
 
   public boolean hasMoreRoutes() {


### PR DESCRIPTION
Versions prior to Android 4.4 (aka Java 6) did not have Socket implementing Closeable.

Closes #3124.