### PR TITLE
Omit the message from MockWebServer's HTTP/2 :status header

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -938,8 +938,8 @@ public final class MockWebServer extends ExternalResource implements Closeable {
         return;
       }
       List<Header> http2Headers = new ArrayList<>();
-      String[] statusParts = response.getStatus().split(" ", 2);
-      if (statusParts.length != 2) {
+      String[] statusParts = response.getStatus().split(" ", 3);
+      if (statusParts.length < 2) {
         throw new AssertionError("Unexpected status: " + response.getStatus());
       }
       // TODO: constants for well-known header names.

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -219,9 +219,11 @@ public final class HttpLoggingInterceptor implements Interceptor {
     ResponseBody responseBody = response.body();
     long contentLength = responseBody.contentLength();
     String bodySize = contentLength != -1 ? contentLength + "-byte" : "unknown-length";
-    logger.log("<-- " + response.code() + ' ' + response.message() + ' '
-        + response.request().url() + " (" + tookMs + "ms" + (!logHeaders ? ", "
-        + bodySize + " body" : "") + ')');
+    logger.log("<-- "
+        + response.code()
+        + (response.message().isEmpty() ? "" : ' ' + response.message())
+        + ' ' + response.request().url()
+        + " (" + tookMs + "ms" + (!logHeaders ? ", " + bodySize + " body" : "") + ')');
 
     if (logHeaders) {
       Headers headers = response.headers();

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -43,11 +43,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 
 public final class HttpLoggingInterceptorTest {
   private static final MediaType PLAIN = MediaType.parse("text/plain; charset=utf-8");
@@ -685,16 +687,16 @@ public final class HttpLoggingInterceptorTest {
 
     server.enqueue(new MockResponse());
     Response response = client.newCall(request().build()).execute();
-    assertEquals(Protocol.HTTP_2, response.protocol());
+    assumeThat(response.protocol(), equalTo(Protocol.HTTP_2));
 
     applicationLogs
         .assertLogEqual("--> GET " + url)
-        .assertLogMatch("<-- 200 OK " + url + " \\(\\d+ms, 0-byte body\\)")
+        .assertLogMatch("<-- 200 " + url + " \\(\\d+ms, 0-byte body\\)")
         .assertNoMoreLogs();
 
     networkLogs
         .assertLogEqual("--> GET " + url + " h2")
-        .assertLogMatch("<-- 200 OK " + url + " \\(\\d+ms, 0-byte body\\)")
+        .assertLogMatch("<-- 200 " + url + " \\(\\d+ms, 0-byte body\\)")
         .assertNoMoreLogs();
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -2326,7 +2326,6 @@ public final class CallTest {
     Call call = client.newCall(request);
     Response response = call.execute();
     assertEquals(100, response.code());
-    assertEquals("Continue", response.message());
     assertEquals("", response.body().string());
 
     RecordedRequest recordedRequest = server.takeRequest();

--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -119,7 +119,7 @@ public final class HttpOverHttp2Test {
 
     assertEquals("ABCDE", response.body().string());
     assertEquals(200, response.code());
-    assertEquals("Sweet", response.message());
+    assertEquals("", response.message());
 
     RecordedRequest request = server.takeRequest();
     assertEquals("GET /foo HTTP/1.1", request.getRequestLine());
@@ -766,7 +766,7 @@ public final class HttpOverHttp2Test {
 
     assertEquals("ABCDE", response.body().string());
     assertEquals(200, response.code());
-    assertEquals("Sweet", response.message());
+    assertEquals("", response.message());
 
     RecordedRequest request = server.takeRequest();
     assertEquals("GET /foo HTTP/1.1", request.getRequestLine());
@@ -792,7 +792,7 @@ public final class HttpOverHttp2Test {
     Response response = call.execute();
     assertEquals("ABCDE", response.body().string());
     assertEquals(200, response.code());
-    assertEquals("Sweet", response.message());
+    assertEquals("", response.message());
 
     RecordedRequest request = server.takeRequest();
     assertEquals("GET /foo HTTP/1.1", request.getRequestLine());


### PR DESCRIPTION
This was a bug carried over from SPDY.

Closes: https://github.com/square/okhttp/issues/3484