### PR TITLE
The WebSocketWriter is single-threaded.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/ws/WebSocketReader.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebSocketReader.java
@@ -46,8 +46,8 @@ import static okhttp3.internal.ws.WebSocketProtocol.toggleMask;
 
 /**
  * An <a href="http://tools.ietf.org/html/rfc6455">RFC 6455</a>-compatible WebSocket frame reader.
- * <p>
- * This class is not thread safe.
+ *
+ * <p>This class is not thread safe.
  */
 final class WebSocketReader {
   public interface FrameCallback {


### PR DESCRIPTION
We were synchronizing to permit multiple writer threads. But that was a carry-over
from the previous design where we supported multiple writer threads. With the
current implementation only one thread writes at a time. This synchronization
was not necessary.