### PR TITLE
Fix occasional hang with http2 goaway frames

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
@@ -43,6 +43,9 @@ public final class MockResponse implements Cloneable {
   private long bodyDelayAmount = 0;
   private TimeUnit bodyDelayUnit = TimeUnit.MILLISECONDS;
 
+  private long headersDelayAmount = 0;
+  private TimeUnit headersDelayUnit = TimeUnit.MILLISECONDS;
+
   private List<PushPromise> promises = new ArrayList<>();
   private Settings settings;
   private WebSocketListener webSocketListener;
@@ -251,6 +254,16 @@ public final class MockResponse implements Cloneable {
 
   public long getBodyDelay(TimeUnit unit) {
     return unit.convert(bodyDelayAmount, bodyDelayUnit);
+  }
+
+  public MockResponse setHeadersDelay(long delay, TimeUnit unit) {
+    headersDelayAmount = delay;
+    headersDelayUnit = unit;
+    return this;
+  }
+
+  public long getHeadersDelay(TimeUnit unit) {
+    return unit.convert(headersDelayAmount, headersDelayUnit);
   }
 
   /**

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -710,7 +710,10 @@ public final class MockWebServer extends ExternalResource implements Closeable {
   }
 
   private void sleepIfDelayed(MockResponse response) {
-    long delayMs = response.getBodyDelay(TimeUnit.MILLISECONDS);
+    sleepIfDelayed(response.getBodyDelay(TimeUnit.MILLISECONDS));
+  }
+
+  private void sleepIfDelayed(long delayMs) {
     if (delayMs != 0) {
       try {
         Thread.sleep(delayMs);
@@ -947,6 +950,8 @@ public final class MockWebServer extends ExternalResource implements Closeable {
       for (int i = 0, size = headers.size(); i < size; i++) {
         http2Headers.add(new Header(headers.name(i), headers.value(i)));
       }
+
+      sleepIfDelayed(response.getHeadersDelay(TimeUnit.MILLISECONDS));
 
       Buffer body = response.getBody();
       boolean closeStreamAfterHeaders = body != null || !response.getPushPromises().isEmpty();

--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -24,12 +24,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+
 import javax.net.ssl.HostnameVerifier;
 import okhttp3.Cache;
 import okhttp3.Call;
+import okhttp3.Callback;
 import okhttp3.Cookie;
 import okhttp3.Credentials;
 import okhttp3.Headers;
@@ -976,6 +980,33 @@ public final class HttpOverHttp2Test {
 
     assertEquals(0, server.takeRequest().getSequenceNumber());
     assertEquals(0, server.takeRequest().getSequenceNumber());
+  }
+
+  @Test public void responseHeadersAfterGoaway() throws Exception {
+    server.enqueue(new MockResponse()
+        .setHeadersDelay(1, SECONDS)
+        .setBody("ABC"));
+    server.enqueue(new MockResponse()
+        .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END)
+        .setBody("DEF"));
+
+    final BlockingQueue<String> bodies = new SynchronousQueue<>();
+    Callback callback = new Callback() {
+      @Override
+      public void onResponse(Call call, Response response) throws IOException {
+        bodies.add(response.body().string());
+      }
+      @Override
+      public void onFailure(Call call, IOException e) {
+        System.out.println(e);
+      }
+    };
+    client.newCall(new Request.Builder().url(server.url("/")).build()).enqueue(callback);
+    client.newCall(new Request.Builder().url(server.url("/")).build()).enqueue(callback);
+
+    assertEquals("DEF", bodies.poll(2, SECONDS));
+    assertEquals("ABC", bodies.poll(2, SECONDS));
+    assertEquals(2, server.getRequestCount());
   }
 
   /**


### PR DESCRIPTION
Http2Connection was dropping headers of healthy streams
after GOAWAY frame.

Fixes #3422
