### PR TITLE
Fix locks

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
@@ -82,11 +82,10 @@ public final class ConnectionPoolTest {
     pool.cleanupRunning = true; // Prevent the cleanup runnable from being started.
 
     RealConnection c1 = newConnection(pool, routeA1, 50L);
-    synchronized (pool) {
-      StreamAllocation streamAllocation = new StreamAllocation(pool, addressA, null,
-          EventListener.NONE, null);
-      streamAllocation.acquire(c1, true);
-    }
+
+    StreamAllocation streamAllocation = new StreamAllocation(pool, addressA, null,
+        EventListener.NONE, null);
+    streamAllocation.acquire(c1, true);
 
     // Running at time 50, the pool returns that nothing can be evicted until time 150.
     assertEquals(100L, pool.cleanup(50L));

--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
@@ -639,10 +639,7 @@ public final class Http2ConnectionTest {
       }
     };
     Http2Connection connection = connect(peer, IGNORE, listener);
-
-    synchronized (connection) {
-      assertEquals(10, connection.peerSettings.getMaxConcurrentStreams(-1));
-    }
+    assertEquals(10, connection.peerSettings.getMaxConcurrentStreams(-1));
     maxConcurrentStreamsUpdated.await();
     assertEquals(10, maxConcurrentStreams.get());
   }
@@ -670,12 +667,10 @@ public final class Http2ConnectionTest {
 
     assertEquals(Http2.TYPE_SETTINGS, peer.takeFrame().type);
     assertEquals(Http2.TYPE_PING, peer.takeFrame().type);
-    synchronized (connection) {
-      assertEquals(10000, connection.peerSettings.getHeaderTableSize());
-      assertEquals(40000, connection.peerSettings.getInitialWindowSize());
-      assertEquals(50000, connection.peerSettings.getMaxFrameSize(-1));
-      assertEquals(60000, connection.peerSettings.getMaxConcurrentStreams(-1));
-    }
+    assertEquals(10000, connection.peerSettings.getHeaderTableSize());
+    assertEquals(40000, connection.peerSettings.getInitialWindowSize());
+    assertEquals(50000, connection.peerSettings.getMaxFrameSize(-1));
+    assertEquals(60000, connection.peerSettings.getMaxConcurrentStreams(-1));
   }
 
   @Test public void clearSettingsBeforeMerge() throws Exception {
@@ -698,12 +693,11 @@ public final class Http2ConnectionTest {
     settings2.set(MAX_CONCURRENT_STREAMS, 60000);
     connection.readerRunnable.settings(true, settings2);
 
-    synchronized (connection) {
-      assertEquals(-1, connection.peerSettings.getHeaderTableSize());
-      assertEquals(DEFAULT_INITIAL_WINDOW_SIZE, connection.peerSettings.getInitialWindowSize());
-      assertEquals(-1, connection.peerSettings.getMaxFrameSize(-1));
-      assertEquals(60000, connection.peerSettings.getMaxConcurrentStreams(-1));
-    }
+    assertEquals(-1, connection.peerSettings.getHeaderTableSize());
+    assertEquals(DEFAULT_INITIAL_WINDOW_SIZE, connection.peerSettings.getInitialWindowSize());
+    assertEquals(-1, connection.peerSettings.getMaxFrameSize(-1));
+    assertEquals(60000, connection.peerSettings.getMaxConcurrentStreams(-1));
+
   }
 
   @Test public void bogusDataFrameDoesNotDisruptConnection() throws Exception {

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -742,8 +742,8 @@ public final class Http2Connection implements Closeable {
         }
       } else {
         Http2Stream stream = getStream(streamId);
-        if (stream != null) {
-          synchronized (stream) {
+        synchronized (Http2Connection.this) {
+          if (stream != null) {
             stream.addBytesToWriteWindow(windowSizeIncrement);
           }
         }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -682,9 +682,7 @@ public final class Http2Connection implements Closeable {
       }
       if (streamsToNotify != null && delta != 0) {
         for (Http2Stream stream : streamsToNotify) {
-          synchronized (stream) {
-            stream.addBytesToWriteWindow(delta);
-          }
+          stream.addBytesToWriteWindow(delta);
         }
       }
     }


### PR DESCRIPTION
I came across a few instances of locking that I thought could be cleaned up a bit. There was one case where it looked like race conditions could still occur (the null check before synchronizing) so I adjusted the logic a bit there.