### PR TITLE
OkHttpsURLConnection.setSSLSocketFactory(null): throw.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -3429,6 +3429,16 @@ public final class URLConnectionTest {
     assertEquals(1, requestB.getSequenceNumber());
   }
 
+  @Test public void nullSSLSocketFactory_throws() throws Exception {
+    server.useHttps(sslClient.socketFactory, false /* tunnelProxy */);
+    HttpsURLConnection connection = (HttpsURLConnection) server.url("/").url().openConnection();
+    try {
+      connection.setSSLSocketFactory(null);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   /**
    * We had a bug where we weren't closing Gzip streams on redirects.
    * https://github.com/square/okhttp/issues/441

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpsURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpsURLConnection.java
@@ -58,6 +58,9 @@ public final class OkHttpsURLConnection extends DelegatingHttpsURLConnection {
   }
 
   @Override public void setSSLSocketFactory(SSLSocketFactory sslSocketFactory) {
+    if (sslSocketFactory == null) {
+        throw new IllegalArgumentException("null sslSocketFactory");
+    }
     // This fails in JDK 9 because OkHttp is unable to extract the trust manager.
     delegate.client = delegate.client.newBuilder()
         .sslSocketFactory(sslSocketFactory)


### PR DESCRIPTION
OkHttpsURLConnection extends javax.net.ssl.HttpsURLConnection.
The super class documentation says that setSSLSocketFactory(null)
throws IllegalArgumentException, but this implementation didn't
do that.

This CL fixed OkHttpsURLConnection.setSSLSocketFactory(null) to
throw, as specified.

Test: not done locally, relying on Travis.