### PR TITLE
Fix for EOFException if response body is empty

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -234,6 +234,11 @@ public final class HttpLoggingInterceptor implements Interceptor {
         logger.log("<-- END HTTP (encoded body omitted)");
       } else {
         BufferedSource source = responseBody.source();
+        if (source.buffer().size() == 0) {
+          logger.log("<-- END HTTP (" + buffer.size() + "-byte body)");
+          return response;
+        }
+		
         source.request(Long.MAX_VALUE); // Buffer the entire body.
         Buffer buffer = source.buffer();
 


### PR DESCRIPTION
When Level is set to BODY and the POST request response status is 200 and response body contains no content - EOFException is thrown. This code handles the situation and doe not try to print body if it is empty.