### PR TITLE
Okhttp

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/mockwebserver/pom.xml
+++ b/mockwebserver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>mockwebserver</artifactId>

--- a/mockwebserver/pom.xml
+++ b/mockwebserver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>mockwebserver</artifactId>

--- a/mockwebserver/pom.xml
+++ b/mockwebserver/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>mockwebserver</artifactId>

--- a/okcurl/pom.xml
+++ b/okcurl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>okcurl</artifactId>

--- a/okcurl/pom.xml
+++ b/okcurl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>okcurl</artifactId>

--- a/okcurl/pom.xml
+++ b/okcurl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>okcurl</artifactId>

--- a/okhttp-android-support/pom.xml
+++ b/okhttp-android-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-android-support</artifactId>

--- a/okhttp-android-support/pom.xml
+++ b/okhttp-android-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-android-support</artifactId>

--- a/okhttp-android-support/pom.xml
+++ b/okhttp-android-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>okhttp-android-support</artifactId>

--- a/okhttp-apache/pom.xml
+++ b/okhttp-apache/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-apache</artifactId>

--- a/okhttp-apache/pom.xml
+++ b/okhttp-apache/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-apache</artifactId>

--- a/okhttp-apache/pom.xml
+++ b/okhttp-apache/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>okhttp-apache</artifactId>

--- a/okhttp-logging-interceptor/pom.xml
+++ b/okhttp-logging-interceptor/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>logging-interceptor</artifactId>

--- a/okhttp-logging-interceptor/pom.xml
+++ b/okhttp-logging-interceptor/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>logging-interceptor</artifactId>

--- a/okhttp-logging-interceptor/pom.xml
+++ b/okhttp-logging-interceptor/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>logging-interceptor</artifactId>

--- a/okhttp-testing-support/pom.xml
+++ b/okhttp-testing-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-testing-support</artifactId>

--- a/okhttp-testing-support/pom.xml
+++ b/okhttp-testing-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-testing-support</artifactId>

--- a/okhttp-testing-support/pom.xml
+++ b/okhttp-testing-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>okhttp-testing-support</artifactId>

--- a/okhttp-tests/pom.xml
+++ b/okhttp-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>okhttp-tests</artifactId>

--- a/okhttp-tests/pom.xml
+++ b/okhttp-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-tests</artifactId>

--- a/okhttp-tests/pom.xml
+++ b/okhttp-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-tests</artifactId>

--- a/okhttp-urlconnection/pom.xml
+++ b/okhttp-urlconnection/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>okhttp-urlconnection</artifactId>

--- a/okhttp-urlconnection/pom.xml
+++ b/okhttp-urlconnection/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-urlconnection</artifactId>

--- a/okhttp-urlconnection/pom.xml
+++ b/okhttp-urlconnection/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp-urlconnection</artifactId>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>okhttp</artifactId>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp</artifactId>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>okhttp</artifactId>

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -178,7 +178,10 @@ public final class StreamAllocation {
       // Now that we have an IP address, make another attempt at getting a connection from the pool.
       // This could match due to connection coalescing.
       Internal.instance.get(connectionPool, address, this, selectedRoute);
-      if (connection != null) return connection;
+      if (connection != null) {
+        route = selectedRoute;
+        return connection;
+      }
 
       // Create a connection and assign it to this allocation immediately. This makes it possible
       // for an asynchronous cancel() to interrupt the handshake we're about to do.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.squareup.okhttp3</groupId>
   <artifactId>parent</artifactId>
-  <version>3.8.1</version>
+  <version>3.8.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>OkHttp (Parent)</name>
@@ -63,7 +63,7 @@
     <url>https://github.com/square/okhttp/</url>
     <connection>scm:git:https://github.com/square/okhttp.git</connection>
     <developerConnection>scm:git:git@github.com:square/okhttp.git</developerConnection>
-    <tag>parent-3.8.1</tag>
+    <tag>parent-3.8.0</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.squareup.okhttp3</groupId>
   <artifactId>parent</artifactId>
-  <version>3.8.0</version>
+  <version>3.8.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>OkHttp (Parent)</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.squareup.okhttp3</groupId>
   <artifactId>parent</artifactId>
-  <version>3.8.1-SNAPSHOT</version>
+  <version>3.8.1</version>
   <packaging>pom</packaging>
 
   <name>OkHttp (Parent)</name>
@@ -63,7 +63,7 @@
     <url>https://github.com/square/okhttp/</url>
     <connection>scm:git:https://github.com/square/okhttp.git</connection>
     <developerConnection>scm:git:git@github.com:square/okhttp.git</developerConnection>
-    <tag>parent-3.8.0</tag>
+    <tag>parent-3.8.1</tag>
   </scm>
 
   <issueManagement>

--- a/samples/crawler/pom.xml
+++ b/samples/crawler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>crawler</artifactId>

--- a/samples/crawler/pom.xml
+++ b/samples/crawler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>crawler</artifactId>

--- a/samples/crawler/pom.xml
+++ b/samples/crawler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>crawler</artifactId>

--- a/samples/guide/pom.xml
+++ b/samples/guide/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>guide</artifactId>

--- a/samples/guide/pom.xml
+++ b/samples/guide/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>guide</artifactId>

--- a/samples/guide/pom.xml
+++ b/samples/guide/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>guide</artifactId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <groupId>com.squareup.okhttp3.sample</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <groupId>com.squareup.okhttp3.sample</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3</groupId>
     <artifactId>parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <groupId>com.squareup.okhttp3.sample</groupId>

--- a/samples/simple-client/pom.xml
+++ b/samples/simple-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>simple-client</artifactId>

--- a/samples/simple-client/pom.xml
+++ b/samples/simple-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>simple-client</artifactId>

--- a/samples/simple-client/pom.xml
+++ b/samples/simple-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>simple-client</artifactId>

--- a/samples/slack/pom.xml
+++ b/samples/slack/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack</artifactId>

--- a/samples/slack/pom.xml
+++ b/samples/slack/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>slack</artifactId>

--- a/samples/slack/pom.xml
+++ b/samples/slack/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack</artifactId>

--- a/samples/static-server/pom.xml
+++ b/samples/static-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1</version>
+    <version>3.8.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>static-server</artifactId>

--- a/samples/static-server/pom.xml
+++ b/samples/static-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.1-SNAPSHOT</version>
+    <version>3.8.1</version>
   </parent>
 
   <artifactId>static-server</artifactId>

--- a/samples/static-server/pom.xml
+++ b/samples/static-server/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.okhttp3.sample</groupId>
     <artifactId>sample-parent</artifactId>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>static-server</artifactId>


### PR DESCRIPTION
It would be great if method canonicalize throw a NullPointerException when input string is null.

There is no check if a value is null whille buiding a body for a POST
RequestBody formBody = new FormBody.Builder() .add("value", value) .build();
if value is null, there is a :
java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference at okhttp3.HttpUrl.canonicalize(HttpUrl.java:1751)
