### PR TITLE
Treat reading the public suffix list as uninterruptible.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/publicsuffix/PublicSuffixDatabaseTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/publicsuffix/PublicSuffixDatabaseTest.java
@@ -17,6 +17,7 @@ package okhttp3.internal.publicsuffix;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import okhttp3.internal.Util;
 import okio.Buffer;
 import okio.BufferedSource;
@@ -27,6 +28,7 @@ import org.junit.Test;
 import static okhttp3.internal.publicsuffix.PublicSuffixDatabase.PUBLIC_SUFFIX_RESOURCE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class PublicSuffixDatabaseTest {
@@ -143,6 +145,16 @@ public final class PublicSuffixDatabaseTest {
 
       String test = "foobar." + exception;
       assertEquals(exception, publicSuffixDatabase.getEffectiveTldPlusOne(test));
+    }
+  }
+
+  @Test public void threadIsInterruptedOnFirstRead() {
+    Thread.currentThread().interrupt();
+    try {
+      String result = publicSuffixDatabase.getEffectiveTldPlusOne("squareup.com");
+      assertEquals("squareup.com", result);
+    } finally {
+      assertTrue(Thread.interrupted());
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/publicsuffix/PublicSuffixDatabase.java
+++ b/okhttp/src/main/java/okhttp3/internal/publicsuffix/PublicSuffixDatabase.java
@@ -17,6 +17,7 @@ package okhttp3.internal.publicsuffix;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.net.IDN;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -106,7 +107,7 @@ public final class PublicSuffixDatabase {
 
   private String[] findMatchingRule(String[] domainLabels) {
     if (!listRead.get() && listRead.compareAndSet(false, true)) {
-      readTheList();
+      readTheListUninterruptibly();
     } else {
       try {
         readCompleteLatch.await();
@@ -275,30 +276,51 @@ public final class PublicSuffixDatabase {
     return match;
   }
 
-  private void readTheList() {
-    byte[] publicSuffixListBytes = null;
-    byte[] publicSuffixExceptionListBytes = null;
-
-    InputStream is = PublicSuffixDatabase.class.getClassLoader().getResourceAsStream(
-        PUBLIC_SUFFIX_RESOURCE);
-
-    if (is != null) {
-      BufferedSource bufferedSource = Okio.buffer(new GzipSource(Okio.source(is)));
-      try {
-        int totalBytes = bufferedSource.readInt();
-        publicSuffixListBytes = new byte[totalBytes];
-        bufferedSource.readFully(publicSuffixListBytes);
-
-        int totalExceptionBytes = bufferedSource.readInt();
-        publicSuffixExceptionListBytes = new byte[totalExceptionBytes];
-        bufferedSource.readFully(publicSuffixExceptionListBytes);
-      } catch (IOException e) {
-        Platform.get().log(Platform.WARN, "Failed to read public suffix list", e);
-        publicSuffixListBytes = null;
-        publicSuffixExceptionListBytes = null;
-      } finally {
-        closeQuietly(bufferedSource);
+  /**
+   * Reads the public suffix list treating the operation as uninterruptible. We always want to read
+   * the list otherwise we'll be left in a bad state. If the thread was interrupted prior to this
+   * operation, it will be re-interrupted after the list is read.
+   */
+  private void readTheListUninterruptibly() {
+    boolean interrupted = false;
+    try {
+      while (true) {
+        try {
+          readTheList();
+          return;
+        } catch (InterruptedIOException e) {
+          interrupted = true;
+        } catch (IOException e) {
+          Platform.get().log(Platform.WARN, "Failed to read public suffix list", e);
+          return;
+        }
       }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private void readTheList() throws IOException {
+    byte[] publicSuffixListBytes;
+    byte[] publicSuffixExceptionListBytes;
+
+    InputStream resource = PublicSuffixDatabase.class.getClassLoader().getResourceAsStream(
+        PUBLIC_SUFFIX_RESOURCE);
+    if (resource == null) return;
+
+    BufferedSource bufferedSource = Okio.buffer(new GzipSource(Okio.source(resource)));
+    try {
+      int totalBytes = bufferedSource.readInt();
+      publicSuffixListBytes = new byte[totalBytes];
+      bufferedSource.readFully(publicSuffixListBytes);
+
+      int totalExceptionBytes = bufferedSource.readInt();
+      publicSuffixExceptionListBytes = new byte[totalExceptionBytes];
+      bufferedSource.readFully(publicSuffixExceptionListBytes);
+    } finally {
+      closeQuietly(bufferedSource);
     }
 
     synchronized (this) {


### PR DESCRIPTION
Fixes: https://github.com/square/okhttp/issues/3404