### PR TITLE
More lenient test involving logging

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -899,6 +899,13 @@ public final class HttpOverHttp2Test {
     assertEquals(Protocol.HTTP_2, response.protocol());
 
     List<String> logs = http2Handler.takeAll();
+
+    if (logs.size() != 20) {
+      for (String s: logs) {
+        System.out.println(s);
+      }
+    }
+
     assertEquals(20, logs.size());
     assertThat("header logged", firstFrame(logs, "HEADERS"), containsString("HEADERS       END_STREAM|END_HEADERS"));
   }
@@ -917,6 +924,13 @@ public final class HttpOverHttp2Test {
     assertEquals(Protocol.HTTP_2, response.protocol());
 
     List<String> logs = http2Handler.takeAll();
+
+    if (logs.size() != 22) {
+      for (String s: logs) {
+        System.out.println(s);
+      }
+    }
+
     assertEquals(22, logs.size());
     assertThat("header logged", firstFrame(logs, "HEADERS"), containsString("HEADERS       END_HEADERS"));
     assertThat("data logged", firstFrame(logs, "DATA"), containsString("0 DATA          END_STREAM"));

--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -900,13 +900,6 @@ public final class HttpOverHttp2Test {
 
     List<String> logs = http2Handler.takeAll();
 
-    if (logs.size() != 20) {
-      for (String s: logs) {
-        System.out.println(s);
-      }
-    }
-
-    assertEquals(20, logs.size());
     assertThat("header logged", firstFrame(logs, "HEADERS"), containsString("HEADERS       END_STREAM|END_HEADERS"));
   }
 
@@ -925,13 +918,6 @@ public final class HttpOverHttp2Test {
 
     List<String> logs = http2Handler.takeAll();
 
-    if (logs.size() != 22) {
-      for (String s: logs) {
-        System.out.println(s);
-      }
-    }
-
-    assertEquals(22, logs.size());
     assertThat("header logged", firstFrame(logs, "HEADERS"), containsString("HEADERS       END_HEADERS"));
     assertThat("data logged", firstFrame(logs, "DATA"), containsString("0 DATA          END_STREAM"));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
             <systemPropertyVariables>
               <okhttp.platform>${okhttp.platform}</okhttp.platform>
             </systemPropertyVariables>
-            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <redirectTestOutputToFile>false</redirectTestOutputToFile>
             <properties>
               <!--
                 Configure a listener for enforcing that no uncaught exceptions issue from OkHttp

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
             <systemPropertyVariables>
               <okhttp.platform>${okhttp.platform}</okhttp.platform>
             </systemPropertyVariables>
-            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+            <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <properties>
               <!--
                 Configure a listener for enforcing that no uncaught exceptions issue from OkHttp


### PR DESCRIPTION
Results in https://github.com/square/okhttp/pull/3857 showed that logging can be affected by prior state.