### PR TITLE
Not to land: reproduce failing test

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -899,6 +899,13 @@ public final class HttpOverHttp2Test {
     assertEquals(Protocol.HTTP_2, response.protocol());
 
     List<String> logs = http2Handler.takeAll();
+
+    if (logs.size() != 20) {
+      for (String s: logs) {
+        System.out.println(s);
+      }
+    }
+
     assertEquals(20, logs.size());
     assertThat("header logged", firstFrame(logs, "HEADERS"), containsString("HEADERS       END_STREAM|END_HEADERS"));
   }
@@ -917,6 +924,13 @@ public final class HttpOverHttp2Test {
     assertEquals(Protocol.HTTP_2, response.protocol());
 
     List<String> logs = http2Handler.takeAll();
+
+    if (logs.size() != 22) {
+      for (String s: logs) {
+        System.out.println(s);
+      }
+    }
+
     assertEquals(22, logs.size());
     assertThat("header logged", firstFrame(logs, "HEADERS"), containsString("HEADERS       END_HEADERS"));
     assertThat("data logged", firstFrame(logs, "DATA"), containsString("0 DATA          END_STREAM"));

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
             <systemPropertyVariables>
               <okhttp.platform>${okhttp.platform}</okhttp.platform>
             </systemPropertyVariables>
-            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <redirectTestOutputToFile>false</redirectTestOutputToFile>
             <properties>
               <!--
                 Configure a listener for enforcing that no uncaught exceptions issue from OkHttp


### PR DESCRIPTION
turn on logging to look at logged frames