### PR TITLE
Add @Nullable annotation for the "route " parameter in method Authenticator.authenticate()

### DIFF
--- a/okhttp/src/main/java/okhttp3/Authenticator.java
+++ b/okhttp/src/main/java/okhttp3/Authenticator.java
@@ -62,7 +62,7 @@ import javax.annotation.Nullable;
 public interface Authenticator {
   /** An authenticator that knows no credentials and makes no attempt to authenticate. */
   Authenticator NONE = new Authenticator() {
-    @Override public Request authenticate(Route route, Response response) {
+    @Override public Request authenticate(@Nullable Route route, Response response) {
       return null;
     }
   };
@@ -71,5 +71,5 @@ public interface Authenticator {
    * Returns a request that includes a credential to satisfy an authentication challenge in {@code
    * response}. Returns null if the challenge cannot be satisfied.
    */
-  @Nullable Request authenticate(Route route, Response response) throws IOException;
+  @Nullable Request authenticate(@Nullable Route route, Response response) throws IOException;
 }


### PR DESCRIPTION
This change let Kotlin know that `route` parameter should be of nullable type `Route?` when overridden.
The parameter `route` declared as non-nullable type causes a crash in Kotlin
implementation of `authenticate` when actual value comes null.

For example, the following implementation in Kotlin 

```
class TokenAuthenticator : Authenticator {
   override fun authenticate(route: Route, response: Response): Request? {
      return null
   }
}
```

caused the exception  `java.lang.IllegalArgumentException Parameter specified as non-null is null: method [...], parameter route`