### PR TITLE
Only make a single pass when removing protocols.

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -832,9 +832,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       }
 
       // Remove protocols that we no longer support.
-      if (protocols.contains(Protocol.SPDY_3)) {
-        protocols.remove(Protocol.SPDY_3);
-      }
+      protocols.remove(Protocol.SPDY_3);
 
       // Assign as an unmodifiable list. This is effectively immutable.
       this.protocols = Collections.unmodifiableList(protocols);


### PR DESCRIPTION
contains() is already iterating the list so we might as well just be doing the remove() operation on that pass.