### PR TITLE
Fix for HttpUrl's IPv6 tests 

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
@@ -426,11 +426,11 @@ public final class HttpUrlTest {
     assertEquals(null, HttpUrl.parse("http://[1:]"));
     assertEquals(null, HttpUrl.parse("http://[1:::]"));
     assertEquals(null, HttpUrl.parse("http://[1:::1]"));
-    assertEquals(null, HttpUrl.parse("http://[00000:0000:0000:0000::0000:0000:0000:0001]"));
+    assertEquals(null, HttpUrl.parse("http://[0000:0000:0000:0000::0000:0000:0000:0001]"));
   }
 
   @Test public void hostIpv6AddressTooManyGroups() throws Exception {
-    assertEquals(null, HttpUrl.parse("http://[00000:0000:0000:0000:0000:0000:0000:0000:0001]"));
+    assertEquals(null, HttpUrl.parse("http://[0000:0000:0000:0000:0000:0000:0000:0000:0001]"));
   }
 
   @Test public void hostIpv6AddressTooMuchCompression() throws Exception {


### PR DESCRIPTION
Looks like the tests were passing for an unintended reason!

```
$ mvn clean verify
[WARNING] Unable to locate Source XRef to link to - DISABLED
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] OkHttp (Parent) .................................... SUCCESS [  1.637 s]
[INFO] OkHttp ............................................. SUCCESS [  6.418 s]
[INFO] OkHttp test support classes ........................ SUCCESS [  0.790 s]
[INFO] MockWebServer ...................................... SUCCESS [  8.441 s]
[INFO] OkHttp URLConnection ............................... SUCCESS [ 10.314 s]
[INFO] OkHttp Tests ....................................... SUCCESS [01:43 min]
[INFO] OkHttp Android Platform Support .................... SUCCESS [ 10.469 s]
[INFO] OkHttp Apache HttpClient ........................... SUCCESS [  1.056 s]
[INFO] OkHttp Logging Interceptor ......................... SUCCESS [  0.987 s]
[INFO] OkCurl ............................................. SUCCESS [  1.732 s]
[INFO] Samples (Parent) ................................... SUCCESS [  0.003 s]
[INFO] Sample: Guide ...................................... SUCCESS [  0.392 s]
[INFO] Sample: Crawler .................................... SUCCESS [  0.242 s]
[INFO] Sample: Simple Client .............................. SUCCESS [  0.218 s]
[INFO] Sample: Slack ...................................... SUCCESS [  0.255 s]
[INFO] Sample: Static Server .............................. SUCCESS [  0.617 s]
[INFO] Benchmarks ......................................... SUCCESS [  0.526 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:28 min
[INFO] Finished at: 2017-04-15T21:57:01-07:00
[INFO] Final Memory: 122M/1113M
[INFO] ------------------------------------------------------------------------
```