### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,16 @@ addons:
     packages:
       - oracle-java8-installer # Updates JDK 8 to the latest available.
 
+before_install:
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
+  
 script: mvn test javadoc:jar source:jar -B
 
+after_script:
+  - testspace [Tests]*/target/surefire-reports/TEST-*.xml{.} target/site/cobertura/coverage.xml
+ 
 after_success:
   - .buildscript/deploy_snapshot.sh
 

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,26 @@
           </signature>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+         <artifactId>cobertura-maven-plugin</artifactId>
+         <version>2.7</version>
+         <executions>
+           <execution>
+              <id>cobertura</id>
+              <phase>test</phase>
+              <goals>
+                  <goal>cobertura</goal>
+              </goals>
+              <configuration>
+                  <formats>
+                      <format>xml</format>
+                  </formats>
+                  <aggregate>true</aggregate>
+              </configuration>
+          </execution>
+      </executions>
+     </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION

Hi, `okhttp` team. We’ve made a few minor changes to demonstrate how you can better manage your Travis CI build results with [Testspace.com](https://www.testspace.com/). Note, we also added code coverage as an example. 

> Monitor the results for **all** of your organization's repositories, their local branches, and pull requests from a single Dashboard!
 
YOUR TEST RESULTS, from `our fork`, at https://open.testspace.com/projects/TryTestspace:okhttp.

---

#### Tired of scrolling through Travis logs to find test failures? 
 
 * Triage failures faster with single-click filtering and complete failure context; call stack, timing info, and more.

#### Wishing your test results were organized?  
 * Move beyond a flat, endless window of test output. In Testspace, your test results mirror your test folders and subfolders as defined in your repo. 
 * For larger volumes of tests, use hierarchy to reflect your overall test design. 

#### Looking for actionable metrics to assess the value of your testing?   
 * View historical tracking of all your important metrics; test case and code coverage growth, static analysis issues, and more.  
 * Leverage analytic indicators to assess the effectiveness of your automated testing. 
 
----

#### Setup is Easy

1. Create a free [Open Source Account](https://signup.testspace.com/?plan_id=open.2)
2. Create a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1