### PR TITLE
Ignore illegal chars to avoid IllegalArgumentException

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/FormBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/FormBodyTest.java
@@ -184,6 +184,14 @@ public final class FormBodyTest {
     assertEquals("%7F", formEncode(127));
     assertEquals("%C2%80", formEncode(128));
     assertEquals("%C3%BF", formEncode(255));
+    //check illegal surrogate chars
+    assertEquals("%ED%9F%BF", formEncode(0xD7FF));
+    assertEquals("?", formEncode(0xD800));
+    assertEquals("?", formEncode(0xDFFF));
+    assertEquals("%EE%80%80", formEncode(0xE000));
+    assertEquals("%EF%BF%BF", formEncode(0xFFFF));
+    assertEquals("%F4%8F%BF%BF", formEncode(0x10FFFF));
+    assertEquals("?", formEncode(0xD83D));
   }
 
   private String formEncode(int codePoint) throws IOException {

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -1787,8 +1787,9 @@ public final class HttpUrl {
     return -1;
   }
 
-  private static boolean isValidCode(int codePoint) {
-    return codePoint < 0xd800 || codePoint > 0xdfff && codePoint <= 0x10ffff;
+  private static boolean isValidCodePoint(int codePoint) {
+    return Character.isValidCodePoint(codePoint)
+            && !Character.isSurrogate((char) codePoint);
   }
 
   /**
@@ -1814,7 +1815,7 @@ public final class HttpUrl {
       codePoint = input.codePointAt(i);
       if (codePoint < 0x20
           || codePoint == 0x7f
-          || codePoint >= 0x80 && asciiOnly && isValidCode(codePoint)
+          || codePoint >= 0x80 && asciiOnly && isValidCodePoint(codePoint)
           || encodeSet.indexOf(codePoint) != -1
           || codePoint == '%' && (!alreadyEncoded || strict && !percentEncoded(input, i, limit))
           || codePoint == '+' && plusIsSpace) {
@@ -1845,7 +1846,7 @@ public final class HttpUrl {
         out.writeUtf8(alreadyEncoded ? "+" : "%2B");
       } else if (codePoint < 0x20
           || codePoint == 0x7f
-          || codePoint >= 0x80 && asciiOnly && isValidCode(codePoint)
+          || codePoint >= 0x80 && asciiOnly && isValidCodePoint(codePoint)
           || encodeSet.indexOf(codePoint) != -1
           || codePoint == '%' && (!alreadyEncoded || strict && !percentEncoded(input, i, limit))) {
         // Percent encode this character.
@@ -1859,7 +1860,7 @@ public final class HttpUrl {
           out.writeByte(HEX_DIGITS[(b >> 4) & 0xf]);
           out.writeByte(HEX_DIGITS[b & 0xf]);
         }
-      } else if (isValidCode(codePoint)) {
+      } else if (isValidCodePoint(codePoint)) {
         // This character doesn't need encoding. Just copy it over.
         out.writeUtf8CodePoint(codePoint);
       }

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -1787,6 +1787,11 @@ public final class HttpUrl {
     return -1;
   }
 
+  private static boolean isValidCode(int codePoint) {
+    return (codePoint < 0xd800 || codePoint > 0xdfff)
+            && codePoint <= 0x10ffff;
+  }
+
   /**
    * Returns a substring of {@code input} on the range {@code [pos..limit)} with the following
    * transformations:
@@ -1810,7 +1815,7 @@ public final class HttpUrl {
       codePoint = input.codePointAt(i);
       if (codePoint < 0x20
           || codePoint == 0x7f
-          || codePoint >= 0x80 && asciiOnly
+          || codePoint >= 0x80 && asciiOnly && isValidCode(codePoint)
           || encodeSet.indexOf(codePoint) != -1
           || codePoint == '%' && (!alreadyEncoded || strict && !percentEncoded(input, i, limit))
           || codePoint == '+' && plusIsSpace) {
@@ -1841,7 +1846,7 @@ public final class HttpUrl {
         out.writeUtf8(alreadyEncoded ? "+" : "%2B");
       } else if (codePoint < 0x20
           || codePoint == 0x7f
-          || codePoint >= 0x80 && asciiOnly
+          || codePoint >= 0x80 && asciiOnly && isValidCode(codePoint)
           || encodeSet.indexOf(codePoint) != -1
           || codePoint == '%' && (!alreadyEncoded || strict && !percentEncoded(input, i, limit))) {
         // Percent encode this character.
@@ -1855,7 +1860,7 @@ public final class HttpUrl {
           out.writeByte(HEX_DIGITS[(b >> 4) & 0xf]);
           out.writeByte(HEX_DIGITS[b & 0xf]);
         }
-      } else {
+      } else if (isValidCode(codePoint)) {
         // This character doesn't need encoding. Just copy it over.
         out.writeUtf8CodePoint(codePoint);
       }

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -1789,7 +1789,7 @@ public final class HttpUrl {
 
   private static boolean isValidCodePoint(int codePoint) {
     return Character.isValidCodePoint(codePoint)
-            && !Character.isSurrogate((char) codePoint);
+            && codePoint < 0xd800 || codePoint > 0xdfff;
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -1788,8 +1788,7 @@ public final class HttpUrl {
   }
 
   private static boolean isValidCode(int codePoint) {
-    return (codePoint < 0xd800 || codePoint > 0xdfff)
-            && codePoint <= 0x10ffff;
+    return codePoint < 0xd800 || codePoint > 0xdfff && codePoint <= 0x10ffff;
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -1789,7 +1789,7 @@ public final class HttpUrl {
 
   private static boolean isValidCodePoint(int codePoint) {
     return Character.isValidCodePoint(codePoint)
-            && codePoint < 0xd800 || codePoint > 0xdfff;
+            && (codePoint < 0xd800 || codePoint > 0xdfff);
   }
 
   /**


### PR DESCRIPTION
This should fix the issue expressed here: [#3171](https://github.com/square/okhttp/issues/3171)