### PR TITLE
API to OkHttpClient to specify an event listener or event listener factory

### DIFF
--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -26,6 +26,13 @@ import java.util.List;
 public class EventListener {
   public static final EventListener NULL_EVENT_LISTENER = new EventListener() {
   };
+  public static final EventListener.Factory constantFactory(final EventListener listener) {
+    return new EventListener.Factory() {
+      public EventListener create(Call call) {
+        return listener;
+      }
+    };
+  }
 
   public void fetchStart(Call call) {
   }

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -216,6 +216,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
   final int readTimeout;
   final int writeTimeout;
   final int pingInterval;
+  final EventListener eventListener;
   final EventListener.Factory eventListenerFactory;
 
   public OkHttpClient() {
@@ -234,6 +235,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     this.cache = builder.cache;
     this.internalCache = builder.internalCache;
     this.socketFactory = builder.socketFactory;
+    this.eventListener = builder.eventListener;
     this.eventListenerFactory = builder.eventListenerFactory;
 
     boolean isTLS = false;

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -216,7 +216,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
   final int readTimeout;
   final int writeTimeout;
   final int pingInterval;
-  final EventListener eventListener;
   final EventListener.Factory eventListenerFactory;
 
   public OkHttpClient() {
@@ -235,7 +234,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     this.cache = builder.cache;
     this.internalCache = builder.internalCache;
     this.socketFactory = builder.socketFactory;
-    this.eventListener = builder.eventListener;
     this.eventListenerFactory = builder.eventListenerFactory;
 
     boolean isTLS = false;

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -216,7 +216,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
   final int readTimeout;
   final int writeTimeout;
   final int pingInterval;
-  final EventListener eventListener;
   final EventListener.Factory eventListenerFactory;
 
   public OkHttpClient() {
@@ -235,7 +234,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     this.cache = builder.cache;
     this.internalCache = builder.internalCache;
     this.socketFactory = builder.socketFactory;
-    this.eventListener = builder.eventListener;
     this.eventListenerFactory = builder.eventListenerFactory;
 
     boolean isTLS = false;
@@ -408,10 +406,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     return networkInterceptors;
   }
 
-  public EventListener eventListener() {
-    return eventListener;
-  }
-
   public EventListener.Factory eventListenerFactory() {
     return eventListenerFactory;
   }
@@ -463,7 +457,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     int readTimeout;
     int writeTimeout;
     int pingInterval;
-    EventListener eventListener;
     EventListener.Factory eventListenerFactory;
 
     public Builder() {
@@ -486,8 +479,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       readTimeout = 10_000;
       writeTimeout = 10_000;
       pingInterval = 0;
-      eventListener = EventListener.NULL_EVENT_LISTENER;
-      eventListenerFactory = null;
+      eventListenerFactory = EventListener.constantFactory(EventListener.NULL_EVENT_LISTENER);
     }
 
     Builder(OkHttpClient okHttpClient) {
@@ -517,7 +509,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       this.readTimeout = okHttpClient.readTimeout;
       this.writeTimeout = okHttpClient.writeTimeout;
       this.pingInterval = okHttpClient.pingInterval;
-      this.eventListener = okHttpClient.eventListener;
       this.eventListenerFactory = okHttpClient.eventListenerFactory;
     }
 
@@ -896,13 +887,17 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       return this;
     }
 
-    public Builder addEventListener(EventListener listener) {
-      eventListener = listener;
+    public Builder setEventListener(EventListener eventListener) {
+      if (eventListener == null) throw new NullPointerException("eventListener == null");
+      this.eventListenerFactory = EventListener.constantFactory(eventListener);
       return this;
     }
 
-    public Builder addEventListenerFactory(EventListener.Factory listenerFactory) {
-      eventListenerFactory = listenerFactory;
+    public Builder setEventListenerFactory(EventListener.Factory eventListenerFactory) {
+      if (eventListenerFactory == null) {
+        throw new NullPointerException("eventListenerFactory == null");
+      }
+      this.eventListenerFactory = eventListenerFactory;
       return this;
     }
 

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -216,6 +216,8 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
   final int readTimeout;
   final int writeTimeout;
   final int pingInterval;
+  final EventListener eventListener;
+  final EventListener.Factory eventListenerFactory;
 
   public OkHttpClient() {
     this(new Builder());
@@ -233,6 +235,8 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     this.cache = builder.cache;
     this.internalCache = builder.internalCache;
     this.socketFactory = builder.socketFactory;
+    this.eventListener = builder.eventListener;
+    this.eventListenerFactory = builder.eventListenerFactory;
 
     boolean isTLS = false;
     for (ConnectionSpec spec : connectionSpecs) {
@@ -404,6 +408,14 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     return networkInterceptors;
   }
 
+  public EventListener eventListener() {
+    return eventListener;
+  }
+
+  public EventListener.Factory eventListenerFactory() {
+    return eventListenerFactory;
+  }
+
   /**
    * Prepares the {@code request} to be executed at some point in the future.
    */
@@ -451,6 +463,8 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     int readTimeout;
     int writeTimeout;
     int pingInterval;
+    EventListener eventListener;
+    EventListener.Factory eventListenerFactory;
 
     public Builder() {
       dispatcher = new Dispatcher();
@@ -472,6 +486,8 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       readTimeout = 10_000;
       writeTimeout = 10_000;
       pingInterval = 0;
+      eventListener = EventListener.NULL_EVENT_LISTENER;
+      eventListenerFactory = null;
     }
 
     Builder(OkHttpClient okHttpClient) {
@@ -501,6 +517,8 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       this.readTimeout = okHttpClient.readTimeout;
       this.writeTimeout = okHttpClient.writeTimeout;
       this.pingInterval = okHttpClient.pingInterval;
+      this.eventListener = okHttpClient.eventListener;
+      this.eventListenerFactory = okHttpClient.eventListenerFactory;
     }
 
     /**
@@ -875,6 +893,16 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
 
     public Builder addNetworkInterceptor(Interceptor interceptor) {
       networkInterceptors.add(interceptor);
+      return this;
+    }
+
+    public Builder addEventListener(EventListener listener) {
+      eventListener = listener;
+      return this;
+    }
+
+    public Builder addEventListenerFactory(EventListener.Factory listenerFactory) {
+      eventListenerFactory = listenerFactory;
       return this;
     }
 

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -33,6 +33,7 @@ import static okhttp3.internal.platform.Platform.INFO;
 final class RealCall implements Call {
   final OkHttpClient client;
   final RetryAndFollowUpInterceptor retryAndFollowUpInterceptor;
+  final EventListener eventListener;
 
   /** The application's original request unadulterated by redirects or auth headers. */
   final Request originalRequest;
@@ -42,10 +43,17 @@ final class RealCall implements Call {
   private boolean executed;
 
   RealCall(OkHttpClient client, Request originalRequest, boolean forWebSocket) {
+    final EventListener.Factory eventListenerFactory = client.eventListenerFactory();
+
     this.client = client;
     this.originalRequest = originalRequest;
     this.forWebSocket = forWebSocket;
     this.retryAndFollowUpInterceptor = new RetryAndFollowUpInterceptor(client, forWebSocket);
+    if (null == eventListenerFactory) {
+      this.eventListener = client.eventListener();
+    } else {
+      this.eventListener = eventListenerFactory.create(this);
+    }
   }
 
   @Override public Request request() {

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -49,7 +49,11 @@ final class RealCall implements Call {
     this.originalRequest = originalRequest;
     this.forWebSocket = forWebSocket;
     this.retryAndFollowUpInterceptor = new RetryAndFollowUpInterceptor(client, forWebSocket);
-    this.eventListener = eventListenerFactory.create(this);
+    if (null == eventListenerFactory) {
+      this.eventListener = client.eventListener();
+    } else {
+      this.eventListener = eventListenerFactory.create(this);
+    }
   }
 
   @Override public Request request() {

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -49,11 +49,7 @@ final class RealCall implements Call {
     this.originalRequest = originalRequest;
     this.forWebSocket = forWebSocket;
     this.retryAndFollowUpInterceptor = new RetryAndFollowUpInterceptor(client, forWebSocket);
-    if (null == eventListenerFactory) {
-      this.eventListener = client.eventListener();
-    } else {
-      this.eventListener = eventListenerFactory.create(this);
-    }
+    this.eventListener = eventListenerFactory.create(this);
   }
 
   @Override public Request request() {


### PR DESCRIPTION
Related to the discussion in #270, this stakes out an API  that could be used to add
Zipkin or other traces to OkHttp requests.

Step one from https://github.com/square/okhttp/pull/3149#issuecomment-277298784