### PR TITLE
Fix a race in WebSocketHttpTest.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -210,6 +210,7 @@ public final class WebSocketHttpTest {
 
     server.close(1000, "bye");
     clientListener.assertFailure(e);
+    serverListener.assertFailure();
     serverListener.assertExhausted();
   }
 


### PR DESCRIPTION
We were assuming on a client failure the server wouldn't have any
further events. But it will get a failure if we give it a moment.
This was causing some test flakiness.