### PR TITLE
RFC: ConnectionPool listener and list method

### DIFF
--- a/okhttp/src/main/java/okhttp3/ConnectionListener.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+/**
+ * Listener for connection events. Extend this class to monitor the new connections and closes.
+ *
+ * <p>All event methods must execute fast, without external locking, cannot throw exceptions,
+ * attempt to mutate the event parameters, or be reentrant back into the client.
+ * Any IO - writing to files or network should be done asynchronously.
+ */
+public abstract class ConnectionListener {
+  public static final ConnectionListener NONE = new ConnectionListener() {
+  };
+
+  public void connectionOpened(Connection connection) {
+  }
+
+  public void connectionClosed(Connection connection) {
+  }
+}

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -154,7 +154,7 @@ public final class ConnectionPool {
       executor.execute(cleanupRunnable);
     }
     connections.add(connection);
-    for (ConnectionListener listener: listeners) {
+    for (ConnectionListener listener : listeners) {
       listener.connectionOpened(new WrappedConnection(connection));
     }
   }
@@ -168,7 +168,7 @@ public final class ConnectionPool {
     if (connection.noNewStreams || maxIdleConnections == 0) {
       connections.remove(connection);
 
-      for (ConnectionListener listener: listeners) {
+      for (ConnectionListener listener : listeners) {
         listener.connectionClosed(new WrappedConnection(connection));
       }
 
@@ -238,7 +238,7 @@ public final class ConnectionPool {
         // of the synchronized block).
         connections.remove(longestIdleConnection);
 
-        for (ConnectionListener listener: listeners) {
+        for (ConnectionListener listener : listeners) {
           listener.connectionClosed(new WrappedConnection(longestIdleConnection));
         }
       } else if (idleConnectionCount > 0) {


### PR DESCRIPTION
I'm trying to understand the behaviour of network connections under different scenarios on Android.  It is tougher without insight into exactly what happens during connectivity changes, e.g. switching between wifi, cell etc.

But just generally seems like a useful feature for teams trying to optimize connection behaviour via adjusting timeouts, as you change timeouts, being able to understand connection churn without wrapping Socket etc.