### PR TITLE
Remove CBC-mode ECDSA cipher suites

### DIFF
--- a/okhttp/src/main/java/okhttp3/ConnectionSpec.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionSpec.java
@@ -54,9 +54,7 @@ public final class ConnectionSpec {
       // Note that the following cipher suites are all on HTTP/2's bad cipher suites list. We'll
       // continue to include them until better suites are commonly available. For example, none
       // of the better cipher suites listed above shipped with Android 4.4 or Java 7.
-      CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
       CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-      CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
       CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
       CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
       CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,


### PR DESCRIPTION
This removes the following cipher suites as supported-by-default:
  TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
  TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA

This tracks a similar change in Chromium 56:
  https://developers.google.com/web/updates/2016/12/chrome-56-deprecations#remove_cbc-mode_ecdsa_ciphers_in_tls

OkHttp's updated cipher suites, plus comparisons to Android, Java,
Chromium, Firefox, and Square's server-site configuration is here:
  https://tinyurl.com/okhttp-cipher-suites

Closes: https://github.com/square/okhttp/issues/3035