### PR TITLE
Fix travis build

### DIFF
--- a/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
@@ -87,7 +87,7 @@ public final class PrintEvents {
     final long callId;
     final long callStartNanos;
 
-    public PrintingEventListener(long callId, long callStartNanos) {
+    PrintingEventListener(long callId, long callStartNanos) {
       this.callId = callId;
       this.callStartNanos = callStartNanos;
     }


### PR DESCRIPTION
Failing on unrelated PRs

`[ERROR] /home/travis/build/square/okhttp/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java:90:5: Redundant 'public' modifier. [RedundantModifier]`