### PR TITLE
Complete EventListener

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -94,11 +94,12 @@ public final class EventListenerTest {
     assertEquals(200, response.code());
     response.body().close();
 
-    List<Class<? extends CallEvent>> expectedEvents = Arrays.asList(FetchStart.class,
-        DnsStart.class, DnsEnd.class, ConnectStart.class, ConnectEnd.class,
-        ConnectionAcquired.class, RequestHeadersStart.class, RequestHeadersEnd.class,
-        ResponseHeadersStart.class, ResponseHeadersEnd.class, ResponseBodyStart.class,
-        ResponseBodyEnd.class, ConnectionReleased.class, FetchEnd.class);
+    // TODO ResponseBodyEnd should not be last event
+    List<String> expectedEvents = Arrays.asList("FetchStart",
+        "DnsStart", "DnsEnd", "ConnectStart", "ConnectEnd",
+        "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd",
+        "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
+        "ConnectionReleased", "FetchEnd", "ResponseBodyEnd");
     assertEquals(expectedEvents, listener.recordedEventTypes());
   }
 
@@ -113,12 +114,13 @@ public final class EventListenerTest {
     assertEquals(200, response.code());
     response.body().close();
 
-    List<Class<? extends CallEvent>> expectedEvents = Arrays.asList(FetchStart.class,
-        DnsStart.class, DnsEnd.class, ConnectStart.class, SecureConnectStart.class,
-        SecureConnectEnd.class, ConnectEnd.class,
-        ConnectionAcquired.class, RequestHeadersStart.class, RequestHeadersEnd.class,
-        ResponseHeadersStart.class, ResponseHeadersEnd.class, ResponseBodyStart.class,
-        ResponseBodyEnd.class, ConnectionReleased.class, FetchEnd.class);
+    // TODO ResponseBodyEnd should not be last event
+    List<String> expectedEvents = Arrays.asList("FetchStart",
+        "DnsStart", "DnsEnd", "ConnectStart", "SecureConnectStart",
+        "SecureConnectEnd", "ConnectEnd",
+        "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd",
+        "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
+        "ConnectionReleased", "FetchEnd", "ResponseBodyEnd");
     assertEquals(expectedEvents, listener.recordedEventTypes());
   }
 
@@ -164,9 +166,9 @@ public final class EventListenerTest {
     assertEquals(200, response2.code());
     response2.body().close();
 
-    List<Class<?>> recordedEvents = listener.recordedEventTypes();
-    assertFalse(recordedEvents.contains(DnsStart.class));
-    assertFalse(recordedEvents.contains(DnsEnd.class));
+    List<String> recordedEvents = listener.recordedEventTypes();
+    assertFalse(recordedEvents.contains("DnsStart"));
+    assertFalse(recordedEvents.contains("DnsEnd"));
   }
 
   @Test public void multipleDnsLookupsForSingleCall() throws IOException {
@@ -536,9 +538,9 @@ public final class EventListenerTest {
     assertEquals(200, response2.code());
     response2.body().close();
 
-    List<Class<?>> recordedEvents = listener.recordedEventTypes();
-    assertFalse(recordedEvents.contains(SecureConnectStart.class));
-    assertFalse(recordedEvents.contains(SecureConnectEnd.class));
+    List<String> recordedEvents = listener.recordedEventTypes();
+    assertFalse(recordedEvents.contains("SecureConnectStart"));
+    assertFalse(recordedEvents.contains("SecureConnectEnd"));
   }
 
   @Test public void successfulConnectionFound() throws IOException {
@@ -571,8 +573,8 @@ public final class EventListenerTest {
 
     listener.removeUpToEvent(ConnectionAcquired.class);
 
-    List<Class<?>> remainingEvents = listener.recordedEventTypes();
-    assertFalse(remainingEvents.contains(ConnectionAcquired.class));
+    List<String> remainingEvents = listener.recordedEventTypes();
+    assertFalse(remainingEvents.contains("ConnectionAcquired"));
   }
 
   @Test public void pooledConnectionFound() throws IOException {

--- a/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.List;
+import javax.annotation.Nullable;
+
+import static org.junit.Assert.assertTrue;
+
+final class RecordingEventListener extends EventListener {
+  final Deque<CallEvent> eventSequence = new ArrayDeque<>();
+
+  /**
+   * Removes recorded events up to (and including) an event is found whose class equals
+   * {@code eventClass} and returns it.
+   */
+  <T> T removeUpToEvent(Class<T> eventClass) {
+    Object event = eventSequence.poll();
+    while (event != null && !eventClass.isInstance(event)) {
+      event = eventSequence.poll();
+    }
+    if (event == null) throw new AssertionError();
+    return (T) event;
+  }
+
+  List<Class<?>> recordedEventTypes() {
+    List<Class<?>> eventTypes = new ArrayList<>();
+    for (Object event : eventSequence) {
+      eventTypes.add(event.getClass());
+    }
+    return eventTypes;
+  }
+
+  void clearAllEvents() {
+    eventSequence.clear();
+  }
+
+  private void logEvent(CallEvent e) {
+    CallEvent startEvent = e.closes();
+
+    if (startEvent != null) {
+      assertTrue(e.getName() + " without matching " + startEvent.getName(),
+          eventSequence.contains(startEvent));
+    }
+
+    eventSequence.offer(e);
+  }
+
+  @Override public void dnsStart(Call call, String domainName) {
+    logEvent(new DnsStart(call, domainName));
+  }
+
+  @Override public void dnsEnd(Call call, String domainName, List<InetAddress> inetAddressList,
+      Throwable throwable) {
+    logEvent(new DnsEnd(call, domainName, inetAddressList, throwable));
+  }
+
+  @Override public void connectStart(Call call, InetSocketAddress inetSocketAddress,
+      Proxy proxy) {
+    logEvent(new ConnectStart(call, inetSocketAddress, proxy));
+  }
+
+  @Override public void secureConnectStart(Call call) {
+    logEvent(new SecureConnectStart(call));
+  }
+
+  @Override public void secureConnectEnd(Call call, Handshake handshake, Throwable throwable) {
+    logEvent(new SecureConnectEnd(call, handshake, throwable));
+  }
+
+  @Override public void connectEnd(Call call, InetSocketAddress inetSocketAddress,
+      Protocol protocol, @Nullable Proxy proxy, Throwable throwable) {
+    logEvent(new ConnectEnd(call, inetSocketAddress, protocol, proxy, throwable));
+  }
+
+  @Override public void connectionAcquired(Call call, Connection connection) {
+    logEvent(new ConnectionAcquired(call, connection));
+  }
+
+  @Override public void connectionReleased(Call call, Connection connection) {
+    logEvent(new ConnectionReleased(call, connection));
+  }
+
+  @Override public void fetchStart(Call call) {
+    logEvent(new FetchStart(call));
+  }
+
+  @Override public void requestHeadersStart(Call call) {
+    logEvent(new RequestHeadersStart(call));
+  }
+
+  @Override public void requestHeadersEnd(Call call, Throwable throwable) {
+    logEvent(new RequestHeadersEnd(call, throwable));
+  }
+
+  @Override public void requestBodyStart(Call call) {
+    logEvent(new RequestBodyStart(call));
+  }
+
+  @Override public void requestBodyEnd(Call call, Throwable throwable) {
+    logEvent(new RequestBodyEnd(call, throwable));
+  }
+
+  @Override public void responseHeadersStart(Call call) {
+    logEvent(new ResponseHeadersStart(call));
+  }
+
+  @Override public void responseHeadersEnd(Call call, Throwable throwable) {
+    logEvent(new ResponseHeadersEnd(call, throwable));
+  }
+
+  @Override public void responseBodyStart(Call call) {
+    logEvent(new ResponseBodyStart(call));
+  }
+
+  @Override public void responseBodyEnd(Call call, Throwable throwable) {
+    logEvent(new ResponseBodyEnd(call, throwable));
+  }
+
+  @Override public void fetchEnd(Call call, Throwable throwable) {
+    logEvent(new FetchEnd(call, throwable));
+  }
+
+  static class CallEvent {
+    final Call call;
+    final List<Object> params;
+
+    CallEvent(Call call, Object... params) {
+      this.call = call;
+      this.params = Arrays.asList(params);
+    }
+
+    public String getName() {
+      return getClass().getSimpleName();
+    }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof CallEvent)) return false;
+
+      CallEvent callEvent = (CallEvent) o;
+
+      if (!getName().equals(callEvent.getName())) return false;
+      if (!call.equals(callEvent.call)) return false;
+      return params.equals(callEvent.params);
+    }
+
+    @Override public int hashCode() {
+      int result = call.hashCode();
+      result = 31 * result + getName().hashCode();
+      result = 31 * result + params.hashCode();
+      return result;
+    }
+
+    public @Nullable CallEvent closes() {
+      return null;
+    }
+  }
+
+  static final class DnsStart extends CallEvent {
+    final String domainName;
+
+    DnsStart(Call call, String domainName) {
+      super(call, domainName);
+      this.domainName = domainName;
+    }
+  }
+
+  static final class DnsEnd extends CallEvent {
+    final String domainName;
+    final List<InetAddress> inetAddressList;
+    final Throwable throwable;
+
+    DnsEnd(Call call, String domainName, List<InetAddress> inetAddressList, Throwable throwable) {
+      super(call, domainName, inetAddressList, throwable);
+      this.domainName = domainName;
+      this.inetAddressList = inetAddressList;
+      this.throwable = throwable;
+    }
+
+    @Nullable @Override public CallEvent closes() {
+      return new DnsStart(call, domainName);
+    }
+  }
+
+  static final class ConnectStart extends CallEvent {
+    final InetSocketAddress inetSocketAddress;
+    final Proxy proxy;
+
+    ConnectStart(Call call, InetSocketAddress inetSocketAddress, Proxy proxy) {
+      super(call, inetSocketAddress, proxy);
+      this.inetSocketAddress = inetSocketAddress;
+      this.proxy = proxy;
+    }
+  }
+
+  static final class ConnectEnd extends CallEvent {
+    final InetSocketAddress inetSocketAddress;
+    final Protocol protocol;
+    final Throwable throwable;
+    final Proxy proxy;
+
+    ConnectEnd(Call call, InetSocketAddress inetSocketAddress, Protocol protocol,
+        Proxy proxy, Throwable throwable) {
+      super(call, inetSocketAddress, protocol, throwable, proxy);
+      this.inetSocketAddress = inetSocketAddress;
+      this.protocol = protocol;
+      this.throwable = throwable;
+      this.proxy = proxy;
+    }
+
+    @Nullable @Override public CallEvent closes() {
+      return new ConnectStart(call, inetSocketAddress, proxy);
+    }
+  }
+
+  static final class SecureConnectStart extends CallEvent {
+    SecureConnectStart(Call call) {
+      super(call);
+    }
+  }
+
+  static final class SecureConnectEnd extends CallEvent {
+    final Handshake handshake;
+    final Throwable throwable;
+
+    SecureConnectEnd(Call call, Handshake handshake, Throwable throwable) {
+      super(call, handshake, throwable);
+      this.handshake = handshake;
+      this.throwable = throwable;
+    }
+
+    @Nullable @Override public CallEvent closes() {
+      return new SecureConnectStart(call);
+    }
+  }
+
+  static final class ConnectionAcquired extends CallEvent {
+    final Connection connection;
+
+    ConnectionAcquired(Call call, Connection connection) {
+      super(call, connection);
+      this.connection = connection;
+    }
+  }
+
+  static final class ConnectionReleased extends CallEvent {
+    final Connection connection;
+
+    ConnectionReleased(Call call, Connection connection) {
+      super(call, connection);
+      this.connection = connection;
+    }
+
+    @Nullable @Override public CallEvent closes() {
+      return new ConnectionAcquired(call, connection);
+    }
+  }
+
+  static final class FetchStart extends CallEvent {
+    FetchStart(Call call) {
+      super(call);
+    }
+  }
+
+  static final class FetchEnd extends CallEvent {
+    final Throwable throwable;
+
+    FetchEnd(Call call, Throwable throwable) {
+      super(call, throwable);
+      this.throwable = throwable;
+    }
+
+    @Nullable @Override public CallEvent closes() {
+      return new FetchStart(call);
+    }
+  }
+
+  static final class RequestHeadersStart extends CallEvent {
+    RequestHeadersStart(Call call) {
+      super(call);
+    }
+  }
+
+  static final class RequestHeadersEnd extends CallEvent {
+    final Throwable throwable;
+
+    RequestHeadersEnd(Call call, Throwable throwable) {
+      super(call, throwable);
+      this.throwable = throwable;
+    }
+
+    @Nullable @Override public CallEvent closes() {
+      return new RequestHeadersStart(call);
+    }
+  }
+
+  static final class RequestBodyStart extends CallEvent {
+    RequestBodyStart(Call call) {
+      super(call);
+    }
+  }
+
+  static final class RequestBodyEnd extends CallEvent {
+    final Throwable throwable;
+
+    RequestBodyEnd(Call call, Throwable throwable) {
+      super(call, throwable);
+      this.throwable = throwable;
+    }
+
+    @Nullable @Override public CallEvent closes() {
+      return new RequestBodyStart(call);
+    }
+  }
+
+  static final class ResponseHeadersStart extends CallEvent {
+    ResponseHeadersStart(Call call) {
+      super(call);
+    }
+  }
+
+  static final class ResponseHeadersEnd extends CallEvent {
+    final Throwable throwable;
+
+    ResponseHeadersEnd(Call call, Throwable throwable) {
+      super(call, throwable);
+      this.throwable = throwable;
+    }
+
+    @Nullable @Override public CallEvent closes() {
+      return new RequestHeadersStart(call);
+    }
+  }
+
+  static final class ResponseBodyStart extends CallEvent {
+    ResponseBodyStart(Call call) {
+      super(call);
+    }
+  }
+
+  static final class ResponseBodyEnd extends CallEvent {
+    final Throwable throwable;
+
+    ResponseBodyEnd(Call call, Throwable throwable) {
+      super(call, throwable);
+      this.throwable = throwable;
+    }
+
+    @Nullable @Override public CallEvent closes() {
+      return new ResponseBodyStart(call);
+    }
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
@@ -89,8 +89,8 @@ final class RecordingEventListener extends EventListener {
   }
 
   @Override public void connectEnd(Call call, InetSocketAddress inetSocketAddress,
-      Protocol protocol, @Nullable Proxy proxy, Throwable throwable) {
-    logEvent(new ConnectEnd(call, inetSocketAddress, protocol, proxy, throwable));
+      @Nullable Proxy proxy, Protocol protocol, Throwable throwable) {
+    logEvent(new ConnectEnd(call, inetSocketAddress, proxy, protocol, throwable));
   }
 
   @Override public void connectionAcquired(Call call, Connection connection) {
@@ -220,13 +220,13 @@ final class RecordingEventListener extends EventListener {
     final Throwable throwable;
     final Proxy proxy;
 
-    ConnectEnd(Call call, InetSocketAddress inetSocketAddress, Protocol protocol,
-        Proxy proxy, Throwable throwable) {
-      super(call, inetSocketAddress, protocol, throwable, proxy);
+    ConnectEnd(Call call, InetSocketAddress inetSocketAddress, Proxy proxy, Protocol protocol,
+        Throwable throwable) {
+      super(call, inetSocketAddress, proxy, protocol, throwable);
       this.inetSocketAddress = inetSocketAddress;
+      this.proxy = proxy;
       this.protocol = protocol;
       this.throwable = throwable;
-      this.proxy = proxy;
     }
 
     @Nullable @Override public CallEvent closes() {

--- a/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
@@ -43,10 +43,10 @@ final class RecordingEventListener extends EventListener {
     return (T) event;
   }
 
-  List<Class<?>> recordedEventTypes() {
-    List<Class<?>> eventTypes = new ArrayList<>();
-    for (Object event : eventSequence) {
-      eventTypes.add(event.getClass());
+  List<String> recordedEventTypes() {
+    List<String> eventTypes = new ArrayList<>();
+    for (CallEvent event : eventSequence) {
+      eventTypes.add(event.getName());
     }
     return eventTypes;
   }

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -33,6 +33,14 @@ public abstract class EventListener {
     };
   }
 
+  /**
+   * Invoked as soon as a call is enqueued or executed by a client. In case of thread or stream
+   * limits, this call may be executed well before processing the request is able to begin.
+   *
+   * <p>This will be invoked only once for a single {@link Call}. Retries of different routes
+   * or redirects will be handled within the boundaries of a single fetchStart and
+   * {@link #fetchEnd(Call, Throwable)} pair.
+   */
   public void fetchStart(Call call) {
   }
 
@@ -131,30 +139,116 @@ public abstract class EventListener {
   public void connectionFound(Call call, Connection connection) {
   }
 
+  /**
+   * Invoked just prior to sending request headers.
+   *
+   * <p>The connection is implicit, and will generally relate to the last
+   * {@link #connectionFound(Call, Connection)} event.
+   *
+   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
+   * to the {@link Call#request()} is a redirect to a different address.
+   */
   public void requestHeadersStart(Call call) {
   }
 
+  /**
+   * Invoked immediately after sending a request body.
+   *
+   * <p>This method is always invoked after {@link #requestHeadersStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to send the headers.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to send the headers.
+   */
   public void requestHeadersEnd(Call call, Throwable throwable) {
   }
 
+  /**
+   * Invoked just prior to sending a request body.  Will only be invoked for request allowing and
+   * having a request body to send.
+   *
+   * <p>The connection is implicit, and will generally relate to the last
+   * {@link #connectionFound(Call, Connection)} event.
+   *
+   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
+   * to the {@link Call#request()} is a redirect to a different address.
+   */
   public void requestBodyStart(Call call) {
   }
 
+  /**
+   * Invoked immediately after sending a request body.
+   *
+   * <p>This method is always invoked after {@link #requestBodyStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to send the body.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to send the body.
+   */
   public void requestBodyEnd(Call call, Throwable throwable) {
   }
 
+  /**
+   * Invoked just prior to receiving response headers.
+   *
+   * <p>The connection is implicit, and will generally relate to the last
+   * {@link #connectionFound(Call, Connection)} event.
+   *
+   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
+   * to the {@link Call#request()} is a redirect to a different address.
+   */
   public void responseHeadersStart(Call call) {
   }
 
+  /**
+   * Invoked immediately after receiving response headers.
+   *
+   * <p>This method is always invoked after {@link #responseHeadersStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to receive the headers.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to receive the headers.
+   */
   public void responseHeadersEnd(Call call, Throwable throwable) {
   }
 
+  /**
+   * Invoked just prior to receiving the response body.
+   *
+   * <p>The connection is implicit, and will generally relate to the last
+   * {@link #connectionFound(Call, Connection)} event.
+   *
+   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
+   * to the {@link Call#request()} is a redirect to a different address.
+   */
   public void responseBodyStart(Call call) {
   }
 
+  /**
+   * Invoked immediately after receiving a request body and completing reading it.
+   *
+   * <p>Will only be invoked for requests having a response body e.g. won't be invoked for a websocket
+   * upgrade.
+   *
+   * <p>This method is always invoked after {@link #requestBodyStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to send the body.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to send the body.
+   */
   public void responseBodyEnd(Call call, Throwable throwable) {
   }
 
+  /**
+   * Invoked immediately after a call has completely ended.  This includes delayed consumption
+   * of response body by the caller.
+   *
+   * <p>This method is always invoked after {@link #fetchStart(Call)}.
+   *
+   * <p>{@code throwable} will be null in the case of a successful attempt to execute the call.
+   *
+   * <p>{@code throwable} will be non-null in the case of a failed attempt to execute the call.
+   */
   public void fetchEnd(Call call, Throwable throwable) {
   }
 

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -119,7 +119,7 @@ public abstract class EventListener {
    * connection attempt.
    */
   public void connectEnd(Call call, InetSocketAddress inetSocketAddress,
-      @Nullable Protocol protocol, @Nullable Throwable throwable) {
+      @Nullable Protocol protocol, @Nullable Proxy proxy, @Nullable Throwable throwable) {
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -33,14 +33,6 @@ public abstract class EventListener {
     };
   }
 
-  /**
-   * Invoked as soon as a call is enqueued or executed by a client. In case of thread or stream
-   * limits, this call may be executed well before processing the request is able to begin.
-   *
-   * <p>This will be invoked only once for a single {@link Call}. Retries of different routes
-   * or redirects will be handled within the boundaries of a single fetchStart and
-   * {@link #fetchEnd(Call, Throwable)} pair.
-   */
   public void fetchStart(Call call) {
   }
 
@@ -136,119 +128,36 @@ public abstract class EventListener {
    * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
    * to the {@link Call#request()} is a redirect to a different address.
    */
-  public void connectionFound(Call call, Connection connection) {
+  public void connectionAcquired(Call call, Connection connection) {
   }
 
-  /**
-   * Invoked just prior to sending request headers.
-   *
-   * <p>The connection is implicit, and will generally relate to the last
-   * {@link #connectionFound(Call, Connection)} event.
-   *
-   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
-   * to the {@link Call#request()} is a redirect to a different address.
-   */
+  public void connectionReleased(Call call, Connection connection) {
+  }
+
   public void requestHeadersStart(Call call) {
   }
 
-  /**
-   * Invoked immediately after sending a request body.
-   *
-   * <p>This method is always invoked after {@link #requestHeadersStart(Call)}.
-   *
-   * <p>{@code throwable} will be null in the case of a successful attempt to send the headers.
-   *
-   * <p>{@code throwable} will be non-null in the case of a failed attempt to send the headers.
-   */
   public void requestHeadersEnd(Call call, Throwable throwable) {
   }
 
-  /**
-   * Invoked just prior to sending a request body.  Will only be invoked for request allowing and
-   * having a request body to send.
-   *
-   * <p>The connection is implicit, and will generally relate to the last
-   * {@link #connectionFound(Call, Connection)} event.
-   *
-   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
-   * to the {@link Call#request()} is a redirect to a different address.
-   */
   public void requestBodyStart(Call call) {
   }
 
-  /**
-   * Invoked immediately after sending a request body.
-   *
-   * <p>This method is always invoked after {@link #requestBodyStart(Call)}.
-   *
-   * <p>{@code throwable} will be null in the case of a successful attempt to send the body.
-   *
-   * <p>{@code throwable} will be non-null in the case of a failed attempt to send the body.
-   */
   public void requestBodyEnd(Call call, Throwable throwable) {
   }
 
-  /**
-   * Invoked just prior to receiving response headers.
-   *
-   * <p>The connection is implicit, and will generally relate to the last
-   * {@link #connectionFound(Call, Connection)} event.
-   *
-   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
-   * to the {@link Call#request()} is a redirect to a different address.
-   */
   public void responseHeadersStart(Call call) {
   }
 
-  /**
-   * Invoked immediately after receiving response headers.
-   *
-   * <p>This method is always invoked after {@link #responseHeadersStart(Call)}.
-   *
-   * <p>{@code throwable} will be null in the case of a successful attempt to receive the headers.
-   *
-   * <p>{@code throwable} will be non-null in the case of a failed attempt to receive the headers.
-   */
   public void responseHeadersEnd(Call call, Throwable throwable) {
   }
 
-  /**
-   * Invoked just prior to receiving the response body.
-   *
-   * <p>The connection is implicit, and will generally relate to the last
-   * {@link #connectionFound(Call, Connection)} event.
-   *
-   * <p>This can be invoked more than 1 time for a single {@link Call}. For example, if the response
-   * to the {@link Call#request()} is a redirect to a different address.
-   */
   public void responseBodyStart(Call call) {
   }
 
-  /**
-   * Invoked immediately after receiving a request body and completing reading it.
-   *
-   * <p>Will only be invoked for requests having a response body e.g. won't be invoked for a
-   * websocket upgrade.
-   *
-   * <p>This method is always invoked after {@link #requestBodyStart(Call)}.
-   *
-   * <p>{@code throwable} will be null in the case of a successful attempt to send the body.
-   *
-   * <p>{@code throwable} will be non-null in the case of a failed attempt to send the body.
-   */
   public void responseBodyEnd(Call call, Throwable throwable) {
   }
 
-  /**
-   * Invoked immediately after a call has completely ended.  This includes delayed consumption
-   * of response body by the caller.
-   *
-   * <p>This method is always invoked after {@link #fetchStart(Call)}.
-   *
-   * <p>{@code throwable} will be null in the case of a successful attempt to execute the call.
-   *
-   * <p>{@code throwable} will be non-null in the case of a failed attempt to execute the call.
-   */
   public void fetchEnd(Call call, Throwable throwable) {
   }
 

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -119,7 +119,8 @@ public abstract class EventListener {
    * connection attempt.
    */
   public void connectEnd(Call call, InetSocketAddress inetSocketAddress,
-      @Nullable Protocol protocol, @Nullable Proxy proxy, @Nullable Throwable throwable) {
+      @Nullable Proxy proxy, @Nullable Protocol protocol,
+      @Nullable Throwable throwable) {
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -227,8 +227,8 @@ public abstract class EventListener {
   /**
    * Invoked immediately after receiving a request body and completing reading it.
    *
-   * <p>Will only be invoked for requests having a response body e.g. won't be invoked for a websocket
-   * upgrade.
+   * <p>Will only be invoked for requests having a response body e.g. won't be invoked for a
+   * websocket upgrade.
    *
    * <p>This method is always invoked after {@link #requestBodyStart(Call)}.
    *

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -158,7 +158,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
           connectSocket(connectTimeout, readTimeout, call, eventListener);
         }
         establishProtocol(connectionSpecSelector, call, eventListener);
-        eventListener.connectEnd(call, route.socketAddress(), protocol, null);
+        eventListener.connectEnd(call, route.socketAddress(), protocol, route.proxy(), null);
         break;
       } catch (IOException e) {
         closeQuietly(socket);
@@ -171,7 +171,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
         protocol = null;
         http2Connection = null;
 
-        eventListener.connectEnd(call, route.socketAddress(), null, e);
+        eventListener.connectEnd(call, route.socketAddress(), null, route.proxy(), e);
 
         if (routeException == null) {
           routeException = new RouteException(e);
@@ -218,7 +218,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
       rawSocket = null;
       sink = null;
       source = null;
-      eventListener.connectEnd(call, route.socketAddress(), null, null);
+      eventListener.connectEnd(call, route.socketAddress(), null, route.proxy(), null);
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -158,7 +158,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
           connectSocket(connectTimeout, readTimeout, call, eventListener);
         }
         establishProtocol(connectionSpecSelector, call, eventListener);
-        eventListener.connectEnd(call, route.socketAddress(), protocol, route.proxy(), null);
+        eventListener.connectEnd(call, route.socketAddress(), route.proxy(), protocol, null);
         break;
       } catch (IOException e) {
         closeQuietly(socket);
@@ -171,7 +171,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
         protocol = null;
         http2Connection = null;
 
-        eventListener.connectEnd(call, route.socketAddress(), null, route.proxy(), e);
+        eventListener.connectEnd(call, route.socketAddress(), route.proxy(), null, e);
 
         if (routeException == null) {
           routeException = new RouteException(e);
@@ -218,7 +218,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
       rawSocket = null;
       sink = null;
       source = null;
-      eventListener.connectEnd(call, route.socketAddress(), null, route.proxy(), null);
+      eventListener.connectEnd(call, route.socketAddress(), route.proxy(), null, null);
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -267,11 +267,11 @@ public final class RealConnection extends Http2Connection.Listener implements Co
     eventListener.secureConnectStart(call);
     try {
       connectTls(connectionSpecSelector);
+      eventListener.secureConnectEnd(call, handshake, null);
     } catch (Exception e) {
       eventListener.secureConnectEnd(call, null, e);
       throw e;
     }
-    eventListener.secureConnectEnd(call, handshake, null);
 
     if (protocol == Protocol.HTTP_2) {
       socket.setSoTimeout(0); // HTTP/2 connection timeouts are set per-stream.

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -78,8 +78,8 @@ public final class StreamAllocation {
   private RouteSelector.Selection routeSelection;
   private Route route;
   private final ConnectionPool connectionPool;
-  private final Call call;
-  private final EventListener eventListener;
+  public final Call call;
+  public final EventListener eventListener;
   private final Object callStackTrace;
 
   // State guarded by connectionPool.

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -113,7 +113,7 @@ public final class StreamAllocation {
       HttpCodec resultCodec = resultConnection.newCodec(client, chain, this);
 
       if (existingConnection != connection) {
-        eventListener.connectionFound(call, connection);
+        eventListener.connectionAcquired(call, connection);
       }
 
       synchronized (connectionPool) {

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -287,6 +287,9 @@ public final class StreamAllocation {
       this.codec = null;
     }
     if (released) {
+      if (connection != null) {
+        eventListener.connectionReleased(call, connection);
+      }
       this.released = true;
     }
     Socket socket = null;

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
@@ -43,36 +43,62 @@ public final class CallServerInterceptor implements Interceptor {
     Request request = realChain.request();
 
     long sentRequestMillis = System.currentTimeMillis();
-    httpCodec.writeRequestHeaders(request);
+
+    realChain.eventListener().requestHeadersStart(realChain.call());
+    try {
+      httpCodec.writeRequestHeaders(request);
+      realChain.eventListener().requestHeadersEnd(realChain.call(), null);
+    } catch (IOException ioe) {
+      realChain.eventListener().requestHeadersEnd(realChain.call(), ioe);
+      throw ioe;
+    }
 
     Response.Builder responseBuilder = null;
+    realChain.eventListener().requestBodyStart(realChain.call());
+    try {
     if (HttpMethod.permitsRequestBody(request.method()) && request.body() != null) {
       // If there's a "Expect: 100-continue" header on the request, wait for a "HTTP/1.1 100
       // Continue" response before transmitting the request body. If we don't get that, return what
       // we did get (such as a 4xx response) without ever transmitting the request body.
       if ("100-continue".equalsIgnoreCase(request.header("Expect"))) {
         httpCodec.flushRequest();
+        // TODO event listener
         responseBuilder = httpCodec.readResponseHeaders(true);
       }
 
-      if (responseBuilder == null) {
-        // Write the request body if the "Expect: 100-continue" expectation was met.
-        Sink requestBodyOut = httpCodec.createRequestBody(request, request.body().contentLength());
-        BufferedSink bufferedRequestBody = Okio.buffer(requestBodyOut);
-        request.body().writeTo(bufferedRequestBody);
-        bufferedRequestBody.close();
-      } else if (!connection.isMultiplexed()) {
-        // If the "Expect: 100-continue" expectation wasn't met, prevent the HTTP/1 connection from
-        // being reused. Otherwise we're still obligated to transmit the request body to leave the
-        // connection in a consistent state.
-        streamAllocation.noNewStreams();
-      }
+        if (responseBuilder == null) {
+          // Write the request body if the "Expect: 100-continue" expectation was met.
+          Sink requestBodyOut =
+              httpCodec.createRequestBody(request, request.body().contentLength());
+          BufferedSink bufferedRequestBody = Okio.buffer(requestBodyOut);
+
+            request.body().writeTo(bufferedRequestBody);
+          bufferedRequestBody.close();
+        } else if (!connection.isMultiplexed()) {
+          // If the "Expect: 100-continue" expectation wasn't met, prevent the HTTP/1 connection
+          // from being reused. Otherwise we're still obligated to transmit the request body to
+          // leave the connection in a consistent state.
+          streamAllocation.noNewStreams();
+        }
+    }
+
+      realChain.eventListener().requestBodyEnd(realChain.call(), null);
+    } catch (IOException ioe) {
+      realChain.eventListener().requestBodyEnd(realChain.call(), ioe);
+      throw ioe;
     }
 
     httpCodec.finishRequest();
 
     if (responseBuilder == null) {
-      responseBuilder = httpCodec.readResponseHeaders(false);
+      realChain.eventListener().responseHeadersStart(realChain.call());
+      try {
+        responseBuilder = httpCodec.readResponseHeaders(false);
+        realChain.eventListener().responseHeadersEnd(realChain.call(), null);
+      } catch (IOException ioe) {
+        realChain.eventListener().responseHeadersEnd(realChain.call(), ioe);
+        throw ioe;
+      }
     }
 
     Response response = responseBuilder
@@ -82,26 +108,35 @@ public final class CallServerInterceptor implements Interceptor {
         .receivedResponseAtMillis(System.currentTimeMillis())
         .build();
 
-    int code = response.code();
-    if (forWebSocket && code == 101) {
-      // Connection is upgrading, but we need to ensure interceptors see a non-null response body.
-      response = response.newBuilder()
-          .body(Util.EMPTY_RESPONSE)
-          .build();
-    } else {
-      response = response.newBuilder()
-          .body(httpCodec.openResponseBody(response))
-          .build();
-    }
+    realChain.eventListener().responseBodyStart(realChain.call());
+    try {
+      int code = response.code();
+      if (forWebSocket && code == 101) {
+        // Connection is upgrading, but we need to ensure interceptors see a non-null response body.
+        response = response.newBuilder()
+            .body(Util.EMPTY_RESPONSE)
+            .build();
+      } else {
+          response = response.newBuilder()
+              .body(httpCodec.openResponseBody(response))
+              .build();
+      }
 
-    if ("close".equalsIgnoreCase(response.request().header("Connection"))
-        || "close".equalsIgnoreCase(response.header("Connection"))) {
-      streamAllocation.noNewStreams();
-    }
+      if ("close".equalsIgnoreCase(response.request().header("Connection"))
+          || "close".equalsIgnoreCase(response.header("Connection"))) {
+        streamAllocation.noNewStreams();
+      }
 
-    if ((code == 204 || code == 205) && response.body().contentLength() > 0) {
-      throw new ProtocolException(
-          "HTTP " + code + " had non-zero Content-Length: " + response.body().contentLength());
+      if ((code == 204 || code == 205) && response.body().contentLength() > 0) {
+        throw new ProtocolException(
+            "HTTP " + code + " had non-zero Content-Length: " + response.body().contentLength());
+      }
+
+      // TODO this is too early, response may not be read
+      realChain.eventListener().responseBodyEnd(realChain.call(), null);
+    } catch (IOException ioe) {
+      realChain.eventListener().responseBodyEnd(realChain.call(), ioe);
+      throw ioe;
     }
 
     return response;

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
@@ -107,11 +107,6 @@ public final class CallServerInterceptor implements Interceptor {
         .receivedResponseAtMillis(System.currentTimeMillis())
         .build();
 
-    if ("close".equalsIgnoreCase(response.request().header("Connection"))
-        || "close".equalsIgnoreCase(response.header("Connection"))) {
-      streamAllocation.noNewStreams();
-    }
-
     int code = response.code();
     if (forWebSocket && code == 101) {
       // Connection is upgrading, but we need to ensure interceptors see a non-null response body.
@@ -122,6 +117,11 @@ public final class CallServerInterceptor implements Interceptor {
       response = response.newBuilder()
           .body(httpCodec.openResponseBody(response))
           .build();
+
+      if ("close".equalsIgnoreCase(response.request().header("Connection"))
+          || "close".equalsIgnoreCase(response.header("Connection"))) {
+        streamAllocation.noNewStreams();
+      }
 
       if ((code == 204 || code == 205) && response.body().contentLength() > 0) {
         throw new ProtocolException(

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
@@ -117,16 +117,16 @@ public final class CallServerInterceptor implements Interceptor {
       response = response.newBuilder()
           .body(httpCodec.openResponseBody(response))
           .build();
+    }
 
-      if ("close".equalsIgnoreCase(response.request().header("Connection"))
-          || "close".equalsIgnoreCase(response.header("Connection"))) {
-        streamAllocation.noNewStreams();
-      }
+    if ("close".equalsIgnoreCase(response.request().header("Connection"))
+        || "close".equalsIgnoreCase(response.header("Connection"))) {
+      streamAllocation.noNewStreams();
+    }
 
-      if ((code == 204 || code == 205) && response.body().contentLength() > 0) {
-        throw new ProtocolException(
-            "HTTP " + code + " had non-zero Content-Length: " + response.body().contentLength());
-      }
+    if ((code == 204 || code == 205) && response.body().contentLength() > 0) {
+      throw new ProtocolException(
+          "HTTP " + code + " had non-zero Content-Length: " + response.body().contentLength());
     }
 
     return response;

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
@@ -54,17 +54,17 @@ public final class CallServerInterceptor implements Interceptor {
     }
 
     Response.Builder responseBuilder = null;
-    realChain.eventListener().requestBodyStart(realChain.call());
-    try {
     if (HttpMethod.permitsRequestBody(request.method()) && request.body() != null) {
-      // If there's a "Expect: 100-continue" header on the request, wait for a "HTTP/1.1 100
-      // Continue" response before transmitting the request body. If we don't get that, return what
-      // we did get (such as a 4xx response) without ever transmitting the request body.
-      if ("100-continue".equalsIgnoreCase(request.header("Expect"))) {
-        httpCodec.flushRequest();
-        // TODO event listener
-        responseBuilder = httpCodec.readResponseHeaders(true);
-      }
+      realChain.eventListener().requestBodyStart(realChain.call());
+      try {
+        // If there's a "Expect: 100-continue" header on the request, wait for a "HTTP/1.1 100
+        // Continue" response before transmitting the request body. If we don't get that, return what
+        // we did get (such as a 4xx response) without ever transmitting the request body.
+        if ("100-continue".equalsIgnoreCase(request.header("Expect"))) {
+          httpCodec.flushRequest();
+          // TODO event listener
+          responseBuilder = httpCodec.readResponseHeaders(true);
+        }
 
         if (responseBuilder == null) {
           // Write the request body if the "Expect: 100-continue" expectation was met.
@@ -72,7 +72,7 @@ public final class CallServerInterceptor implements Interceptor {
               httpCodec.createRequestBody(request, request.body().contentLength());
           BufferedSink bufferedRequestBody = Okio.buffer(requestBodyOut);
 
-            request.body().writeTo(bufferedRequestBody);
+          request.body().writeTo(bufferedRequestBody);
           bufferedRequestBody.close();
         } else if (!connection.isMultiplexed()) {
           // If the "Expect: 100-continue" expectation wasn't met, prevent the HTTP/1 connection
@@ -80,12 +80,11 @@ public final class CallServerInterceptor implements Interceptor {
           // leave the connection in a consistent state.
           streamAllocation.noNewStreams();
         }
-    }
-
-      realChain.eventListener().requestBodyEnd(realChain.call(), null);
-    } catch (IOException ioe) {
-      realChain.eventListener().requestBodyEnd(realChain.call(), ioe);
-      throw ioe;
+        realChain.eventListener().requestBodyEnd(realChain.call(), null);
+      } catch (IOException ioe) {
+        realChain.eventListener().requestBodyEnd(realChain.call(), ioe);
+        throw ioe;
+      }
     }
 
     httpCodec.finishRequest();
@@ -108,35 +107,34 @@ public final class CallServerInterceptor implements Interceptor {
         .receivedResponseAtMillis(System.currentTimeMillis())
         .build();
 
-    realChain.eventListener().responseBodyStart(realChain.call());
-    try {
-      int code = response.code();
-      if (forWebSocket && code == 101) {
-        // Connection is upgrading, but we need to ensure interceptors see a non-null response body.
+    if ("close".equalsIgnoreCase(response.request().header("Connection"))
+        || "close".equalsIgnoreCase(response.header("Connection"))) {
+      streamAllocation.noNewStreams();
+    }
+
+    int code = response.code();
+    if (forWebSocket && code == 101) {
+      // Connection is upgrading, but we need to ensure interceptors see a non-null response body.
+      response = response.newBuilder()
+          .body(Util.EMPTY_RESPONSE)
+          .build();
+    } else {
+      realChain.eventListener().responseBodyStart(realChain.call());
+      try {
         response = response.newBuilder()
-            .body(Util.EMPTY_RESPONSE)
+            .body(httpCodec.openResponseBody(response))
             .build();
-      } else {
-          response = response.newBuilder()
-              .body(httpCodec.openResponseBody(response))
-              .build();
-      }
 
-      if ("close".equalsIgnoreCase(response.request().header("Connection"))
-          || "close".equalsIgnoreCase(response.header("Connection"))) {
-        streamAllocation.noNewStreams();
-      }
+        if ((code == 204 || code == 205) && response.body().contentLength() > 0) {
+          throw new ProtocolException(
+              "HTTP " + code + " had non-zero Content-Length: " + response.body().contentLength());
+        }
 
-      if ((code == 204 || code == 205) && response.body().contentLength() > 0) {
-        throw new ProtocolException(
-            "HTTP " + code + " had non-zero Content-Length: " + response.body().contentLength());
+        realChain.eventListener().responseBodyEnd(realChain.call(), null);
+      } catch (IOException ioe) {
+        realChain.eventListener().responseBodyEnd(realChain.call(), ioe);
+        throw ioe;
       }
-
-      // TODO this is too early, response may not be read
-      realChain.eventListener().responseBodyEnd(realChain.call(), null);
-    } catch (IOException ioe) {
-      realChain.eventListener().responseBodyEnd(realChain.call(), ioe);
-      throw ioe;
     }
 
     return response;

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
@@ -58,8 +58,8 @@ public final class CallServerInterceptor implements Interceptor {
       realChain.eventListener().requestBodyStart(realChain.call());
       try {
         // If there's a "Expect: 100-continue" header on the request, wait for a "HTTP/1.1 100
-        // Continue" response before transmitting the request body. If we don't get that, return what
-        // we did get (such as a 4xx response) without ever transmitting the request body.
+        // Continue" response before transmitting the request body. If we don't get that, return
+        // what we did get (such as a 4xx response) without ever transmitting the request body.
         if ("100-continue".equalsIgnoreCase(request.header("Expect"))) {
           httpCodec.flushRequest();
           // TODO event listener

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
@@ -119,21 +119,13 @@ public final class CallServerInterceptor implements Interceptor {
           .body(Util.EMPTY_RESPONSE)
           .build();
     } else {
-      realChain.eventListener().responseBodyStart(realChain.call());
-      try {
-        response = response.newBuilder()
-            .body(httpCodec.openResponseBody(response))
-            .build();
+      response = response.newBuilder()
+          .body(httpCodec.openResponseBody(response))
+          .build();
 
-        if ((code == 204 || code == 205) && response.body().contentLength() > 0) {
-          throw new ProtocolException(
-              "HTTP " + code + " had non-zero Content-Length: " + response.body().contentLength());
-        }
-
-        realChain.eventListener().responseBodyEnd(realChain.call(), null);
-      } catch (IOException ioe) {
-        realChain.eventListener().responseBodyEnd(realChain.call(), ioe);
-        throw ioe;
+      if ((code == 204 || code == 205) && response.body().contentLength() > 0) {
+        throw new ProtocolException(
+            "HTTP " + code + " had non-zero Content-Length: " + response.body().contentLength());
       }
     }
 

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
@@ -124,7 +124,6 @@ public final class Http1Codec implements HttpCodec {
    * header field receives the proper value.
    */
   @Override public void writeRequestHeaders(Request request) throws IOException {
-
     String requestLine = RequestLine.get(
         request, streamAllocation.connection().route().proxy().type());
     writeRequest(request.headers(), requestLine);


### PR DESCRIPTION
Call all methods in EventListener.
Adds proxy to connectEnd to allow matching to start event unambiguously.
Test EventListener fails fast for unmatched end event.
Make RecordingEventListener a top level class.

n.b. Ordering of ResponseBodyEvent needs to be addressed in another PR.  Currently it can be delayed by client not consuming output, even if all bytes have been read off the wire.