### PR TITLE
Use header delay instead of body delay before status line

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -704,7 +704,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
 
   private void writeHttpResponse(Socket socket, BufferedSink sink, MockResponse response)
       throws IOException {
-    sleepIfDelayed(response.getBodyDelay(TimeUnit.MILLISECONDS));
+    sleepIfDelayed(response.getHeadersDelay(TimeUnit.MILLISECONDS));
     sink.writeUtf8(response.getStatus());
     sink.writeUtf8("\r\n");
 


### PR DESCRIPTION
As noted in https://github.com/square/okhttp/issues/4006

header delay is ignored for HTTP 1.1 responses, instead body delay is used twice.