### PR TITLE
Fix MockWebServer websockets to be thread safe.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -465,8 +465,6 @@ public final class MockWebServer extends ExternalResource implements Closeable {
               + " didn't make a request");
         }
 
-        source.close();
-        sink.close();
         socket.close();
         openClientSockets.remove(socket);
       }
@@ -681,7 +679,6 @@ public final class MockWebServer extends ExternalResource implements Closeable {
     } catch (IOException e) {
       webSocket.failWebSocket(e, null);
     } finally {
-      closeQuietly(sink);
       closeQuietly(source);
     }
   }

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -322,7 +322,7 @@ public final class WebSocketHttpTest {
             assertNull(chain.request().body());
             Response response = chain.proceed(chain.request());
             assertEquals("Upgrade", response.header("Connection"));
-            assertTrue("", response.body().source().exhausted());
+            assertTrue(response.body().source().exhausted());
             interceptedCount.incrementAndGet();
             return response;
           }


### PR DESCRIPTION
Closing the sink while another thread is writing the sink is a
potential source for races.

Closes: https://github.com/square/okhttp/issues/3138