### PR TITLE
junit 5 compatibility for MockWebServer

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -76,9 +76,7 @@ import okio.ByteString;
 import okio.Okio;
 import okio.Sink;
 import okio.Timeout;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+import org.junit.rules.ExternalResource;
 
 import static okhttp3.internal.Util.closeQuietly;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
@@ -98,7 +96,7 @@ import static okhttp3.mockwebserver.SocketPolicy.UPGRADE_TO_SSL_AT_END;
  * A scriptable web server. Callers supply canned responses and the server replays them upon request
  * in sequence.
  */
-public final class MockWebServer implements TestRule, Closeable {
+public final class MockWebServer extends ExternalResource implements Closeable {
   static {
     Internal.initializeInstanceForTests();
   }
@@ -142,7 +140,7 @@ public final class MockWebServer implements TestRule, Closeable {
 
   private boolean started;
 
-  private synchronized void maybeStart() {
+  protected synchronized void before() {
     if (started) return;
     try {
       start();
@@ -151,35 +149,18 @@ public final class MockWebServer implements TestRule, Closeable {
     }
   }
 
-  @Override public Statement apply(final Statement base, Description description) {
-    return new Statement() {
-      @Override public void evaluate() throws Throwable {
-        maybeStart();
-        try {
-          base.evaluate();
-        } finally {
-          try {
-            shutdown();
-          } catch (IOException e) {
-            logger.log(Level.WARNING, "MockWebServer shutdown failed", e);
-          }
-        }
-      }
-    };
-  }
-
   public int getPort() {
-    maybeStart();
+    before();
     return port;
   }
 
   public String getHostName() {
-    maybeStart();
+    before();
     return inetSocketAddress.getHostName();
   }
 
   public Proxy toProxyAddress() {
-    maybeStart();
+    before();
     InetSocketAddress address = new InetSocketAddress(inetSocketAddress.getAddress(), getPort());
     return new Proxy(Proxy.Type.HTTP, address);
   }
@@ -395,6 +376,14 @@ public final class MockWebServer implements TestRule, Closeable {
       }
     } catch (InterruptedException e) {
       throw new AssertionError();
+    }
+  }
+
+  public synchronized void after() {
+    try {
+      shutdown();
+    } catch (IOException e) {
+      logger.log(Level.WARNING, "MockWebServer shutdown failed", e);
     }
   }
 

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -140,7 +140,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
 
   private boolean started;
 
-  protected synchronized void before() {
+  @Override protected synchronized void before() {
     if (started) return;
     try {
       start();
@@ -379,7 +379,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
     }
   }
 
-  public synchronized void after() {
+  @Override protected synchronized void after() {
     try {
       shutdown();
     } catch (IOException e) {


### PR DESCRIPTION
Junit 5 support for MockWebServer via extending a known base class.

http://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4-rulesupport