### PR TITLE
support dns

### DIFF
--- a/okhttp/src/main/java/okhttp3/Address.java
+++ b/okhttp/src/main/java/okhttp3/Address.java
@@ -47,8 +47,11 @@ public final class Address {
   final @Nullable SSLSocketFactory sslSocketFactory;
   final @Nullable HostnameVerifier hostnameVerifier;
   final @Nullable CertificatePinner certificatePinner;
-
-  public Address(String uriHost, int uriPort, Dns dns, SocketFactory socketFactory,
+  String headerHost=null;
+  public String host() {
+    return headerHost;
+  }
+  public Address(String uriHost,String headerHost, int uriPort, Dns dns, SocketFactory socketFactory,
       @Nullable SSLSocketFactory sslSocketFactory, @Nullable HostnameVerifier hostnameVerifier,
       @Nullable CertificatePinner certificatePinner, Authenticator proxyAuthenticator,
       @Nullable Proxy proxy, List<Protocol> protocols, List<ConnectionSpec> connectionSpecs,
@@ -83,6 +86,7 @@ public final class Address {
     this.sslSocketFactory = sslSocketFactory;
     this.hostnameVerifier = hostnameVerifier;
     this.certificatePinner = certificatePinner;
+    this.headerHost = headerHost;
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/internal/Version.java
+++ b/okhttp/src/main/java/okhttp3/internal/Version.java
@@ -1,0 +1,13 @@
+package okhttp3.internal;
+
+/**
+ * Created by mu on 17/8/22.
+ */
+public class Version {
+    public static String userAgent() {
+        return "okhttp/3.8.1";
+    }
+
+    private Version() {
+    }
+}

--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
@@ -104,7 +104,7 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
     Request request = chain.request();
 
     streamAllocation = new StreamAllocation(
-        client.connectionPool(), createAddress(request.url()), callStackTrace);
+        client.connectionPool(), createAddress(request.url(),request), callStackTrace);
 
     int followUpCount = 0;
     Response priorResponse = null;
@@ -173,7 +173,7 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
       if (!sameConnection(response, followUp.url())) {
         streamAllocation.release();
         streamAllocation = new StreamAllocation(
-            client.connectionPool(), createAddress(followUp.url()), callStackTrace);
+            client.connectionPool(), createAddress(followUp.url(),request), callStackTrace);
       } else if (streamAllocation.codec() != null) {
         throw new IllegalStateException("Closing the body of " + response
             + " didn't close its backing stream. Bad interceptor?");
@@ -184,7 +184,7 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
     }
   }
 
-  private Address createAddress(HttpUrl url) {
+  private Address createAddress(HttpUrl url,Request request) {
     SSLSocketFactory sslSocketFactory = null;
     HostnameVerifier hostnameVerifier = null;
     CertificatePinner certificatePinner = null;
@@ -194,7 +194,7 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
       certificatePinner = client.certificatePinner();
     }
 
-    return new Address(url.host(), url.port(), client.dns(), client.socketFactory(),
+    return new Address(url.host(), request.header("Host"),url.port(), client.dns(), client.socketFactory(),
         sslSocketFactory, hostnameVerifier, certificatePinner, client.proxyAuthenticator(),
         client.proxy(), client.protocols(), client.connectionSpecs(), client.proxySelector());
   }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -127,6 +127,7 @@ public final class Http2Codec implements HttpCodec {
 
   public static List<Header> http2HeadersList(Request request) {
     Headers headers = request.headers();
+
     List<Header> result = new ArrayList<>(headers.size() + 4);
     result.add(new Header(TARGET_METHOD, request.method()));
     result.add(new Header(TARGET_PATH, RequestLine.requestPath(request.url())));

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -15,7 +15,7 @@
  */
 package okhttp3.internal.platform;
 
-import android.util.Log;
+//import android.util.Log;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -119,8 +119,8 @@ class AndroidPlatform extends Platform {
   }
 
   @Override public void log(int level, String message, Throwable t) {
-    int logLevel = level == WARN ? Log.WARN : Log.DEBUG;
-    if (t != null) message = message + '\n' + Log.getStackTraceString(t);
+    //int logLevel = level == WARN ? Log.WARN : Log.DEBUG;
+    //if (t != null) message = message + '\n' + Log.getStackTraceString(t);
 
     // Split by line, then ensure each line can fit into Log's maximum length.
     for (int i = 0, length = message.length(); i < length; i++) {
@@ -128,7 +128,7 @@ class AndroidPlatform extends Platform {
       newline = newline != -1 ? newline : length;
       do {
         int end = Math.min(newline, i + MAX_LOG_LENGTH);
-        Log.println(logLevel, "OkHttp", message.substring(i, end));
+        //Log.println(logLevel, "OkHttp", message.substring(i, end));
         i = end;
       } while (i < newline);
     }


### PR DESCRIPTION
 okhttp 3.8.1 doesn't support https dns,when i replace https reqeuest header as some domain,it doesn't work,and i fix it .