### PR TITLE
Don't hold a lock on the connection when writing settings.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -495,8 +495,8 @@ public final class Http2Connection implements Closeable {
           throw new ConnectionShutdownException();
         }
         okHttpSettings.merge(settings);
-        writer.settings(settings);
       }
+      writer.settings(settings);
     }
   }
 


### PR DESCRIPTION
This breaks our concurrency rules. Fortunately it's only academic; only
MockWebServer ever writes settings, and it only does so in very specialized
tests.