### PR TITLE
Ensure encodedQuery doesn't include the URL's fragment

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
@@ -1440,6 +1440,13 @@ public final class HttpUrlTest {
     assertEquals(" ", url.queryParameter(" "));
   }
 
+  @Test public void parsedQueryDoesntIncludeFragment() {
+    HttpUrl url = HttpUrl.parse("http://host/?#fragment");
+    assertEquals("fragment", url.fragment());
+    assertEquals("", url.query());
+    assertEquals("", url.encodedQuery());
+  }
+
   @Test public void roundTripBuilder() throws Exception {
     HttpUrl url = new HttpUrl.Builder()
         .scheme("http")

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -611,7 +611,7 @@ public final class HttpUrl {
   public @Nullable String encodedQuery() {
     if (queryNamesAndValues == null) return null; // No query.
     int queryStart = url.indexOf('?') + 1;
-    int queryEnd = delimiterOffset(url, queryStart + 1, url.length(), '#');
+    int queryEnd = delimiterOffset(url, queryStart, url.length(), '#');
     return url.substring(queryStart, queryEnd);
   }
 


### PR DESCRIPTION
Before updating the call to `delimiterOffset`, the test failed with: 

```
org.junit.ComparisonFailure: 
Expected :
Actual   :#fragment
 <Click to see difference>
```

I did a quick check of other calls to `delimiterOffset`, and those looked fine.