### PR TITLE
Build javadoc and source jars in normal build

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -21,6 +21,6 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
   echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'."
 else
   echo "Deploying snapshot..."
-  mvn clean package source:jar javadoc:jar deploy --settings=".buildscript/settings.xml" -Dmaven.javadoc.failOnError=false -DskipTests
+  mvn clean source:jar javadoc:jar deploy --settings=".buildscript/settings.xml" -DskipTests
   echo "Snapshot deployed!"
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
     packages:
       - oracle-java8-installer # Updates JDK 8 to the latest available.
 
+script: mvn test javadoc:jar source:jar -B
+
 after_success:
   - .buildscript/deploy_snapshot.sh
 


### PR DESCRIPTION
Build javadoc and sources in normal build for travis instead of waiting for post build script