### PR TITLE
Android 4 and Java 1.7 prefer TLSv1.2 provider

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -23,12 +23,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -425,6 +427,15 @@ class AndroidPlatform extends Platform {
     @Override
     public int hashCode() {
       return trustManager.hashCode() + 31 * findByIssuerAndSignatureMethod.hashCode();
+    }
+  }
+
+  @Override public SSLContext getSSLContext() {
+    // Override Platform to keep the existing Android behaviour for now
+    try {
+      return SSLContext.getInstance("TLS");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("No TLS provider", e);
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -431,7 +431,14 @@ class AndroidPlatform extends Platform {
   }
 
   @Override public SSLContext getSSLContext() {
-    // Override Platform to keep the existing Android behaviour for now
+    if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 22) {
+      try {
+        return SSLContext.getInstance("TLSv1.2");
+      } catch (NoSuchAlgorithmException e) {
+        // fallback to TLS
+      }
+    }
+
     try {
       return SSLContext.getInstance("TLS");
     } catch (NoSuchAlgorithmException e) {

--- a/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
@@ -98,13 +98,4 @@ final class Jdk9Platform extends Platform {
 
     return null;
   }
-
-  @Override public SSLContext getSSLContext() {
-    // Override Platform to keep the existing behaviour for now on newer Platforms
-    try {
-      return SSLContext.getInstance("TLS");
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("No TLS provider", e);
-    }
-  }
 }

--- a/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
@@ -17,8 +17,10 @@ package okhttp3.internal.platform;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -95,5 +97,14 @@ final class Jdk9Platform extends Platform {
     }
 
     return null;
+  }
+
+  @Override public SSLContext getSSLContext() {
+    // Override Platform to keep the existing behaviour for now on newer Platforms
+    try {
+      return SSLContext.getInstance("TLS");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("No TLS provider", e);
+    }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
@@ -17,10 +17,8 @@ package okhttp3.internal.platform;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -267,15 +267,20 @@ public class Platform {
   }
 
   public SSLContext getSSLContext() {
-    try {
-      // JDK 1.7 (public version) only support > TLSv1 with named protocols
-      return SSLContext.getInstance("TLSv1.2");
-    } catch (NoSuchAlgorithmException e) {
+    String jvmVersion = System.getProperty("java.specification.version");
+    if ("1.7".equals(jvmVersion)) {
       try {
-        return SSLContext.getInstance("TLS");
-      } catch (NoSuchAlgorithmException e2) {
-        throw new IllegalStateException("No TLS provider", e);
+        // JDK 1.7 (public version) only support > TLSv1 with named protocols
+        return SSLContext.getInstance("TLSv1.2");
+      } catch (NoSuchAlgorithmException e) {
+        // fallback to TLS
       }
+    }
+
+    try {
+      return SSLContext.getInstance("TLS");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("No TLS provider", e);
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -124,8 +124,8 @@ public class Platform {
     return null;
   }
 
-  public void connectSocket(Socket socket, InetSocketAddress address,
-      int connectTimeout) throws IOException {
+  public void connectSocket(Socket socket, InetSocketAddress address, int connectTimeout)
+      throws IOException {
     socket.connect(address, connectTimeout);
   }
 
@@ -176,8 +176,10 @@ public class Platform {
     X509TrustManager trustManager = trustManager(sslSocketFactory);
 
     if (trustManager == null) {
-      throw new IllegalStateException("Unable to extract the trust manager on " + Platform.get()
-          + ", sslSocketFactory is " + sslSocketFactory.getClass());
+      throw new IllegalStateException("Unable to extract the trust manager on "
+          + Platform.get()
+          + ", sslSocketFactory is "
+          + sslSocketFactory.getClass());
     }
 
     return buildCertificateChainCleaner(trustManager);
@@ -265,21 +267,15 @@ public class Platform {
   }
 
   public SSLContext getSSLContext() {
-    // v 1.7 unpaid version requires optin to TLSv1.2
-    // https://github.com/square/okhttp/issues/4086
-    String jvmVersion = System.getProperty("java.specification.version");
-    if ("1.7".equals(jvmVersion)) {
-      try {
-        return SSLContext.getInstance("TLSv1.2");
-      } catch (NoSuchAlgorithmException e) {
-        // drop back to TLS
-      }
-    }
-
     try {
-      return SSLContext.getInstance("TLS");
+      // JDK 1.7 (public version) only support > TLSv1 with named protocols
+      return SSLContext.getInstance("TLSv1.2");
     } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("No TLS provider", e);
+      try {
+        return SSLContext.getInstance("TLS");
+      } catch (NoSuchAlgorithmException e2) {
+        throw new IllegalStateException("No TLS provider", e);
+      }
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -265,6 +265,17 @@ public class Platform {
   }
 
   public SSLContext getSSLContext() {
+    // v 1.7 unpaid version requires optin to TLSv1.2
+    // https://github.com/square/okhttp/issues/4086
+    String jvmVersion = System.getProperty("java.specification.version");
+    if ("1.7".equals(jvmVersion)) {
+      try {
+        return SSLContext.getInstance("TLSv1.2");
+      } catch (NoSuchAlgorithmException e) {
+        // drop back to TLS
+      }
+    }
+
     try {
       return SSLContext.getInstance("TLS");
     } catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
Public (unpaid version) of Java 1.7u80 supports TLSv1.2 only via a different provider. 

Newer paid version u95 support a system property (jdk.tls.client.protocols), and u131 defaults to supporting TLSv1.2

https://www.java.com/en/configure_crypto.html#enableTLSv1_2