### PR TITLE
Retry-After support 

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -1647,13 +1647,11 @@ public final class CallTest {
         .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END)
         .setResponseCode(408)
         .setHeader("Connection", "Close")
-        .setHeader("Retry-After", "0")
         .setBody("You took too long!"));
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END)
         .setResponseCode(408)
         .setHeader("Connection", "Close")
-        .setHeader("Retry-After", "0")
         .setBody("You took too long!"));
 
     Request request = new Request.Builder()

--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
@@ -48,7 +48,6 @@ import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
 import static java.net.HttpURLConnection.HTTP_MULT_CHOICE;
 import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
 import static java.net.HttpURLConnection.HTTP_SEE_OTHER;
-import static java.net.HttpURLConnection.HTTP_SERVER_ERROR;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static okhttp3.internal.Util.closeQuietly;


### PR DESCRIPTION
Two effective changes 

- Support for 503, with 0 Retry-After meaning retry automatically
- Check with 408, and don't do automatic retry if there is a delay