### PR TITLE
Invalidate the cache even if the response has no body.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -745,8 +745,8 @@ public final class CacheTest {
   }
 
   private void testRequestMethod(String requestMethod, boolean expectCached) throws Exception {
-    // 1. seed the cache (potentially)
-    // 2. expect a cache hit or miss
+    // 1. Seed the cache (potentially).
+    // 2. Expect a cache hit or miss.
     server.enqueue(new MockResponse()
         .addHeader("Expires: " + formatDate(1, TimeUnit.HOURS))
         .addHeader("X-Response-ID: 1"));
@@ -791,9 +791,9 @@ public final class CacheTest {
   }
 
   private void testMethodInvalidates(String requestMethod) throws Exception {
-    // 1. seed the cache
-    // 2. invalidate it
-    // 3. expect a cache miss
+    // 1. Seed the cache.
+    // 2. Invalidate it.
+    // 3. Expect a cache miss.
     server.enqueue(new MockResponse()
         .setBody("A")
         .addHeader("Expires: " + formatDate(1, TimeUnit.HOURS)));
@@ -817,9 +817,9 @@ public final class CacheTest {
   }
 
   @Test public void postInvalidatesCacheWithUncacheableResponse() throws Exception {
-    // 1. seed the cache
-    // 2. invalidate it with uncacheable response
-    // 3. expect a cache miss
+    // 1. Seed the cache.
+    // 2. Invalidate it with an uncacheable response.
+    // 3. Expect a cache miss.
     server.enqueue(new MockResponse()
         .setBody("A")
         .addHeader("Expires: " + formatDate(1, TimeUnit.HOURS)));
@@ -839,6 +839,33 @@ public final class CacheTest {
         .build();
     Response invalidate = client.newCall(request).execute();
     assertEquals("B", invalidate.body().string());
+
+    assertEquals("C", get(url).body().string());
+  }
+
+  @Test public void putInvalidatesWithNoContentResponse() throws Exception {
+    // 1. Seed the cache.
+    // 2. Invalidate it.
+    // 3. Expect a cache miss.
+    server.enqueue(new MockResponse()
+        .setBody("A")
+        .addHeader("Expires: " + formatDate(1, TimeUnit.HOURS)));
+    server.enqueue(new MockResponse()
+        .clearHeaders()
+        .setResponseCode(HttpURLConnection.HTTP_NO_CONTENT));
+    server.enqueue(new MockResponse()
+        .setBody("C"));
+
+    HttpUrl url = server.url("/");
+
+    assertEquals("A", get(url).body().string());
+
+    Request request = new Request.Builder()
+        .url(url)
+        .put(RequestBody.create(MediaType.parse("text/plain"), "foo"))
+        .build();
+    Response invalidate = client.newCall(request).execute();
+    assertEquals("", invalidate.body().string());
 
     assertEquals("C", get(url).body().string());
   }
@@ -908,8 +935,8 @@ public final class CacheTest {
   }
 
   @Test public void partialRangeResponsesDoNotCorruptCache() throws Exception {
-    // 1. request a range
-    // 2. request a full document, expecting a cache miss
+    // 1. Request a range.
+    // 2. Request a full document, expecting a cache miss.
     server.enqueue(new MockResponse()
         .setBody("AA")
         .setResponseCode(HttpURLConnection.HTTP_PARTIAL)

--- a/okhttp/src/main/java/okhttp3/CookieJar.java
+++ b/okhttp/src/main/java/okhttp3/CookieJar.java
@@ -22,7 +22,7 @@ import java.util.List;
  * Provides <strong>policy</strong> and <strong>persistence</strong> for HTTP cookies.
  *
  * <p>As policy, implementations of this interface are responsible for selecting which cookies to
- * accept and which to reject. A reasonable policy is to reject all cookies, though that may be
+ * accept and which to reject. A reasonable policy is to reject all cookies, though that may
  * interfere with session-based authentication schemes that require cookies.
  *
  * <p>As persistence, implementations of this interface must also provide storage of cookies. Simple

--- a/okhttp/src/main/java/okhttp3/internal/http2/Settings.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Settings.java
@@ -94,7 +94,6 @@ public final class Settings {
     return ((bit & set) != 0 ? values[ENABLE_PUSH] : defaultValue ? 1 : 0) == 1;
   }
 
-  // TODO: honor this setting.
   int getMaxConcurrentStreams(int defaultValue) {
     int bit = 1 << MAX_CONCURRENT_STREAMS;
     return (bit & set) != 0 ? values[MAX_CONCURRENT_STREAMS] : defaultValue;


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/3203