### PR TITLE
Build Provider through the Platform

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/internal/tls/SslClient.java
+++ b/mockwebserver/src/main/java/okhttp3/internal/tls/SslClient.java
@@ -80,7 +80,7 @@ public final class SslClient {
     private final List<X509Certificate> certificates = new ArrayList<>();
     private KeyPair keyPair;
     private String keyStoreType = KeyStore.getDefaultType();
-    private SSLContext sslContext = null;
+    private SSLContext sslContext;
 
     /**
      * Configure the certificate chain to use when serving HTTPS responses. The first certificate is

--- a/okcurl/src/main/java/okhttp3/curl/Main.java
+++ b/okcurl/src/main/java/okhttp3/curl/Main.java
@@ -47,6 +47,7 @@ import okhttp3.Response;
 import okhttp3.internal.Util;
 import okhttp3.internal.http.StatusLine;
 import okhttp3.internal.http2.Http2;
+import okhttp3.internal.platform.Platform;
 import okio.BufferedSource;
 import okio.Okio;
 import okio.Sink;
@@ -257,7 +258,7 @@ public class Main extends HelpOption implements Runnable {
 
   private static SSLSocketFactory createInsecureSslSocketFactory(TrustManager trustManager) {
     try {
-      SSLContext context = SSLContext.getInstance("TLS");
+      SSLContext context = Platform.get().getSSLContext();
       context.init(null, new TrustManager[] {trustManager}, null);
       return context.getSocketFactory();
     } catch (Exception e) {

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -31,6 +31,7 @@ import java.net.ProxySelector;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
@@ -70,6 +71,7 @@ import okhttp3.internal.SingleInetAddressDns;
 import okhttp3.internal.Util;
 import okhttp3.internal.Version;
 import okhttp3.internal.huc.OkHttpURLConnection;
+import okhttp3.internal.platform.Platform;
 import okhttp3.internal.tls.SslClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -659,7 +661,7 @@ public final class URLConnectionTest {
     HttpURLConnection connection1 = urlFactory.open(server.url("/").url());
     assertContent("this response comes via HTTPS", connection1);
 
-    SSLContext sslContext2 = SSLContext.getInstance("TLS");
+    SSLContext sslContext2 = Platform.get().getSSLContext();
     sslContext2.init(null, null, null);
     SSLSocketFactory sslSocketFactory2 = sslContext2.getSocketFactory();
 
@@ -2423,7 +2425,7 @@ public final class URLConnectionTest {
   @Test public void httpsWithCustomTrustManager() throws Exception {
     RecordingHostnameVerifier hostnameVerifier = new RecordingHostnameVerifier();
     RecordingTrustManager trustManager = new RecordingTrustManager(sslClient.trustManager);
-    SSLContext sslContext = SSLContext.getInstance("TLS");
+    SSLContext sslContext = Platform.get().getSSLContext();
     sslContext.init(null, new TrustManager[] { trustManager }, null);
 
     urlFactory.setClient(urlFactory.client().newBuilder()
@@ -3395,6 +3397,8 @@ public final class URLConnectionTest {
       // RI response to the FAIL_HANDSHAKE
     } catch (SSLHandshakeException expected) {
       // Android's response to the FAIL_HANDSHAKE
+    } catch (SocketException expected) {
+      // Conscrypt's response to the FAIL_HANDSHAKE
     }
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
@@ -18,6 +18,9 @@ package okhttp3.internal.tls;
 import java.io.IOException;
 import java.net.SocketException;
 import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
@@ -35,7 +38,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static okhttp3.TestUtil.defaultClient;
+import static okhttp3.internal.platform.PlatformTest.getPlatform;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class ClientAuthTest {
@@ -172,6 +177,7 @@ public final class ClientAuthTest {
     } catch (SSLHandshakeException expected) {
     } catch (SocketException expected) {
       // JDK 9
+      assertTrue(getPlatform().equals("jdk9"));
     }
   }
 
@@ -218,6 +224,7 @@ public final class ClientAuthTest {
     } catch (SSLHandshakeException expected) {
     } catch (SocketException expected) {
       // JDK 9
+      assertTrue(getPlatform().equals("jdk9"));
     }
   }
 
@@ -236,10 +243,13 @@ public final class ClientAuthTest {
   }
 
   public SSLSocketFactory buildServerSslSocketFactory(final ClientAuth clientAuth) {
+    // The test uses JDK default SSL Context instead of the Platform provided one
+    // as Conscrypt seems to have some differences, we only want to test client side here.
     SslClient serverSslClient = new SslClient.Builder()
         .addTrustedCertificate(serverRootCa.certificate)
         .addTrustedCertificate(clientRootCa.certificate)
         .certificateChain(serverCert, serverIntermediateCa)
+        .sslContext(getSslContext())
         .build();
 
     return new DelegatingSSLSocketFactory(serverSslClient.socketFactory) {
@@ -253,5 +263,13 @@ public final class ClientAuthTest {
         return super.configureSocket(sslSocket);
       }
     };
+  }
+
+  private SSLContext getSslContext() {
+    try {
+      return SSLContext.getInstance("TLS");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("unable to build JDK default SSLContext");
+    }
   }
 }

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -297,7 +297,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
 
   private SSLSocketFactory systemDefaultSslSocketFactory(X509TrustManager trustManager) {
     try {
-      SSLContext sslContext = SSLContext.getInstance("TLS");
+      SSLContext sslContext = Platform.get().getSSLContext();
       sslContext.init(null, new TrustManager[] { trustManager }, null);
       return sslContext.getSocketFactory();
     } catch (GeneralSecurityException e) {

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -183,15 +183,6 @@ public class Platform {
 
   /** Attempt to match the host runtime to a capable Platform implementation. */
   private static Platform findPlatform() {
-    if ("conscrypt".equals(System.getProperty("okhttp.platform"))) {
-      // TODO better installation mechanism for new platforms
-      Platform conscrypt = ConscryptPlatform.buildIfSupported();
-
-      if (conscrypt != null) {
-        return conscrypt;
-      }
-    }
-
     Platform android = AndroidPlatform.buildIfSupported();
 
     if (android != null) {


### PR DESCRIPTION
The SSL Provider may not always be the default one e.g. for Android (GMS) or Conscrypt, so move this logic in to the internal Provider API.