### PR TITLE
256kB header limit

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -1872,7 +1872,7 @@ public final class CallTest {
   }
 
   @Test public void httpWithExcessiveHeaders() throws IOException {
-    String longLine = "HTTP/1.1 200 " + stringFill('O', 100 * 1024) + "K";
+    String longLine = "HTTP/1.1 200 " + stringFill('O', 256 * 1024) + "K";
 
     server.setProtocols(Collections.singletonList(Protocol.HTTP_1_1));
 

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -1871,6 +1871,25 @@ public final class CallTest {
         .assertFailure("HTTP 205 had non-zero Content-Length: 39");
   }
 
+  @Test public void httpWithExcessiveHeaders() throws IOException {
+    String longLine = "HTTP/1.1 200 " + stringFill('O', 100 * 1024) + "K";
+
+    server.setProtocols(Collections.singletonList(Protocol.HTTP_1_1));
+
+    server.enqueue(new MockResponse()
+        .setStatus(longLine)
+        .setBody("I'm not even supposed to be here today."));
+
+    executeSynchronously("/")
+        .assertFailureMatches(".*unexpected end of stream on Connection.*");
+  }
+
+  private String stringFill(char fillChar, int length) {
+    char[] value = new char[length];
+    Arrays.fill(value, fillChar);
+    return new String(value);
+  }
+
   @Test public void canceledBeforeExecute() throws Exception {
     Call call = client.newCall(new Request.Builder().url(server.url("/a")).build());
     call.cancel();

--- a/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordedResponse.java
@@ -157,7 +157,7 @@ public final class RecordedResponse {
   }
 
   public RecordedResponse assertFailure(String... messages) {
-    assertNotNull(failure);
+    assertNotNull("No failure found", failure);
     assertTrue(failure.getMessage(), Arrays.asList(messages).contains(failure.getMessage()));
     return this;
   }


### PR DESCRIPTION
Two main goals

- Don't allow a malicious server to flood a client
- Turn these hangs into clear failures, e.g. "no header line received within X characters: content starting 'XXXXXXXXX'"