### PR TITLE
Remove WebSocket API support for optional close code

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -81,7 +81,7 @@ public final class RealWebSocketTest {
 
   @Test public void clientCloseWith0Fails() throws IOException {
     try {
-    client.webSocket.close(0, null);
+      client.webSocket.close(0, null);
     } catch (IllegalArgumentException expected) {
       assertEquals(expected.getMessage(), "Code must be in range [1000,5000): 0");
     }

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -79,6 +79,14 @@ public final class RealWebSocketTest {
     assertFalse(client.webSocket.send("Hello!"));
   }
 
+  @Test public void clientCloseWith0Fails() throws IOException {
+    try {
+    client.webSocket.close(0, null);
+    } catch (IllegalArgumentException expected) {
+      assertEquals(expected.getMessage(), "Code must be in range [1000,5000): 0");
+    }
+  }
+
   @Test public void afterSocketClosedPingFailsWebSocket() throws IOException {
     client2Server.source().close();
     client.webSocket.pong(ByteString.encodeUtf8("Ping!"));

--- a/okhttp/src/main/java/okhttp3/WebSocket.java
+++ b/okhttp/src/main/java/okhttp3/WebSocket.java
@@ -99,8 +99,9 @@ public interface WebSocket {
    * a graceful shutdown was already underway or if the web socket is already closed or canceled.
    *
    * @param code Status code as defined by <a
-   * href="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a> or {@code 0}.
+   * href="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a>.
    * @param reason Reason for shutting down or {@code null}.
+   * @throws IllegalArgumentException if code is invalid.
    */
   boolean close(int code, @Nullable String reason);
 


### PR DESCRIPTION
close(0, null) still supported internally on WebSocketWriter.close, but no longer supported on public API.