### PR TITLE
Encode more characters when using addQueryParameter().

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/UrlComponentEncodingTester.java
+++ b/okhttp-tests/src/test/java/okhttp3/UrlComponentEncodingTester.java
@@ -402,6 +402,25 @@ class UrlComponentEncodingTester {
         return query.substring(1, query.length() - 1);
       }
     },
+    QUERY_VALUE {
+      @Override public String urlString(String value) {
+        return "http://example.com/?q=a" + value + "z";
+      }
+
+      @Override public String encodedValue(HttpUrl url) {
+        String query = url.encodedQuery();
+        return query.substring(3, query.length() - 1);
+      }
+
+      @Override public void set(HttpUrl.Builder builder, String value) {
+        builder.addQueryParameter("q", "a" + value + "z");
+      }
+
+      @Override public String get(HttpUrl url) {
+        String value = url.queryParameter("q");
+        return value.substring(1, value.length() - 1);
+      }
+    },
     FRAGMENT {
       @Override public String urlString(String value) {
         return "http://example.com/#a" + value + "z";

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -293,7 +293,8 @@ public final class HttpUrl {
   static final String PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#";
   static final String PATH_SEGMENT_ENCODE_SET_URI = "[]";
   static final String QUERY_ENCODE_SET = " \"'<>#";
-  static final String QUERY_COMPONENT_ENCODE_SET = " \"'<>#&=";
+  static final String QUERY_COMPONENT_REENCODE_SET = " \"'<>#&=";
+  static final String QUERY_COMPONENT_ENCODE_SET = " !\"#$&'(),/:;<=>?@[]\\^`{|}~";
   static final String QUERY_COMPONENT_ENCODE_SET_URI = "\\^`{|}";
   static final String FORM_ENCODE_SET = " \"':;<=>@[]^`{}|/\\?#&!$(),~";
   static final String FRAGMENT_ENCODE_SET = "";
@@ -1170,9 +1171,9 @@ public final class HttpUrl {
       if (encodedName == null) throw new NullPointerException("encodedName == null");
       if (encodedQueryNamesAndValues == null) encodedQueryNamesAndValues = new ArrayList<>();
       encodedQueryNamesAndValues.add(
-          canonicalize(encodedName, QUERY_COMPONENT_ENCODE_SET, true, false, true, true));
+          canonicalize(encodedName, QUERY_COMPONENT_REENCODE_SET, true, false, true, true));
       encodedQueryNamesAndValues.add(encodedValue != null
-          ? canonicalize(encodedValue, QUERY_COMPONENT_ENCODE_SET, true, false, true, true)
+          ? canonicalize(encodedValue, QUERY_COMPONENT_REENCODE_SET, true, false, true, true)
           : null);
       return this;
     }
@@ -1202,7 +1203,7 @@ public final class HttpUrl {
       if (encodedName == null) throw new NullPointerException("encodedName == null");
       if (encodedQueryNamesAndValues == null) return this;
       removeAllCanonicalQueryParameters(
-          canonicalize(encodedName, QUERY_COMPONENT_ENCODE_SET, true, false, true, true));
+          canonicalize(encodedName, QUERY_COMPONENT_REENCODE_SET, true, false, true, true));
       return this;
     }
 


### PR DESCRIPTION
Though it's good for OkHttp to retain the user's provided encoding, we
should be encoding more characters than we are when the user provides
us with unencoded data.

Closes: https://github.com/square/okhttp/issues/3235