### PR TITLE
Improve handling of HEAD requests with a Content-Length specified.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -83,6 +83,7 @@ import org.junit.rules.Timeout;
 import static java.net.CookiePolicy.ACCEPT_ORIGINAL_SERVER;
 import static okhttp3.TestUtil.awaitGarbageCollection;
 import static okhttp3.TestUtil.defaultClient;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -243,10 +244,9 @@ public final class CallTest {
         .url(server.url("/"))
         .head()
         .build();
-    executeSynchronously(headRequest)
-        .assertCode(200)
-        .assertHeader("Content-Length", "100")
-        .assertBody("");
+    Response response = client.newCall(headRequest).execute();
+    assertEquals(200, response.code());
+    assertArrayEquals(new byte[0], response.body().bytes());
 
     Request getRequest = new Request.Builder()
         .url(server.url("/"))

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
@@ -207,8 +207,10 @@ public final class CacheInterceptor implements Interceptor {
       }
     };
 
+    String contentType = response.header("Content-Type");
+    long contentLength = response.body().contentLength();
     return response.newBuilder()
-        .body(new RealResponseBody(response.headers(), Okio.buffer(cacheWritingSource)))
+        .body(new RealResponseBody(contentType, contentLength, Okio.buffer(cacheWritingSource)))
         .build();
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.java
@@ -106,7 +106,8 @@ public final class BridgeInterceptor implements Interceptor {
           .removeAll("Content-Length")
           .build();
       responseBuilder.headers(strippedHeaders);
-      responseBuilder.body(new RealResponseBody(strippedHeaders, Okio.buffer(responseBody)));
+      String contentType = networkResponse.header("Content-Type");
+      responseBuilder.body(new RealResponseBody(contentType, -1L, Okio.buffer(responseBody)));
     }
 
     return responseBuilder.build();

--- a/okhttp/src/main/java/okhttp3/internal/http/RealResponseBody.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealResponseBody.java
@@ -15,27 +15,33 @@
  */
 package okhttp3.internal.http;
 
-import okhttp3.Headers;
+import javax.annotation.Nullable;
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 import okio.BufferedSource;
 
 public final class RealResponseBody extends ResponseBody {
-  private final Headers headers;
+  /**
+   * Use a string to avoid parsing the content type until needed. This also defers problems caused
+   * by malformed content types.
+   */
+  private final @Nullable String contentTypeString;
+  private final long contentLength;
   private final BufferedSource source;
 
-  public RealResponseBody(Headers headers, BufferedSource source) {
-    this.headers = headers;
+  public RealResponseBody(
+      @Nullable String contentTypeString, long contentLength, BufferedSource source) {
+    this.contentTypeString = contentTypeString;
+    this.contentLength = contentLength;
     this.source = source;
   }
 
   @Override public MediaType contentType() {
-    String contentType = headers.get("Content-Type");
-    return contentType != null ? MediaType.parse(contentType) : null;
+    return contentTypeString != null ? MediaType.parse(contentTypeString) : null;
   }
 
   @Override public long contentLength() {
-    return HttpHeaders.contentLength(headers);
+    return contentLength;
   }
 
   @Override public BufferedSource source() {

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -32,6 +32,7 @@ import okhttp3.internal.Internal;
 import okhttp3.internal.Util;
 import okhttp3.internal.connection.StreamAllocation;
 import okhttp3.internal.http.HttpCodec;
+import okhttp3.internal.http.HttpHeaders;
 import okhttp3.internal.http.RealResponseBody;
 import okhttp3.internal.http.RequestLine;
 import okhttp3.internal.http.StatusLine;
@@ -186,8 +187,10 @@ public final class Http2Codec implements HttpCodec {
 
   @Override public ResponseBody openResponseBody(Response response) throws IOException {
     streamAllocation.eventListener.responseBodyStart(streamAllocation.call);
+    String contentType = response.header("Content-Type");
+    long contentLength = HttpHeaders.contentLength(response);
     Source source = new StreamFinishingSource(stream.getSource());
-    return new RealResponseBody(response.headers(), Okio.buffer(source));
+    return new RealResponseBody(contentType, contentLength, Okio.buffer(source));
   }
 
   @Override public void cancel() {


### PR DESCRIPTION
Rather than getting the content length from a header on demand, this gets it
at the time that the RealResponseBody is created. This means that HEAD requests
can have a non-zero Content-Length header while their bodies have no content.

Closes: https://github.com/square/okhttp/issues/3365