### PR TITLE
Log gzipped bodies when HttpLoggingInterceptor is used as a NetworkInterceptor

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -248,7 +248,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
             try {
                 gzippedResponseBody = new GzipSource(buffer.clone());
                 buffer = new Buffer();
-                gzippedResponseBody.read(buffer, Long.MAX_VALUE);
+                buffer.writeAll(gzippedResponseBody);
             } finally {
                 if (gzippedResponseBody != null) {
                     gzippedResponseBody.close();

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -243,17 +243,17 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
         Long gzippedLength = null;
         if ("gzip".equalsIgnoreCase(headers.get("Content-Encoding"))) {
-            gzippedLength = buffer.size();
-            GzipSource gzippedResponseBody = null;
-            try {
-                gzippedResponseBody = new GzipSource(buffer.clone());
-                buffer = new Buffer();
-                buffer.writeAll(gzippedResponseBody);
-            } finally {
-                if (gzippedResponseBody != null) {
-                    gzippedResponseBody.close();
-                }
+          gzippedLength = buffer.size();
+          GzipSource gzippedResponseBody = null;
+          try {
+            gzippedResponseBody = new GzipSource(buffer.clone());
+            buffer = new Buffer();
+            buffer.writeAll(gzippedResponseBody);
+          } finally {
+            if (gzippedResponseBody != null) {
+              gzippedResponseBody.close();
             }
+          }
         }
 
         Charset charset = UTF8;

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -183,7 +183,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
       if (!logBody || !hasRequestBody) {
         logger.log("--> END " + request.method());
-      } else if (bodyHasUnknownEncofing(request.headers())) {
+      } else if (bodyHasUnknownEncoding(request.headers())) {
         logger.log("--> END " + request.method() + " (encoded body omitted)");
       } else {
         Buffer buffer = new Buffer();
@@ -234,7 +234,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
       if (!logBody || !HttpHeaders.hasBody(response)) {
         logger.log("<-- END HTTP");
-      } else if (bodyHasUnknownEncofing(response.headers())) {
+      } else if (bodyHasUnknownEncoding(response.headers())) {
         logger.log("<-- END HTTP (encoded body omitted)");
       } else {
         BufferedSource source = responseBody.source();
@@ -309,7 +309,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
     }
   }
 
-  private boolean bodyHasUnknownEncofing(Headers headers) {
+  private boolean bodyHasUnknownEncoding(Headers headers) {
     String contentEncoding = headers.get("Content-Encoding");
     return contentEncoding != null
         && !contentEncoding.equalsIgnoreCase("identity")

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -274,7 +274,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
         }
 
         if (gzippedLength != null) {
-            logger.log("<-- END HTTP (" + buffer.size() + "-byte "
+            logger.log("<-- END HTTP (" + buffer.size() + "-byte, "
                 + gzippedLength + "-gzipped-byte body)");
         } else {
             logger.log("<-- END HTTP (" + buffer.size() + "-byte body)");

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -244,7 +244,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
         Long gzippedLength = null;
         if ("gzip".equalsIgnoreCase(headers.get("Content-Encoding"))) {
             gzippedLength = buffer.size();
-            try (GzipSource gzippedResponseBody = new GzipSource(buffer)) {
+            try (GzipSource gzippedResponseBody = new GzipSource(buffer.clone())) {
                 buffer = new Buffer();
                 gzippedResponseBody.read(buffer, Long.MAX_VALUE);
             }

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -31,6 +31,7 @@ import okhttp3.RecordingHostnameVerifier;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okhttp3.internal.tls.SslClient;
 import okhttp3.logging.HttpLoggingInterceptor.Level;
 import okhttp3.mockwebserver.MockResponse;
@@ -541,7 +542,10 @@ public final class HttpLoggingInterceptorTest {
         .setBody(new Buffer().write(ByteString.decodeBase64(
             "H4sIAAAAAAAAAPNIzcnJ11HwQKIAdyO+9hMAAAA="))));
     Response response = client.newCall(request().build()).execute();
-    response.body().close();
+
+    ResponseBody responseBody = response.body();
+    assertEquals("Expected response body to be valid","Hello, Hello, Hello", responseBody.string());
+    responseBody.close();
 
     networkLogs
         .assertLogEqual("--> GET " + url + " http/1.1")

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -554,7 +554,9 @@ public final class HttpLoggingInterceptorTest {
         .assertLogEqual("Content-Encoding: gzip")
         .assertLogEqual("Content-Type: text/plain; charset=utf-8")
         .assertLogMatch("Content-Length: \\d+")
-        .assertLogEqual("<-- END HTTP (encoded body omitted)")
+        .assertLogEqual("")
+        .assertLogEqual("Hello, Hello, Hello")
+        .assertLogEqual("<-- END HTTP (19-byte 29-gzipped-byte body)")
         .assertNoMoreLogs();
 
     applicationLogs

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -556,7 +556,7 @@ public final class HttpLoggingInterceptorTest {
         .assertLogMatch("Content-Length: \\d+")
         .assertLogEqual("")
         .assertLogEqual("Hello, Hello, Hello")
-        .assertLogEqual("<-- END HTTP (19-byte 29-gzipped-byte body)")
+        .assertLogEqual("<-- END HTTP (19-byte, 29-gzipped-byte body)")
         .assertNoMoreLogs();
 
     applicationLogs


### PR DESCRIPTION
Makes HttpLoggingInterceptor decompress and log the body of a response which is gzip encoded when used as a networkInterceptor (where previously it just logged that an encoded body was seen).

This is useful in the case where you want to log both any redirects which occur during the call and the response bodies. 

Fixes issue #3780

(My first time touching any of the okio stuff directly - very happy to hear if I've missed a better way to do something)