### PR TITLE
Move conscrypt NONE checks internal to Handshake

### DIFF
--- a/okhttp/src/main/java/okhttp3/Handshake.java
+++ b/okhttp/src/main/java/okhttp3/Handshake.java
@@ -50,6 +50,7 @@ public final class Handshake {
   public static Handshake get(SSLSession session) throws IOException {
     String cipherSuiteString = session.getCipherSuite();
     if (cipherSuiteString == null) throw new IllegalStateException("cipherSuite == null");
+    if ("SSL_NULL_WITH_NULL_NULL".equals(cipherSuiteString)) throw new IOException("cipherSuite == SSL_NULL_WITH_NULL_NULL");
     CipherSuite cipherSuite = CipherSuite.forJavaName(cipherSuiteString);
 
     String tlsVersionString = session.getProtocol();

--- a/okhttp/src/main/java/okhttp3/Handshake.java
+++ b/okhttp/src/main/java/okhttp3/Handshake.java
@@ -50,7 +50,9 @@ public final class Handshake {
   public static Handshake get(SSLSession session) throws IOException {
     String cipherSuiteString = session.getCipherSuite();
     if (cipherSuiteString == null) throw new IllegalStateException("cipherSuite == null");
-    if ("SSL_NULL_WITH_NULL_NULL".equals(cipherSuiteString)) throw new IOException("cipherSuite == SSL_NULL_WITH_NULL_NULL");
+    if ("SSL_NULL_WITH_NULL_NULL".equals(cipherSuiteString)) {
+      throw new IOException("cipherSuite == SSL_NULL_WITH_NULL_NULL");
+    }
     CipherSuite cipherSuite = CipherSuite.forJavaName(cipherSuiteString);
 
     String tlsVersionString = session.getProtocol();

--- a/okhttp/src/main/java/okhttp3/Handshake.java
+++ b/okhttp/src/main/java/okhttp3/Handshake.java
@@ -15,6 +15,7 @@
  */
 package okhttp3;
 
+import java.io.IOException;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -46,13 +47,14 @@ public final class Handshake {
     this.localCertificates = localCertificates;
   }
 
-  public static Handshake get(SSLSession session) {
+  public static Handshake get(SSLSession session) throws IOException {
     String cipherSuiteString = session.getCipherSuite();
     if (cipherSuiteString == null) throw new IllegalStateException("cipherSuite == null");
     CipherSuite cipherSuite = CipherSuite.forJavaName(cipherSuiteString);
 
     String tlsVersionString = session.getProtocol();
     if (tlsVersionString == null) throw new IllegalStateException("tlsVersion == null");
+    if ("NONE".equals(tlsVersionString)) throw new IOException("tlsVersion == NONE");
     TlsVersion tlsVersion = TlsVersion.forJavaName(tlsVersionString);
 
     Certificate[] peerCertificates;

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -318,9 +318,6 @@ public final class RealConnection extends Http2Connection.Listener implements Co
       sslSocket.startHandshake();
       // block for session establishment
       SSLSession sslSocketSession = sslSocket.getSession();
-      if (!isValid(sslSocketSession)) {
-        throw new IOException("a valid ssl session was not established");
-      }
       Handshake unverifiedHandshake = Handshake.get(sslSocketSession);
 
       // Verify that the socket's certificates are acceptable for the target host.
@@ -359,12 +356,6 @@ public final class RealConnection extends Http2Connection.Listener implements Co
         closeQuietly(sslSocket);
       }
     }
-  }
-
-  private boolean isValid(SSLSession sslSocketSession) {
-    // don't use SslSocket.getSession since for failed results it returns SSL_NULL_WITH_NULL_NULL
-    return !"NONE".equals(sslSocketSession.getProtocol()) && !"SSL_NULL_WITH_NULL_NULL".equals(
-        sslSocketSession.getCipherSuite());
   }
 
   /**


### PR DESCRIPTION
Based on https://github.com/square/okhttp/issues/3973, looks like this can still happen