### PR TITLE
MockWebServer: Expose request URL as HttpUrl

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
@@ -20,6 +20,7 @@ import java.net.Socket;
 import java.util.List;
 import javax.net.ssl.SSLSocket;
 import okhttp3.Headers;
+import okhttp3.HttpUrl;
 import okhttp3.TlsVersion;
 import okio.Buffer;
 
@@ -34,6 +35,7 @@ public final class RecordedRequest {
   private final Buffer body;
   private final int sequenceNumber;
   private final TlsVersion tlsVersion;
+  private final HttpUrl requestUrl;
 
   public RecordedRequest(String requestLine, Headers headers, List<Integer> chunkSizes,
       long bodySize, Buffer body, int sequenceNumber, Socket socket) {
@@ -52,10 +54,20 @@ public final class RecordedRequest {
       int pathEnd = requestLine.indexOf(' ', methodEnd + 1);
       this.method = requestLine.substring(0, methodEnd);
       this.path = requestLine.substring(methodEnd + 1, pathEnd);
+
+      String scheme = socket instanceof SSLSocket ? "https" : "http";
+      String hostname = socket.getInetAddress().getHostName();
+      int port = socket.getLocalPort();
+      this.requestUrl = HttpUrl.parse(String.format("%s://%s:%s%s", scheme, hostname, port, path));
     } else {
+      this.requestUrl = null;
       this.method = null;
       this.path = null;
     }
+  }
+
+  public HttpUrl getRequestUrl() {
+    return requestUrl;
   }
 
   public String getRequestLine() {


### PR DESCRIPTION
It might be helpful for example when dealing with lots of query parameters in tests because all the URL parsing facilities from `HttpUrl` can be reused.  I'm not sure that the suggested change is the best possible solution and I'm open for suggestions.