### PR TITLE
Forbid null for a handshake's TLS version.

### DIFF
--- a/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
+++ b/okhttp-android-support/src/main/java/okhttp3/internal/huc/JavaApiConverter.java
@@ -42,6 +42,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.TlsVersion;
 import okhttp3.internal.Internal;
 import okhttp3.internal.JavaNetHeaders;
 import okhttp3.internal.Util;
@@ -133,7 +134,7 @@ public final class JavaApiConverter {
 
       String cipherSuiteString = httpsUrlConnection.getCipherSuite();
       CipherSuite cipherSuite = CipherSuite.forJavaName(cipherSuiteString);
-      Handshake handshake = Handshake.get(null, cipherSuite,
+      Handshake handshake = Handshake.get(TlsVersion.SSL_3_0, cipherSuite,
           nullSafeImmutableList(peerCertificates), nullSafeImmutableList(localCertificates));
       okResponseBuilder.handshake(handshake);
     }
@@ -260,7 +261,8 @@ public final class JavaApiConverter {
 
       String cipherSuiteString = javaSecureCacheResponse.getCipherSuite();
       CipherSuite cipherSuite = CipherSuite.forJavaName(cipherSuiteString);
-      Handshake handshake = Handshake.get(null, cipherSuite, peerCertificates, localCertificates);
+      Handshake handshake = Handshake.get(
+          TlsVersion.SSL_3_0, cipherSuite, peerCertificates, localCertificates);
       okResponseBuilder.handshake(handshake);
     }
 

--- a/okhttp-android-support/src/test/java/okhttp3/internal/huc/JavaApiConverterTest.java
+++ b/okhttp-android-support/src/test/java/okhttp3/internal/huc/JavaApiConverterTest.java
@@ -47,6 +47,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.TlsVersion;
 import okhttp3.internal.Internal;
 import okhttp3.internal.Util;
 import okhttp3.mockwebserver.MockWebServer;
@@ -464,7 +465,7 @@ public class JavaApiConverterTest {
         .get()
         .url("https://secure/request")
         .build();
-    Handshake handshake = Handshake.get(null, CipherSuite.TLS_RSA_WITH_NULL_MD5,
+    Handshake handshake = Handshake.get(TlsVersion.SSL_3_0, CipherSuite.TLS_RSA_WITH_NULL_MD5,
         Arrays.<Certificate>asList(SERVER_CERT), Arrays.<Certificate>asList(LOCAL_CERT));
     Response okResponse = createArbitraryOkResponse(okRequest).newBuilder()
         .handshake(handshake)
@@ -554,7 +555,7 @@ public class JavaApiConverterTest {
             .post(createRequestBody("RequestBody"))
             .build();
     ResponseBody responseBody = createResponseBody("ResponseBody");
-    Handshake handshake = Handshake.get(null, CipherSuite.TLS_RSA_WITH_NULL_MD5,
+    Handshake handshake = Handshake.get(TlsVersion.SSL_3_0, CipherSuite.TLS_RSA_WITH_NULL_MD5,
         Arrays.<Certificate>asList(SERVER_CERT), Arrays.<Certificate>asList(LOCAL_CERT));
     Response okResponse = createArbitraryOkResponse(okRequest).newBuilder()
         .protocol(Protocol.HTTP_1_1)

--- a/okhttp/src/main/java/okhttp3/Cache.java
+++ b/okhttp/src/main/java/okhttp3/Cache.java
@@ -580,7 +580,7 @@ public final class Cache implements Closeable, Flushable {
           List<Certificate> localCertificates = readCertificateList(source);
           TlsVersion tlsVersion = !source.exhausted()
               ? TlsVersion.forJavaName(source.readUtf8LineStrict())
-              : null;
+              : TlsVersion.SSL_3_0;
           handshake = Handshake.get(tlsVersion, cipherSuite, peerCertificates, localCertificates);
         } else {
           handshake = null;
@@ -644,11 +644,7 @@ public final class Cache implements Closeable, Flushable {
             .writeByte('\n');
         writeCertList(sink, handshake.peerCertificates());
         writeCertList(sink, handshake.localCertificates());
-        // The handshake’s TLS version is null on HttpsURLConnection and on older cached responses.
-        if (handshake.tlsVersion() != null) {
-          sink.writeUtf8(handshake.tlsVersion().javaName())
-              .writeByte('\n');
-        }
+        sink.writeUtf8(handshake.tlsVersion().javaName()).writeByte('\n');
       }
       sink.close();
     }

--- a/okhttp/src/main/java/okhttp3/Handshake.java
+++ b/okhttp/src/main/java/okhttp3/Handshake.java
@@ -74,14 +74,15 @@ public final class Handshake {
 
   public static Handshake get(TlsVersion tlsVersion, CipherSuite cipherSuite,
       List<Certificate> peerCertificates, List<Certificate> localCertificates) {
+    if (tlsVersion == null) throw new NullPointerException("tlsVersion == null");
     if (cipherSuite == null) throw new NullPointerException("cipherSuite == null");
     return new Handshake(tlsVersion, cipherSuite, Util.immutableList(peerCertificates),
         Util.immutableList(localCertificates));
   }
 
   /**
-   * Returns the TLS version used for this connection. May return null if the response was cached
-   * with a version of OkHttp prior to 3.0.
+   * Returns the TLS version used for this connection. This value wasn't tracked prior to OkHttp
+   * 3.0. For responses cached by preceding versions this returns {@link TlsVersion#SSL_3_0}.
    */
   public TlsVersion tlsVersion() {
     return tlsVersion;
@@ -119,7 +120,7 @@ public final class Handshake {
   @Override public boolean equals(Object other) {
     if (!(other instanceof Handshake)) return false;
     Handshake that = (Handshake) other;
-    return Util.equal(cipherSuite, that.cipherSuite)
+    return tlsVersion.equals(that.tlsVersion)
         && cipherSuite.equals(that.cipherSuite)
         && peerCertificates.equals(that.peerCertificates)
         && localCertificates.equals(that.localCertificates);
@@ -127,7 +128,7 @@ public final class Handshake {
 
   @Override public int hashCode() {
     int result = 17;
-    result = 31 * result + (tlsVersion != null ? tlsVersion.hashCode() : 0);
+    result = 31 * result + tlsVersion.hashCode();
     result = 31 * result + cipherSuite.hashCode();
     result = 31 * result + peerCertificates.hashCode();
     result = 31 * result + localCertificates.hashCode();


### PR DESCRIPTION
This value is almost always non-null. The only exception is when it was
persisted by a version of OkHttp prior to 3.0.

Rather than accepting null, and forcing clients to handle that value,
I'm changing the API to reject null. I'm forcing a default of SSL_3_0
for responses that we don't have a version for. I don't anticipate this
causing problems in practice.