### PR TITLE
alpn boot versions 171+172

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -619,6 +619,23 @@
       <properties>
         <alpn.jdk8.version>8.1.12.v20180117</alpn.jdk8.version>
       </properties>
+    <profile>
+      <id>alpn-when-jdk8_171</id>
+      <activation>
+        <jdk>1.8.0_171</jdk>
+      </activation>
+      <properties>
+        <alpn.jdk8.version>8.1.12.v20180117</alpn.jdk8.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>alpn-when-jdk8_172</id>
+      <activation>
+        <jdk>1.8.0_172</jdk>
+      </activation>
+      <properties>
+        <alpn.jdk8.version>8.1.12.v20180117</alpn.jdk8.version>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -619,6 +619,7 @@
       <properties>
         <alpn.jdk8.version>8.1.12.v20180117</alpn.jdk8.version>
       </properties>
+    </profile>
     <profile>
       <id>alpn-when-jdk8_171</id>
       <activation>


### PR DESCRIPTION
No jetty release... yet.

Nothing obviously coming from http://www.oracle.com/technetwork/java/javase/8all-relnotes-2226344.html

Should fix travis build for now