### PR TITLE
JDK 8u141 & 8u144 Compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -552,5 +552,23 @@
         <alpn.jdk8.version>8.1.11.v20170118</alpn.jdk8.version>
       </properties>
     </profile>
+    <profile>
+      <id>alpn-when-jdk8_141</id>
+      <activation>
+        <jdk>1.8.0_141</jdk>
+      </activation>
+      <properties>
+        <alpn.jdk8.version>8.1.11.v20170118</alpn.jdk8.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>alpn-when-jdk8_144</id>
+      <activation>
+        <jdk>1.8.0_144</jdk>
+      </activation>
+      <properties>
+        <alpn.jdk8.version>8.1.11.v20170118</alpn.jdk8.version>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Per [this comment](https://github.com/jetty-project/jetty-alpn/commit/d58174d8924eda832f22606d68abaf879f4553fa#commitcomment-23304619) & reply from @sbordet, pom.xml was modified for jdk8u141, and tests succeeded.

An update today to 8u144 and subsequent test with u144's profile also successfully tested.

My completed CLA form was submitted about five minutes ago.