### PR TITLE
Avoid index out of bounds with Http/2 settings id in the experimental range

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2Test.java
@@ -278,6 +278,21 @@ public final class Http2Test {
     assertEquals(settingValue.intValue(), 1);
   }
 
+  @Test public void readSettingsFrameExperimentalId() throws IOException {
+    writeMedium(frame, 6); // 2 for the code and 4 for the value
+    frame.writeByte(Http2.TYPE_SETTINGS);
+    frame.writeByte(Http2.FLAG_NONE);
+    frame.writeInt(0); // Settings are always on the connection stream 0.
+    frame.write(ByteString.decodeHex("f000")); // Id reserved for experimental use.
+    frame.writeInt(1);
+
+    reader.nextFrame(false, new BaseTestHandler() {
+      @Override public void settings(boolean clearPrevious, Settings settings) {
+        // no-op
+      }
+    });
+  }
+
   @Test public void readSettingsFrameNegativeWindowSize() throws IOException {
     writeMedium(frame, 6); // 2 for the code and 4 for the value
     frame.writeByte(Http2.TYPE_SETTINGS);

--- a/okhttp/src/main/java/okhttp3/internal/http2/Settings.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Settings.java
@@ -56,7 +56,7 @@ public final class Settings {
   }
 
   Settings set(int id, int value) {
-    if (id >= values.length) {
+    if (id < 0 || id >= values.length) {
       return this; // Discard unknown settings.
     }
 


### PR DESCRIPTION
Currently HTTP/2 setting ids in the [designated experimental range](http://httpwg.org/specs/rfc7540.html#iana-settings), `#f000` to `#ffff`, cause an index-out-of-bounds exception when consumed by `Http2Reader#readSettings`, as `readShort()` interprets the bytes as negative integers. This expands the out-of-bounds check in `Settings#set` to check for a negative index. Without the code change, the added test fails, demonstrating the bug.

I'm not fully familiar with OkHttp internals to know if this is the best approach for the fix, but it seemed better to add a PR with a repro case than just opening an issue. This popped up in gRPC Java (https://github.com/grpc/grpc-java/issues/3032), and extends the earlier fix from  https://github.com/square/okhttp/pull/2299.