### PR TITLE
Move all failures into connectFailed and callFailed.

### DIFF
--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -76,10 +76,10 @@ final class RealCall implements Call {
       client.dispatcher().executed(this);
       Response result = getResponseWithInterceptorChain();
       if (result == null) throw new IOException("Canceled");
-      eventListener.callEnd(this, null);
+      eventListener.callEnd(this);
       return result;
     } catch (IOException e) {
-      eventListener.callEnd(this, e);
+      eventListener.callFailed(this, e);
       throw e;
     } finally {
       client.dispatcher().finished(this);
@@ -153,13 +153,13 @@ final class RealCall implements Call {
           signalledCallback = true;
           responseCallback.onResponse(RealCall.this, response);
         }
-        eventListener.callEnd(RealCall.this, null);
+        eventListener.callEnd(RealCall.this);
       } catch (IOException e) {
         if (signalledCallback) {
           // Do not signal the callback twice!
           Platform.get().log(INFO, "Callback failure for " + toLoggableString(), e);
         } else {
-          eventListener.callEnd(RealCall.this, e);
+          eventListener.callFailed(RealCall.this, e);
           responseCallback.onFailure(RealCall.this, e);
         }
       } finally {

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -158,7 +158,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
           connectSocket(connectTimeout, readTimeout, call, eventListener);
         }
         establishProtocol(connectionSpecSelector, call, eventListener);
-        eventListener.connectEnd(call, route.socketAddress(), route.proxy(), protocol, null);
+        eventListener.connectEnd(call, route.socketAddress(), route.proxy(), protocol);
         break;
       } catch (IOException e) {
         closeQuietly(socket);
@@ -171,7 +171,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
         protocol = null;
         http2Connection = null;
 
-        eventListener.connectEnd(call, route.socketAddress(), route.proxy(), null, e);
+        eventListener.connectFailed(call, route.socketAddress(), route.proxy(), null, e);
 
         if (routeException == null) {
           routeException = new RouteException(e);
@@ -218,7 +218,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
       rawSocket = null;
       sink = null;
       source = null;
-      eventListener.connectEnd(call, route.socketAddress(), route.proxy(), null, null);
+      eventListener.connectEnd(call, route.socketAddress(), route.proxy(), null);
     }
   }
 
@@ -265,13 +265,8 @@ public final class RealConnection extends Http2Connection.Listener implements Co
     }
 
     eventListener.secureConnectStart(call);
-    try {
-      connectTls(connectionSpecSelector);
-      eventListener.secureConnectEnd(call, handshake, null);
-    } catch (IOException ioe) {
-      eventListener.secureConnectEnd(call, null, ioe);
-      throw ioe;
-    }
+    connectTls(connectionSpecSelector);
+    eventListener.secureConnectEnd(call, handshake);
 
     if (protocol == Protocol.HTTP_2) {
       socket.setSoTimeout(0); // HTTP/2 connection timeouts are set per-stream.

--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
@@ -182,21 +182,12 @@ public final class RouteSelector {
       eventListener.dnsStart(call, socketHost);
 
       // Try each address for best behavior in mixed IPv4/IPv6 environments.
-      List<InetAddress> addresses;
-      try {
-        addresses = address.dns().lookup(socketHost);
-      } catch (IOException ioe) {
-        eventListener.dnsEnd(call, socketHost, null, ioe);
-        throw ioe;
-      }
+      List<InetAddress> addresses = address.dns().lookup(socketHost);
       if (addresses.isEmpty()) {
-        UnknownHostException exception = new UnknownHostException(
-            address.dns() + " returned no addresses for " + socketHost);
-        eventListener.dnsEnd(call, socketHost, null, exception);
-        throw exception;
+        throw new UnknownHostException(address.dns() + " returned no addresses for " + socketHost);
       }
 
-      eventListener.dnsEnd(call, socketHost, addresses, null);
+      eventListener.dnsEnd(call, socketHost, addresses);
 
       for (int i = 0, size = addresses.size(); i < size; i++) {
         InetAddress inetAddress = addresses.get(i);

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
@@ -375,7 +375,7 @@ public final class Http1Codec implements HttpCodec {
 
       state = STATE_CLOSED;
       if (streamAllocation != null) {
-        streamAllocation.eventListener.responseBodyEnd(streamAllocation.call, bytesRead, e);
+        streamAllocation.eventListener.responseBodyEnd(streamAllocation.call, bytesRead);
         streamAllocation.streamFinished(!reuseConnection, Http1Codec.this);
       }
     }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -223,7 +223,7 @@ public final class Http2Codec implements HttpCodec {
     private void endOfInput(IOException e) {
       if (completed) return;
       completed = true;
-      streamAllocation.eventListener.responseBodyEnd(streamAllocation.call, bytesRead, e);
+      streamAllocation.eventListener.responseBodyEnd(streamAllocation.call, bytesRead);
       streamAllocation.streamFinished(false, Http2Codec.this);
     }
   }


### PR DESCRIPTION
I think applications might be simple by tracking successful events
separately from failure events.