### PR TITLE
RFC: example configure hook

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/DelegatingSocketFactory.java
+++ b/okhttp-tests/src/test/java/okhttp3/DelegatingSocketFactory.java
@@ -58,7 +58,7 @@ public class DelegatingSocketFactory extends SocketFactory {
     return configureSocket(socket);
   }
 
-  protected Socket configureSocket(Socket socket) throws IOException {
+  public Socket configureSocket(Socket socket) throws IOException {
     // No-op by default.
     return socket;
   }

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -2533,7 +2533,7 @@ public final class URLConnectionTest {
         });
     urlFactory.setClient(urlFactory.client().newBuilder()
         .socketFactory(new DelegatingSocketFactory(SocketFactory.getDefault()) {
-          @Override protected Socket configureSocket(Socket socket) throws IOException {
+          @Override public Socket configureSocket(Socket socket) throws IOException {
             socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
             socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
             return socket;

--- a/okhttp-tests/src/test/java/okhttp3/XxX.java
+++ b/okhttp-tests/src/test/java/okhttp3/XxX.java
@@ -1,0 +1,39 @@
+package okhttp3;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+import javax.net.SocketFactory;
+
+public class XxX {
+  public static void main(String[] args) throws IOException {
+    SocketFactory socketFactory = new MyDelegatingSocketFactory();
+    OkHttpClient.Builder builder = new OkHttpClient.Builder();
+    builder.proxy(new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("localhost", 2001)));
+    builder.connectTimeout(10, TimeUnit.SECONDS);
+    builder.socketFactory(socketFactory);
+    OkHttpClient client = builder.build();
+
+    Request req = new Request.Builder().url("https://google.com/robots.txt").build();
+    try (Response response = client.newCall(req).execute()) {
+      System.out.println(response.body.string().length());
+    }
+  }
+
+  public static class MyDelegatingSocketFactory extends DelegatingSocketFactory {
+    public MyDelegatingSocketFactory() {
+      super(SocketFactory.getDefault());
+    }
+
+    @Override public Socket configureSocket(Socket socket) throws IOException {
+      // set android
+      //TrafficStats.tagSocket(socket);
+
+      System.out.println("configured");
+
+      return socket;
+    }
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/DisconnectTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/DisconnectTest.java
@@ -59,7 +59,7 @@ public final class DisconnectTest {
         });
     client = defaultClient().newBuilder()
         .socketFactory(new DelegatingSocketFactory(SocketFactory.getDefault()) {
-          @Override protected Socket configureSocket(Socket socket) throws IOException {
+          @Override public Socket configureSocket(Socket socket) throws IOException {
             socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
             socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
             return socket;

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/ThreadInterruptTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/ThreadInterruptTest.java
@@ -61,8 +61,7 @@ public final class ThreadInterruptTest {
         });
     client = defaultClient().newBuilder()
         .socketFactory(new DelegatingSocketFactory(SocketFactory.getDefault()) {
-          @Override
-          protected Socket configureSocket(Socket socket) throws IOException {
+          @Override public Socket configureSocket(Socket socket) throws IOException {
             socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
             socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
             return socket;

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -260,7 +260,8 @@ public final class RealConnection extends Http2Connection.Listener implements Co
   }
 
   private Socket configure(SocketFactory socketFactory, Socket socket) {
-    OptionalMethod<SocketFactory> m = new OptionalMethod<SocketFactory>(Socket.class, "configureSocket", Socket.class);
+    OptionalMethod<SocketFactory> m =
+        new OptionalMethod<SocketFactory>(Socket.class, "configureSocket", Socket.class);
 
     try {
       m.invoke(socketFactory, socket);

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -18,6 +18,7 @@ package okhttp3.internal.connection;
 
 import java.io.IOException;
 import java.lang.ref.Reference;
+import java.lang.reflect.InvocationTargetException;
 import java.net.ConnectException;
 import java.net.ProtocolException;
 import java.net.Proxy;
@@ -30,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.net.SocketFactory;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -58,6 +60,7 @@ import okhttp3.internal.http2.ErrorCode;
 import okhttp3.internal.http2.Http2Codec;
 import okhttp3.internal.http2.Http2Connection;
 import okhttp3.internal.http2.Http2Stream;
+import okhttp3.internal.platform.OptionalMethod;
 import okhttp3.internal.platform.Platform;
 import okhttp3.internal.tls.OkHostnameVerifier;
 import okhttp3.internal.ws.RealWebSocket;
@@ -230,7 +233,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
 
     rawSocket = proxy.type() == Proxy.Type.DIRECT || proxy.type() == Proxy.Type.HTTP
         ? address.socketFactory().createSocket()
-        : new Socket(proxy);
+        : configure(address.socketFactory(), new Socket(proxy));
 
     eventListener.connectStart(call, route.socketAddress(), proxy);
     rawSocket.setSoTimeout(readTimeout);
@@ -254,6 +257,18 @@ public final class RealConnection extends Http2Connection.Listener implements Co
         throw new IOException(npe);
       }
     }
+  }
+
+  private Socket configure(SocketFactory socketFactory, Socket socket) {
+    OptionalMethod<SocketFactory> m = new OptionalMethod<SocketFactory>(Socket.class, "configureSocket", Socket.class);
+
+    try {
+      m.invoke(socketFactory, socket);
+    } catch (InvocationTargetException e) {
+      e.printStackTrace();
+    }
+
+    return socket;
   }
 
   private void establishProtocol(ConnectionSpecSelector connectionSpecSelector, Call call,

--- a/okhttp/src/main/java/okhttp3/internal/platform/OptionalMethod.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/OptionalMethod.java
@@ -26,7 +26,7 @@ import java.lang.reflect.Modifier;
  *
  * @param <T> the type of the object the method might be on, typically an interface or base class
  */
-class OptionalMethod<T> {
+public class OptionalMethod<T> {
 
   /** The return type of the method. null means "don't care". */
   private final Class<?> returnType;
@@ -42,7 +42,7 @@ class OptionalMethod<T> {
    * @param methodName the name of the method
    * @param methodParams the method parameter types
    */
-  OptionalMethod(Class<?> returnType, String methodName, Class... methodParams) {
+  public OptionalMethod(Class<?> returnType, String methodName, Class... methodParams) {
     this.returnType = returnType;
     this.methodName = methodName;
     this.methodParams = methodParams;


### PR DESCRIPTION
Key line is really just 

`configure(address.socketFactory(), new Socket(proxy));`

Question is whether OkHttp should support a configure hook for creating raw sockets, that is hit in all cases?  

Currently a SocketFactory can be used to configure the socket created, except for when a SOCKS proxy is used.

```
    rawSocket = proxy.type() == Proxy.Type.DIRECT || proxy.type() == Proxy.Type.HTTP
        ? address.socketFactory().createSocket()
        : new Socket(proxy);
```

Configure hook options?

1) poor OptionalMethod like below.
2) an optional interface for SocketFactory supporting just a configureSocket method?