### PR TITLE
Fix "Unexpected TLS version:NONE" (#3973)

### DIFF
--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -153,15 +153,22 @@ final class RealCall implements Call {
           responseCallback.onResponse(RealCall.this, response);
         }
       } catch (IOException e) {
-        if (signalledCallback) {
-          // Do not signal the callback twice!
-          Platform.get().log(INFO, "Callback failure for " + toLoggableString(), e);
-        } else {
-          eventListener.callFailed(RealCall.this, e);
-          responseCallback.onFailure(RealCall.this, e);
-        }
+	    fireFailure(signalledCallback, e);
+      } catch (Exception e) {
+        fireFailure(signalledCallback, new IOException(e));
+
       } finally {
         client.dispatcher().finished(this);
+      }
+    }
+
+    void fireFailure(boolean signalledCallback, IOException e) {
+      if (signalledCallback) {
+        // Do not signal the callback twice!
+        Platform.get().log(INFO, "Callback failure for " + toLoggableString(), e);
+      } else {
+        eventListener.callFailed(RealCall.this, e);
+        responseCallback.onFailure(RealCall.this, e);
       }
     }
   }


### PR DESCRIPTION
On the Android platform, when the TLS handshake is interrupted, SSLSession.getProtocol() may return "NONE".
https://github.com/square/okhttp/issues/3719
https://github.com/square/okhttp/issues/3973