### PR TITLE
Make EventListener public and begin implementing Dns events.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
@@ -83,7 +83,8 @@ public final class ConnectionPoolTest {
 
     RealConnection c1 = newConnection(pool, routeA1, 50L);
     synchronized (pool) {
-      StreamAllocation streamAllocation = new StreamAllocation(pool, addressA, null);
+      StreamAllocation streamAllocation = new StreamAllocation(pool, addressA, null,
+          EventListener.NONE, null);
       streamAllocation.acquire(c1);
     }
 
@@ -176,7 +177,8 @@ public final class ConnectionPoolTest {
   /** Use a helper method so there's no hidden reference remaining on the stack. */
   private void allocateAndLeakAllocation(ConnectionPool pool, RealConnection connection) {
     synchronized (pool) {
-      StreamAllocation leak = new StreamAllocation(pool, connection.route().address(), null);
+      StreamAllocation leak = new StreamAllocation(pool, connection.route().address(), null,
+          EventListener.NONE, null);
       leak.acquire(connection);
     }
   }

--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import okhttp3.internal.SingleInetAddressDns;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class EventListenerTest {
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  private OkHttpClient client;
+  private final RecordingEventListener listener = new RecordingEventListener();
+
+  @Before public void setUp() {
+    client = new OkHttpClient.Builder()
+        .dns(new SingleInetAddressDns())
+        .eventListener(listener)
+        .build();
+  }
+
+  @Test public void successfulDnsLookup() throws IOException {
+    server.enqueue(new MockResponse());
+
+    Call call = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    Response response = call.execute();
+    assertEquals(200, response.code());
+    response.body().close();
+
+    DnsStart dnsStart = listener.expectNextEvent(DnsStart.class);
+    assertSame(call, dnsStart.call);
+    assertEquals("localhost", dnsStart.domainName);
+
+    DnsEnd dnsEnd = listener.expectNextEvent(DnsEnd.class);
+    assertSame(call, dnsEnd.call);
+    assertEquals("localhost", dnsEnd.domainName);
+    assertEquals(1, dnsEnd.inetAddressList.size());
+    assertNull(dnsEnd.throwable);
+  }
+
+  @Test public void failedDnsLookup() {
+    client = client.newBuilder()
+        .dns(new FakeDns())
+        .build();
+    Call call = client.newCall(new Request.Builder()
+        .url("http://fakeurl/")
+        .build());
+    try {
+      call.execute();
+      fail();
+    } catch (IOException expected) {
+    }
+
+    listener.expectNextEvent(DnsStart.class);
+
+    DnsEnd dnsEnd = listener.expectNextEvent(DnsEnd.class);
+    assertSame(call, dnsEnd.call);
+    assertEquals("fakeurl", dnsEnd.domainName);
+    assertNull(dnsEnd.inetAddressList);
+    assertTrue(dnsEnd.throwable instanceof UnknownHostException);
+  }
+
+  @Test public void emptyDnsLookup() {
+    Dns emptyDns = new Dns() {
+      @Override public List<InetAddress> lookup(String hostname) throws UnknownHostException {
+        return Collections.emptyList();
+      }
+    };
+
+    client = client.newBuilder()
+        .dns(emptyDns)
+        .build();
+    Call call = client.newCall(new Request.Builder()
+        .url("http://fakeurl/")
+        .build());
+    try {
+      call.execute();
+      fail();
+    } catch (IOException expected) {
+    }
+
+    listener.expectNextEvent(DnsStart.class);
+
+    DnsEnd dnsEnd = listener.expectNextEvent(DnsEnd.class);
+    assertSame(call, dnsEnd.call);
+    assertEquals("fakeurl", dnsEnd.domainName);
+    assertNull(dnsEnd.inetAddressList);
+    assertTrue(dnsEnd.throwable instanceof UnknownHostException);
+  }
+
+  static final class DnsStart {
+    final Call call;
+    final String domainName;
+
+    DnsStart(Call call, String domainName) {
+      this.call = call;
+      this.domainName = domainName;
+    }
+  }
+
+  static final class DnsEnd {
+    final Call call;
+    final String domainName;
+    final List<InetAddress> inetAddressList;
+    final Throwable throwable;
+
+    DnsEnd(Call call, String domainName, List<InetAddress> inetAddressList, Throwable throwable) {
+      this.call = call;
+      this.domainName = domainName;
+      this.inetAddressList = inetAddressList;
+      this.throwable = throwable;
+    }
+  }
+
+  static final class RecordingEventListener extends EventListener {
+    final Deque<Object> eventSequence = new ArrayDeque<>();
+
+    <T> T expectNextEvent(Class<T> eventClass) {
+      Object event = eventSequence.poll();
+      if (!eventClass.isInstance(event)) {
+        fail("Expected event type: " + eventClass.getName());
+      }
+      return (T) event;
+    }
+
+    @Override public void dnsStart(Call call, String domainName) {
+      eventSequence.offer(new DnsStart(call, domainName));
+    }
+
+    @Override public void dnsEnd(Call call, String domainName, List<InetAddress> inetAddressList,
+        Throwable throwable) {
+      eventSequence.offer(new DnsEnd(call, domainName, inetAddressList, throwable));
+    }
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteSelectorTest.java
@@ -34,6 +34,7 @@ import javax.net.ssl.SSLSocketFactory;
 import okhttp3.Address;
 import okhttp3.Authenticator;
 import okhttp3.ConnectionSpec;
+import okhttp3.EventListener;
 import okhttp3.FakeDns;
 import okhttp3.Protocol;
 import okhttp3.Route;
@@ -84,7 +85,8 @@ public final class RouteSelectorTest {
 
   @Test public void singleRoute() throws Exception {
     Address address = httpAddress();
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
 
     assertTrue(routeSelector.hasNext());
     dns.set(uriHost, dns.allocate(1));
@@ -101,13 +103,14 @@ public final class RouteSelectorTest {
 
   @Test public void singleRouteReturnsFailedRoute() throws Exception {
     Address address = httpAddress();
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
 
     assertTrue(routeSelector.hasNext());
     dns.set(uriHost, dns.allocate(1));
     Route route = routeSelector.next();
     routeDatabase.failed(route);
-    routeSelector = new RouteSelector(address, routeDatabase);
+    routeSelector = new RouteSelector(address, routeDatabase, null, EventListener.NONE);
     assertRoute(routeSelector.next(), address, NO_PROXY, dns.lookup(uriHost, 0), uriPort);
     assertFalse(routeSelector.hasNext());
     try {
@@ -120,7 +123,8 @@ public final class RouteSelectorTest {
   @Test public void explicitProxyTriesThatProxysAddressesOnly() throws Exception {
     Address address = new Address(uriHost, uriPort, dns, socketFactory, null, null, null,
         authenticator, proxyA, protocols, connectionSpecs, proxySelector);
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
 
     assertTrue(routeSelector.hasNext());
     dns.set(proxyAHost, dns.allocate(2));
@@ -135,7 +139,8 @@ public final class RouteSelectorTest {
   @Test public void explicitDirectProxy() throws Exception {
     Address address = new Address(uriHost, uriPort, dns, socketFactory, null, null, null,
         authenticator, NO_PROXY, protocols, connectionSpecs, proxySelector);
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
 
     assertTrue(routeSelector.hasNext());
     dns.set(uriHost, dns.allocate(2));
@@ -162,7 +167,8 @@ public final class RouteSelectorTest {
 
     Address address = new Address(uriHost, uriPort, dns, socketFactory, null, null, null,
         authenticator, null, protocols, connectionSpecs, nullProxySelector);
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
     assertTrue(routeSelector.hasNext());
     dns.set(uriHost, dns.allocate(1));
     assertRoute(routeSelector.next(), address, NO_PROXY, dns.lookup(uriHost, 0), uriPort);
@@ -173,7 +179,8 @@ public final class RouteSelectorTest {
 
   @Test public void proxySelectorReturnsNoProxies() throws Exception {
     Address address = httpAddress();
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
 
     assertTrue(routeSelector.hasNext());
     dns.set(uriHost, dns.allocate(2));
@@ -190,7 +197,8 @@ public final class RouteSelectorTest {
 
     proxySelector.proxies.add(proxyA);
     proxySelector.proxies.add(proxyB);
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
     proxySelector.assertRequests(address.url().uri());
 
     // First try the IP addresses of the first proxy, in sequence.
@@ -214,7 +222,8 @@ public final class RouteSelectorTest {
     Address address = httpAddress();
 
     proxySelector.proxies.add(NO_PROXY);
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
     proxySelector.assertRequests(address.url().uri());
 
     // Only the origin server will be attempted.
@@ -232,7 +241,8 @@ public final class RouteSelectorTest {
     proxySelector.proxies.add(proxyA);
     proxySelector.proxies.add(proxyB);
     proxySelector.proxies.add(proxyA);
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
     proxySelector.assertRequests(address.url().uri());
 
     assertTrue(routeSelector.hasNext());
@@ -261,7 +271,8 @@ public final class RouteSelectorTest {
     Address address = httpsAddress();
     proxySelector.proxies.add(proxyA);
     proxySelector.proxies.add(proxyB);
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
 
     // Proxy A
     dns.set(proxyAHost, dns.allocate(2));
@@ -281,7 +292,8 @@ public final class RouteSelectorTest {
 
   @Test public void failedRoutesAreLast() throws Exception {
     Address address = httpsAddress();
-    RouteSelector routeSelector = new RouteSelector(address, routeDatabase);
+    RouteSelector routeSelector = new RouteSelector(address, routeDatabase, null,
+        EventListener.NONE);
 
     final int numberOfAddresses = 2;
     dns.set(uriHost, dns.allocate(numberOfAddresses));
@@ -297,7 +309,7 @@ public final class RouteSelectorTest {
     // Add first regular route as failed.
     routeDatabase.failed(regularRoutes.get(0));
     // Reset selector
-    routeSelector = new RouteSelector(address, routeDatabase);
+    routeSelector = new RouteSelector(address, routeDatabase, null, EventListener.NONE);
 
     List<Route> routesWithFailedRoute = new ArrayList<>();
     while (routeSelector.hasNext()) {

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -17,9 +17,9 @@ package okhttp3;
 
 import java.net.InetAddress;
 import java.util.List;
+import javax.annotation.Nullable;
 
-// TODO(jwilson): make this public after the 3.8 release.
-abstract class EventListener {
+public abstract class EventListener {
   public static final EventListener NONE = new EventListener() {
   };
 
@@ -34,11 +34,21 @@ abstract class EventListener {
   public void fetchStart(Call call) {
   }
 
+  /** Invoked just prior to a DNS lookup. See {@link Dns#lookup(String)}. */
   public void dnsStart(Call call, String domainName) {
   }
 
-  public void dnsEnd(Call call, String domainName, List<InetAddress> inetAddressList,
-      Throwable throwable) {
+  /**
+   * Invoked immediately after a DNS lookup.
+   *
+   * <p>{@code inetAddressList} will be non-null and {@code throwable} will be null in the case of a
+   * successful DNS lookup.
+   *
+   * <p>{@code inetAddressList} will be null and {@code throwable} will be non-null in the case of a
+   * failed DNS lookup.
+   */
+  public void dnsEnd(Call call, String domainName, @Nullable List<InetAddress> inetAddressList,
+      @Nullable Throwable throwable) {
   }
 
   public void connectStart(Call call, InetAddress address, int port) {
@@ -83,6 +93,16 @@ abstract class EventListener {
   }
 
   public interface Factory {
+    /**
+     * Creates an instance of the {@link EventListener} for a particular {@link Call}. The returned
+     * {@link EventListener} instance will be used during the lifecycle of the {@code call}.
+     *
+     * <p>This method is invoked after the {@code call} is created. See
+     * {@link OkHttpClient#newCall(Request)}.
+     *
+     * <p><strong>It is an error for implementations to issue any mutating operations on the
+     * {@code call} instance from this method.</strong>
+     */
     EventListener create(Call call);
   }
 }

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -186,7 +186,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       }
 
       @Override public Call newWebSocketCall(OkHttpClient client, Request originalRequest) {
-        return new RealCall(client, originalRequest, true);
+        return RealCall.newRealCall(client, originalRequest, true);
       }
     };
   }
@@ -407,8 +407,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     return networkInterceptors;
   }
 
-  // TODO(jwilson): make this public after the 3.8 release.
-  /*public*/ EventListener.Factory eventListenerFactory() {
+  public EventListener.Factory eventListenerFactory() {
     return eventListenerFactory;
   }
 
@@ -416,7 +415,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
    * Prepares the {@code request} to be executed at some point in the future.
    */
   @Override public Call newCall(Request request) {
-    return new RealCall(this, request, false /* for web socket */);
+    return RealCall.newRealCall(this, request, false /* for web socket */);
   }
 
   /**
@@ -887,15 +886,13 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       return this;
     }
 
-    // TODO(jwilson): make this public after the 3.8 release.
-    /*public*/ Builder eventListener(EventListener eventListener) {
+    public Builder eventListener(EventListener eventListener) {
       if (eventListener == null) throw new NullPointerException("eventListener == null");
       this.eventListenerFactory = EventListener.factory(eventListener);
       return this;
     }
 
-    // TODO(jwilson): make this public after the 3.8 release.
-    /*public*/ Builder eventListenerFactory(EventListener.Factory eventListenerFactory) {
+    public Builder eventListenerFactory(EventListener.Factory eventListenerFactory) {
       if (eventListenerFactory == null) {
         throw new NullPointerException("eventListenerFactory == null");
       }

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -33,7 +33,12 @@ import static okhttp3.internal.platform.Platform.INFO;
 final class RealCall implements Call {
   final OkHttpClient client;
   final RetryAndFollowUpInterceptor retryAndFollowUpInterceptor;
-  final EventListener eventListener;
+
+  /**
+   * There is a cycle between the {@link Call} and {@link EventListener} that makes this awkward.
+   * This will be set after we create the call instance then create the event listener instance.
+   */
+  private EventListener eventListener;
 
   /** The application's original request unadulterated by redirects or auth headers. */
   final Request originalRequest;
@@ -42,16 +47,18 @@ final class RealCall implements Call {
   // Guarded by this.
   private boolean executed;
 
-  RealCall(OkHttpClient client, Request originalRequest, boolean forWebSocket) {
-    final EventListener.Factory eventListenerFactory = client.eventListenerFactory();
-
+  private RealCall(OkHttpClient client, Request originalRequest, boolean forWebSocket) {
     this.client = client;
     this.originalRequest = originalRequest;
     this.forWebSocket = forWebSocket;
     this.retryAndFollowUpInterceptor = new RetryAndFollowUpInterceptor(client, forWebSocket);
+  }
 
-    // TODO(jwilson): this is unsafe publication and not threadsafe.
-    this.eventListener = eventListenerFactory.create(this);
+  static RealCall newRealCall(OkHttpClient client, Request originalRequest, boolean forWebSocket) {
+    // Safely publish the Call instance to the EventListener.
+    RealCall call = new RealCall(client, originalRequest, forWebSocket);
+    call.eventListener = client.eventListenerFactory().create(call);
+    return call;
   }
 
   @Override public Request request() {
@@ -102,7 +109,7 @@ final class RealCall implements Call {
 
   @SuppressWarnings("CloneDoesntCallSuperClone") // We are a final type & this saves clearing state.
   @Override public RealCall clone() {
-    return new RealCall(client, originalRequest, forWebSocket);
+    return RealCall.newRealCall(client, originalRequest, forWebSocket);
   }
 
   StreamAllocation streamAllocation() {
@@ -181,7 +188,7 @@ final class RealCall implements Call {
     interceptors.add(new CallServerInterceptor(forWebSocket));
 
     Interceptor.Chain chain = new RealInterceptorChain(
-        interceptors, null, null, null, 0, originalRequest);
+        interceptors, null, null, null, 0, originalRequest, this, eventListener);
     return chain.proceed(originalRequest);
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import okhttp3.Address;
+import okhttp3.Call;
+import okhttp3.EventListener;
 import okhttp3.HttpUrl;
 import okhttp3.Route;
 import okhttp3.internal.Util;
@@ -38,6 +40,8 @@ import okhttp3.internal.Util;
 public final class RouteSelector {
   private final Address address;
   private final RouteDatabase routeDatabase;
+  private final Call call;
+  private final EventListener eventListener;
 
   /* The most recently attempted route. */
   private Proxy lastProxy;
@@ -54,9 +58,12 @@ public final class RouteSelector {
   /* State for negotiating failed routes */
   private final List<Route> postponedRoutes = new ArrayList<>();
 
-  public RouteSelector(Address address, RouteDatabase routeDatabase) {
+  public RouteSelector(Address address, RouteDatabase routeDatabase, Call call,
+      EventListener eventListener) {
     this.address = address;
     this.routeDatabase = routeDatabase;
+    this.call = call;
+    this.eventListener = eventListener;
 
     resetNextProxy(address.url(), address.proxy());
   }
@@ -167,11 +174,24 @@ public final class RouteSelector {
     if (proxy.type() == Proxy.Type.SOCKS) {
       inetSocketAddresses.add(InetSocketAddress.createUnresolved(socketHost, socketPort));
     } else {
+      eventListener.dnsStart(call, socketHost);
+
       // Try each address for best behavior in mixed IPv4/IPv6 environments.
-      List<InetAddress> addresses = address.dns().lookup(socketHost);
-      if (addresses.isEmpty()) {
-        throw new UnknownHostException(address.dns() + " returned no addresses for " + socketHost);
+      List<InetAddress> addresses;
+      try {
+        addresses = address.dns().lookup(socketHost);
+      } catch (Exception e) {
+        eventListener.dnsEnd(call, socketHost, null, e);
+        throw e;
       }
+      if (addresses.isEmpty()) {
+        UnknownHostException exception = new UnknownHostException(
+            address.dns() + " returned no addresses for " + socketHost);
+        eventListener.dnsEnd(call, socketHost, null, exception);
+        throw exception;
+      }
+
+      eventListener.dnsEnd(call, socketHost, addresses, null);
 
       for (int i = 0, size = addresses.size(); i < size; i++) {
         InetAddress inetAddress = addresses.get(i);

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -20,7 +20,9 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.net.Socket;
 import okhttp3.Address;
+import okhttp3.Call;
 import okhttp3.ConnectionPool;
+import okhttp3.EventListener;
 import okhttp3.OkHttpClient;
 import okhttp3.Route;
 import okhttp3.internal.Internal;
@@ -83,10 +85,11 @@ public final class StreamAllocation {
   private boolean canceled;
   private HttpCodec codec;
 
-  public StreamAllocation(ConnectionPool connectionPool, Address address, Object callStackTrace) {
+  public StreamAllocation(ConnectionPool connectionPool, Address address, Call call,
+      EventListener eventListener, Object callStackTrace) {
     this.connectionPool = connectionPool;
     this.address = address;
-    this.routeSelector = new RouteSelector(address, routeDatabase());
+    this.routeSelector = new RouteSelector(address, routeDatabase(), call, eventListener);
     this.callStackTrace = callStackTrace;
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.java
@@ -17,7 +17,9 @@ package okhttp3.internal.http;
 
 import java.io.IOException;
 import java.util.List;
+import okhttp3.Call;
 import okhttp3.Connection;
+import okhttp3.EventListener;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -35,16 +37,21 @@ public final class RealInterceptorChain implements Interceptor.Chain {
   private final RealConnection connection;
   private final int index;
   private final Request request;
+  private final Call call;
+  private final EventListener eventListener;
   private int calls;
 
   public RealInterceptorChain(List<Interceptor> interceptors, StreamAllocation streamAllocation,
-      HttpCodec httpCodec, RealConnection connection, int index, Request request) {
+      HttpCodec httpCodec, RealConnection connection, int index, Request request, Call call,
+      EventListener eventListener) {
     this.interceptors = interceptors;
     this.connection = connection;
     this.streamAllocation = streamAllocation;
     this.httpCodec = httpCodec;
     this.index = index;
     this.request = request;
+    this.call = call;
+    this.eventListener = eventListener;
   }
 
   @Override public Connection connection() {
@@ -57,6 +64,14 @@ public final class RealInterceptorChain implements Interceptor.Chain {
 
   public HttpCodec httpStream() {
     return httpCodec;
+  }
+
+  public Call call() {
+    return call;
+  }
+
+  public EventListener eventListener() {
+    return eventListener;
   }
 
   @Override public Request request() {
@@ -86,8 +101,8 @@ public final class RealInterceptorChain implements Interceptor.Chain {
     }
 
     // Call the next interceptor in the chain.
-    RealInterceptorChain next = new RealInterceptorChain(
-        interceptors, streamAllocation, httpCodec, connection, index + 1, request);
+    RealInterceptorChain next = new RealInterceptorChain(interceptors, streamAllocation, httpCodec,
+        connection, index + 1, request, call, eventListener);
     Interceptor interceptor = interceptors.get(index);
     Response response = interceptor.intercept(next);
 


### PR DESCRIPTION
I'm interested in this one. 

I found this challenging because of the cycle between EventListener and Call. Notably, it seems like RealCall wants a reference to EventListener but the EventListener factory wants the instance of the Call. The approach in this PR is also broken 'cause someone could `execute` the call from the EventListener.

In addition, I attempted to use the EventListener for a successful DNS lookup. It became clear that this will require passing around the reference to EventListener. Also because every method takes in a Call, I think it means passing around the Call as well.

I probably am missing something here, or maybe this can help refine the EventListener class.