### PR TITLE
First step towards HTTP/2 automatic pings.

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -568,14 +568,15 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     }
 
     /**
-     * Sets the interval between web socket pings initiated by this client. Use this to
-     * automatically send web socket ping frames until either the web socket fails or it is closed.
-     * This keeps the connection alive and may detect connectivity failures.
+     * Sets the interval between HTTP/2 and web socket pings initiated by this client. Use this to
+     * automatically send ping frames until either the connection fails or it is closed. This keeps
+     * the connection alive and may detect connectivity failures.
      *
      * <p>If the server does not respond to each ping with a pong within {@code interval}, this
-     * client will assume that connectivity has been lost. When this happens the connection is
-     * canceled and its listener is {@linkplain WebSocketListener#onFailure notified of the
-     * failure}.
+     * client will assume that connectivity has been lost. When this happens on a web socket the
+     * connection is canceled and its listener is {@linkplain WebSocketListener#onFailure notified
+     * of the failure}. When it happens on an HTTP/2 connection the connection is closed and any
+     * calls it is carrying {@linkplain java.io.IOException will fail with an IOException}.
      *
      * <p>The default value of 0 disables client-initiated pings.
      */

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -107,11 +107,12 @@ public final class StreamAllocation {
     int connectTimeout = chain.connectTimeoutMillis();
     int readTimeout = chain.readTimeoutMillis();
     int writeTimeout = chain.writeTimeoutMillis();
+    int pingIntervalMillis = client.pingIntervalMillis();
     boolean connectionRetryEnabled = client.retryOnConnectionFailure();
 
     try {
       RealConnection resultConnection = findHealthyConnection(connectTimeout, readTimeout,
-          writeTimeout, connectionRetryEnabled, doExtensiveHealthChecks);
+          writeTimeout, pingIntervalMillis, connectionRetryEnabled, doExtensiveHealthChecks);
       HttpCodec resultCodec = resultConnection.newCodec(client, chain, this);
 
       synchronized (connectionPool) {
@@ -128,11 +129,11 @@ public final class StreamAllocation {
    * until a healthy connection is found.
    */
   private RealConnection findHealthyConnection(int connectTimeout, int readTimeout,
-      int writeTimeout, boolean connectionRetryEnabled, boolean doExtensiveHealthChecks)
-      throws IOException {
+      int writeTimeout, int pingIntervalMillis, boolean connectionRetryEnabled,
+      boolean doExtensiveHealthChecks) throws IOException {
     while (true) {
       RealConnection candidate = findConnection(connectTimeout, readTimeout, writeTimeout,
-          connectionRetryEnabled);
+          pingIntervalMillis, connectionRetryEnabled);
 
       // If this is a brand new connection, we can skip the extensive health checks.
       synchronized (connectionPool) {
@@ -157,7 +158,7 @@ public final class StreamAllocation {
    * then the pool, finally building a new connection.
    */
   private RealConnection findConnection(int connectTimeout, int readTimeout, int writeTimeout,
-      boolean connectionRetryEnabled) throws IOException {
+      int pingIntervalMillis, boolean connectionRetryEnabled) throws IOException {
     boolean foundPooledConnection = false;
     RealConnection result = null;
     Route selectedRoute = null;
@@ -253,8 +254,8 @@ public final class StreamAllocation {
     }
 
     // Do TCP + TLS handshakes. This is a blocking operation.
-    result.connect(
-        connectTimeout, readTimeout, writeTimeout, connectionRetryEnabled, call, eventListener);
+    result.connect(connectTimeout, readTimeout, writeTimeout, pingIntervalMillis,
+        connectionRetryEnabled, call, eventListener);
     routeDatabase().connected(result.route());
 
     Socket socket = null;


### PR DESCRIPTION
This changes the executor services in HTTP/2 connection to split up
listener executors (of which there may be many threads) from writer
executors (of which there is one per connection).

This adds a scheduled executor job to send pings on an interval. We
don't yet fail the connection if pongs are not received.

For follow-up there's some work to remove exising APIs to send pings
through the HTTP/2 APIs. These are unused and make it awkard to
confirm that only the automatic pings are being replied to.

See https://github.com/square/okhttp/issues/3261