### PR TITLE
Mark some EventListener parameters as non-null.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
@@ -105,8 +105,8 @@ public final class RecordingEventListener extends EventListener {
     logEvent(new ConnectEnd(call, inetSocketAddress, proxy, protocol));
   }
 
-  @Override public void connectFailed(Call call, InetSocketAddress inetSocketAddress,
-      @Nullable Proxy proxy, @Nullable Protocol protocol, @Nullable IOException ioe) {
+  @Override public void connectFailed(Call call, InetSocketAddress inetSocketAddress, Proxy proxy,
+      @Nullable Protocol protocol, IOException ioe) {
     logEvent(new ConnectFailed(call, inetSocketAddress, proxy, protocol, ioe));
   }
 

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -95,7 +95,7 @@ public abstract class EventListener {
    *
    * <p>This method is invoked after {@link #dnsStart}.
    */
-  public void dnsEnd(Call call, String domainName, @Nullable List<InetAddress> inetAddressList) {
+  public void dnsEnd(Call call, String domainName, List<InetAddress> inetAddressList) {
   }
 
   /**
@@ -140,8 +140,8 @@ public abstract class EventListener {
    * {@link #secureConnectEnd(Call, Handshake)}, otherwise it will invoked after
    * {@link #connectStart(Call, InetSocketAddress, Proxy)}.
    */
-  public void connectEnd(Call call, InetSocketAddress inetSocketAddress,
-      @Nullable Proxy proxy, @Nullable Protocol protocol) {
+  public void connectEnd(Call call, InetSocketAddress inetSocketAddress, Proxy proxy,
+      @Nullable Protocol protocol) {
   }
 
   /**
@@ -152,8 +152,8 @@ public abstract class EventListener {
    * Handshake)}, otherwise it will invoked after {@link #connectStart(Call, InetSocketAddress,
    * Proxy)}.
    */
-  public void connectFailed(Call call, InetSocketAddress inetSocketAddress,
-      @Nullable Proxy proxy, @Nullable Protocol protocol, @Nullable IOException ioe) {
+  public void connectFailed(Call call, InetSocketAddress inetSocketAddress, Proxy proxy,
+      @Nullable Protocol protocol, IOException ioe) {
   }
 
   /**


### PR DESCRIPTION
These look like accidents, but it's very possible I missed some context on why these were nullable.