### PR TITLE
Confirm we check all DNS ips against existing connections before creating a new one.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
@@ -17,9 +17,12 @@ package okhttp3;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
@@ -245,6 +248,18 @@ public final class ConnectionCoalescingTest {
     server.enqueue(new MockResponse().setResponseCode(200));
     server.enqueue(new MockResponse().setResponseCode(200));
 
+    final AtomicInteger count = new AtomicInteger();
+    EventListener eventListener = new EventListener() {
+      @Override public void connectStart(Call call, InetSocketAddress inetSocketAddress,
+          Proxy proxy) {
+        count.incrementAndGet();
+      }
+    };
+
+    client = client.newBuilder()
+        .eventListener(eventListener)
+        .build();
+
     assert200Http2Response(execute(url), server.getHostName());
 
     HttpUrl sanUrl = url.newBuilder().host("san.com").build();
@@ -254,6 +269,7 @@ public final class ConnectionCoalescingTest {
     assert200Http2Response(execute(sanUrl), "san.com");
 
     assertEquals(1, client.connectionPool().connectionCount());
+    assertEquals(1, count.get());
   }
 
   /** Check that wildcard SANs are supported. */


### PR DESCRIPTION
I accidentally stumbled on this while working on the connection found event. This test was failing because the connection pool had 2 connections instead of 1.

Apparently, I recently added my hostname to `/etc/hosts` as `127.0.0.1`. This test will attempt to connect to `0.0.0.0` and it succeeds. From the comment, I _think_ the intent is to enumerate all the IP's from DNS and look for an existing connection, but I could be wrong.

What do you think?