### PR TITLE
HTTP/2 reject DATA frame on streamId is zero

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2Test.java
@@ -392,6 +392,23 @@ public final class Http2Test {
     });
   }
 
+  @Test public void dataFrameNotAssociateWithStream() throws IOException {
+    byte[] payload = new byte[] {0x01, 0x02};
+
+    writeMedium(frame, payload.length);
+    frame.writeByte(Http2.TYPE_DATA);
+    frame.writeByte(Http2.FLAG_NONE);
+    frame.writeInt(0);
+    frame.write(payload);
+
+    try {
+      reader.nextFrame(false, new BaseTestHandler());
+      fail();
+    } catch (IOException e) {
+      assertEquals("PROTOCOL_ERROR: TYPE_DATA streamId == 0", e.getMessage());
+    }
+  }
+
   /** We do not send SETTINGS_COMPRESS_DATA = 1, nor want to. Let's make sure we error. */
   @Test public void compressedDataFrameWhenSettingDisabled() throws IOException {
     byte[] expectedData = new byte[Http2.INITIAL_MAX_FRAME_SIZE];

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Reader.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Reader.java
@@ -199,6 +199,8 @@ final class Http2Reader implements Closeable {
 
   private void readData(Handler handler, int length, byte flags, int streamId)
       throws IOException {
+    if (streamId == 0) throw ioException("PROTOCOL_ERROR: TYPE_DATA streamId == 0");
+
     // TODO: checkState open or half-closed (local) or raise STREAM_CLOSED
     boolean inFinished = (flags & FLAG_END_STREAM) != 0;
     boolean gzipped = (flags & FLAG_COMPRESSED) != 0;


### PR DESCRIPTION
This is my first PR to this repository!

When I had run some tests with tool that will check about http2 spec violation,
I found that when okhttp client didn't handle well when received DATA frame on streamId=0

##### Scenario
sending DATA(streamId=0) frame to okhttp client with a custom mock server

##### Expected
okhttp client should treat it as connection error with type PROTOCOL_ERROR

##### Actual
okhttp send RST_STREAM on streamId=0

##### Reference
[rfc7540#section-6.1](https://tools.ietf.org/html/rfc7540#section-6.1)
> DATA frames MUST be associated with a stream.  If a DATA frame is
   received whose stream identifier field is 0x0, the recipient MUST
   respond with a connection error (Section 5.4.1) of type
   PROTOCOL_ERROR.