### PR TITLE
Don't fire events for Web Sockets.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-final class RecordingEventListener extends EventListener {
+public final class RecordingEventListener extends EventListener {
   final Deque<CallEvent> eventSequence = new ArrayDeque<>();
 
   final List<Object> forbiddenLocks = new ArrayList<>();
@@ -43,7 +43,7 @@ final class RecordingEventListener extends EventListener {
    * Removes recorded events up to (and including) an event is found whose class equals
    * {@code eventClass} and returns it.
    */
-  <T> T removeUpToEvent(Class<T> eventClass) {
+  public <T> T removeUpToEvent(Class<T> eventClass) {
     Object event = eventSequence.poll();
     while (event != null && !eventClass.isInstance(event)) {
       event = eventSequence.poll();
@@ -52,7 +52,7 @@ final class RecordingEventListener extends EventListener {
     return eventClass.cast(event);
   }
 
-  List<String> recordedEventTypes() {
+  public List<String> recordedEventTypes() {
     List<String> eventTypes = new ArrayList<>();
     for (CallEvent event : eventSequence) {
       eventTypes.add(event.getName());
@@ -60,7 +60,7 @@ final class RecordingEventListener extends EventListener {
     return eventTypes;
   }
 
-  void clearAllEvents() {
+  public void clearAllEvents() {
     eventSequence.clear();
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -19,12 +19,14 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.net.ProtocolException;
 import java.net.SocketTimeoutException;
+import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import okhttp3.RecordingEventListener;
 import okhttp3.RecordingHostnameVerifier;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -572,6 +574,33 @@ public final class WebSocketHttpTest {
     // Close the server and confirm it saw what we expected.
     server.close(1000, null);
     serverListener.assertClosed(1000, "goodbye");
+  }
+
+  @Test public void webSocketsDontTriggerEventListener() throws IOException {
+    RecordingEventListener listener = new RecordingEventListener();
+
+    client = client.newBuilder()
+        .eventListener(listener)
+        .build();
+
+    webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
+    WebSocket webSocket = newWebSocket();
+
+    clientListener.assertOpen();
+    WebSocket server = serverListener.assertOpen();
+
+    webSocket.send("Web Sockets and Events?!");
+    serverListener.assertTextMessage("Web Sockets and Events?!");
+
+    webSocket.close(1000, "");
+    serverListener.assertClosing(1000, "");
+
+    server.close(1000, "");
+    clientListener.assertClosing(1000, "");
+    clientListener.assertClosed(1000, "");
+    serverListener.assertClosed(1000, "");
+
+    assertEquals(Collections.emptyList(), listener.recordedEventTypes());
   }
 
   private MockResponse upgradeResponse(RecordedRequest request) {

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.EventListener;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
@@ -168,6 +169,7 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
 
   public void connect(OkHttpClient client) {
     client = client.newBuilder()
+        .eventListener(EventListener.NONE)
         .protocols(ONLY_HTTP1)
         .build();
     final int pingIntervalMillis = client.pingIntervalMillis();


### PR DESCRIPTION
We probably want to support this, but at the moment it isn't yet
tested. Turn it off until we get something we really like.