### PR TITLE
fix #3895: Set Conscrypt.setUseEngineSocket per SocketFactory

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -256,6 +256,10 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       this.certificateChainCleaner = CertificateChainCleaner.get(trustManager);
     }
 
+    if (sslSocketFactory != null) {
+      Platform.get().configureSslSocketFactory(sslSocketFactory);
+    }
+
     this.hostnameVerifier = builder.hostnameVerifier;
     this.certificatePinner = builder.certificatePinner.withCertificateChainCleaner(
         certificateChainCleaner);

--- a/okhttp/src/main/java/okhttp3/internal/platform/ConscryptPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/ConscryptPlatform.java
@@ -103,10 +103,16 @@ public class ConscryptPlatform extends Platform {
         return null;
       }
 
-      Conscrypt.setUseEngineSocketByDefault(true);
       return new ConscryptPlatform();
     } catch (ClassNotFoundException e) {
       return null;
+    }
+  }
+
+  @Override
+  public void configureSslSocketFactory(SSLSocketFactory socketFactory) {
+    if (Conscrypt.isConscrypt(socketFactory)) {
+      Conscrypt.setUseEngineSocket(socketFactory, true);
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -275,4 +275,7 @@ public class Platform {
   public TrustRootIndex buildTrustRootIndex(X509TrustManager trustManager) {
     return new BasicTrustRootIndex(trustManager.getAcceptedIssuers());
   }
+
+  public void configureSslSocketFactory(SSLSocketFactory socketFactory) {
+  }
 }


### PR DESCRIPTION
This change avoids static configuration which may cause issues
for applications using both OkHttp and HttpsUrlConnections.