### PR TITLE
Prevent NPE in Reponse#close() when body is null

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ResponseTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ResponseTest.java
@@ -24,6 +24,8 @@ import okio.Timeout;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public final class ResponseTest {
@@ -59,6 +61,19 @@ public final class ResponseTest {
     assertEquals("abcdef", response.body().string());
     assertEquals("abcd", p1.string());
     assertEquals("ab", p2.string());
+  }
+
+  @Test public void closeDoesNotThrowNPEIfBodyIsNull() throws Exception {
+    Response response = newResponse(null);
+    response.close();
+    assertNull(response.body());
+  }
+
+  @Test public void closingResponseTwiceSucceeds() throws Exception {
+    Response response = newResponse(responseBody("abcdef"));
+    assertNotNull(response.body());
+    response.close();
+    response.close();
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/Response.java
+++ b/okhttp/src/main/java/okhttp3/Response.java
@@ -270,7 +270,9 @@ public final class Response implements Closeable {
 
   /** Closes the response body. Equivalent to {@code body().close()}. */
   @Override public void close() {
-    body.close();
+    if (body != null) {
+      body.close();
+    }
   }
 
   @Override public String toString() {


### PR DESCRIPTION
The `Response#close()` method threw a `NullPointerException` if it was called and
the response body was `null`.

Since Response is `Closable` (and transitively `AutoClosable`), it should be possible
to use a `Response `object in a [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) block without thinking about whether
the `#close()` method would throw an exception in some cases.

**Examples:**

Before:

    Response response = client.newCall(call).execute();
    try {
      // do something with response
    } finally {
      if (response.body() != null) {
        response.close();
      }
    }

After:

    try (Response response = client.newCall(call).execute()) {
      // do something with response
    }