### PR TITLE
Consider all routes when looking for candidate coalesced connections.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
@@ -43,17 +43,12 @@ public final class RouteSelector {
   private final Call call;
   private final EventListener eventListener;
 
-  /* The most recently attempted route. */
-  private Proxy lastProxy;
-  private InetSocketAddress lastInetSocketAddress;
-
   /* State for negotiating the next proxy to use. */
   private List<Proxy> proxies = Collections.emptyList();
   private int nextProxyIndex;
 
   /* State for negotiating the next socket address to use. */
   private List<InetSocketAddress> inetSocketAddresses = Collections.emptyList();
-  private int nextInetSocketAddressIndex;
 
   /* State for negotiating failed routes */
   private final List<Route> postponedRoutes = new ArrayList<>();
@@ -69,35 +64,45 @@ public final class RouteSelector {
   }
 
   /**
-   * Returns true if there's another route to attempt. Every address has at least one route.
+   * Returns true if there's another set of routes to attempt. Every address has at least one route.
    */
   public boolean hasNext() {
-    return hasNextInetSocketAddress()
-        || hasNextProxy()
-        || hasNextPostponed();
+    return hasNextProxy() || !postponedRoutes.isEmpty();
   }
 
-  public Route next() throws IOException {
-    // Compute the next route to attempt.
-    if (!hasNextInetSocketAddress()) {
-      if (!hasNextProxy()) {
-        if (!hasNextPostponed()) {
-          throw new NoSuchElementException();
+  public Selection next() throws IOException {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    // Compute the next set of routes to attempt.
+    List<Route> routes = new ArrayList<>();
+    while (hasNextProxy()) {
+      // Postponed routes are always tried last. For example, if we have 2 proxies and all the
+      // routes for proxy1 should be postponed, we'll move to proxy2. Only after we've exhausted
+      // all the good routes will we attempt the postponed routes.
+      Proxy lastProxy = nextProxy();
+      for (int i = 0, size = inetSocketAddresses.size(); i < size; i++) {
+        Route route = new Route(address, lastProxy, inetSocketAddresses.get(i));
+        if (routeDatabase.shouldPostpone(route)) {
+          postponedRoutes.add(route);
+        } else {
+          routes.add(route);
         }
-        return nextPostponed();
       }
-      lastProxy = nextProxy();
-    }
-    lastInetSocketAddress = nextInetSocketAddress();
 
-    Route route = new Route(address, lastProxy, lastInetSocketAddress);
-    if (routeDatabase.shouldPostpone(route)) {
-      postponedRoutes.add(route);
-      // We will only recurse in order to skip previously failed routes. They will be tried last.
-      return next();
+      if (!routes.isEmpty()) {
+        break;
+      }
     }
 
-    return route;
+    if (routes.isEmpty()) {
+      // We've exhausted all Proxies so fallback to the postponed routes.
+      routes.addAll(postponedRoutes);
+      postponedRoutes.clear();
+    }
+
+    return new Selection(routes);
   }
 
   /**
@@ -198,8 +203,6 @@ public final class RouteSelector {
         inetSocketAddresses.add(new InetSocketAddress(inetAddress, socketPort));
       }
     }
-
-    nextInetSocketAddressIndex = 0;
   }
 
   /**
@@ -220,27 +223,28 @@ public final class RouteSelector {
     return address.getHostAddress();
   }
 
-  /** Returns true if there's another socket address to try. */
-  private boolean hasNextInetSocketAddress() {
-    return nextInetSocketAddressIndex < inetSocketAddresses.size();
-  }
+  /** A set of selected Routes. */
+  public static final class Selection {
+    private final List<Route> routes;
+    private int nextRouteIndex = 0;
 
-  /** Returns the next socket address to try. */
-  private InetSocketAddress nextInetSocketAddress() throws IOException {
-    if (!hasNextInetSocketAddress()) {
-      throw new SocketException("No route to " + address.url().host()
-          + "; exhausted inet socket addresses: " + inetSocketAddresses);
+    Selection(List<Route> routes) {
+      this.routes = routes;
     }
-    return inetSocketAddresses.get(nextInetSocketAddressIndex++);
-  }
 
-  /** Returns true if there is another postponed route to try. */
-  private boolean hasNextPostponed() {
-    return !postponedRoutes.isEmpty();
-  }
+    public boolean hasNext() {
+      return nextRouteIndex < routes.size();
+    }
 
-  /** Returns the next postponed route to try. */
-  private Route nextPostponed() {
-    return postponedRoutes.remove(0);
+    public Route next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      return routes.get(nextRouteIndex++);
+    }
+
+    public List<Route> getAll() {
+      return new ArrayList<>(routes);
+    }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.net.Socket;
+import java.util.List;
 import okhttp3.Address;
 import okhttp3.Call;
 import okhttp3.ConnectionPool;
@@ -74,6 +75,7 @@ import static okhttp3.internal.Util.closeQuietly;
  */
 public final class StreamAllocation {
   public final Address address;
+  private RouteSelector.Selection routeSelection;
   private Route route;
   private final ConnectionPool connectionPool;
   private final Call call;
@@ -181,21 +183,33 @@ public final class StreamAllocation {
       selectedRoute = route;
     }
 
-    // If we need a route, make one. This is a blocking operation.
-    if (selectedRoute == null) {
-      selectedRoute = routeSelector.next();
+    // If we need a route selection, make one. This is a blocking operation.
+    boolean newRouteSelection = false;
+    if (selectedRoute == null && (routeSelection == null || !routeSelection.hasNext())) {
+      newRouteSelection = true;
+      routeSelection = routeSelector.next();
     }
 
     RealConnection result;
     synchronized (connectionPool) {
       if (canceled) throw new IOException("Canceled");
 
-      // Now that we have an IP address, make another attempt at getting a connection from the pool.
-      // This could match due to connection coalescing.
-      Internal.instance.get(connectionPool, address, this, selectedRoute);
-      if (connection != null) {
-        route = selectedRoute;
-        return connection;
+      if (newRouteSelection) {
+        // Now that we have a set of IP addresses, make another attempt at getting a connection from
+        // the pool. This could match due to connection coalescing.
+        List<Route> routes = routeSelection.getAll();
+        for (int i = 0, size = routes.size(); i < size; i++) {
+          Route route = routes.get(i);
+          Internal.instance.get(connectionPool, address, this, route);
+          if (connection != null) {
+            this.route = route;
+            return connection;
+          }
+        }
+      }
+
+      if (selectedRoute == null) {
+        selectedRoute = routeSelection.next();
       }
 
       // Create a connection and assign it to this allocation immediately. This makes it possible
@@ -405,7 +419,9 @@ public final class StreamAllocation {
   }
 
   public boolean hasMoreRoutes() {
-    return route != null || routeSelector.hasNext();
+    return route != null
+        || (routeSelection != null && routeSelection.hasNext())
+        || routeSelector.hasNext();
   }
 
   @Override public String toString() {


### PR DESCRIPTION
Previously we'd only look at one route at a time. If DNS returned
results in random order it would lower our chances of finding a
coalesced connection. Now we consider all routes at once which hopefully
improves our chances.