### PR TITLE
Fix canonicalization of IPv6 addresses in HttpUrl

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
@@ -491,9 +491,14 @@ public final class HttpUrlTest {
     assertEquals("a::b:0:0:0", HttpUrl.parse("http://[a:0:0:0:b:0:0:0]/").host());
     assertEquals("::a:b:0:0:0", HttpUrl.parse("http://[0:0:0:a:b:0:0:0]/").host());
     assertEquals("::a:0:0:0:b", HttpUrl.parse("http://[0:0:0:a:0:0:0:b]/").host());
-    assertEquals("::a:b:c:d:e:f:1", HttpUrl.parse("http://[0:a:b:c:d:e:f:1]/").host());
-    assertEquals("a:b:c:d:e:f:1::", HttpUrl.parse("http://[a:b:c:d:e:f:1:0]/").host());
+    assertEquals("0:a:b:c:d:e:f:1", HttpUrl.parse("http://[0:a:b:c:d:e:f:1]/").host());
+    assertEquals("a:b:c:d:e:f:1:0", HttpUrl.parse("http://[a:b:c:d:e:f:1:0]/").host());
     assertEquals("ff01::101", HttpUrl.parse("http://[FF01:0:0:0:0:0:0:101]/").host());
+    assertEquals("2001:db8::1", HttpUrl.parse("http://[2001:db8::1]/").host());
+    assertEquals("2001:db8::2:1", HttpUrl.parse("http://[2001:db8:0:0:0:0:2:1]/").host());
+    assertEquals("2001:db8:0:1:1:1:1:1", HttpUrl.parse("http://[2001:db8:0:1:1:1:1:1]/").host());
+    assertEquals("2001:db8::1:0:0:1", HttpUrl.parse("http://[2001:db8:0:0:1:0:0:1]/").host());
+    assertEquals("2001:0:0:1::1", HttpUrl.parse("http://[2001:0:0:1:0:0:0:1]/").host());
     assertEquals("1::", HttpUrl.parse("http://[1:0:0:0:0:0:0:0]/").host());
     assertEquals("::1", HttpUrl.parse("http://[0:0:0:0:0:0:0:1]/").host());
     assertEquals("::", HttpUrl.parse("http://[0:0:0:0:0:0:0:0]/").host());

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -1677,8 +1677,11 @@ public final class HttpUrl {
       return true; // Success.
     }
 
+    /** Encodes an IPv6 address in canonical form according to RFC 5952. */
     private static String inet6AddressToAscii(byte[] address) {
       // Go through the address looking for the longest run of 0s. Each group is 2-bytes.
+      // A run must be longer than one group (section 4.2.2).
+      // If there are multiple equal runs, the first one must be used (section 4.2.3).
       int longestRunOffset = -1;
       int longestRunLength = 0;
       for (int i = 0; i < address.length; i += 2) {
@@ -1687,7 +1690,7 @@ public final class HttpUrl {
           i += 2;
         }
         int currentRunLength = i - currentRunOffset;
-        if (currentRunLength > longestRunLength) {
+        if (currentRunLength > longestRunLength && currentRunLength >= 4) {
           longestRunOffset = currentRunOffset;
           longestRunLength = currentRunLength;
         }


### PR DESCRIPTION
Per RFC 5952, section 4.2.2, a single 16-bit field must not be shortened.
Improper canonicalization can break TLS hostname verification because
the canonicalized name will not match the server certificate.

This change adds the examples from the RFC to the tests.