### PR TITLE
Forbid null for a response's message.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ResponseTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ResponseTest.java
@@ -95,6 +95,7 @@ public final class ResponseTest {
             .build())
         .protocol(Protocol.HTTP_1_1)
         .code(200)
+        .message("OK")
         .body(responseBody)
         .build();
   }

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -312,6 +312,7 @@ public final class RealWebSocketTest {
       String url = "http://example.com/websocket";
       Response response = new Response.Builder()
           .code(101)
+          .message("OK")
           .request(new Request.Builder().url(url).build())
           .protocol(Protocol.HTTP_1_1)
           .build();

--- a/okhttp/src/main/java/okhttp3/Response.java
+++ b/okhttp/src/main/java/okhttp3/Response.java
@@ -105,7 +105,7 @@ public final class Response implements Closeable {
     return code >= 200 && code < 300;
   }
 
-  /** Returns the HTTP status message or null if it is unknown. */
+  /** Returns the HTTP status message. */
   public String message() {
     return message;
   }
@@ -427,6 +427,7 @@ public final class Response implements Closeable {
       if (request == null) throw new IllegalStateException("request == null");
       if (protocol == null) throw new IllegalStateException("protocol == null");
       if (code < 0) throw new IllegalStateException("code < 0: " + code);
+      if (message == null) throw new IllegalStateException("message == null");
       return new Response(this);
     }
   }


### PR DESCRIPTION
This was only ever null in test code. Everything that parses responses from
the network gets a non-null value. The message may be empty.