### PR TITLE
Fill out documentation for EventListener

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -746,7 +746,7 @@ public final class EventListenerTest {
       eventSequence.offer(new ConnectEnd(call, inetSocketAddress, protocol, throwable));
     }
 
-    @Override public void connectionFound(Call call, Connection connection) {
+    @Override public void connectionAcquired(Call call, Connection connection) {
       eventSequence.offer(new ConnectionFound(call, connection));
     }
   }

--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -752,7 +752,7 @@ public final class EventListenerTest {
     }
 
     @Override public void connectEnd(Call call, InetSocketAddress inetSocketAddress,
-        Protocol protocol, Throwable throwable) {
+        Proxy proxy, Protocol protocol, Throwable throwable) {
       eventSequence.offer(new ConnectEnd(call, inetSocketAddress, protocol, throwable));
     }
 

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -136,14 +136,25 @@ public abstract class EventListener {
    * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
    * to the {@link Call#request()} is a redirect to a different address.
    */
-  public void connectionFound(Call call, Connection connection) {
+  public void connectionAcquired(Call call, Connection connection) {
+  }
+
+  /**
+   * Invoked after a connection has been released for the {@code call}.
+   *
+   * <p>This method is always invoked after {@link #connectionAcquired(Call, Connection)}.
+   *
+   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
+   * to the {@link Call#request()} is a redirect to a different address.
+   */
+  public void connectionReleased(Call call, Connection connection) {
   }
 
   /**
    * Invoked just prior to sending request headers.
    *
    * <p>The connection is implicit, and will generally relate to the last
-   * {@link #connectionFound(Call, Connection)} event.
+   * {@link #connectionAcquired(Call, Connection)} event.
    *
    * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
    * to the {@link Call#request()} is a redirect to a different address.
@@ -168,7 +179,7 @@ public abstract class EventListener {
    * having a request body to send.
    *
    * <p>The connection is implicit, and will generally relate to the last
-   * {@link #connectionFound(Call, Connection)} event.
+   * {@link #connectionAcquired(Call, Connection)} event.
    *
    * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
    * to the {@link Call#request()} is a redirect to a different address.
@@ -192,7 +203,7 @@ public abstract class EventListener {
    * Invoked just prior to receiving response headers.
    *
    * <p>The connection is implicit, and will generally relate to the last
-   * {@link #connectionFound(Call, Connection)} event.
+   * {@link #connectionAcquired(Call, Connection)} event.
    *
    * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
    * to the {@link Call#request()} is a redirect to a different address.
@@ -216,7 +227,7 @@ public abstract class EventListener {
    * Invoked just prior to receiving the response body.
    *
    * <p>The connection is implicit, and will generally relate to the last
-   * {@link #connectionFound(Call, Connection)} event.
+   * {@link #connectionAcquired(Call, Connection)} event.
    *
    * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
    * to the {@link Call#request()} is a redirect to a different address.

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -238,8 +238,8 @@ public abstract class EventListener {
   /**
    * Invoked immediately after receiving a request body and completing reading it.
    *
-   * <p>Will only be invoked for requests having a response body e.g. won't be invoked for a websocket
-   * upgrade.
+   * <p>Will only be invoked for requests having a response body e.g. won't be invoked for a
+   * websocket upgrade.
    *
    * <p>This method is always invoked after {@link #requestBodyStart(Call)}.
    *

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -163,7 +163,7 @@ public abstract class EventListener {
   }
 
   /**
-   * Invoked immediately after sending a request body.
+   * Invoked immediately after sending request headers.
    *
    * <p>This method is always invoked after {@link #requestHeadersStart(Call)}.
    *
@@ -236,7 +236,7 @@ public abstract class EventListener {
   }
 
   /**
-   * Invoked immediately after receiving a request body and completing reading it.
+   * Invoked immediately after receiving a response body and completing reading it.
    *
    * <p>Will only be invoked for requests having a response body e.g. won't be invoked for a
    * websocket upgrade.

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -33,6 +33,14 @@ public abstract class EventListener {
     };
   }
 
+  /**
+   * Invoked as soon as a call is enqueued or executed by a client. In case of thread or stream
+   * limits, this call may be executed well before processing the request is able to begin.
+   *
+   * <p>This will be invoked only once for a single {@link Call}. Retries of different routes
+   * or redirects will be handled within the boundaries of a single fetchStart and
+   * {@link #fetchEnd(Call, Throwable)} pair.
+   */
   public void fetchStart(Call call) {
   }
 
@@ -131,30 +139,116 @@ public abstract class EventListener {
   public void connectionFound(Call call, Connection connection) {
   }
 
+  /**
+   * Invoked just prior to sending request headers.
+   *
+   * <p>The connection is implicit, and will generally relate to the last
+   * {@link #connectionFound(Call, Connection)} event.
+   *
+   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
+   * to the {@link Call#request()} is a redirect to a different address.
+   */
   public void requestHeadersStart(Call call) {
   }
 
+  /**
+   * Invoked immediately after sending a request body.
+   *
+   * <p>This method is always invoked after {@link #requestHeadersStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to send the headers.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to send the headers.
+   */
   public void requestHeadersEnd(Call call, Throwable throwable) {
   }
 
+  /**
+   * Invoked just prior to sending a request body.  Will only be invoked for request allowing and
+   * having a request body to send.
+   *
+   * <p>The connection is implicit, and will generally relate to the last
+   * {@link #connectionFound(Call, Connection)} event.
+   *
+   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
+   * to the {@link Call#request()} is a redirect to a different address.
+   */
   public void requestBodyStart(Call call) {
   }
 
+  /**
+   * Invoked immediately after sending a request body.
+   *
+   * <p>This method is always invoked after {@link #requestBodyStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to send the body.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to send the body.
+   */
   public void requestBodyEnd(Call call, Throwable throwable) {
   }
 
+  /**
+   * Invoked just prior to receiving response headers.
+   *
+   * <p>The connection is implicit, and will generally relate to the last
+   * {@link #connectionFound(Call, Connection)} event.
+   *
+   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
+   * to the {@link Call#request()} is a redirect to a different address.
+   */
   public void responseHeadersStart(Call call) {
   }
 
+  /**
+   * Invoked immediately after receiving response headers.
+   *
+   * <p>This method is always invoked after {@link #responseHeadersStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to receive the headers.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to receive the headers.
+   */
   public void responseHeadersEnd(Call call, Throwable throwable) {
   }
 
+  /**
+   * Invoked just prior to receiving the response body.
+   *
+   * <p>The connection is implicit, and will generally relate to the last
+   * {@link #connectionFound(Call, Connection)} event.
+   *
+   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
+   * to the {@link Call#request()} is a redirect to a different address.
+   */
   public void responseBodyStart(Call call) {
   }
 
+  /**
+   * Invoked immediately after receiving a request body and completing reading it.
+   *
+   * <p>Will only be invoked for requests having a response body e.g. won't be invoked for a websocket
+   * upgrade.
+   *
+   * <p>This method is always invoked after {@link #requestBodyStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to send the body.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to send the body.
+   */
   public void responseBodyEnd(Call call, Throwable throwable) {
   }
 
+  /**
+   * Invoked immediately after a call has completely ended.  This includes delayed consumption
+   * of response body by the caller.
+   *
+   * <p>This method is always invoked after {@link #fetchStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to execute the call.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to execute the call.
+   */
   public void fetchEnd(Call call, Throwable throwable) {
   }
 

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -120,14 +120,14 @@ public abstract class EventListener {
    * {@link #secureConnectEnd(Call, Handshake, Throwable)}, otherwise it will invoked after
    * {@link #connectStart(Call, InetSocketAddress, Proxy)}.
    *
-   * <p>{@code protocol} will be non-null and {@code throwable} will be null when the connection is
-   * successfully established.
+   * <p>{@code protocol} and {@code proxy} will be non-null and {@code throwable} will be null when
+   * the connection is successfully established.
    *
-   * <p>{@code protocol} will be null and {@code throwable} will be non-null in the case of a failed
-   * connection attempt.
+   * <p>{@code protocol} and {@code proxy} will be null and {@code throwable} will be non-null in
+   * the case of a failed connection attempt.
    */
   public void connectEnd(Call call, InetSocketAddress inetSocketAddress,
-      @Nullable Protocol protocol, @Nullable Throwable throwable) {
+      Proxy proxy, @Nullable Protocol protocol, @Nullable Throwable throwable) {
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -229,8 +229,8 @@ public abstract class EventListener {
    * <p>The connection is implicit, and will generally relate to the last
    * {@link #connectionAcquired(Call, Connection)} event.
    *
-   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
-   * to the {@link Call#request()} is a redirect to a different address.
+   * <p>This will usually be invoked only 1 time for a single {@link Call},
+   * exceptions are a limited set of cases including failure recovery.
    */
   public void responseBodyStart(Call call) {
   }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -158,7 +158,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
           connectSocket(connectTimeout, readTimeout, call, eventListener);
         }
         establishProtocol(connectionSpecSelector, call, eventListener);
-        eventListener.connectEnd(call, route.socketAddress(), protocol, null);
+        eventListener.connectEnd(call, route.socketAddress(), route.proxy(), protocol, null);
         break;
       } catch (IOException e) {
         closeQuietly(socket);
@@ -171,7 +171,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
         protocol = null;
         http2Connection = null;
 
-        eventListener.connectEnd(call, route.socketAddress(), null, e);
+        eventListener.connectEnd(call, route.socketAddress(), route.proxy(), null, e);
 
         if (routeException == null) {
           routeException = new RouteException(e);
@@ -218,7 +218,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
       rawSocket = null;
       sink = null;
       source = null;
-      eventListener.connectEnd(call, route.socketAddress(), null, null);
+      eventListener.connectEnd(call, route.socketAddress(), route.proxy(), null, null);
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -113,7 +113,7 @@ public final class StreamAllocation {
       HttpCodec resultCodec = resultConnection.newCodec(client, chain, this);
 
       if (existingConnection != connection) {
-        eventListener.connectionFound(call, connection);
+        eventListener.connectionAcquired(call, connection);
       }
 
       synchronized (connectionPool) {


### PR DESCRIPTION
Fill out documentation clearing up the semantics of the EventListener API

Things to call out
- I've defined fetchStart/End to be from enqueue/execute to caller closing the Response body.
- There is no easy hook in request/response(Header|Body)(Start|End) except implicit ordering.  All useful classes e.g. StreamAllocation are internal.
- There is no event to signify when OkHttp really starts processing, or has handed off the response to the caller.