### PR TITLE
Confirm top-level domain cookie matching.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CookieTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CookieTest.java
@@ -228,6 +228,13 @@ public final class CookieTest {
     assertFalse(cookie.matches(HttpUrl.parse("http://square.com")));
   }
 
+  @Test public void topLevelDomainMatches() {
+    Cookie cookie = Cookie.parse(url, "a=b; domain=com");
+    assertTrue(cookie.matches(HttpUrl.parse("http://example.com")));
+    assertTrue(cookie.matches(HttpUrl.parse("http://www.example.com")));
+    assertTrue(cookie.matches(HttpUrl.parse("http://square.com")));
+  }
+
   /** Ignore an optional leading `.` in the domain. */
   @Test public void domainMatchesIgnoresLeadingDot() throws Exception {
     Cookie cookie = Cookie.parse(url, "a=b; domain=.example.com");


### PR DESCRIPTION
I'm attempting to make my way through RFC 6265 and stumbled on this. Apparently, there is no algorithmic way to figure this out, so "_the list_" was created https://publicsuffix.org/.

I'm wondering if any action should be taken here. I came up with 3 options:

1. Don't bother: most applications know the origin server, so there is minimal risk.
2. Make it optional: Give users the option of adding a separate dependency that maintains this list. That way, users who don't use the functionality won't incur the cost, but those who do have an option.
3. Include it: This will increase the size of the library and add a size cost to those who don't use the functionality.