### PR TITLE
Fix NullPointerException in BridgeInterceptor

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.java
@@ -82,7 +82,7 @@ public final class BridgeInterceptor implements Interceptor {
     }
 
     List<Cookie> cookies = cookieJar.loadForRequest(userRequest.url());
-    if (!cookies.isEmpty()) {
+    if (null != cookies && !cookies.isEmpty()) {
       requestBuilder.header("Cookie", cookieHeader(cookies));
     }
 


### PR DESCRIPTION
Fix NullPointerException when implementation of CookieJar’s loadForRequest() return null