### PR TITLE
workaround broken system dns behaviour

### DIFF
--- a/okhttp/src/main/java/okhttp3/Dns.java
+++ b/okhttp/src/main/java/okhttp3/Dns.java
@@ -36,7 +36,14 @@ public interface Dns {
   Dns SYSTEM = new Dns() {
     @Override public List<InetAddress> lookup(String hostname) throws UnknownHostException {
       if (hostname == null) throw new UnknownHostException("hostname == null");
-      return Arrays.asList(InetAddress.getAllByName(hostname));
+      try {
+        return Arrays.asList(InetAddress.getAllByName(hostname));
+      } catch (NullPointerException e) {
+        UnknownHostException unknownHostException =
+            new UnknownHostException("Broken system behaviour for dns lookup of " + hostname);
+        unknownHostException.initCause(e);
+        throw unknownHostException;
+      }
     }
   };
 


### PR DESCRIPTION
Not ideal, but some Android phones fails at least some Dns requests.  The OkHttp Dns fails in a non-recoverable way, so instead catch this and treat it as a zero length result.