### PR TITLE
Avoid android specific code for TrustRootIndex

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.security.cert.Certificate;
+import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -31,7 +32,9 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Protocol;
 import okhttp3.internal.Util;
+import okhttp3.internal.tls.BasicTrustRootIndex;
 import okhttp3.internal.tls.CertificateChainCleaner;
+import okhttp3.internal.tls.TrustRootIndex;
 
 /** Android 2.3 or better. */
 class AndroidPlatform extends Platform {
@@ -230,6 +233,21 @@ class AndroidPlatform extends Platform {
     return null;
   }
 
+  @Override
+  public TrustRootIndex buildTrustRootIndex(X509TrustManager trustManager) {
+
+    try {
+      // From org.conscrypt.TrustManagerImpl, we want the method with this signature:
+      // private TrustAnchor findTrustAnchorByIssuerAndSignature(X509Certificate lastCert);
+      Method method = trustManager.getClass().getDeclaredMethod(
+              "findTrustAnchorByIssuerAndSignature", X509Certificate.class);
+      method.setAccessible(true);
+      return new AndroidTrustRootIndex(trustManager, method);
+    } catch (NoSuchMethodException e) {
+      return super.buildTrustRootIndex(trustManager);
+    }
+  }
+
   /**
    * X509TrustManagerExtensions was added to Android in API 17 (Android 4.2, released in late 2012).
    * This is the best way to get a clean chain on Android because it uses the same code as the TLS
@@ -325,6 +343,57 @@ class AndroidPlatform extends Platform {
         warnIfOpenMethod = null;
       }
       return new CloseGuard(getMethod, openMethod, warnIfOpenMethod);
+    }
+  }
+
+  /**
+   * An index of trusted root certificates that exploits knowledge of Android implementation
+   * details. This class is potentially much faster to initialize than {@link BasicTrustRootIndex}
+   * because it doesn't need to load and index trusted CA certificates.
+   *
+   * <p>This class uses APIs added to Android in API 14 (Android 4.0, released October 2011). This
+   * class shouldn't be used in Android API 17 or better because those releases are better served by
+   * {@link AndroidPlatform.AndroidCertificateChainCleaner}.
+   */
+  static final class AndroidTrustRootIndex implements TrustRootIndex {
+    private final X509TrustManager trustManager;
+    private final Method findByIssuerAndSignatureMethod;
+
+    AndroidTrustRootIndex(X509TrustManager trustManager, Method findByIssuerAndSignatureMethod) {
+      this.findByIssuerAndSignatureMethod = findByIssuerAndSignatureMethod;
+      this.trustManager = trustManager;
+    }
+
+    @Override public X509Certificate findByIssuerAndSignature(X509Certificate cert) {
+      try {
+        TrustAnchor trustAnchor = (TrustAnchor) findByIssuerAndSignatureMethod.invoke(
+                trustManager, cert);
+        return trustAnchor != null
+                ? trustAnchor.getTrustedCert()
+                : null;
+      } catch (IllegalAccessException e) {
+        throw new AssertionError();
+      } catch (InvocationTargetException e) {
+        return null;
+      }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof AndroidTrustRootIndex)) {
+        return false;
+      }
+      AndroidTrustRootIndex that = (AndroidTrustRootIndex) obj;
+      return trustManager.equals(that.trustManager)
+              && findByIssuerAndSignatureMethod.equals(that.findByIssuerAndSignatureMethod);
+    }
+
+    @Override
+    public int hashCode() {
+      return trustManager.hashCode() + 31 * findByIssuerAndSignatureMethod.hashCode();
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -30,6 +30,7 @@ import javax.net.ssl.X509TrustManager;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.internal.tls.BasicCertificateChainCleaner;
+import okhttp3.internal.tls.BasicTrustRootIndex;
 import okhttp3.internal.tls.CertificateChainCleaner;
 import okhttp3.internal.tls.TrustRootIndex;
 import okio.Buffer;
@@ -164,7 +165,7 @@ public class Platform {
   }
 
   public CertificateChainCleaner buildCertificateChainCleaner(X509TrustManager trustManager) {
-    return new BasicCertificateChainCleaner(TrustRootIndex.get(trustManager));
+    return new BasicCertificateChainCleaner(buildTrustRootIndex(trustManager));
   }
 
   /** Attempt to match the host runtime to a capable Platform implementation. */
@@ -228,4 +229,8 @@ public class Platform {
 
     return null;
   }
+
+    public TrustRootIndex buildTrustRootIndex(X509TrustManager trustManager) {
+      return new BasicTrustRootIndex(trustManager.getAcceptedIssuers());
+    }
 }

--- a/okhttp/src/main/java/okhttp3/internal/tls/BasicTrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/BasicTrustRootIndex.java
@@ -1,0 +1,54 @@
+package okhttp3.internal.tls;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/** A simple index that of trusted root certificates that have been loaded into memory. */
+public final class BasicTrustRootIndex implements TrustRootIndex {
+  private final Map<X500Principal, Set<X509Certificate>> subjectToCaCerts;
+
+  public BasicTrustRootIndex(X509Certificate... caCerts) {
+    subjectToCaCerts = new LinkedHashMap<>();
+    for (X509Certificate caCert : caCerts) {
+      X500Principal subject = caCert.getSubjectX500Principal();
+      Set<X509Certificate> subjectCaCerts = subjectToCaCerts.get(subject);
+      if (subjectCaCerts == null) {
+        subjectCaCerts = new LinkedHashSet<>(1);
+        subjectToCaCerts.put(subject, subjectCaCerts);
+      }
+      subjectCaCerts.add(caCert);
+    }
+  }
+
+  @Override public X509Certificate findByIssuerAndSignature(X509Certificate cert) {
+    X500Principal issuer = cert.getIssuerX500Principal();
+    Set<X509Certificate> subjectCaCerts = subjectToCaCerts.get(issuer);
+    if (subjectCaCerts == null) return null;
+
+    for (X509Certificate caCert : subjectCaCerts) {
+      PublicKey publicKey = caCert.getPublicKey();
+      try {
+        cert.verify(publicKey);
+        return caCert;
+      } catch (Exception ignored) {
+      }
+    }
+
+    return null;
+  }
+
+  @Override public boolean equals(Object other) {
+    if (other == this) return true;
+    return other instanceof okhttp3.internal.tls.BasicTrustRootIndex
+        && ((okhttp3.internal.tls.BasicTrustRootIndex) other).subjectToCaCerts.equals(subjectToCaCerts);
+  }
+
+  @Override public int hashCode() {
+    return subjectToCaCerts.hashCode();
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/tls/BasicTrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/BasicTrustRootIndex.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okhttp3.internal.tls;
 
 import javax.security.auth.x500.X500Principal;

--- a/okhttp/src/main/java/okhttp3/internal/tls/BasicTrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/BasicTrustRootIndex.java
@@ -15,13 +15,13 @@
  */
 package okhttp3.internal.tls;
 
-import javax.security.auth.x500.X500Principal;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.security.auth.x500.X500Principal;
 
 /** A simple index that of trusted root certificates that have been loaded into memory. */
 public final class BasicTrustRootIndex implements TrustRootIndex {
@@ -60,7 +60,8 @@ public final class BasicTrustRootIndex implements TrustRootIndex {
   @Override public boolean equals(Object other) {
     if (other == this) return true;
     return other instanceof okhttp3.internal.tls.BasicTrustRootIndex
-        && ((okhttp3.internal.tls.BasicTrustRootIndex) other).subjectToCaCerts.equals(subjectToCaCerts);
+        && ((okhttp3.internal.tls.BasicTrustRootIndex) other).subjectToCaCerts.equals(
+        subjectToCaCerts);
   }
 
   @Override public int hashCode() {

--- a/okhttp/src/main/java/okhttp3/internal/tls/CertificateChainCleaner.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/CertificateChainCleaner.java
@@ -42,6 +42,6 @@ public abstract class CertificateChainCleaner {
   }
 
   public static CertificateChainCleaner get(X509Certificate... caCerts) {
-    return new BasicCertificateChainCleaner(TrustRootIndex.get(caCerts));
+    return new BasicCertificateChainCleaner(new BasicTrustRootIndex(caCerts));
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/tls/TrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/TrustRootIndex.java
@@ -15,19 +15,7 @@
  */
 package okhttp3.internal.tls;
 
-import okhttp3.internal.platform.Platform;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.security.PublicKey;
-import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-import javax.net.ssl.X509TrustManager;
-import javax.security.auth.x500.X500Principal;
 
 public interface TrustRootIndex {
   /** Returns the trusted CA certificate that signed {@code cert}. */

--- a/okhttp/src/main/java/okhttp3/internal/tls/TrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/TrustRootIndex.java
@@ -15,6 +15,8 @@
  */
 package okhttp3.internal.tls;
 
+import okhttp3.internal.platform.Platform;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.PublicKey;
@@ -27,120 +29,7 @@ import java.util.Set;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
 
-public abstract class TrustRootIndex {
+public interface TrustRootIndex {
   /** Returns the trusted CA certificate that signed {@code cert}. */
-  public abstract X509Certificate findByIssuerAndSignature(X509Certificate cert);
-
-  public static TrustRootIndex get(X509TrustManager trustManager) {
-    try {
-      // From org.conscrypt.TrustManagerImpl, we want the method with this signature:
-      // private TrustAnchor findTrustAnchorByIssuerAndSignature(X509Certificate lastCert);
-      Method method = trustManager.getClass().getDeclaredMethod(
-          "findTrustAnchorByIssuerAndSignature", X509Certificate.class);
-      method.setAccessible(true);
-      return new AndroidTrustRootIndex(trustManager, method);
-    } catch (NoSuchMethodException e) {
-      return get(trustManager.getAcceptedIssuers());
-    }
-  }
-
-  public static TrustRootIndex get(X509Certificate... caCerts) {
-    return new BasicTrustRootIndex(caCerts);
-  }
-
-  /**
-   * An index of trusted root certificates that exploits knowledge of Android implementation
-   * details. This class is potentially much faster to initialize than {@link BasicTrustRootIndex}
-   * because it doesn't need to load and index trusted CA certificates.
-   *
-   * <p>This class uses APIs added to Android in API 14 (Android 4.0, released October 2011). This
-   * class shouldn't be used in Android API 17 or better because those releases are better served by
-   * {@link okhttp3.internal.AndroidPlatform.AndroidCertificateChainCleaner}.
-   */
-  static final class AndroidTrustRootIndex extends TrustRootIndex {
-    private final X509TrustManager trustManager;
-    private final Method findByIssuerAndSignatureMethod;
-
-    AndroidTrustRootIndex(X509TrustManager trustManager, Method findByIssuerAndSignatureMethod) {
-      this.findByIssuerAndSignatureMethod = findByIssuerAndSignatureMethod;
-      this.trustManager = trustManager;
-    }
-
-    @Override public X509Certificate findByIssuerAndSignature(X509Certificate cert) {
-      try {
-        TrustAnchor trustAnchor = (TrustAnchor) findByIssuerAndSignatureMethod.invoke(
-            trustManager, cert);
-        return trustAnchor != null
-            ? trustAnchor.getTrustedCert()
-            : null;
-      } catch (IllegalAccessException e) {
-        throw new AssertionError();
-      } catch (InvocationTargetException e) {
-        return null;
-      }
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (obj == this) {
-        return true;
-      }
-      if (!(obj instanceof AndroidTrustRootIndex)) {
-        return false;
-      }
-      AndroidTrustRootIndex that = (AndroidTrustRootIndex) obj;
-      return trustManager.equals(that.trustManager)
-              && findByIssuerAndSignatureMethod.equals(that.findByIssuerAndSignatureMethod);
-    }
-
-    @Override
-    public int hashCode() {
-      return trustManager.hashCode() + 31 * findByIssuerAndSignatureMethod.hashCode();
-    }
-  }
-
-  /** A simple index that of trusted root certificates that have been loaded into memory. */
-  static final class BasicTrustRootIndex extends TrustRootIndex {
-    private final Map<X500Principal, Set<X509Certificate>> subjectToCaCerts;
-
-    BasicTrustRootIndex(X509Certificate... caCerts) {
-      subjectToCaCerts = new LinkedHashMap<>();
-      for (X509Certificate caCert : caCerts) {
-        X500Principal subject = caCert.getSubjectX500Principal();
-        Set<X509Certificate> subjectCaCerts = subjectToCaCerts.get(subject);
-        if (subjectCaCerts == null) {
-          subjectCaCerts = new LinkedHashSet<>(1);
-          subjectToCaCerts.put(subject, subjectCaCerts);
-        }
-        subjectCaCerts.add(caCert);
-      }
-    }
-
-    @Override public X509Certificate findByIssuerAndSignature(X509Certificate cert) {
-      X500Principal issuer = cert.getIssuerX500Principal();
-      Set<X509Certificate> subjectCaCerts = subjectToCaCerts.get(issuer);
-      if (subjectCaCerts == null) return null;
-
-      for (X509Certificate caCert : subjectCaCerts) {
-        PublicKey publicKey = caCert.getPublicKey();
-        try {
-          cert.verify(publicKey);
-          return caCert;
-        } catch (Exception ignored) {
-        }
-      }
-
-      return null;
-    }
-
-    @Override public boolean equals(Object other) {
-      if (other == this) return true;
-      return other instanceof BasicTrustRootIndex
-          && ((BasicTrustRootIndex) other).subjectToCaCerts.equals(subjectToCaCerts);
-    }
-
-    @Override public int hashCode() {
-      return subjectToCaCerts.hashCode();
-    }
-  }
+  X509Certificate findByIssuerAndSignature(X509Certificate cert);
 }


### PR DESCRIPTION
Split out Android TrustRootIndex into AndroidPlatform only code, avoid executing on other platforms