### PR TITLE
Including support for detour in proxy case configured

### DIFF
--- a/okhttp/src/main/java/okhttp3/AutomaticProxySelector.java
+++ b/okhttp/src/main/java/okhttp3/AutomaticProxySelector.java
@@ -1,20 +1,14 @@
 package okhttp3;
 
-import sun.net.spi.DefaultProxySelector;
-
 import java.io.IOException;
 import java.net.Proxy;
+import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 
-public class AutomaticProxySelector extends DefaultProxySelector {
-
-    public AutomaticProxySelector(List<String> noProxyForHosts, List<Proxy> proxies) {
-        this.noProxyForHosts = noProxyForHosts;
-        this.proxies = proxies;
-    }
+public class AutomaticProxySelector extends ProxySelector {
 
     private List<String> noProxyForHosts;
     private List<Proxy> proxies;
@@ -43,5 +37,13 @@ public class AutomaticProxySelector extends DefaultProxySelector {
             }
         }
         return false;
+    }
+
+    public void setNoProxyForHosts(List<String> noProxyForHosts) {
+        this.noProxyForHosts = noProxyForHosts;
+    }
+
+    public void setProxies(List<Proxy> proxies) {
+        this.proxies = proxies;
     }
 }

--- a/okhttp/src/main/java/okhttp3/AutomaticProxySelector.java
+++ b/okhttp/src/main/java/okhttp3/AutomaticProxySelector.java
@@ -1,0 +1,47 @@
+package okhttp3;
+
+import sun.net.spi.DefaultProxySelector;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+public class AutomaticProxySelector extends DefaultProxySelector {
+
+    public AutomaticProxySelector(List<String> noProxyForHosts, List<Proxy> proxies) {
+        this.noProxyForHosts = noProxyForHosts;
+        this.proxies = proxies;
+    }
+
+    private List<String> noProxyForHosts;
+    private List<Proxy> proxies;
+
+    @Override
+    public List<Proxy> select(URI uri) {
+        if (hostsContainHost(uri.getHost())) {
+            return Collections.singletonList(Proxy.NO_PROXY);
+        }
+
+        return proxies;
+    }
+
+    @Override
+    public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+        getDefault().connectFailed(uri, sa, ioe);
+    }
+
+    private boolean hostsContainHost(String host) {
+        if (noProxyForHosts != null
+                && !noProxyForHosts.isEmpty()) {
+            for (String url : noProxyForHosts) {
+                if (url.equals(host)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -18,6 +18,7 @@ package okhttp3;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
 import okhttp3.internal.NamedRunnable;
 import okhttp3.internal.cache.CacheInterceptor;
 import okhttp3.internal.connection.ConnectInterceptor;
@@ -56,6 +57,7 @@ final class RealCall implements Call {
 
   static RealCall newRealCall(OkHttpClient client, Request originalRequest, boolean forWebSocket) {
     // Safely publish the Call instance to the EventListener.
+    client = client.disableProxyCaseNoProxyListContainsHost(originalRequest.url.host);
     RealCall call = new RealCall(client, originalRequest, forWebSocket);
     call.eventListener = client.eventListenerFactory().create(call);
     return call;

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -57,7 +57,6 @@ final class RealCall implements Call {
 
   static RealCall newRealCall(OkHttpClient client, Request originalRequest, boolean forWebSocket) {
     // Safely publish the Call instance to the EventListener.
-    client = client.disableProxyCaseNoProxyListContainsHost(originalRequest.url.host);
     RealCall call = new RealCall(client, originalRequest, forWebSocket);
     call.eventListener = client.eventListenerFactory().create(call);
     return call;


### PR DESCRIPTION
- Included implementation of ProxySelector (AutomatiProxySelector), which consists in selecting a particular proxy according to the request URI.

- Included List in OkHttpClient to save hosts that do not need to use proxy in their requests (noProxyForHosts).

- Changed OkHttpClient build () to set an AutomatiProxySelector when there is a custom proxy set in the OkHttpClient and a noProxyForHosts List, then the implemented ProxySelector will automatically set between the custom Proxy (when the host is not in noProxyForHosts) and ProxySelector.getDefault () (when the host is in noProxyForHosts).