### PR TITLE
Remove permitsRequestBody in HTTP Methods

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -60,7 +60,6 @@ import okhttp3.Response;
 import okhttp3.internal.Internal;
 import okhttp3.internal.NamedRunnable;
 import okhttp3.internal.Util;
-import okhttp3.internal.http.HttpMethod;
 import okhttp3.internal.http2.ErrorCode;
 import okhttp3.internal.http2.Header;
 import okhttp3.internal.http2.Http2Connection;

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -203,15 +203,6 @@ public final class CallTest {
     repeatedHeaderNames();
   }
 
-  @Test public void getWithRequestBody() throws Exception {
-    server.enqueue(new MockResponse());
-
-    try {
-      new Request.Builder().method("GET", RequestBody.create(MediaType.parse("text/plain"), "abc"));
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
-  }
 
   @Test public void head() throws Exception {
     server.enqueue(new MockResponse().addHeader("Content-Type: text/plain"));

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -2801,16 +2801,6 @@ public final class URLConnectionTest {
     connection.getInputStream().close();
   }
 
-  @Test public void getOutputStreamOnGetFails() throws Exception {
-    server.enqueue(new MockResponse());
-    connection = urlFactory.open(server.url("/").url());
-    try {
-      connection.getOutputStream();
-      fail();
-    } catch (ProtocolException expected) {
-    }
-    connection.getInputStream().close();
-  }
 
   @Test public void getOutputAfterGetInputStreamFails() throws Exception {
     server.enqueue(new MockResponse());
@@ -2885,16 +2875,6 @@ public final class URLConnectionTest {
     assertEquals("GET /?query HTTP/1.1", request.getRequestLine());
   }
 
-  @Test public void doOutputForMethodThatDoesntSupportOutput() throws Exception {
-    connection = urlFactory.open(server.url("/").url());
-    connection.setRequestMethod("HEAD");
-    connection.setDoOutput(true);
-    try {
-      connection.connect();
-      fail();
-    } catch (IOException expected) {
-    }
-  }
 
   // http://code.google.com/p/android/issues/detail?id=20442
   @Test public void inputStreamAvailableWithChunkedEncoding() throws Exception {

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
@@ -54,7 +54,6 @@ import okhttp3.internal.Util;
 import okhttp3.internal.Version;
 import okhttp3.internal.http.HttpDate;
 import okhttp3.internal.http.HttpHeaders;
-import okhttp3.internal.http.HttpMethod;
 import okhttp3.internal.http.StatusLine;
 import okhttp3.internal.platform.Platform;
 

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
@@ -335,8 +335,6 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
       if (method.equals("GET")) {
         // they are requesting a stream to write to. This implies a POST method
         method = "POST";
-      } else if (!HttpMethod.permitsRequestBody(method)) {
-        throw new ProtocolException(method + " does not support writing");
       }
     }
 
@@ -345,8 +343,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
     }
 
     OutputStreamRequestBody requestBody = null;
-    if (HttpMethod.permitsRequestBody(method)) {
-      // Add a content type for the request body, if one isn't already present.
+
       String contentType = requestHeaders.get("Content-Type");
       if (contentType == null) {
         contentType = "application/x-www-form-urlencoded";
@@ -367,7 +364,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
           ? new StreamedRequestBody(contentLength)
           : new BufferedRequestBody(contentLength);
       requestBody.timeout().timeout(client.writeTimeoutMillis(), TimeUnit.MILLISECONDS);
-    }
+
 
     Request request = new Request.Builder()
         .url(Internal.instance.getHttpUrlChecked(getURL().toString()))

--- a/okhttp/src/main/java/okhttp3/Request.java
+++ b/okhttp/src/main/java/okhttp3/Request.java
@@ -231,9 +231,7 @@ public final class Request {
     public Builder method(String method, @Nullable RequestBody body) {
       if (method == null) throw new NullPointerException("method == null");
       if (method.length() == 0) throw new IllegalArgumentException("method.length() == 0");
-      if (body != null && !HttpMethod.permitsRequestBody(method)) {
-        throw new IllegalArgumentException("method " + method + " must not have a request body.");
-      }
+
       if (body == null && HttpMethod.requiresRequestBody(method)) {
         throw new IllegalArgumentException("method " + method + " must have a request body.");
       }

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.java
@@ -51,7 +51,7 @@ public final class CallServerInterceptor implements Interceptor {
     realChain.eventListener().requestHeadersEnd(realChain.call(), request);
 
     Response.Builder responseBuilder = null;
-    if (HttpMethod.permitsRequestBody(request.method()) && request.body() != null) {
+    if (request.body() != null) {
       // If there's a "Expect: 100-continue" header on the request, wait for a "HTTP/1.1 100
       // Continue" response before transmitting the request body. If we don't get that, return
       // what we did get (such as a 4xx response) without ever transmitting the request body.

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpMethod.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpMethod.java
@@ -32,15 +32,6 @@ public final class HttpMethod {
         || method.equals("REPORT");   // CalDAV/CardDAV (defined in WebDAV Versioning)
   }
 
-  public static boolean permitsRequestBody(String method) {
-    return requiresRequestBody(method)
-        || method.equals("OPTIONS")
-        || method.equals("DELETE")    // Permitted as spec is ambiguous.
-        || method.equals("PROPFIND")  // (WebDAV) without body: request <allprop/>
-        || method.equals("MKCOL")     // (WebDAV) may contain a body, but behaviour is unspecified
-        || method.equals("LOCK");     // (WebDAV) body: create lock, without body: refresh lock
-  }
-
   public static boolean redirectsWithBody(String method) {
     return method.equals("PROPFIND"); // (WebDAV) redirects should also maintain the request body
   }

--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
@@ -316,7 +316,6 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
 
         // Most redirects don't include a request body.
         Request.Builder requestBuilder = userResponse.request().newBuilder();
-        if (HttpMethod.permitsRequestBody(method)) {
           final boolean maintainBody = HttpMethod.redirectsWithBody(method);
           if (HttpMethod.redirectsToGet(method)) {
             requestBuilder.method("GET", null);
@@ -329,7 +328,7 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
             requestBuilder.removeHeader("Content-Length");
             requestBuilder.removeHeader("Content-Type");
           }
-        }
+
 
         // When redirecting across hosts, drop all authentication headers. This
         // is potentially annoying to the application layer since they have no


### PR DESCRIPTION
Remove permitsRequestBody in HTTP Methods to allow custom method with the body.
https://github.com/square/okhttp/issues/229