### PR TITLE
Don't report connectionAcquired until actually connected.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
@@ -85,7 +85,7 @@ public final class ConnectionPoolTest {
     synchronized (pool) {
       StreamAllocation streamAllocation = new StreamAllocation(pool, addressA, null,
           EventListener.NONE, null);
-      streamAllocation.acquire(c1);
+      streamAllocation.acquire(c1, true);
     }
 
     // Running at time 50, the pool returns that nothing can be evicted until time 150.
@@ -179,7 +179,7 @@ public final class ConnectionPoolTest {
     synchronized (pool) {
       StreamAllocation leak = new StreamAllocation(pool, connection.route().address(), null,
           EventListener.NONE, null);
-      leak.acquire(connection);
+      leak.acquire(connection, true);
     }
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -113,7 +113,7 @@ public final class EventListenerTest {
     response.body().close();
 
     List<String> expectedEvents = Arrays.asList("CallStart", "DnsStart", "DnsEnd",
-        "ConnectionAcquired", "ConnectStart", "ConnectEnd", "RequestHeadersStart",
+        "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
     assertEquals(expectedEvents, listener.recordedEventTypes());
@@ -144,7 +144,7 @@ public final class EventListenerTest {
     completionLatch.await();
 
     List<String> expectedEvents = Arrays.asList("CallStart", "DnsStart", "DnsEnd",
-        "ConnectionAcquired", "ConnectStart", "ConnectEnd", "RequestHeadersStart",
+        "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
         "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
     assertEquals(expectedEvents, listener.recordedEventTypes());
@@ -166,7 +166,7 @@ public final class EventListenerTest {
     }
 
     List<String> expectedEvents = Arrays.asList("CallStart", "DnsStart", "DnsEnd",
-        "ConnectionAcquired", "ConnectStart", "ConnectEnd", "RequestHeadersStart",
+        "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ConnectionReleased", "CallFailed");
     assertEquals(expectedEvents, listener.recordedEventTypes());
   }
@@ -198,8 +198,8 @@ public final class EventListenerTest {
 
     assumeThat(response, responseMatcher);
 
-    List<String> expectedEvents = asList("CallStart", "DnsStart", "DnsEnd", "ConnectionAcquired",
-        "ConnectStart", "SecureConnectStart", "SecureConnectEnd", "ConnectEnd",
+    List<String> expectedEvents = asList("CallStart", "DnsStart", "DnsEnd", "ConnectStart",
+        "SecureConnectStart", "SecureConnectEnd", "ConnectEnd", "ConnectionAcquired",
         "RequestHeadersStart", "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd",
         "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
 
@@ -239,7 +239,8 @@ public final class EventListenerTest {
       RequestHeadersEnd responseHeadersEnd = listener.removeUpToEvent(RequestHeadersEnd.class);
       assertThat("request header length", responseHeadersEnd.headerLength, requestHeaderLength);
     } else {
-      assertFalse("Found RequestHeadersEnd", listener.recordedEventTypes().contains("RequestHeadersEnd"));
+      assertFalse("Found RequestHeadersEnd",
+          listener.recordedEventTypes().contains("RequestHeadersEnd"));
     }
 
     if (requestBodyBytes != null) {
@@ -253,14 +254,16 @@ public final class EventListenerTest {
       ResponseHeadersEnd responseHeadersEnd = listener.removeUpToEvent(ResponseHeadersEnd.class);
       assertThat("response header length", responseHeadersEnd.headerLength, responseHeaderLength);
     } else {
-      assertFalse("Found ResponseHeadersEnd", listener.recordedEventTypes().contains("ResponseHeadersEnd"));
+      assertFalse("Found ResponseHeadersEnd",
+          listener.recordedEventTypes().contains("ResponseHeadersEnd"));
     }
 
     if (responseBodyBytes != null) {
       ResponseBodyEnd responseBodyEnd = listener.removeUpToEvent(ResponseBodyEnd.class);
       assertThat("response body bytes", responseBodyEnd.bytesRead, responseBodyBytes);
     } else {
-      assertFalse("Found ResponseBodyEnd", listener.recordedEventTypes().contains("ResponseBodyEnd"));
+      assertFalse("Found ResponseBodyEnd",
+          listener.recordedEventTypes().contains("ResponseBodyEnd"));
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -123,7 +123,7 @@ public final class ConnectionPool {
     assert (Thread.holdsLock(this));
     for (RealConnection connection : connections) {
       if (connection.isEligible(address, route)) {
-        streamAllocation.acquire(connection);
+        streamAllocation.acquire(connection, true);
         return connection;
       }
     }


### PR DESCRIPTION
Currently our implementation acquires the connection early so that we have
something to close if the call is canceled. Event listeners are simpler if
they only get a connectionAcquired event once the connection has been
actually established.