### PR TITLE
Fail web sockets if the pong is not received

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -79,12 +79,12 @@ import okio.Timeout;
 import org.junit.rules.ExternalResource;
 
 import static okhttp3.internal.Util.closeQuietly;
+import static okhttp3.mockwebserver.SocketPolicy.CONTINUE_ALWAYS;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AT_END;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AT_START;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_DURING_REQUEST_BODY;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY;
-import static okhttp3.mockwebserver.SocketPolicy.CONTINUE_ALWAYS;
 import static okhttp3.mockwebserver.SocketPolicy.EXPECT_CONTINUE;
 import static okhttp3.mockwebserver.SocketPolicy.FAIL_HANDSHAKE;
 import static okhttp3.mockwebserver.SocketPolicy.NO_RESPONSE;
@@ -665,10 +665,10 @@ public final class MockWebServer extends ExternalResource implements Closeable {
       }
     };
     RealWebSocket webSocket = new RealWebSocket(fancyRequest,
-        response.getWebSocketListener(), new SecureRandom());
+        response.getWebSocketListener(), new SecureRandom(), 0);
     response.getWebSocketListener().onOpen(webSocket, fancyResponse);
     String name = "MockWebServer WebSocket " + request.getPath();
-    webSocket.initReaderAndWriter(name, 0, streams);
+    webSocket.initReaderAndWriter(name, streams);
     try {
       webSocket.loopReader();
 

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -326,8 +326,8 @@ public final class RealWebSocketTest {
           .request(new Request.Builder().url(url).build())
           .protocol(Protocol.HTTP_1_1)
           .build();
-      webSocket = new RealWebSocket(response.request(), listener, random);
-      webSocket.initReaderAndWriter(name, pingIntervalMillis, this);
+      webSocket = new RealWebSocket(response.request(), listener, random, pingIntervalMillis);
+      webSocket.initReaderAndWriter(name, this);
     }
 
     public boolean processNextFrame() throws IOException {

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -434,7 +434,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
    * Uses {@code request} to connect a new web socket.
    */
   @Override public WebSocket newWebSocket(Request request, WebSocketListener listener) {
-    RealWebSocket webSocket = new RealWebSocket(request, listener, new Random());
+    RealWebSocket webSocket = new RealWebSocket(request, listener, new Random(), pingInterval);
     webSocket.connect(this);
     return webSocket;
   }
@@ -570,8 +570,12 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     /**
      * Sets the interval between web socket pings initiated by this client. Use this to
      * automatically send web socket ping frames until either the web socket fails or it is closed.
-     * This keeps the connection alive and may detect connectivity failures early. No timeouts are
-     * enforced on the acknowledging pongs.
+     * This keeps the connection alive and may detect connectivity failures.
+     *
+     * <p>If the server does not respond to each ping with a pong within {@code interval}, this
+     * client will assume that connectivity has been lost. When this happens the connection is
+     * canceled and its listener is {@linkplain WebSocketListener#onFailure notified of the
+     * failure}.
      *
      * <p>The default value of 0 disables client-initiated pings.
      */


### PR DESCRIPTION
There are several options for when to expect the pong response. I've
chosen to overload the ping interval. This seems reasonable because the
ping interval is the maximum amount of time that should elapse before
a connection failure is detected.

Closes: https://github.com/square/okhttp/issues/3227