### PR TITLE
Allow using a charset other than UTF-8 for creating urlencoded form bodies.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/FormBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/FormBodyTest.java
@@ -18,6 +18,7 @@ package okhttp3;
 import java.io.IOException;
 import okio.Buffer;
 import org.junit.Test;
+import java.nio.charset.Charset;
 
 import static org.junit.Assert.assertEquals;
 
@@ -195,5 +196,18 @@ public final class FormBodyTest {
     body.writeTo(buffer);
     buffer.skip(3); // Skip "a=b" prefix.
     return buffer.readUtf8(buffer.size() - 1); // Skip the "c" suffix.
+  }
+
+  @Test public void manualCharset() throws Exception {
+    FormBody body = new FormBody.Builder(Charset.forName("ISO-8859-1"))
+        .add("name", "Nicolás")
+        .build();
+
+    String expected = "name=Nicol%E1s";
+    assertEquals(expected.length(), body.contentLength());
+
+    Buffer out = new Buffer();
+    body.writeTo(out);
+    assertEquals(expected, out.readUtf8());
   }
 }

--- a/okhttp/src/main/java/okhttp3/FormBody.java
+++ b/okhttp/src/main/java/okhttp3/FormBody.java
@@ -16,6 +16,7 @@
 package okhttp3;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -105,16 +106,25 @@ public final class FormBody extends RequestBody {
   public static final class Builder {
     private final List<String> names = new ArrayList<>();
     private final List<String> values = new ArrayList<>();
+    private final Charset charset;
+
+    public Builder() {
+      this(null);
+    }
+
+    public Builder(Charset charset) {
+      this.charset = charset;
+    }
 
     public Builder add(String name, String value) {
-      names.add(HttpUrl.canonicalize(name, FORM_ENCODE_SET, false, false, true, true));
-      values.add(HttpUrl.canonicalize(value, FORM_ENCODE_SET, false, false, true, true));
+      names.add(HttpUrl.canonicalize(name, FORM_ENCODE_SET, false, false, true, true, charset));
+      values.add(HttpUrl.canonicalize(value, FORM_ENCODE_SET, false, false, true, true, charset));
       return this;
     }
 
     public Builder addEncoded(String name, String value) {
-      names.add(HttpUrl.canonicalize(name, FORM_ENCODE_SET, true, false, true, true));
-      values.add(HttpUrl.canonicalize(value, FORM_ENCODE_SET, true, false, true, true));
+      names.add(HttpUrl.canonicalize(name, FORM_ENCODE_SET, true, false, true, true, charset));
+      values.add(HttpUrl.canonicalize(value, FORM_ENCODE_SET, true, false, true, true, charset));
       return this;
     }
 

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -1892,8 +1892,7 @@ public final class HttpUrl {
         if (charset == null || charset.equals(Util.UTF_8)) {
           encodedCharBuffer.writeUtf8CodePoint(codePoint);
         } else {
-          encodedCharBuffer.writeString(input.substring(i, i + Character.charCount(codePoint)),
-              charset);
+          encodedCharBuffer.writeString(input, i, i + Character.charCount(codePoint), charset);
         }
 
         while (!encodedCharBuffer.exhausted()) {


### PR DESCRIPTION
This is useful when accessing a web server you don't control which receives form data encoded in a charset other than UTF-8 (e.g. ISO-8859-1).

To use this you pass an encoding to FormBody.Builder constructor. The constructor is used so it's clear you shouldn't switch encodings in the middle of building a form body.

The result is undefined is a character cannot be encoded in the specified charset (as the result of Java's String.getBytes(charset) is also undefined in that case.