### PR TITLE
Rename H2C to H2_PRIOR_KNOWLEDGE.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -214,11 +214,12 @@ public final class MockWebServer extends ExternalResource implements Closeable {
    */
   public void setProtocols(List<Protocol> protocols) {
     protocols = Util.immutableList(protocols);
-    if (protocols.contains(Protocol.H2C) && protocols.size() > 1) {
-      // when using h2c prior knowledge, no other protocol should be supported.
-      throw new IllegalArgumentException("protocols containing h2c cannot use other protocols: "
-              + protocols);
-    } else if (!protocols.contains(Protocol.H2C) && !protocols.contains(Protocol.HTTP_1_1)) {
+    if (protocols.contains(Protocol.H2_PRIOR_KNOWLEDGE) && protocols.size() > 1) {
+      // when using h2_prior_knowledge, no other protocol should be supported.
+      throw new IllegalArgumentException(
+          "protocols containing h2_prior_knowledge cannot use other protocols: " + protocols);
+    } else if (!protocols.contains(Protocol.H2_PRIOR_KNOWLEDGE)
+        && !protocols.contains(Protocol.HTTP_1_1)) {
       throw new IllegalArgumentException("protocols doesn't contain http/1.1: " + protocols);
     }
     if (protocols.contains(null)) {
@@ -444,9 +445,9 @@ public final class MockWebServer extends ExternalResource implements Closeable {
             protocol = protocolString != null ? Protocol.get(protocolString) : Protocol.HTTP_1_1;
           }
           openClientSockets.remove(raw);
-        } else if (protocols.contains(Protocol.H2C)) {
+        } else if (protocols.contains(Protocol.H2_PRIOR_KNOWLEDGE)) {
           socket = raw;
-          protocol = Protocol.H2C;
+          protocol = Protocol.H2_PRIOR_KNOWLEDGE;
         } else {
           socket = raw;
         }
@@ -455,7 +456,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
           return; // Ignore the socket until the server is shut down!
         }
 
-        if (protocol == Protocol.HTTP_2 || protocol == Protocol.H2C) {
+        if (protocol == Protocol.HTTP_2 || protocol == Protocol.H2_PRIOR_KNOWLEDGE) {
           Http2SocketHandler http2SocketHandler = new Http2SocketHandler(socket, protocol);
           Http2Connection connection = new Http2Connection.Builder(false)
               .socket(socket)
@@ -905,7 +906,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
           method = value;
         } else if (name.equals(Header.TARGET_PATH)) {
           path = value;
-        } else if (protocol == Protocol.HTTP_2 || protocol == Protocol.H2C) {
+        } else if (protocol == Protocol.HTTP_2 || protocol == Protocol.H2_PRIOR_KNOWLEDGE) {
           httpHeaders.add(name.utf8(), value);
         } else {
           throw new IllegalStateException();

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
@@ -458,29 +458,31 @@ public final class MockWebServerTest {
     assertEquals("request", request.getBody().readUtf8());
   }
 
-  @Test public void testH2CServerFallback() {
+  @Test public void testH2PriorKnowledgeServerFallback() {
     try {
-      server.setProtocols(Arrays.asList(Protocol.H2C, Protocol.HTTP_1_1));
-      fail("When H2C is specified, no other protocol can be specified");
+      server.setProtocols(Arrays.asList(Protocol.H2_PRIOR_KNOWLEDGE, Protocol.HTTP_1_1));
+      fail();
     } catch (IllegalArgumentException expected) {
-      assertEquals("protocols containing h2c cannot use other protocols: [h2c, http/1.1]", expected.getMessage());
+      assertEquals("protocols containing h2_prior_knowledge cannot use other protocols: "
+              + "[h2_prior_knowledge, http/1.1]", expected.getMessage());
     }
   }
 
-  @Test public void testH2CServerDuplicates() {
+  @Test public void testH2PriorKnowledgeServerDuplicates() {
     try {
       // Treating this use case as user error
-      server.setProtocols(Arrays.asList(Protocol.H2C, Protocol.H2C));
-      fail("When H2C is specified, no other protocol can be specified");
+      server.setProtocols(Arrays.asList(Protocol.H2_PRIOR_KNOWLEDGE, Protocol.H2_PRIOR_KNOWLEDGE));
+      fail();
     } catch (IllegalArgumentException expected) {
-      assertEquals("protocols containing h2c cannot use other protocols: [h2c, h2c]", expected.getMessage());
+      assertEquals("protocols containing h2_prior_knowledge cannot use other protocols: "
+          + "[h2_prior_knowledge, h2_prior_knowledge]", expected.getMessage());
     }
   }
 
-  @Test public void testMockWebServerH2CProtocol() {
-    server.setProtocols(Arrays.asList(Protocol.H2C));
+  @Test public void testMockWebServerH2PriorKnowledgeProtocol() {
+    server.setProtocols(Arrays.asList(Protocol.H2_PRIOR_KNOWLEDGE));
 
     assertEquals(1, server.protocols().size());
-    assertEquals(Protocol.H2C, server.protocols().get(0));
+    assertEquals(Protocol.H2_PRIOR_KNOWLEDGE, server.protocols().get(0));
   }
 }

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -1187,6 +1187,25 @@ public final class CallTest {
     }
   }
 
+  @Test public void httpsCallsFailWhenProtocolIsH2PriorKnowledge() throws Exception {
+    client = client.newBuilder()
+        .protocols(Collections.singletonList(Protocol.H2_PRIOR_KNOWLEDGE))
+        .build();
+
+    server.useHttps(sslClient.socketFactory, false);
+    server.enqueue(new MockResponse());
+
+    Call call = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    try {
+      call.execute();
+      fail();
+    } catch (UnknownServiceException expected) {
+      assertEquals("H2_PRIOR_KNOWLEDGE cannot be used with HTTPS", expected.getMessage());
+    }
+  }
+
   @Test public void setFollowSslRedirectsFalse() throws Exception {
     enableTls();
     server.enqueue(new MockResponse()

--- a/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/OkHttpClientTest.java
@@ -170,34 +170,33 @@ public final class OkHttpClientTest {
     }
   }
 
-  @Test public void testH2COkHttpClientConstructionFallback() {
-    // fallbacks are not allowed when using h2c prior knowledge
+  @Test public void testH2PriorKnowledgeOkHttpClientConstructionFallback() {
     try {
       new OkHttpClient.Builder()
-              .protocols(Arrays.asList(Protocol.H2C, Protocol.HTTP_1_1));
-      fail("When H2C is specified, no other protocol can be specified");
+          .protocols(Arrays.asList(Protocol.H2_PRIOR_KNOWLEDGE, Protocol.HTTP_1_1));
+      fail();
     } catch (IllegalArgumentException expected) {
-      assertEquals("protocols containing h2c cannot use other protocols: [h2c, http/1.1]", expected.getMessage());
+      assertEquals("protocols containing h2_prior_knowledge cannot use other protocols: "
+          + "[h2_prior_knowledge, http/1.1]", expected.getMessage());
     }
   }
 
-  @Test public void testH2COkHttpClientConstructionDuplicates() {
-    // Treating this use case as user error
+  @Test public void testH2PriorKnowledgeOkHttpClientConstructionDuplicates() {
     try {
       new OkHttpClient.Builder()
-              .protocols(Arrays.asList(Protocol.H2C, Protocol.H2C));
-      fail("When H2C is specified, no other protocol can be specified");
+          .protocols(Arrays.asList(Protocol.H2_PRIOR_KNOWLEDGE, Protocol.H2_PRIOR_KNOWLEDGE));
+      fail();
     } catch (IllegalArgumentException expected) {
-      assertEquals("protocols containing h2c cannot use other protocols: [h2c, h2c]", expected.getMessage());
+      assertEquals("protocols containing h2_prior_knowledge cannot use other protocols: "
+          + "[h2_prior_knowledge, h2_prior_knowledge]", expected.getMessage());
     }
   }
 
-  @Test public void testH2COkHttpClientConstructionSuccess() {
+  @Test public void testH2PriorKnowledgeOkHttpClientConstructionSuccess() {
     OkHttpClient okHttpClient = new OkHttpClient.Builder()
-            .protocols(Arrays.asList(Protocol.H2C))
-            .build();
-
+        .protocols(Arrays.asList(Protocol.H2_PRIOR_KNOWLEDGE))
+        .build();
     assertEquals(1, okHttpClient.protocols().size());
-    assertEquals(Protocol.H2C, okHttpClient.protocols().get(0));
+    assertEquals(Protocol.H2_PRIOR_KNOWLEDGE, okHttpClient.protocols().get(0));
   }
 }

--- a/okhttp-tests/src/test/java/okhttp3/ProtocolTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ProtocolTest.java
@@ -15,9 +15,8 @@
  */
 package okhttp3;
 
-import org.junit.Test;
-
 import java.io.IOException;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
@@ -28,7 +27,7 @@ public class ProtocolTest {
     assertEquals(Protocol.HTTP_1_1, Protocol.get("http/1.1"));
     assertEquals(Protocol.SPDY_3, Protocol.get("spdy/3.1"));
     assertEquals(Protocol.HTTP_2, Protocol.get("h2"));
-    assertEquals(Protocol.H2C, Protocol.get("h2c"));
+    assertEquals(Protocol.H2_PRIOR_KNOWLEDGE, Protocol.get("h2_prior_knowledge"));
     assertEquals(Protocol.QUIC, Protocol.get("quic"));
   }
 
@@ -43,7 +42,7 @@ public class ProtocolTest {
     assertEquals("http/1.1", Protocol.HTTP_1_1.toString());
     assertEquals("spdy/3.1", Protocol.SPDY_3.toString());
     assertEquals("h2", Protocol.HTTP_2.toString());
-    assertEquals("h2c", Protocol.H2C.toString());
+    assertEquals("h2_prior_knowledge", Protocol.H2_PRIOR_KNOWLEDGE.toString());
     assertEquals("quic", Protocol.QUIC.toString());
   }
 }

--- a/okhttp/src/main/java/okhttp3/Protocol.java
+++ b/okhttp/src/main/java/okhttp3/Protocol.java
@@ -62,13 +62,13 @@ public enum Protocol {
   HTTP_2("h2"),
 
   /**
-   * Cleartext implementation of HTTP2. This enumeration exists for the "prior knowledge" upgrade
-   * semantic supported by the protocol.
+   * Cleartext HTTP/2 with no "upgrade" round trip. This option requires the client to have prior
+   * knowledge that the server supports cleartext HTTP/2.
    *
    * @see <a href="https://tools.ietf.org/html/rfc7540#section-3.4">Starting HTTP/2 with Prior
    * Knowledge</a>
    */
-  H2C("h2c"),
+  H2_PRIOR_KNOWLEDGE("h2_prior_knowledge"),
 
   /**
    * QUIC (Quick UDP Internet Connection) is a new multiplexed and secure transport atop UDP,
@@ -95,7 +95,7 @@ public enum Protocol {
     // Unroll the loop over values() to save an allocation.
     if (protocol.equals(HTTP_1_0.protocol)) return HTTP_1_0;
     if (protocol.equals(HTTP_1_1.protocol)) return HTTP_1_1;
-    if (protocol.equals(H2C.protocol)) return H2C;
+    if (protocol.equals(H2_PRIOR_KNOWLEDGE.protocol)) return H2_PRIOR_KNOWLEDGE;
     if (protocol.equals(HTTP_2.protocol)) return HTTP_2;
     if (protocol.equals(SPDY_3.protocol)) return SPDY_3;
     if (protocol.equals(QUIC.protocol)) return QUIC;

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -146,6 +146,11 @@ public final class RealConnection extends Http2Connection.Listener implements Co
         throw new RouteException(new UnknownServiceException(
             "CLEARTEXT communication to " + host + " not permitted by network security policy"));
       }
+    } else {
+      if (route.address().protocols().contains(Protocol.H2_PRIOR_KNOWLEDGE)) {
+        throw new RouteException(new UnknownServiceException(
+            "H2_PRIOR_KNOWLEDGE cannot be used with HTTPS"));
+      }
     }
 
     while (true) {
@@ -261,9 +266,9 @@ public final class RealConnection extends Http2Connection.Listener implements Co
   private void establishProtocol(ConnectionSpecSelector connectionSpecSelector,
       int pingIntervalMillis, Call call, EventListener eventListener) throws IOException {
     if (route.address().sslSocketFactory() == null) {
-      if (route.address().protocols().contains(Protocol.H2C)) {
+      if (route.address().protocols().contains(Protocol.H2_PRIOR_KNOWLEDGE)) {
         socket = rawSocket;
-        protocol = Protocol.H2C;
+        protocol = Protocol.H2_PRIOR_KNOWLEDGE;
         startHttp2(pingIntervalMillis);
         return;
       }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -85,7 +85,6 @@ public final class Http2Codec implements HttpCodec {
       ENCODING,
       UPGRADE);
 
-  private final OkHttpClient client;
   private final Interceptor.Chain chain;
   final StreamAllocation streamAllocation;
   private final Http2Connection connection;
@@ -94,12 +93,12 @@ public final class Http2Codec implements HttpCodec {
 
   public Http2Codec(OkHttpClient client, Interceptor.Chain chain, StreamAllocation streamAllocation,
       Http2Connection connection) {
-    this.client = client;
     this.chain = chain;
     this.streamAllocation = streamAllocation;
     this.connection = connection;
-
-    protocol = client.protocols().contains(Protocol.H2C) ? Protocol.H2C : Protocol.HTTP_2;
+    this.protocol = client.protocols().contains(Protocol.H2_PRIOR_KNOWLEDGE)
+        ? Protocol.H2_PRIOR_KNOWLEDGE
+        : Protocol.HTTP_2;
   }
 
   @Override public Sink createRequestBody(Request request, long contentLength) {


### PR DESCRIPTION
The string h2c is used with cleartext upgrades. We're not doing those here,
so that identifier isn't appropriate.