### PR TITLE
[Early WIP] Websockets over HTTP/2

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -57,6 +57,7 @@ import okhttp3.HttpUrl;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.Streams;
 import okhttp3.internal.Internal;
 import okhttp3.internal.NamedRunnable;
 import okhttp3.internal.Util;
@@ -676,7 +677,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
         .build();
 
     final CountDownLatch connectionClose = new CountDownLatch(1);
-    RealWebSocket.Streams streams = new RealWebSocket.Streams(false, source, sink) {
+    Streams streams = new Streams(false, source, sink) {
       @Override public void close() {
         connectionClose.countDown();
       }

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.Streams;
 import okio.ByteString;
 import okio.Okio;
 import okio.Pipe;
@@ -343,7 +344,7 @@ public final class RealWebSocketTest {
   }
 
   /** One peer's streams, listener, and web socket in the test. */
-  private static class TestStreams extends RealWebSocket.Streams {
+  private static class TestStreams extends Streams {
     private final String name;
     private final WebSocketRecorder listener;
     private RealWebSocket webSocket;

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -703,9 +703,8 @@ public final class WebSocketHttpTest {
   }
 
   private RealWebSocket newWebSocket(Request request) {
-    RealWebSocket webSocket = new RealWebSocket(
-        request, clientListener, random, client.pingIntervalMillis());
-    webSocket.connect(client);
-    return webSocket;
+    WebsocketUpgradeHandler handler =
+        new WebsocketUpgradeHandler(request, clientListener, random, client.pingIntervalMillis());
+    return (RealWebSocket) handler.connect(client);
   }
 }

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -48,6 +48,7 @@ import okhttp3.internal.platform.Platform;
 import okhttp3.internal.tls.CertificateChainCleaner;
 import okhttp3.internal.tls.OkHostnameVerifier;
 import okhttp3.internal.ws.RealWebSocket;
+import okhttp3.internal.ws.WebsocketUpgradeHandler;
 import okio.Sink;
 import okio.Source;
 
@@ -438,9 +439,13 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
    * Uses {@code request} to connect a new web socket.
    */
   @Override public WebSocket newWebSocket(Request request, WebSocketListener listener) {
-    RealWebSocket webSocket = new RealWebSocket(request, listener, new Random(), pingInterval);
-    webSocket.connect(this);
-    return webSocket;
+    WebsocketUpgradeHandler upgradeHandler = new WebsocketUpgradeHandler(request, listener, new Random(), pingInterval);
+
+    return upgrade(request, upgradeHandler);
+  }
+
+  private <T> T upgrade(Request request, UpgradeHandler<T> upgradeHandler) {
+    return upgradeHandler.connect(this);
   }
 
   public Builder newBuilder() {

--- a/okhttp/src/main/java/okhttp3/Streams.java
+++ b/okhttp/src/main/java/okhttp3/Streams.java
@@ -1,0 +1,17 @@
+package okhttp3;
+
+import java.io.Closeable;
+import okio.BufferedSink;
+import okio.BufferedSource;
+
+public abstract class Streams implements Closeable {
+    public final boolean client;
+    public final BufferedSource source;
+    public final BufferedSink sink;
+
+    public Streams(boolean client, BufferedSource source, BufferedSink sink) {
+      this.client = client;
+      this.source = source;
+      this.sink = sink;
+    }
+  }

--- a/okhttp/src/main/java/okhttp3/UpgradeHandler.java
+++ b/okhttp/src/main/java/okhttp3/UpgradeHandler.java
@@ -1,0 +1,20 @@
+package okhttp3;
+
+import java.io.IOException;
+
+/**
+ * https://datatracker.ietf.org/doc/draft-ietf-httpbis-h2-websockets/?include_text=1
+ */
+public interface UpgradeHandler<T> {
+  boolean supportsHttp11();
+
+  boolean supportsHttp2();
+
+  String connectProtocol();
+
+  Request addUpgradeHeaders(Request upgradeRequest);
+
+  T complete(Response response, Streams streams) throws IOException;
+
+  void failConnect(Response response, IOException e) throws IOException;
+}

--- a/okhttp/src/main/java/okhttp3/UpgradeHandler.java
+++ b/okhttp/src/main/java/okhttp3/UpgradeHandler.java
@@ -6,15 +6,18 @@ import java.io.IOException;
  * https://datatracker.ietf.org/doc/draft-ietf-httpbis-h2-websockets/?include_text=1
  */
 public interface UpgradeHandler<T> {
+  T connect(OkHttpClient client);
+
   boolean supportsHttp11();
 
   boolean supportsHttp2();
 
+  /**
+   * https://www.iana.org/assignments/http-upgrade-tokens/http-upgrade-tokens.xhtml
+   */
   String connectProtocol();
 
   Request addUpgradeHeaders(Request upgradeRequest);
-
-  T complete(Response response, Streams streams) throws IOException;
 
   void failConnect(Response response, IOException e) throws IOException;
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -49,6 +49,7 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.Route;
+import okhttp3.Streams;
 import okhttp3.internal.Internal;
 import okhttp3.internal.Util;
 import okhttp3.internal.Version;
@@ -507,8 +508,8 @@ public final class RealConnection extends Http2Connection.Listener implements Co
     }
   }
 
-  public RealWebSocket.Streams newWebSocketStreams(final StreamAllocation streamAllocation) {
-    return new RealWebSocket.Streams(true, source, sink) {
+  public Streams newWebSocketStreams(final StreamAllocation streamAllocation) {
+    return new Streams(true, source, sink) {
       @Override public void close() throws IOException {
         streamAllocation.streamFinished(true, streamAllocation.codec(), -1L, null);
       }

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebsocketUpgradeHandler.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebsocketUpgradeHandler.java
@@ -2,23 +2,119 @@ package okhttp3.internal.ws;
 
 import java.io.IOException;
 import java.net.ProtocolException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.EventListener;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.Streams;
 import okhttp3.UpgradeHandler;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okhttp3.internal.Internal;
+import okhttp3.internal.connection.StreamAllocation;
 import okio.ByteString;
 
-public class WebsocketUpgradeHandler implements UpgradeHandler {
-  private final Random random;
+import static okhttp3.internal.Util.closeQuietly;
+
+public class WebsocketUpgradeHandler implements UpgradeHandler<WebSocket> {
+  private static final List<Protocol> ONLY_HTTP1 = Collections.singletonList(Protocol.HTTP_1_1);
+
+  private final RealWebSocket webSocket;
+  private final Request originalRequest;
+  private WebSocketListener listener;
   private final String key;
 
-  public WebsocketUpgradeHandler(Random random) {
-    this.random = random;
+  public WebsocketUpgradeHandler(Request request, WebSocketListener listener, Random random,
+      int pingInterval) {
+    this.listener = listener;
+
+    this.originalRequest = request;
+    webSocket = new RealWebSocket(request, listener, random, pingInterval);
 
     byte[] nonce = new byte[16];
     random.nextBytes(nonce);
     this.key = ByteString.of(nonce).base64();
+  }
+
+  void checkResponse(Response response) throws ProtocolException {
+    if (response.code() != 101) {
+      throw new ProtocolException("Expected HTTP 101 response but was '"
+          + response.code()
+          + " "
+          + response.message()
+          + "'");
+    }
+
+    String headerConnection = response.header("Connection");
+    if (!"Upgrade".equalsIgnoreCase(headerConnection)) {
+      throw new ProtocolException(
+          "Expected 'Connection' header value 'Upgrade' but was '" + headerConnection + "'");
+    }
+
+    String headerUpgrade = response.header("Upgrade");
+    if (!"websocket".equalsIgnoreCase(headerUpgrade)) {
+      throw new ProtocolException(
+          "Expected 'Upgrade' header value 'websocket' but was '" + headerUpgrade + "'");
+    }
+
+    String headerAccept = response.header("Sec-WebSocket-Accept");
+    String acceptExpected =
+        ByteString.encodeUtf8(key + WebSocketProtocol.ACCEPT_MAGIC).sha1().base64();
+    if (!acceptExpected.equals(headerAccept)) {
+      throw new ProtocolException("Expected 'Sec-WebSocket-Accept' header value '"
+          + acceptExpected
+          + "' but was '"
+          + headerAccept
+          + "'");
+    }
+  }
+
+  public WebSocket connect(OkHttpClient client) {
+    client = client.newBuilder().eventListener(EventListener.NONE).protocols(ONLY_HTTP1).build();
+    final Request request = originalRequest.newBuilder()
+        .header("Upgrade", "websocket")
+        .header("Connection", "Upgrade")
+        .build();
+    Call call = Internal.instance.newWebSocketCall(client, request);
+    call.enqueue(new Callback() {
+      @Override public void onResponse(Call call, Response response) {
+        try {
+          checkResponse(response);
+        } catch (ProtocolException e) {
+          webSocket.failWebSocket(e, response);
+          closeQuietly(response);
+          return;
+        }
+
+        // Promote the HTTP streams into web socket streams.
+        StreamAllocation streamAllocation = Internal.instance.streamAllocation(call);
+        streamAllocation.noNewStreams(); // Prevent connection pooling!
+        Streams streams = streamAllocation.connection().newWebSocketStreams(streamAllocation);
+
+        // Process all web socket messages.
+        try {
+          listener.onOpen(webSocket, response);
+          String name = "OkHttp WebSocket " + request.url().redact();
+          webSocket.initReaderAndWriter(name, streams);
+          streamAllocation.connection().socket().setSoTimeout(0);
+          webSocket.loopReader();
+        } catch (Exception e) {
+          webSocket.failWebSocket(e, null);
+        }
+      }
+
+      @Override public void onFailure(Call call, IOException e) {
+        webSocket.failWebSocket(e, null);
+      }
+    });
+
+    return webSocket;
   }
 
   @Override public boolean supportsHttp11() {
@@ -26,7 +122,7 @@ public class WebsocketUpgradeHandler implements UpgradeHandler {
   }
 
   @Override public boolean supportsHttp2() {
-    return true;
+    return false;
   }
 
   @Override public String connectProtocol() {
@@ -40,18 +136,8 @@ public class WebsocketUpgradeHandler implements UpgradeHandler {
         .build();
   }
 
-  @Override public Object complete(Response response, Streams streams) throws IOException {
-    String headerAccept = response.header("Sec-WebSocket-Accept");
-    String acceptExpected =
-        ByteString.encodeUtf8(key + WebSocketProtocol.ACCEPT_MAGIC).sha1().base64();
-    if (!acceptExpected.equals(headerAccept)) {
-      throw new ProtocolException("Expected 'Sec-WebSocket-Accept' header value '"
-          + acceptExpected
-          + "' but was '"
-          + headerAccept
-          + "'");
-    }
-
-    return null;
+  @Override public void failConnect(Response response, IOException e) throws IOException {
+    listener.onFailure(webSocket, e, response);
+    throw e;
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebsocketUpgradeHandler.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebsocketUpgradeHandler.java
@@ -1,0 +1,57 @@
+package okhttp3.internal.ws;
+
+import java.io.IOException;
+import java.net.ProtocolException;
+import java.util.Random;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Streams;
+import okhttp3.UpgradeHandler;
+import okio.ByteString;
+
+public class WebsocketUpgradeHandler implements UpgradeHandler {
+  private final Random random;
+  private final String key;
+
+  public WebsocketUpgradeHandler(Random random) {
+    this.random = random;
+
+    byte[] nonce = new byte[16];
+    random.nextBytes(nonce);
+    this.key = ByteString.of(nonce).base64();
+  }
+
+  @Override public boolean supportsHttp11() {
+    return true;
+  }
+
+  @Override public boolean supportsHttp2() {
+    return true;
+  }
+
+  @Override public String connectProtocol() {
+    return "websocket";
+  }
+
+  @Override public Request addUpgradeHeaders(Request upgradeRequest) {
+    return upgradeRequest.newBuilder()
+        .header("Sec-WebSocket-Key", key)
+        .header("Sec-WebSocket-Version", "13")
+        .build();
+  }
+
+  @Override public Object complete(Response response, Streams streams) throws IOException {
+    String headerAccept = response.header("Sec-WebSocket-Accept");
+    String acceptExpected =
+        ByteString.encodeUtf8(key + WebSocketProtocol.ACCEPT_MAGIC).sha1().base64();
+    if (!acceptExpected.equals(headerAccept)) {
+      throw new ProtocolException("Expected 'Sec-WebSocket-Accept' header value '"
+          + acceptExpected
+          + "' but was '"
+          + headerAccept
+          + "'");
+    }
+
+    return null;
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebsocketUpgradeHandler.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebsocketUpgradeHandler.java
@@ -77,10 +77,10 @@ public class WebsocketUpgradeHandler implements UpgradeHandler<WebSocket> {
 
   public WebSocket connect(OkHttpClient client) {
     client = client.newBuilder().eventListener(EventListener.NONE).protocols(ONLY_HTTP1).build();
-    final Request request = originalRequest.newBuilder()
+    final Request request = addUpgradeHeaders(originalRequest.newBuilder()
         .header("Upgrade", "websocket")
         .header("Connection", "Upgrade")
-        .build();
+        .build());
     Call call = Internal.instance.newWebSocketCall(client, request);
     call.enqueue(new Callback() {
       @Override public void onResponse(Call call, Response response) {

--- a/okhttp/src/main/java/okhttp3/internal/ws/package-info.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/package-info.java
@@ -1,0 +1,2 @@
+@javax.annotation.ParametersAreNonnullByDefault
+package okhttp3.internal.ws;


### PR DESCRIPTION
Towards https://datatracker.ietf.org/doc/draft-ietf-httpbis-h2-websockets/?include_text=1

Steps - working on step 2 currently

1. Introduce an API for UpgradeHandler
2. Refactor existing Websocket code to cleanly work with UpgradeHandler for HTTP/1.1
3. Introduce HTTP/1.1 upgrade flow
4. Introduce OkHttpClient.upgrade method 
5. Implement HTTP/2 upgrade flow

API changes

1. New public API UpgradeHandler and OkHttpClient.upgrade(UpgradeHandler) method
2. New public class Streams for "socket", two bidirectional streams, over HTTP/1.1 or HTTP/2 
