### PR TITLE
Hide EventListener from the public API for OkHttp 3.7.

### DIFF
--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -18,7 +18,8 @@ package okhttp3;
 import java.net.InetAddress;
 import java.util.List;
 
-public abstract class EventListener {
+// TODO(jwilson): make this public after the 3.7 release.
+abstract class EventListener {
   public static final EventListener NONE = new EventListener() {
   };
 

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -406,7 +406,8 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     return networkInterceptors;
   }
 
-  public EventListener.Factory eventListenerFactory() {
+  // TODO(jwilson): make this public after the 3.7 release.
+  /*public*/ EventListener.Factory eventListenerFactory() {
     return eventListenerFactory;
   }
 
@@ -887,13 +888,15 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       return this;
     }
 
-    public Builder eventListener(EventListener eventListener) {
+    // TODO(jwilson): make this public after the 3.7 release.
+    /*public*/ Builder eventListener(EventListener eventListener) {
       if (eventListener == null) throw new NullPointerException("eventListener == null");
       this.eventListenerFactory = EventListener.factory(eventListener);
       return this;
     }
 
-    public Builder eventListenerFactory(EventListener.Factory eventListenerFactory) {
+    // TODO(jwilson): make this public after the 3.7 release.
+    /*public*/ Builder eventListenerFactory(EventListener.Factory eventListenerFactory) {
       if (eventListenerFactory == null) {
         throw new NullPointerException("eventListenerFactory == null");
       }

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -49,6 +49,8 @@ final class RealCall implements Call {
     this.originalRequest = originalRequest;
     this.forWebSocket = forWebSocket;
     this.retryAndFollowUpInterceptor = new RetryAndFollowUpInterceptor(client, forWebSocket);
+
+    // TODO(jwilson): this is unsafe publication and not threadsafe.
     this.eventListener = eventListenerFactory.create(this);
   }
 


### PR DESCRIPTION
It isn't wired up yet.