### PR TITLE
Recover from a severe cache initialization failure.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/cache/DiskLruCacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/cache/DiskLruCacheTest.java
@@ -94,9 +94,7 @@ public final class DiskLruCacheTest {
     assertJournalEquals();
   }
 
-  @Test
-  @Ignore
-  public void recoverFromInitializationFailure() throws IOException {
+  @Test public void recoverFromInitializationFailure() throws IOException {
     // Add an uncommitted entry. This will get detected on initialization, and the cache will
     // attempt to delete the file. Do not explicitly close the cache here so the entry is left as
     // incomplete.
@@ -105,7 +103,7 @@ public final class DiskLruCacheTest {
     sink.writeUtf8("Hello");
     sink.close();
 
-    // Simulate a filesystem failure on the first initialization.
+    // Simulate a severe filesystem failure on the first initialization.
     fileSystem.setFaultyDelete(new File(cacheDir, "k1.0.tmp"), true);
     fileSystem.setFaultyDelete(cacheDir, true);
 
@@ -115,7 +113,7 @@ public final class DiskLruCacheTest {
     try {
       cache.get("k1");
       fail();
-    } catch (Exception expected) {
+    } catch (IOException expected) {
     }
 
     // Now let it operate normally.

--- a/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.java
@@ -231,7 +231,13 @@ public final class DiskLruCache implements Closeable, Flushable {
       } catch (IOException journalIsCorrupt) {
         Platform.get().log(WARN, "DiskLruCache " + directory + " is corrupt: "
             + journalIsCorrupt.getMessage() + ", removing", journalIsCorrupt);
+      }
+
+      // The cache is corrupted, attempt to delete the contents of the directory. This can throw and
+      // we'll let that propagate out as it likely means there is a severe filesystem problem.
+      try {
         delete();
+      } finally {
         closed = false;
       }
     }


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/3115