### PR TITLE
Fix MockWebServer handling of 'Expect: 100 Continue'

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -581,7 +581,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
     Headers.Builder headers = new Headers.Builder();
     long contentLength = -1;
     boolean chunked = false;
-    boolean readBody = true;
+    boolean expectContinue = false;
     String header;
     while ((header = source.readUtf8LineStrict()).length() != 0) {
       Internal.instance.addLenient(headers, header);
@@ -595,25 +595,22 @@ public final class MockWebServer extends ExternalResource implements Closeable {
       }
       if (lowercaseHeader.startsWith("expect:")
           && lowercaseHeader.substring(7).trim().equalsIgnoreCase("100-continue")) {
-        readBody = false;
+        expectContinue = true;
       }
     }
 
-    if (!readBody && dispatcher.peek().getSocketPolicy() == EXPECT_CONTINUE) {
+    if (expectContinue && dispatcher.peek().getSocketPolicy() == EXPECT_CONTINUE) {
       sink.writeUtf8("HTTP/1.1 100 Continue\r\n");
       sink.writeUtf8("Content-Length: 0\r\n");
       sink.writeUtf8("\r\n");
       sink.flush();
-      readBody = true;
     }
 
     boolean hasBody = false;
     TruncatingBuffer requestBody = new TruncatingBuffer(bodyLimit);
     List<Integer> chunkSizes = new ArrayList<>();
     MockResponse policy = dispatcher.peek();
-    if (!readBody) {
-      // Don't read the body unless we've invited the client to send it.
-    } else if (contentLength != -1) {
+    if (contentLength != -1) {
       hasBody = contentLength > 0;
       throttledTransfer(policy, socket, source, Okio.buffer(requestBody), contentLength, true);
     } else if (chunked) {

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
@@ -23,11 +23,11 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
-import java.net.InetAddress;
 import java.net.ProtocolException;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -438,5 +438,22 @@ public final class MockWebServerTest {
     assertEquals(server.getPort(), requestUrl.port());
     assertEquals("/a/deep/path", requestUrl.encodedPath());
     assertEquals("foo bar", requestUrl.queryParameter("key"));
+  }
+
+  @Test public void http100Continue() throws Exception {
+    server.enqueue(new MockResponse().setBody("response"));
+
+    URL url = server.url("/").url();
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Expect", "100-Continue");
+    connection.getOutputStream().write("request".getBytes(StandardCharsets.UTF_8));
+
+    InputStream in = connection.getInputStream();
+    BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+    assertEquals("response", reader.readLine());
+
+    RecordedRequest request = server.takeRequest();
+    assertEquals("request", request.getBody().readUtf8());
   }
 }

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/RecordingProxySelector.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/RecordingProxySelector.java
@@ -45,9 +45,8 @@ public final class RecordingProxySelector extends ProxySelector {
 
   @Override public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
     InetSocketAddress socketAddress = (InetSocketAddress) sa;
-    failures.add(
-        Util.format("%s %s:%d %s", uri, socketAddress.getHostName(), socketAddress.getPort(),
-            ioe.getMessage()));
+    failures.add(Util.format("%s %s:%d %s",
+        uri, socketAddress, socketAddress.getPort(), ioe.getMessage()));
   }
 
   @Override public String toString() {


### PR DESCRIPTION
Previously we'd skip the request body unless the socket policy was
EXPECT_CONTINUE.

Closes: https://github.com/square/okhttp/issues/3498