### PR TITLE
Replaced explicit null checks by automatically generated

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -126,7 +126,6 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
   /** Change the level at which this interceptor logs. */
   public HttpLoggingInterceptor setLevel(Level level) {
-    if (level == null) throw new NullPointerException("level == null. Use Level.NONE instead.");
     this.level = level;
     return this;
   }

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -102,7 +102,7 @@ public final class HttpLoggingInterceptorTest {
       applicationInterceptor.setLevel(null);
       fail();
     } catch (NullPointerException expected) {
-      assertEquals("level == null. Use Level.NONE instead.", expected.getMessage());
+      assertEquals("level == null", expected.getMessage());
     }
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
@@ -133,7 +133,7 @@ public final class OkHttpClientTest {
     try {
       builder.addInterceptor(null);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (NullPointerException expected) {
       assertEquals("interceptor == null", expected.getMessage());
     }
   }
@@ -143,7 +143,7 @@ public final class OkHttpClientTest {
     try {
       builder.addNetworkInterceptor(null);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (NullPointerException expected) {
       assertEquals("interceptor == null", expected.getMessage());
     }
   }

--- a/okhttp/src/main/java/okhttp3/Address.java
+++ b/okhttp/src/main/java/okhttp3/Address.java
@@ -59,26 +59,12 @@ public final class Address {
         .port(uriPort)
         .build();
 
-    if (dns == null) throw new NullPointerException("dns == null");
     this.dns = dns;
-
-    if (socketFactory == null) throw new NullPointerException("socketFactory == null");
     this.socketFactory = socketFactory;
-
-    if (proxyAuthenticator == null) {
-      throw new NullPointerException("proxyAuthenticator == null");
-    }
     this.proxyAuthenticator = proxyAuthenticator;
-
-    if (protocols == null) throw new NullPointerException("protocols == null");
     this.protocols = Util.immutableList(protocols);
-
-    if (connectionSpecs == null) throw new NullPointerException("connectionSpecs == null");
     this.connectionSpecs = Util.immutableList(connectionSpecs);
-
-    if (proxySelector == null) throw new NullPointerException("proxySelector == null");
     this.proxySelector = proxySelector;
-
     this.proxy = proxy;
     this.sslSocketFactory = sslSocketFactory;
     this.hostnameVerifier = hostnameVerifier;

--- a/okhttp/src/main/java/okhttp3/Cache.java
+++ b/okhttp/src/main/java/okhttp3/Cache.java
@@ -737,7 +737,7 @@ public final class Cache implements Closeable, Flushable {
     private final @Nullable String contentLength;
 
     CacheResponseBody(final DiskLruCache.Snapshot snapshot,
-        String contentType, String contentLength) {
+        @Nullable String contentType, @Nullable String contentLength) {
       this.snapshot = snapshot;
       this.contentType = contentType;
       this.contentLength = contentLength;

--- a/okhttp/src/main/java/okhttp3/CertificatePinner.java
+++ b/okhttp/src/main/java/okhttp3/CertificatePinner.java
@@ -328,8 +328,6 @@ public final class CertificatePinner {
      * Info, base64-encoded and prefixed with either {@code sha256/} or {@code sha1/}.
      */
     public Builder add(String pattern, String... pins) {
-      if (pattern == null) throw new NullPointerException("pattern == null");
-
       for (String pin : pins) {
         this.pins.add(new Pin(pattern, pin));
       }

--- a/okhttp/src/main/java/okhttp3/Challenge.java
+++ b/okhttp/src/main/java/okhttp3/Challenge.java
@@ -31,9 +31,6 @@ public final class Challenge {
   }
 
   private Challenge(String scheme, String realm, Charset charset) {
-    if (scheme == null) throw new NullPointerException("scheme == null");
-    if (realm == null) throw new NullPointerException("realm == null");
-    if (charset == null) throw new NullPointerException("charset == null");
     this.scheme = scheme;
     this.realm = realm;
     this.charset = charset;

--- a/okhttp/src/main/java/okhttp3/CipherSuite.java
+++ b/okhttp/src/main/java/okhttp3/CipherSuite.java
@@ -413,9 +413,6 @@ public final class CipherSuite {
   }
 
   private CipherSuite(String javaName) {
-    if (javaName == null) {
-      throw new NullPointerException();
-    }
     this.javaName = javaName;
   }
 

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -119,7 +119,7 @@ public final class ConnectionPool {
    * Returns a recycled connection to {@code address}, or null if no such connection exists. The
    * route is null if the address has not yet been routed.
    */
-  @Nullable RealConnection get(Address address, StreamAllocation streamAllocation, Route route) {
+  @Nullable RealConnection get(Address address, StreamAllocation streamAllocation, @Nullable Route route) {
     assert (Thread.holdsLock(this));
     for (RealConnection connection : connections) {
       if (connection.isEligible(address, route)) {

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -119,7 +119,8 @@ public final class ConnectionPool {
    * Returns a recycled connection to {@code address}, or null if no such connection exists. The
    * route is null if the address has not yet been routed.
    */
-  @Nullable RealConnection get(Address address, StreamAllocation streamAllocation, @Nullable Route route) {
+  @Nullable RealConnection get(Address address, StreamAllocation streamAllocation,
+      @Nullable Route route) {
     assert (Thread.holdsLock(this));
     for (RealConnection connection : connections) {
       if (connection.isEligible(address, route)) {

--- a/okhttp/src/main/java/okhttp3/Cookie.java
+++ b/okhttp/src/main/java/okhttp3/Cookie.java
@@ -78,10 +78,6 @@ public final class Cookie {
   }
 
   Cookie(Builder builder) {
-    if (builder.name == null) throw new NullPointerException("builder.name == null");
-    if (builder.value == null) throw new NullPointerException("builder.value == null");
-    if (builder.domain == null) throw new NullPointerException("builder.domain == null");
-
     this.name = builder.name;
     this.value = builder.value;
     this.expiresAt = builder.expiresAt;
@@ -469,14 +465,12 @@ public final class Cookie {
     boolean hostOnly;
 
     public Builder name(String name) {
-      if (name == null) throw new NullPointerException("name == null");
       if (!name.trim().equals(name)) throw new IllegalArgumentException("name is not trimmed");
       this.name = name;
       return this;
     }
 
     public Builder value(String value) {
-      if (value == null) throw new NullPointerException("value == null");
       if (!value.trim().equals(value)) throw new IllegalArgumentException("value is not trimmed");
       this.value = value;
       return this;
@@ -507,7 +501,6 @@ public final class Cookie {
     }
 
     private Builder domain(String domain, boolean hostOnly) {
-      if (domain == null) throw new NullPointerException("domain == null");
       String canonicalDomain = Util.canonicalizeHost(domain);
       if (canonicalDomain == null) {
         throw new IllegalArgumentException("unexpected domain: " + domain);

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -95,7 +95,8 @@ public abstract class EventListener {
    *
    * <p>This method is invoked after {@link #dnsStart}.
    */
-  public void dnsEnd(@Nullable Call call, String domainName, @Nullable List<InetAddress> inetAddressList) {
+  public void dnsEnd(@Nullable Call call, String domainName,
+      @Nullable List<InetAddress> inetAddressList) {
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -87,7 +87,7 @@ public abstract class EventListener {
    * <p>If the {@link Call} is able to reuse an existing pooled connection, this method will not be
    * invoked. See {@link ConnectionPool}.
    */
-  public void dnsStart(Call call, String domainName) {
+  public void dnsStart(@Nullable Call call, String domainName) {
   }
 
   /**
@@ -95,7 +95,7 @@ public abstract class EventListener {
    *
    * <p>This method is invoked after {@link #dnsStart}.
    */
-  public void dnsEnd(Call call, String domainName, @Nullable List<InetAddress> inetAddressList) {
+  public void dnsEnd(@Nullable Call call, String domainName, @Nullable List<InetAddress> inetAddressList) {
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/FormBody.java
+++ b/okhttp/src/main/java/okhttp3/FormBody.java
@@ -112,7 +112,7 @@ public final class FormBody extends RequestBody {
       this(null);
     }
 
-    public Builder(Charset charset) {
+    public Builder(@Nullable Charset charset) {
       this.charset = charset;
     }
 

--- a/okhttp/src/main/java/okhttp3/Handshake.java
+++ b/okhttp/src/main/java/okhttp3/Handshake.java
@@ -75,8 +75,6 @@ public final class Handshake {
 
   public static Handshake get(TlsVersion tlsVersion, CipherSuite cipherSuite,
       List<Certificate> peerCertificates, List<Certificate> localCertificates) {
-    if (tlsVersion == null) throw new NullPointerException("tlsVersion == null");
-    if (cipherSuite == null) throw new NullPointerException("cipherSuite == null");
     return new Handshake(tlsVersion, cipherSuite, Util.immutableList(peerCertificates),
         Util.immutableList(localCertificates));
   }

--- a/okhttp/src/main/java/okhttp3/Headers.java
+++ b/okhttp/src/main/java/okhttp3/Headers.java
@@ -204,7 +204,6 @@ public final class Headers {
    * arguments, and they must alternate between header names and values.
    */
   public static Headers of(String... namesAndValues) {
-    if (namesAndValues == null) throw new NullPointerException("namesAndValues == null");
     if (namesAndValues.length % 2 != 0) {
       throw new IllegalArgumentException("Expected alternating header names and values");
     }
@@ -232,8 +231,6 @@ public final class Headers {
    * Returns headers for the header names and values in the {@link Map}.
    */
   public static Headers of(Map<String, String> headers) {
-    if (headers == null) throw new NullPointerException("headers == null");
-
     // Make a defensive copy and clean it up.
     String[] namesAndValues = new String[headers.size() * 2];
     int i = 0;
@@ -322,7 +319,6 @@ public final class Headers {
     }
 
     private void checkNameAndValue(String name, String value) {
-      if (name == null) throw new NullPointerException("name == null");
       if (name.isEmpty()) throw new IllegalArgumentException("name is empty");
       for (int i = 0, length = name.length(); i < length; i++) {
         char c = name.charAt(i);
@@ -331,7 +327,6 @@ public final class Headers {
               "Unexpected char %#04x at %d in header name: %s", (int) c, i, name));
         }
       }
-      if (value == null) throw new NullPointerException("value for name " + name + " == null");
       for (int i = 0, length = value.length(); i < length; i++) {
         char c = value.charAt(i);
         if ((c <= '\u001f' && c != '\t') || c >= '\u007f') {

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -988,9 +988,7 @@ public final class HttpUrl {
     }
 
     public Builder scheme(String scheme) {
-      if (scheme == null) {
-        throw new NullPointerException("scheme == null");
-      } else if (scheme.equalsIgnoreCase("http")) {
+      if (scheme.equalsIgnoreCase("http")) {
         this.scheme = "http";
       } else if (scheme.equalsIgnoreCase("https")) {
         this.scheme = "https";
@@ -1001,26 +999,22 @@ public final class HttpUrl {
     }
 
     public Builder username(String username) {
-      if (username == null) throw new NullPointerException("username == null");
       this.encodedUsername = canonicalize(username, USERNAME_ENCODE_SET, false, false, false, true);
       return this;
     }
 
     public Builder encodedUsername(String encodedUsername) {
-      if (encodedUsername == null) throw new NullPointerException("encodedUsername == null");
       this.encodedUsername = canonicalize(
           encodedUsername, USERNAME_ENCODE_SET, true, false, false, true);
       return this;
     }
 
     public Builder password(String password) {
-      if (password == null) throw new NullPointerException("password == null");
       this.encodedPassword = canonicalize(password, PASSWORD_ENCODE_SET, false, false, false, true);
       return this;
     }
 
     public Builder encodedPassword(String encodedPassword) {
-      if (encodedPassword == null) throw new NullPointerException("encodedPassword == null");
       this.encodedPassword = canonicalize(
           encodedPassword, PASSWORD_ENCODE_SET, true, false, false, true);
       return this;
@@ -1031,7 +1025,6 @@ public final class HttpUrl {
      * address.
      */
     public Builder host(String host) {
-      if (host == null) throw new NullPointerException("host == null");
       String encoded = canonicalizeHost(host, 0, host.length());
       if (encoded == null) throw new IllegalArgumentException("unexpected host: " + host);
       this.host = encoded;
@@ -1049,7 +1042,6 @@ public final class HttpUrl {
     }
 
     public Builder addPathSegment(String pathSegment) {
-      if (pathSegment == null) throw new NullPointerException("pathSegment == null");
       push(pathSegment, 0, pathSegment.length(), false, false);
       return this;
     }
@@ -1059,14 +1051,10 @@ public final class HttpUrl {
      * {@code pathSegments} starts with a slash, the resulting URL will have empty path segment.
      */
     public Builder addPathSegments(String pathSegments) {
-      if (pathSegments == null) throw new NullPointerException("pathSegments == null");
       return addPathSegments(pathSegments, false);
     }
 
     public Builder addEncodedPathSegment(String encodedPathSegment) {
-      if (encodedPathSegment == null) {
-        throw new NullPointerException("encodedPathSegment == null");
-      }
       push(encodedPathSegment, 0, encodedPathSegment.length(), false, true);
       return this;
     }
@@ -1077,9 +1065,6 @@ public final class HttpUrl {
      * segment.
      */
     public Builder addEncodedPathSegments(String encodedPathSegments) {
-      if (encodedPathSegments == null) {
-        throw new NullPointerException("encodedPathSegments == null");
-      }
       return addPathSegments(encodedPathSegments, true);
     }
 
@@ -1095,7 +1080,6 @@ public final class HttpUrl {
     }
 
     public Builder setPathSegment(int index, String pathSegment) {
-      if (pathSegment == null) throw new NullPointerException("pathSegment == null");
       String canonicalPathSegment = canonicalize(
           pathSegment, 0, pathSegment.length(), PATH_SEGMENT_ENCODE_SET, false, false, false, true,
               null);
@@ -1107,9 +1091,6 @@ public final class HttpUrl {
     }
 
     public Builder setEncodedPathSegment(int index, String encodedPathSegment) {
-      if (encodedPathSegment == null) {
-        throw new NullPointerException("encodedPathSegment == null");
-      }
       String canonicalPathSegment = canonicalize(encodedPathSegment,
           0, encodedPathSegment.length(), PATH_SEGMENT_ENCODE_SET, true, false, false, true,
           null);
@@ -1129,7 +1110,6 @@ public final class HttpUrl {
     }
 
     public Builder encodedPath(String encodedPath) {
-      if (encodedPath == null) throw new NullPointerException("encodedPath == null");
       if (!encodedPath.startsWith("/")) {
         throw new IllegalArgumentException("unexpected encodedPath: " + encodedPath);
       }
@@ -1155,7 +1135,6 @@ public final class HttpUrl {
 
     /** Encodes the query parameter using UTF-8 and adds it to this URL's query string. */
     public Builder addQueryParameter(String name, @Nullable String value) {
-      if (name == null) throw new NullPointerException("name == null");
       if (encodedQueryNamesAndValues == null) encodedQueryNamesAndValues = new ArrayList<>();
       encodedQueryNamesAndValues.add(
           canonicalize(name, QUERY_COMPONENT_ENCODE_SET, false, false, true, true));
@@ -1167,7 +1146,6 @@ public final class HttpUrl {
 
     /** Adds the pre-encoded query parameter to this URL's query string. */
     public Builder addEncodedQueryParameter(String encodedName, @Nullable String encodedValue) {
-      if (encodedName == null) throw new NullPointerException("encodedName == null");
       if (encodedQueryNamesAndValues == null) encodedQueryNamesAndValues = new ArrayList<>();
       encodedQueryNamesAndValues.add(
           canonicalize(encodedName, QUERY_COMPONENT_ENCODE_SET, true, false, true, true));
@@ -1190,7 +1168,6 @@ public final class HttpUrl {
     }
 
     public Builder removeAllQueryParameters(String name) {
-      if (name == null) throw new NullPointerException("name == null");
       if (encodedQueryNamesAndValues == null) return this;
       String nameToRemove = canonicalize(
           name, QUERY_COMPONENT_ENCODE_SET, false, false, true, true);
@@ -1199,7 +1176,6 @@ public final class HttpUrl {
     }
 
     public Builder removeAllEncodedQueryParameters(String encodedName) {
-      if (encodedName == null) throw new NullPointerException("encodedName == null");
       if (encodedQueryNamesAndValues == null) return this;
       removeAllCanonicalQueryParameters(
           canonicalize(encodedName, QUERY_COMPONENT_ENCODE_SET, true, false, true, true));
@@ -1680,7 +1656,7 @@ public final class HttpUrl {
    */
   static String canonicalize(String input, int pos, int limit, String encodeSet,
       boolean alreadyEncoded, boolean strict, boolean plusIsSpace, boolean asciiOnly,
-      Charset charset) {
+      @Nullable Charset charset) {
     int codePoint;
     for (int i = pos; i < limit; i += Character.charCount(codePoint)) {
       codePoint = input.codePointAt(i);
@@ -1705,7 +1681,7 @@ public final class HttpUrl {
 
   static void canonicalize(Buffer out, String input, int pos, int limit, String encodeSet,
       boolean alreadyEncoded, boolean strict, boolean plusIsSpace, boolean asciiOnly,
-      Charset charset) {
+      @Nullable Charset charset) {
     Buffer encodedCharBuffer = null; // Lazily allocated.
     int codePoint;
     for (int i = pos; i < limit; i += Character.charCount(codePoint)) {
@@ -1746,7 +1722,7 @@ public final class HttpUrl {
   }
 
   static String canonicalize(String input, String encodeSet, boolean alreadyEncoded, boolean strict,
-      boolean plusIsSpace, boolean asciiOnly, Charset charset) {
+      boolean plusIsSpace, boolean asciiOnly, @Nullable Charset charset) {
     return canonicalize(
         input, 0, input.length(), encodeSet, alreadyEncoded, strict, plusIsSpace, asciiOnly,
             charset);

--- a/okhttp/src/main/java/okhttp3/MultipartBody.java
+++ b/okhttp/src/main/java/okhttp3/MultipartBody.java
@@ -228,9 +228,6 @@ public final class MultipartBody extends RequestBody {
     }
 
     public static Part create(@Nullable Headers headers, RequestBody body) {
-      if (body == null) {
-        throw new NullPointerException("body == null");
-      }
       if (headers != null && headers.get("Content-Type") != null) {
         throw new IllegalArgumentException("Unexpected header: Content-Type");
       }
@@ -245,9 +242,6 @@ public final class MultipartBody extends RequestBody {
     }
 
     public static Part createFormData(String name, @Nullable String filename, RequestBody body) {
-      if (name == null) {
-        throw new NullPointerException("name == null");
-      }
       StringBuilder disposition = new StringBuilder("form-data; name=");
       appendQuotedString(disposition, name);
 
@@ -294,9 +288,6 @@ public final class MultipartBody extends RequestBody {
      * #ALTERNATIVE}, {@link #DIGEST}, {@link #PARALLEL} and {@link #FORM}.
      */
     public Builder setType(MediaType type) {
-      if (type == null) {
-        throw new NullPointerException("type == null");
-      }
       if (!type.type().equals("multipart")) {
         throw new IllegalArgumentException("multipart != " + type);
       }
@@ -326,7 +317,6 @@ public final class MultipartBody extends RequestBody {
 
     /** Add a part to the body. */
     public Builder addPart(Part part) {
-      if (part == null) throw new NullPointerException("part == null");
       parts.add(part);
       return this;
     }

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -149,7 +149,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       }
 
       @Override public RealConnection get(ConnectionPool pool, Address address,
-          StreamAllocation streamAllocation, Route route) {
+          StreamAllocation streamAllocation, @Nullable Route route) {
         return pool.get(address, streamAllocation, route);
       }
 
@@ -594,7 +594,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * <p>If unset, {@linkplain CookieJar#NO_COOKIES no cookies} will be accepted nor provided.
      */
     public Builder cookieJar(CookieJar cookieJar) {
-      if (cookieJar == null) throw new NullPointerException("cookieJar == null");
       this.cookieJar = cookieJar;
       return this;
     }
@@ -618,7 +617,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * <p>If unset, the {@link Dns#SYSTEM system-wide default} DNS will be used.
      */
     public Builder dns(Dns dns) {
-      if (dns == null) throw new NullPointerException("dns == null");
       this.dns = dns;
       return this;
     }
@@ -632,7 +630,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * be used.
      */
     public Builder socketFactory(SocketFactory socketFactory) {
-      if (socketFactory == null) throw new NullPointerException("socketFactory == null");
       this.socketFactory = socketFactory;
       return this;
     }
@@ -647,7 +644,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      *     #sslSocketFactory(SSLSocketFactory, X509TrustManager)}, which avoids such reflection.
      */
     public Builder sslSocketFactory(SSLSocketFactory sslSocketFactory) {
-      if (sslSocketFactory == null) throw new NullPointerException("sslSocketFactory == null");
       this.sslSocketFactory = sslSocketFactory;
       this.certificateChainCleaner = Platform.get().buildCertificateChainCleaner(sslSocketFactory);
       return this;
@@ -685,8 +681,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      */
     public Builder sslSocketFactory(
         SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
-      if (sslSocketFactory == null) throw new NullPointerException("sslSocketFactory == null");
-      if (trustManager == null) throw new NullPointerException("trustManager == null");
       this.sslSocketFactory = sslSocketFactory;
       this.certificateChainCleaner = CertificateChainCleaner.get(trustManager);
       return this;
@@ -699,7 +693,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * <p>If unset, a default hostname verifier will be used.
      */
     public Builder hostnameVerifier(HostnameVerifier hostnameVerifier) {
-      if (hostnameVerifier == null) throw new NullPointerException("hostnameVerifier == null");
       this.hostnameVerifier = hostnameVerifier;
       return this;
     }
@@ -710,7 +703,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * Pinning certificates avoids the need to trust certificate authorities.
      */
     public Builder certificatePinner(CertificatePinner certificatePinner) {
-      if (certificatePinner == null) throw new NullPointerException("certificatePinner == null");
       this.certificatePinner = certificatePinner;
       return this;
     }
@@ -722,7 +714,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * <p>If unset, the {@linkplain Authenticator#NONE no authentication will be attempted}.
      */
     public Builder authenticator(Authenticator authenticator) {
-      if (authenticator == null) throw new NullPointerException("authenticator == null");
       this.authenticator = authenticator;
       return this;
     }
@@ -734,7 +725,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * <p>If unset, the {@linkplain Authenticator#NONE no authentication will be attempted}.
      */
     public Builder proxyAuthenticator(Authenticator proxyAuthenticator) {
-      if (proxyAuthenticator == null) throw new NullPointerException("proxyAuthenticator == null");
       this.proxyAuthenticator = proxyAuthenticator;
       return this;
     }
@@ -745,7 +735,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * <p>If unset, a new connection pool will be used.
      */
     public Builder connectionPool(ConnectionPool connectionPool) {
-      if (connectionPool == null) throw new NullPointerException("connectionPool == null");
       this.connectionPool = connectionPool;
       return this;
     }
@@ -864,7 +853,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     }
 
     public Builder addInterceptor(Interceptor interceptor) {
-      if (interceptor == null) throw new IllegalArgumentException("interceptor == null");
       interceptors.add(interceptor);
       return this;
     }
@@ -879,7 +867,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     }
 
     public Builder addNetworkInterceptor(Interceptor interceptor) {
-      if (interceptor == null) throw new IllegalArgumentException("interceptor == null");
       networkInterceptors.add(interceptor);
       return this;
     }
@@ -891,7 +878,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * @see EventListener for semantics and restrictions on listener implementations.
      */
     public Builder eventListener(EventListener eventListener) {
-      if (eventListener == null) throw new NullPointerException("eventListener == null");
       this.eventListenerFactory = EventListener.factory(eventListener);
       return this;
     }
@@ -903,9 +889,6 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
      * @see EventListener for semantics and restrictions on listener implementations.
      */
     public Builder eventListenerFactory(EventListener.Factory eventListenerFactory) {
-      if (eventListenerFactory == null) {
-        throw new NullPointerException("eventListenerFactory == null");
-      }
       this.eventListenerFactory = eventListenerFactory;
       return this;
     }

--- a/okhttp/src/main/java/okhttp3/Request.java
+++ b/okhttp/src/main/java/okhttp3/Request.java
@@ -118,7 +118,6 @@ public final class Request {
     }
 
     public Builder url(HttpUrl url) {
-      if (url == null) throw new NullPointerException("url == null");
       this.url = url;
       return this;
     }
@@ -130,8 +129,6 @@ public final class Request {
      * exception by calling {@link HttpUrl#parse}; it returns null for invalid URLs.
      */
     public Builder url(String url) {
-      if (url == null) throw new NullPointerException("url == null");
-
       // Silently replace web socket URLs with HTTP URLs.
       if (url.regionMatches(true, 0, "ws:", 0, 3)) {
         url = "http:" + url.substring(3);
@@ -151,7 +148,6 @@ public final class Request {
      * https}.
      */
     public Builder url(URL url) {
-      if (url == null) throw new NullPointerException("url == null");
       HttpUrl parsed = HttpUrl.get(url);
       if (parsed == null) throw new IllegalArgumentException("unexpected url: " + url);
       return url(parsed);
@@ -229,7 +225,6 @@ public final class Request {
     }
 
     public Builder method(String method, @Nullable RequestBody body) {
-      if (method == null) throw new NullPointerException("method == null");
       if (method.length() == 0) throw new IllegalArgumentException("method.length() == 0");
       if (body != null && !HttpMethod.permitsRequestBody(method)) {
         throw new IllegalArgumentException("method " + method + " must not have a request body.");

--- a/okhttp/src/main/java/okhttp3/RequestBody.java
+++ b/okhttp/src/main/java/okhttp3/RequestBody.java
@@ -83,7 +83,6 @@ public abstract class RequestBody {
   /** Returns a new request body that transmits {@code content}. */
   public static RequestBody create(final @Nullable MediaType contentType, final byte[] content,
       final int offset, final int byteCount) {
-    if (content == null) throw new NullPointerException("content == null");
     Util.checkOffsetAndCount(content.length, offset, byteCount);
     return new RequestBody() {
       @Override public @Nullable MediaType contentType() {
@@ -102,8 +101,6 @@ public abstract class RequestBody {
 
   /** Returns a new request body that transmits the content of {@code file}. */
   public static RequestBody create(final @Nullable MediaType contentType, final File file) {
-    if (file == null) throw new NullPointerException("content == null");
-
     return new RequestBody() {
       @Override public @Nullable MediaType contentType() {
         return contentType;

--- a/okhttp/src/main/java/okhttp3/ResponseBody.java
+++ b/okhttp/src/main/java/okhttp3/ResponseBody.java
@@ -213,7 +213,6 @@ public abstract class ResponseBody implements Closeable {
   /** Returns a new response body that transmits {@code content}. */
   public static ResponseBody create(final @Nullable MediaType contentType,
       final long contentLength, final BufferedSource content) {
-    if (content == null) throw new NullPointerException("source == null");
     return new ResponseBody() {
       @Override public @Nullable MediaType contentType() {
         return contentType;

--- a/okhttp/src/main/java/okhttp3/Route.java
+++ b/okhttp/src/main/java/okhttp3/Route.java
@@ -40,15 +40,6 @@ public final class Route {
   final InetSocketAddress inetSocketAddress;
 
   public Route(Address address, Proxy proxy, InetSocketAddress inetSocketAddress) {
-    if (address == null) {
-      throw new NullPointerException("address == null");
-    }
-    if (proxy == null) {
-      throw new NullPointerException("proxy == null");
-    }
-    if (inetSocketAddress == null) {
-      throw new NullPointerException("inetSocketAddress == null");
-    }
     this.address = address;
     this.proxy = proxy;
     this.inetSocketAddress = inetSocketAddress;

--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -471,7 +471,6 @@ public final class Util {
 
   public static int checkDuration(String name, long duration, TimeUnit unit) {
     if (duration < 0) throw new IllegalArgumentException(name + " < 0");
-    if (unit == null) throw new NullPointerException("unit == null");
     long millis = unit.toMillis(duration);
     if (millis > Integer.MAX_VALUE) throw new IllegalArgumentException(name + " too large.");
     if (millis == 0 && duration > 0) throw new IllegalArgumentException(name + " too small.");

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
@@ -74,8 +74,6 @@ public final class Http2Stream {
 
   Http2Stream(int id, Http2Connection connection, boolean outFinished, boolean inFinished,
       List<Header> requestHeaders) {
-    if (connection == null) throw new NullPointerException("connection == null");
-    if (requestHeaders == null) throw new NullPointerException("requestHeaders == null");
     this.id = id;
     this.connection = connection;
     this.bytesLeftInWriteWindow =
@@ -169,9 +167,6 @@ public final class Http2Stream {
    */
   public void sendResponseHeaders(List<Header> responseHeaders, boolean out) throws IOException {
     assert (!Thread.holdsLock(Http2Stream.this));
-    if (responseHeaders == null) {
-      throw new NullPointerException("responseHeaders == null");
-    }
     boolean outFinished = false;
     synchronized (this) {
       this.hasResponseHeaders = true;

--- a/okhttp/src/main/java/okhttp3/internal/publicsuffix/PublicSuffixDatabase.java
+++ b/okhttp/src/main/java/okhttp3/internal/publicsuffix/PublicSuffixDatabase.java
@@ -75,8 +75,6 @@ public final class PublicSuffixDatabase {
    *    encoded.
    */
   public String getEffectiveTldPlusOne(String domain) {
-    if (domain == null) throw new NullPointerException("domain == null");
-
     // We use UTF-8 in the list so we need to convert to Unicode.
     String unicodeDomain = IDN.toUnicode(domain);
     String[] domainLabels = unicodeDomain.split("\\.");

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -358,12 +358,10 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
   // Writer methods to enqueue frames. They'll be sent asynchronously by the writer thread.
 
   @Override public boolean send(String text) {
-    if (text == null) throw new NullPointerException("text == null");
     return send(ByteString.encodeUtf8(text), OPCODE_TEXT);
   }
 
   @Override public boolean send(ByteString bytes) {
-    if (bytes == null) throw new NullPointerException("bytes == null");
     return send(bytes, OPCODE_BINARY);
   }
 
@@ -393,11 +391,11 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
     return true;
   }
 
-  @Override public boolean close(int code, String reason) {
+  @Override public boolean close(int code, @Nullable String reason) {
     return close(code, reason, CANCEL_AFTER_CLOSE_MILLIS);
   }
 
-  synchronized boolean close(int code, String reason, long cancelAfterCloseMillis) {
+  synchronized boolean close(int code, @Nullable String reason, long cancelAfterCloseMillis) {
     validateCloseCode(code);
 
     ByteString reasonBytes = null;
@@ -564,7 +562,7 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
     final ByteString reason;
     final long cancelAfterCloseMillis;
 
-    Close(int code, ByteString reason, long cancelAfterCloseMillis) {
+    Close(int code, @Nullable ByteString reason, long cancelAfterCloseMillis) {
       this.code = code;
       this.reason = reason;
       this.cancelAfterCloseMillis = cancelAfterCloseMillis;

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebSocketReader.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebSocketReader.java
@@ -76,8 +76,6 @@ final class WebSocketReader {
   final byte[] maskBuffer = new byte[8192];
 
   WebSocketReader(boolean isClient, BufferedSource source, FrameCallback frameCallback) {
-    if (source == null) throw new NullPointerException("source == null");
-    if (frameCallback == null) throw new NullPointerException("frameCallback == null");
     this.isClient = isClient;
     this.source = source;
     this.frameCallback = frameCallback;

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebSocketWriter.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebSocketWriter.java
@@ -23,6 +23,8 @@ import okio.ByteString;
 import okio.Sink;
 import okio.Timeout;
 
+import javax.annotation.Nullable;
+
 import static okhttp3.internal.ws.WebSocketProtocol.B0_FLAG_FIN;
 import static okhttp3.internal.ws.WebSocketProtocol.B1_FLAG_MASK;
 import static okhttp3.internal.ws.WebSocketProtocol.OPCODE_CONTINUATION;
@@ -59,8 +61,6 @@ final class WebSocketWriter {
   final byte[] maskBuffer;
 
   WebSocketWriter(boolean isClient, BufferedSink sink, Random random) {
-    if (sink == null) throw new NullPointerException("sink == null");
-    if (random == null) throw new NullPointerException("random == null");
     this.isClient = isClient;
     this.sink = sink;
     this.random = random;
@@ -87,7 +87,7 @@ final class WebSocketWriter {
    * href="http://tools.ietf.org/html/rfc6455#section-7.4">Section 7.4 of RFC 6455</a> or {@code 0}.
    * @param reason Reason for shutting down or {@code null}.
    */
-  void writeClose(int code, ByteString reason) throws IOException {
+  void writeClose(int code, @Nullable ByteString reason) throws IOException {
     ByteString payload = ByteString.EMPTY;
     if (code != 0 || reason != null) {
       if (code != 0) {

--- a/okhttp/src/main/java/okhttp3/internal/ws/package-info.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/package-info.java
@@ -1,0 +1,2 @@
+@javax.annotation.ParametersAreNonnullByDefault
+package okhttp3.internal.ws;

--- a/okhttp/src/main/java/okhttp3/internal/ws/package-info.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/package-info.java
@@ -1,2 +1,3 @@
+/** An OkHttp Web Socket support. */
 @javax.annotation.ParametersAreNonnullByDefault
 package okhttp3.internal.ws;

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,17 @@
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
             <source>${java.version}</source>
             <target>${java.version}</target>
+            <compilerArgs>
+              <arg>-Xplugin:Traute</arg>
+              <arg>-Atraute.failure.text.parameter=$${PARAMETER_NAME} == null</arg>
+            </compilerArgs>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>tech.harmonysoft</groupId>
+                <artifactId>traute-javac</artifactId>
+                <version>1.1.6</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
           <dependencies>
             <dependency>


### PR DESCRIPTION
This *PR* applies [Traute](https://github.com/square/okhttp) *javac* plugin to the project. It generates *null*-checks based on configured annotations ([package-level ParametersAreNonnullByDefault](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/package-info.java#L2)).  

Let's consider [Address](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/Address.java) class as en example:  

*Source code*  

```java
public Address(String uriHost, int uriPort, Dns dns, SocketFactory socketFactory,
      @Nullable SSLSocketFactory sslSocketFactory, @Nullable HostnameVerifier hostnameVerifier,
      @Nullable CertificatePinner certificatePinner, Authenticator proxyAuthenticator,
      @Nullable Proxy proxy, List<Protocol> protocols, List<ConnectionSpec> connectionSpecs,
      ProxySelector proxySelector) {
    ...
}
```  

Resulting bytecode looks like it's compiled from the source below (note that no checks are generated for parameters marked by *Nullable*):  

```java
public Address(String uriHost, int uriPort, Dns dns, SocketFactory socketFactory,
      @Nullable SSLSocketFactory sslSocketFactory, @Nullable HostnameVerifier hostnameVerifier,
      @Nullable CertificatePinner certificatePinner, Authenticator proxyAuthenticator,
      @Nullable Proxy proxy, List<Protocol> protocols, List<ConnectionSpec> connectionSpecs,
      ProxySelector proxySelector) {
    if (uriHost == null) {
        throw new NullPointerException("uriHost == null");
    }
    if (dns == null) {
        throw new NullPointerException("dns == null");
    }
    if (socketFactory == null) {
        throw new NullPointerException("socketFactory == null");
    }
    if (proxyAuthenticator == null) {
        throw new NullPointerException("proxyAuthenticator == null");
    }
    if (protocols == null) {
        throw new NullPointerException("protocols == null");
    }
    if (connectionSpecs == null) {
        throw new NullPointerException("connectionSpecs == null");
    }
    if (proxySelector == null) {
        throw new NullPointerException("proxySelector == null");
    }
    ...
}
```  

*Bytecode*  

```
javap -c ./okhttp/target/classes/okhttp3/Address.class
...
  public okhttp3.Address(java.lang.String, int, okhttp3.Dns, javax.net.SocketFactory, javax.net.ssl.SSLSocketFactory, javax.net.ssl.HostnameVerifier, okhttp3.CertificatePinner, okhttp3.Authenticator, java.net.Proxy, java.util.List<okhttp3.Protocol>, java.util.List<okhttp3.ConnectionSpec>, java.net.ProxySelector);
    Code:
       0: aload_0
       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
       4: aload_1
       5: ifnonnull     18
       8: new           #2                  // class java/lang/NullPointerException
      11: dup
      12: ldc           #3                  // String uriHost == null
      14: invokespecial #4                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      17: athrow
      18: aload_3
      19: ifnonnull     32
      22: new           #2                  // class java/lang/NullPointerException
      25: dup
      26: ldc           #5                  // String dns == null
      28: invokespecial #4                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      31: athrow
...
```