### PR TITLE
fix javadoc link

### DIFF
--- a/okhttp/src/main/java/okhttp3/Protocol.java
+++ b/okhttp/src/main/java/okhttp3/Protocol.java
@@ -96,7 +96,7 @@ public enum Protocol {
    * Returns the string used to identify this protocol for ALPN, like "http/1.1", "spdy/3.1" or
    * "h2".
    *
-   * @see <a href="https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml">IANA
+   * @see <a href="https://www.iana.org/assignments/tls-extensiontype-values">IANA
    * tls-extensiontype-values</a>
    */
   @Override public String toString() {

--- a/okhttp/src/main/java/okhttp3/Protocol.java
+++ b/okhttp/src/main/java/okhttp3/Protocol.java
@@ -96,7 +96,8 @@ public enum Protocol {
    * Returns the string used to identify this protocol for ALPN, like "http/1.1", "spdy/3.1" or
    * "h2".
    *
-   * @link https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml
+   * @see <a href="https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml">IANA
+   * tls-extensiontype-values</a>
    */
   @Override public String toString() {
     return protocol;


### PR DESCRIPTION
Before

```
[ERROR] /Users/yschimke/workspace/okhttp/okhttp/src/main/java/okhttp3/Credentials.java:29: warning: no @param for username
[ERROR]   public static String basic(String username, String password) {
[ERROR]                        ^
[ERROR] /Users/yschimke/workspace/okhttp/okhttp/src/main/java/okhttp3/Protocol.java:99: error: incorrect use of inline tag
[ERROR]    * @link https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml
[ERROR]      ^
[ERROR]
[ERROR] Command line was: /Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/bin/javadoc @options @packages
[ERROR]
[ERROR] Refer to the generated Javadoc files in '/Users/yschimke/workspace/okhttp/okhttp/target/apidocs' dir.
```

After

```
[WARNING] /Users/yschimke/workspace/okhttp/okhttp/src/main/java/okhttp3/Credentials.java:29: warning: no @param for username
[WARNING] public static String basic(String username, String password) {
[WARNING] ^
[INFO] Building jar: /Users/yschimke/workspace/okhttp/okhttp/target/okhttp-3.10.0-SNAPSHOT-javadoc.jar
```