### PR TITLE
Disallow creating Responses with no body.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ResponseTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ResponseTest.java
@@ -61,6 +61,39 @@ public final class ResponseTest {
     assertEquals("ab", p2.string());
   }
 
+  @Test public void responseBuilderValidates() throws Exception {
+    try {
+      newResponse(responseBody("")).newBuilder().request(null).build();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("request == null", expected.getMessage());
+    }
+    try {
+      newResponse(responseBody("")).newBuilder().protocol(null).build();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("protocol == null", expected.getMessage());
+    }
+    try {
+      newResponse(responseBody("")).newBuilder().code(-1).build();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("code < 0: -1", expected.getMessage());
+    }
+    try {
+      newResponse(responseBody("")).newBuilder().message(null).build();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("message == null", expected.getMessage());
+    }
+    try {
+      newResponse(null);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("body == null", expected.getMessage());
+    }
+  }
+
   /**
    * Returns a new response body that refuses to be read once it has been closed. This is true of
    * most {@link BufferedSource} instances, but not of {@link Buffer}.

--- a/okhttp/src/main/java/okhttp3/Response.java
+++ b/okhttp/src/main/java/okhttp3/Response.java
@@ -438,6 +438,7 @@ public final class Response implements Closeable {
       if (protocol == null) throw new IllegalStateException("protocol == null");
       if (code < 0) throw new IllegalStateException("code < 0: " + code);
       if (message == null) throw new IllegalStateException("message == null");
+      if (body == null) throw new IllegalStateException("body == null");
       return new Response(this);
     }
   }


### PR DESCRIPTION
via https://github.com/square/retrofit/issues/2362
Is there a valid use case for making synthetic cache responses, though?