### PR TITLE
multipart filter option

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -125,6 +125,8 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
   private volatile Level level = Level.NONE;
 
+  private boolean showMultipartLog = true;
+
   /** Change the level at which this interceptor logs. */
   public HttpLoggingInterceptor setLevel(Level level) {
     if (level == null) throw new NullPointerException("level == null. Use Level.NONE instead.");
@@ -134,6 +136,23 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
   public Level getLevel() {
     return level;
+  }
+
+  /**
+   *
+   * @return check mutipart logging is enabled or not
+   */
+  public boolean isShowMultipartLog() {
+    return showMultipartLog;
+  }
+
+  /**
+   *
+   * @param showMultipartLogging set to false to display multipart length in integer instead of non-plain text (by default true)]
+   *        set to false before you attach logging interceptor.
+   */
+  public void setShowMultipartLog(boolean showMultipartLogging) {
+    this.showMultipartLog = showMultipartLogging;
   }
 
   @Override public Response intercept(Chain chain) throws IOException {
@@ -197,7 +216,11 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
         logger.log("");
         if (isPlaintext(buffer)) {
-          logger.log(buffer.readString(charset));
+          if (showMultipartLog)
+            logger.log(buffer.readString(charset));
+          else
+            logger.log(String.valueOf("Multipart length transmitted->"+buffer.readString(charset).length()));
+
           logger.log("--> END " + request.method()
               + " (" + requestBody.contentLength() + "-byte body)");
         } else {

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -125,6 +125,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
   private volatile Level level = Level.NONE;
 
+  /** set to false to skip multipart body. */
   private boolean showMultipartLog = true;
 
   /** Change the level at which this interceptor logs. */
@@ -138,19 +139,11 @@ public final class HttpLoggingInterceptor implements Interceptor {
     return level;
   }
 
-  /**
-   *
-   * @return check mutipart logging is enabled or not
-   */
+
   public boolean isShowMultipartLog() {
     return showMultipartLog;
   }
 
-  /**
-   *
-   * @param showMultipartLogging set to false to display multipart length in integer instead of non-plain text (by default true)]
-   *        set to false before you attach logging interceptor.
-   */
   public void setShowMultipartLog(boolean showMultipartLogging) {
     this.showMultipartLog = showMultipartLogging;
   }


### PR DESCRIPTION
To avoid multipart data in logcat.

based on [this](https://stackoverflow.com/questions/48661623/okhttp-logging-interceptor-disable-multipart-data) & [this](https://stackoverflow.com/questions/38563394/okhttp-loggin-interceptor-in-multipart) problem

By setting `interceptor.setShowMultipartLog(false);` we can see actual request data in log cat.


How to apply?


       `HttpLoggingInterceptor interceptor= new HttpLoggingInterceptor ();
        logging.setShowMultipartLog(false); // set true to display multipart data (by default true)
        httpClient.addInterceptor(interceptor);`



Output in logcat:

D/OkHttp: --> POST api-end-point
D/OkHttp: Content-Type: application/json; charset=UTF-8
D/OkHttp: Content-Length: 7556444
D/OkHttp: Multipart length transmitted->7556444
D/OkHttp: --> END POST (7556444-byte body)

