### PR TITLE
Checking for a null socket input and output streams to prevent illegal argument exception in okio

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -242,6 +242,11 @@ public final class RealConnection extends Http2Connection.Listener implements Co
       throw ce;
     }
 
+    // Protecting against rare occasion when input or output stream is null due to hardware/firmware issues
+    if (rawSocket.getInputStream() == null || rawSocket.getOutputStream() == null) {
+      throw new IOException("Socket's input or output stream is null");
+    }
+
     // The following try/catch block is a pseudo hacky way to get around a crash on Android 7.0
     // More details:
     // https://github.com/square/okhttp/issues/3245


### PR DESCRIPTION
### Description
- Some devices occasionally have hardware/firmware issues with socket inputStream and outputStreams.  This change checks for a null socket inputStream and outputStream before using the Okio.sink and Okio.source methods.  This is necessary because 3rd party libraries that developers don't control might not be handling this exception correctly, causing their apps to crash.  It's best to just fix this issue at the source.

An example of the crash:
```
Fatal Exception: java.lang.IllegalArgumentException: out == null
       at okio.Okio.sink(SourceFile:69)
       at okio.Okio.sink(SourceFile:118)
       at okhttp3.internal.connection.RealConnection.connectSocket(SourceFile:251)
       at okhttp3.internal.connection.RealConnection.connect(SourceFile:158)
       at okhttp3.internal.connection.StreamAllocation.findConnection(SourceFile:256)
       at okhttp3.internal.connection.StreamAllocation.findHealthyConnection(SourceFile:134)
       at okhttp3.internal.connection.StreamAllocation.newStream(SourceFile:113)
       at okhttp3.internal.connection.ConnectInterceptor.intercept(SourceFile:42)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:147)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:121)
       at okhttp3.internal.cache.CacheInterceptor.intercept(SourceFile:93)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:147)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:121)
       at okhttp3.internal.http.BridgeInterceptor.intercept(SourceFile:93)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:147)
       at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(SourceFile:125)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:147)
       at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:121)
       at okhttp3.RealCall.getResponseWithInterceptorChain(SourceFile:200)
       at okhttp3.RealCall$AsyncCall.execute(SourceFile:147)
       at okhttp3.internal.NamedRunnable.run(SourceFile:32)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
       at java.lang.Thread.run(Thread.java:818)```