### PR TITLE
304 Not Modified overrides Content-Encoding and breaks cache

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -1033,6 +1033,22 @@ public final class CacheTest {
     assertEquals("ABCABCABC", get(server.url("/")).body().string());
   }
 
+  @Test public void previouslyNotGzippedContentIsNotModifiedAndSpecifiesGzipEncoding() throws Exception {
+    server.enqueue(new MockResponse()
+            .setBody("ABCABCABC")
+            .addHeader("Last-Modified: " + formatDate(-2, TimeUnit.HOURS))
+            .addHeader("Expires: " + formatDate(-1, TimeUnit.HOURS)));
+    server.enqueue(new MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED)
+            .addHeader("Content-Encoding: gzip"));
+    server.enqueue(new MockResponse()
+            .setBody("DEFDEFDEF"));
+
+    assertEquals("ABCABCABC", get(server.url("/")).body().string());
+    assertEquals("ABCABCABC", get(server.url("/")).body().string());
+    assertEquals("DEFDEFDEF", get(server.url("/")).body().string());
+  }
+
   @Test public void notModifiedSpecifiesEncoding() throws Exception {
     server.enqueue(new MockResponse()
         .setBody(gzip("ABCABCABC"))

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -1036,10 +1036,12 @@ public final class CacheTest {
   @Test public void previouslyNotGzippedContentIsNotModifiedAndSpecifiesGzipEncoding() throws Exception {
     server.enqueue(new MockResponse()
             .setBody("ABCABCABC")
+            .addHeader("Content-Type: text/plain")
             .addHeader("Last-Modified: " + formatDate(-2, TimeUnit.HOURS))
             .addHeader("Expires: " + formatDate(-1, TimeUnit.HOURS)));
     server.enqueue(new MockResponse()
             .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED)
+            .addHeader("Content-Type: text/plain")
             .addHeader("Content-Encoding: gzip"));
     server.enqueue(new MockResponse()
             .setBody("DEFDEFDEF"));

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -1051,6 +1051,25 @@ public final class CacheTest {
     assertEquals("DEFDEFDEF", get(server.url("/")).body().string());
   }
 
+  @Test public void changedGzippedContentIsNotModifiedAndSpecifiesNewEncoding() throws Exception {
+    server.enqueue(new MockResponse()
+            .setBody(gzip("ABCABCABC"))
+            .addHeader("Content-Type: text/plain")
+            .addHeader("Last-Modified: " + formatDate(-2, TimeUnit.HOURS))
+            .addHeader("Expires: " + formatDate(-1, TimeUnit.HOURS))
+            .addHeader("Content-Encoding: gzip"));
+    server.enqueue(new MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED)
+            .addHeader("Content-Type: text/plain")
+            .addHeader("Content-Encoding: identity"));
+    server.enqueue(new MockResponse()
+            .setBody("DEFDEFDEF"));
+
+    assertEquals("ABCABCABC", get(server.url("/")).body().string());
+    assertEquals("ABCABCABC", get(server.url("/")).body().string());
+    assertEquals("DEFDEFDEF", get(server.url("/")).body().string());
+  }
+
   @Test public void notModifiedSpecifiesEncoding() throws Exception {
     server.enqueue(new MockResponse()
         .setBody(gzip("ABCABCABC"))

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
@@ -101,7 +101,10 @@ public final class CacheInterceptor implements Interceptor {
     // If we have a cache response too, then we're doing a conditional get.
     if (cacheResponse != null) {
       if (networkResponse.code() == HTTP_NOT_MODIFIED) {
-        Headers.Builder newResponseHeadersBuilder = combine(cacheResponse.headers(), networkResponse.headers()).newBuilder();
+        Headers.Builder newResponseHeadersBuilder = combine(
+            cacheResponse.headers(),
+            networkResponse.headers()
+        ).newBuilder();
 
         // If we have Content-Encoding IN the new response, but NOT in the old response our
         // response body will be broken that's why we ignore the new Content-Encoding header. See

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
@@ -103,10 +103,14 @@ public final class CacheInterceptor implements Interceptor {
       if (networkResponse.code() == HTTP_NOT_MODIFIED) {
         Headers.Builder newResponseHeadersBuilder = combine(cacheResponse.headers(), networkResponse.headers()).newBuilder();
 
-        // If we have Content-Encoding IN the new response, but NOT in the old response our response body will be broken
-        // that's why we ignore the new Content-Encoding header. See https://github.com/square/okhttp/pull/3700 for more information.
-        if (!cacheResponse.headers().names().contains("Content-Encoding")) {
+        // If we have Content-Encoding IN the new response, but NOT in the old response our
+        // response body will be broken that's why we ignore the new Content-Encoding header. See
+        // https://github.com/square/okhttp/pull/3700 for more information.
+        String cachedContentEncoding = cacheResponse.headers().get("Content-Encoding");
+        if (cachedContentEncoding == null) {
           newResponseHeadersBuilder.removeAll("Content-Encoding");
+        } else {
+          newResponseHeadersBuilder.set("Content-Encoding", cachedContentEncoding);
         }
 
         Response response = cacheResponse.newBuilder()

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
@@ -224,7 +224,8 @@ public final class CacheInterceptor implements Interceptor {
       if ("Warning".equalsIgnoreCase(fieldName) && value.startsWith("1")) {
         continue; // Drop 100-level freshness warnings.
       }
-      if (!isNotContentSpecificHeader(fieldName) || !isEndToEnd(fieldName) || networkHeaders.get(fieldName) == null) {
+      if (!isNotContentSpecificHeader(fieldName) || !isEndToEnd(fieldName)
+              || networkHeaders.get(fieldName) == null) {
         Internal.instance.addLenient(result, fieldName, value);
       }
     }
@@ -256,7 +257,7 @@ public final class CacheInterceptor implements Interceptor {
 
   /**
    * Returns true if {@code fieldName} should be ignored, when combining cache headers with
-   * network headers
+   * network headers.
    */
   static boolean isNotContentSpecificHeader(String fieldName) {
     return !"Content-Length".equalsIgnoreCase(fieldName)

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
@@ -224,7 +224,7 @@ public final class CacheInterceptor implements Interceptor {
       if ("Warning".equalsIgnoreCase(fieldName) && value.startsWith("1")) {
         continue; // Drop 100-level freshness warnings.
       }
-      if (!isNotContentSpecificHeader(fieldName) || !isEndToEnd(fieldName)
+      if (isContentSpecificHeader(fieldName) || !isEndToEnd(fieldName)
               || networkHeaders.get(fieldName) == null) {
         Internal.instance.addLenient(result, fieldName, value);
       }
@@ -232,7 +232,7 @@ public final class CacheInterceptor implements Interceptor {
 
     for (int i = 0, size = networkHeaders.size(); i < size; i++) {
       String fieldName = networkHeaders.name(i);
-      if (isNotContentSpecificHeader(fieldName) && isEndToEnd(fieldName)) {
+      if (!isContentSpecificHeader(fieldName) && isEndToEnd(fieldName)) {
         Internal.instance.addLenient(result, fieldName, networkHeaders.value(i));
       }
     }
@@ -256,12 +256,12 @@ public final class CacheInterceptor implements Interceptor {
   }
 
   /**
-   * Returns true if {@code fieldName} should be ignored, when combining cache headers with
-   * network headers.
+   * Returns true if {@code fieldName} is content specific and therefor should always be used
+   * from cached headers.
    */
-  static boolean isNotContentSpecificHeader(String fieldName) {
-    return !"Content-Length".equalsIgnoreCase(fieldName)
-        && !"Content-Encoding".equalsIgnoreCase(fieldName)
-        && !"Content-Type".equalsIgnoreCase(fieldName);
+  static boolean isContentSpecificHeader(String fieldName) {
+    return "Content-Length".equalsIgnoreCase(fieldName)
+        || "Content-Encoding".equalsIgnoreCase(fieldName)
+        || "Content-Type".equalsIgnoreCase(fieldName);
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java
@@ -256,7 +256,7 @@ public final class CacheInterceptor implements Interceptor {
   }
 
   /**
-   * Returns true if {@code fieldName} is content specific and therefor should always be used
+   * Returns true if {@code fieldName} is content specific and therefore should always be used
    * from cached headers.
    */
   static boolean isContentSpecificHeader(String fieldName) {


### PR DESCRIPTION
One of our clients uses the android version of okhttp and runs into the following issue:

Our api used to respond the content without gzip. The response is cached on the clients with corresponding etags. Now our api returns the content with "Content-Encoding: gzip", even in case of 304 Not Modified.

okhttp fails with:

```
java.io.EOFException
	at okio.RealBufferedSource.require(RealBufferedSource.java:60)
	at okio.GzipSource.consumeHeader(GzipSource.java:114)
	at okio.GzipSource.read(GzipSource.java:73)
	at okio.RealBufferedSource.request(RealBufferedSource.java:67)
	at okio.RealBufferedSource.rangeEquals(RealBufferedSource.java:408)
	at okio.RealBufferedSource.rangeEquals(RealBufferedSource.java:392)
	at okhttp3.internal.Util.bomAwareCharset(Util.java:449)
	at okhttp3.ResponseBody.string(ResponseBody.java:174)
	at okhttp3.CacheTest.previouslyNotGzippedContentIsNotModifiedAndSpecifiesGzipEncoding(CacheTest.java:1048)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at okhttp3.internal.io.InMemoryFileSystem$1.evaluate(InMemoryFileSystem.java:45)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```

The first commit of this PR adds a failing test.

I found the reason. In https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.java#L105 okhttp follows the spec at https://tools.ietf.org/html/rfc7234#section-4.3.4 but breaks the body of the cached response if the "Content-Encoding" actually only appears on 304 Not Modified but hasn't been available before. Thus my fix just removes the "Content-Encoding" response header in the merged cache entry IF it wasn't available before.

After review by @yschimke I added the following changes to the PR:

- "Content-Encoding" and "Content-Type" are now removed in the same way, like "Content-Length" was removed before, when merging cached headers with network headers.