### PR TITLE
Add ResponseBody factory overload for ByteString

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ResponseBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ResponseBodyTest.java
@@ -397,7 +397,7 @@ public final class ResponseBodyTest {
 
   static ResponseBody body(String hex, String charset) {
     MediaType mediaType = charset == null ? null : MediaType.parse("any/thing; charset=" + charset);
-    return ResponseBody.create(mediaType, ByteString.decodeHex(hex).toByteArray());
+    return ResponseBody.create(mediaType, ByteString.decodeHex(hex));
   }
 
   static String exhaust(Reader reader) throws IOException {

--- a/okhttp/src/main/java/okhttp3/ResponseBody.java
+++ b/okhttp/src/main/java/okhttp3/ResponseBody.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import okhttp3.internal.Util;
 import okio.Buffer;
 import okio.BufferedSource;
+import okio.ByteString;
 
 import static okhttp3.internal.Util.UTF_8;
 
@@ -208,6 +209,12 @@ public abstract class ResponseBody implements Closeable {
   public static ResponseBody create(final @Nullable MediaType contentType, byte[] content) {
     Buffer buffer = new Buffer().write(content);
     return create(contentType, content.length, buffer);
+  }
+
+  /** Returns a new response body that transmits {@code content}. */
+  public static ResponseBody create(@Nullable MediaType contentType, ByteString content) {
+    Buffer buffer = new Buffer().write(content);
+    return create(contentType, content.size(), buffer);
   }
 
   /** Returns a new response body that transmits {@code content}. */


### PR DESCRIPTION
We shouldn't punish people with a roundtrip through byte[] for using a superior type!