### PR TITLE
Fix WebSocketHttpTest.throwingOnMessageClosesImmediatelyAndFails().

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -203,7 +203,7 @@ public final class RealWebSocketTest {
     client.listener.assertFailure(ProtocolException.class, "Control frames must be final.");
 
     server.processNextFrame();
-    server.listener.assertFailure(EOFException.class, null);
+    server.listener.assertFailure(EOFException.class);
   }
 
   @Test public void protocolErrorInCloseResponseClosesConnection() throws IOException {
@@ -242,7 +242,7 @@ public final class RealWebSocketTest {
   @Test public void networkErrorReportedAsFailure() throws IOException {
     server.sink.close();
     client.processNextFrame();
-    client.listener.assertFailure(EOFException.class, null);
+    client.listener.assertFailure(EOFException.class);
   }
 
   @Test public void closeThrowingFailsConnection() throws IOException {

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -15,6 +15,7 @@
  */
 package okhttp3.internal.ws;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.ProtocolException;
 import java.net.SocketTimeoutException;
@@ -187,6 +188,7 @@ public final class WebSocketHttpTest {
 
     server.send("Hello, WebSockets!");
     clientListener.assertFailure(e);
+    serverListener.assertFailure(EOFException.class);
     serverListener.assertExhausted();
   }
 
@@ -465,7 +467,7 @@ public final class WebSocketHttpTest {
 
     WebSocket webSocket = newWebSocket();
 
-    clientListener.assertFailure(SocketTimeoutException.class, "timeout");
+    clientListener.assertFailure(SocketTimeoutException.class, "timeout", "Read timed out");
     assertFalse(webSocket.close(1000, null));
   }
 
@@ -487,7 +489,7 @@ public final class WebSocketHttpTest {
     WebSocket webSocket = newWebSocket();
     clientListener.assertOpen();
 
-    clientListener.assertFailure(SocketTimeoutException.class, "timeout");
+    clientListener.assertFailure(SocketTimeoutException.class, "timeout", "Read timed out");
     assertFalse(webSocket.close(1000, null));
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
@@ -16,6 +16,7 @@
 package okhttp3.internal.ws;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -183,7 +184,7 @@ public final class WebSocketRecorder extends WebSocketListener {
     assertSame(t, failure.t);
   }
 
-  public void assertFailure(Class<? extends IOException> cls, String message) {
+  public void assertFailure(Class<? extends IOException> cls, String... messages) {
     Object event = nextEvent();
     if (!(event instanceof Failure)) {
       throw new AssertionError("Expected Failure but was " + event);
@@ -191,7 +192,9 @@ public final class WebSocketRecorder extends WebSocketListener {
     Failure failure = (Failure) event;
     assertNull(failure.response);
     assertEquals(cls, failure.t.getClass());
-    assertEquals(message, failure.t.getMessage());
+    if (messages.length > 0) {
+      assertTrue(failure.t.getMessage(), Arrays.asList(messages).contains(failure.t.getMessage()));
+    }
   }
 
   public void assertFailure() {


### PR DESCRIPTION
The server will receive an EOFException when the client errors out.
But because that didn't usually happen immediately our test got away
with confirming there were no further events.

Also fix WebSocketHttpTest.readTimeoutAppliesToHttpRequest().

Closes: https://github.com/square/okhttp/issues/3228
Closes: https://github.com/square/okhttp/issues/3090