### PR TITLE
API for handling an unexpected SSE response

### DIFF
--- a/okhttp-sse/src/main/java/okhttp3/internal/sse/RealEventSource.java
+++ b/okhttp-sse/src/main/java/okhttp3/internal/sse/RealEventSource.java
@@ -51,6 +51,10 @@ public final class RealEventSource
   }
 
   @Override public void onResponse(Call call, Response response) {
+    processResponse(response);
+  }
+
+  public void processResponse(Response response) {
     try {
       //noinspection ConstantConditions main body is never null
       BufferedSource source = response.body().source();

--- a/okhttp-sse/src/main/java/okhttp3/sse/EventSources.java
+++ b/okhttp-sse/src/main/java/okhttp3/sse/EventSources.java
@@ -17,6 +17,7 @@ package okhttp3.sse;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Response;
 import okhttp3.internal.sse.RealEventSource;
 
 public final class EventSources {
@@ -28,6 +29,11 @@ public final class EventSources {
         return eventSource;
       }
     };
+  }
+
+  public static void processResponse(Response response, EventSourceListener listener) {
+    RealEventSource eventSource = new RealEventSource(response.request(), listener);
+    eventSource.processResponse(response);
   }
 
   private EventSources() {


### PR DESCRIPTION
My existing SSE use case is simplified if I don't need to specify a SSE request beforehand.  So on checking the response a text/event-stream content-type is enough to process the result as a stream.  Expose a basic API for this.