### PR TITLE
Defer StreamResetException until response body buffer is fully read.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -71,7 +71,7 @@ public final class Http2Connection implements Closeable {
   // operations must synchronize on 'this' last. This ensures that we never
   // wait for a blocking operation while holding 'this'.
 
-  private static final int OKHTTP_CLIENT_WINDOW_SIZE = 16 * 1024 * 1024;
+  static final int OKHTTP_CLIENT_WINDOW_SIZE = 16 * 1024 * 1024;
 
   /**
    * Shared executor to send notifications of incoming streams. This executor requires multiple


### PR DESCRIPTION
We rely on the application layer to read the response body buffer
before sending WINDOW_UPDATE's. Previously we'd immediately throw a
StreamResetException. This prevented the application layer from reading
the buffer which in turn means we would not send WINDOW_UPDATE's. This
has potential to deplete the flow-control window.

https://github.com/square/okhttp/issues/3915