### PR TITLE
Fix a thread leak in MockWebServer's web socket tests.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -15,14 +15,11 @@
  */
 package okhttp3;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Authenticator;
 import java.net.ConnectException;
-import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.HttpRetryException;
 import java.net.HttpURLConnection;
@@ -38,7 +35,6 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
-import java.nio.charset.Charset;
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -81,7 +77,6 @@ import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -52,9 +52,13 @@ public final class RealWebSocketTest {
     server.initWebSocket(random, 0);
   }
 
-  @After public void tearDown() {
+  @After public void tearDown() throws Exception {
     client.listener.assertExhausted();
     server.listener.assertExhausted();
+    server.source.close();
+    client.source.close();
+    server.webSocket.tearDown();
+    client.webSocket.tearDown();
   }
 
   @Test public void close() throws IOException {

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -284,6 +284,17 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
     executor.awaitTermination(timeout, timeUnit);
   }
 
+  /**
+   * For testing: force this web socket to release its threads.
+   */
+  void tearDown() throws InterruptedException {
+    if (cancelFuture != null) {
+      cancelFuture.cancel(false);
+    }
+    executor.shutdown();
+    executor.awaitTermination(10, TimeUnit.SECONDS);
+  }
+
   synchronized int pingCount() {
     return pingCount;
   }
@@ -517,7 +528,7 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
     }
   }
 
-  void failWebSocket(Exception e, Response response) {
+  public void failWebSocket(Exception e, Response response) {
     Streams streamsToClose;
     synchronized (this) {
       if (failed) return; // Already failed.


### PR DESCRIPTION
We were creating threads and not shutting them down as eagerly as we could have.