### PR TITLE
Do not fall back to COMPATIBLE_TLS (TLSv1) by default.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
@@ -143,8 +143,16 @@ public final class RecordedResponse {
     return new RecordedResponse(cacheResponse.request(), cacheResponse, null, null, null);
   }
 
-  public RecordedResponse assertFailure(Class<?> exceptionClass) {
-    assertTrue(exceptionClass.isInstance(failure));
+  public RecordedResponse assertFailure(Class<?>... allowedExceptionTypes) {
+    boolean found = false;
+    for (Class expectedClass : allowedExceptionTypes) {
+      if (expectedClass.isInstance(failure)) {
+        found = true;
+        break;
+      }
+    }
+    assertTrue("Expected exception type among " + Arrays.toString(allowedExceptionTypes)
+            + ", got " + failure, found);
     return this;
   }
 

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -123,7 +123,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       Protocol.HTTP_2, Protocol.HTTP_1_1);
 
   static final List<ConnectionSpec> DEFAULT_CONNECTION_SPECS = Util.immutableList(
-      ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS, ConnectionSpec.CLEARTEXT);
+      ConnectionSpec.MODERN_TLS, ConnectionSpec.CLEARTEXT);
 
   static {
     Internal.instance = new Internal() {


### PR DESCRIPTION
Insecure TLS version fallback is a compatibility workaround to connect
to servers that do not implement TLS protocol version negotiation
correctly; it is vulnerable to man-in-the-middle-attacks (POODLE).
Support for TLS version fallback was removed in Firefox 37 (Mar 2015)
and Chrome 50 (Apr 2016). As of late 2015, fewer than 0.01% of web
servers relied on protocol fallback.

After this commit, OkHttp still supports TLS version fallback, but it
is now opt-in rather than opt-out.

Existing tests for fallback functionality were modified to opt-in
to the fallback; new tests in CallTest and URLConnectionTest
assert that no fallback happens by default (when not opted-in).