### PR TITLE
Retain interrupted state when throwing InterruptedIOException

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -19,7 +19,6 @@ package okhttp3.mockwebserver;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ProtocolException;
@@ -692,7 +691,8 @@ public final class MockWebServer extends ExternalResource implements Closeable {
       // Even if messages are no longer being read we need to wait for the connection close signal.
       try {
         connectionClose.await();
-      } catch (InterruptedException ignored) {
+      } catch (InterruptedException e) {
+        throw new AssertionError(e);
       }
 
     } catch (IOException e) {
@@ -781,7 +781,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
         try {
           Thread.sleep(periodDelayMs);
         } catch (InterruptedException e) {
-          throw new AssertionError();
+          throw new AssertionError(e);
         }
       }
     }
@@ -863,7 +863,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
           stream.close(ErrorCode.fromHttp2(peekedResponse.getHttp2ErrorCode()));
           return;
         } catch (InterruptedException e) {
-          throw new InterruptedIOException();
+          throw new AssertionError(e);
         }
       }
 

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/CustomDispatcherTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/CustomDispatcherTest.java
@@ -39,7 +39,7 @@ public class CustomDispatcherTest {
     final List<RecordedRequest> requestsMade = new ArrayList<>();
     final Dispatcher dispatcher = new Dispatcher() {
       @Override
-      public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+      public MockResponse dispatch(RecordedRequest request) {
         requestsMade.add(request);
         return new MockResponse();
       }

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
@@ -294,7 +294,7 @@ public final class MockWebServerTest {
     in.close();
   }
 
-  @Test public void disconnectRequestHalfway() throws IOException, InterruptedException {
+  @Test public void disconnectRequestHalfway() throws Exception {
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_DURING_REQUEST_BODY));
     // Limit the size of the request body that the server holds in memory to an arbitrary
     // 3.5 MBytes so this test can pass on devices with little memory.

--- a/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
@@ -225,7 +225,7 @@ public final class DispatcherTest {
     assertFalse(a4.isCanceled());
   }
 
-  @Test public void idleCallbackInvokedWhenIdle() throws InterruptedException {
+  @Test public void idleCallbackInvokedWhenIdle() throws Exception {
     final AtomicBoolean idle = new AtomicBoolean();
     dispatcher.setIdleCallback(new Runnable() {
       @Override public void run() {
@@ -329,8 +329,7 @@ public final class DispatcherTest {
       throw new UnsupportedOperationException();
     }
 
-    @Override public boolean awaitTermination(long timeout, TimeUnit unit)
-        throws InterruptedException {
+    @Override public boolean awaitTermination(long timeout, TimeUnit unit) {
       throw new UnsupportedOperationException();
     }
   }

--- a/okhttp-tests/src/test/java/okhttp3/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/InterceptorTest.java
@@ -944,7 +944,7 @@ public final class InterceptorTest {
       });
     }
 
-    public Exception takeException() throws InterruptedException {
+    public Exception takeException() throws Exception {
       return exceptions.take();
     }
   }

--- a/okhttp-tests/src/test/java/okhttp3/TestLogHandler.java
+++ b/okhttp-tests/src/test/java/okhttp3/TestLogHandler.java
@@ -50,7 +50,7 @@ public final class TestLogHandler extends Handler {
     return list;
   }
 
-  public String take() throws InterruptedException {
+  public String take() throws Exception {
     String message = logs.poll(10, TimeUnit.SECONDS);
     if (message == null) {
       throw new AssertionError("Timed out waiting for log message.");

--- a/okhttp-tests/src/test/java/okhttp3/TestUtil.java
+++ b/okhttp-tests/src/test/java/okhttp3/TestUtil.java
@@ -53,7 +53,7 @@ public final class TestUtil {
    * https://android.googlesource.com/platform/libcore/+/master/support/src/test/java/libcore/
    * java/lang/ref/FinalizationTester.java
    */
-  public static void awaitGarbageCollection() throws InterruptedException {
+  public static void awaitGarbageCollection() throws Exception {
     Runtime.getRuntime().gc();
     Thread.sleep(100);
     System.runFinalization();

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -121,7 +121,7 @@ public final class URLConnectionTest {
   private HttpURLConnection connection;
   private Cache cache;
 
-  @Before public void setUp() throws Exception {
+  @Before public void setUp() {
     server.setProtocolNegotiationEnabled(false);
     urlFactory = new OkUrlFactory(defaultClient());
   }
@@ -140,7 +140,7 @@ public final class URLConnectionTest {
     }
   }
 
-  @Test public void requestHeaders() throws IOException, InterruptedException {
+  @Test public void requestHeaders() throws Exception {
     server.enqueue(new MockResponse());
 
     connection = urlFactory.open(server.url("/").url());
@@ -201,14 +201,14 @@ public final class URLConnectionTest {
     }
   }
 
-  @Test public void getRequestPropertyReturnsLastValue() throws Exception {
+  @Test public void getRequestPropertyReturnsLastValue() {
     connection = urlFactory.open(server.url("/").url());
     connection.addRequestProperty("A", "value1");
     connection.addRequestProperty("A", "value2");
     assertEquals("value2", connection.getRequestProperty("A"));
   }
 
-  @Test public void responseHeaders() throws IOException, InterruptedException {
+  @Test public void responseHeaders() throws Exception {
     server.enqueue(new MockResponse().setStatus("HTTP/1.0 200 Fantastic")
         .addHeader("A: c")
         .addHeader("B: d")
@@ -242,7 +242,7 @@ public final class URLConnectionTest {
     connection.getInputStream().close();
   }
 
-  @Test public void serverSendsInvalidResponseHeaders() throws Exception {
+  @Test public void serverSendsInvalidResponseHeaders() {
     server.enqueue(new MockResponse().setStatus("HTP/1.1 200 OK"));
 
     connection = urlFactory.open(server.url("/").url());
@@ -253,7 +253,7 @@ public final class URLConnectionTest {
     }
   }
 
-  @Test public void serverSendsInvalidCodeTooLarge() throws Exception {
+  @Test public void serverSendsInvalidCodeTooLarge() {
     server.enqueue(new MockResponse().setStatus("HTTP/1.1 2147483648 OK"));
 
     connection = urlFactory.open(server.url("/").url());
@@ -264,7 +264,7 @@ public final class URLConnectionTest {
     }
   }
 
-  @Test public void serverSendsInvalidCodeNotANumber() throws Exception {
+  @Test public void serverSendsInvalidCodeNotANumber() {
     server.enqueue(new MockResponse().setStatus("HTTP/1.1 00a OK"));
 
     connection = urlFactory.open(server.url("/").url());
@@ -275,7 +275,7 @@ public final class URLConnectionTest {
     }
   }
 
-  @Test public void serverSendsUnnecessaryWhitespace() throws Exception {
+  @Test public void serverSendsUnnecessaryWhitespace() {
     server.enqueue(new MockResponse().setStatus(" HTTP/1.1 2147483648 OK"));
 
     connection = urlFactory.open(server.url("/").url());
@@ -766,7 +766,7 @@ public final class URLConnectionTest {
    *
    * http://code.google.com/p/android/issues/detail?id=13178
    */
-  @Test public void connectViaHttpsToUntrustedServer() throws IOException, InterruptedException {
+  @Test public void connectViaHttpsToUntrustedServer() throws Exception {
     server.useHttps(sslClient.socketFactory, false);
     server.enqueue(new MockResponse()); // unused
 
@@ -1024,7 +1024,7 @@ public final class URLConnectionTest {
     assertEquals("android.com:443", connect.getHeader("Host"));
   }
 
-  private void initResponseCache() throws IOException {
+  private void initResponseCache() {
     cache = new Cache(tempDir.getRoot(), Integer.MAX_VALUE);
     urlFactory.setClient(urlFactory.client().newBuilder()
         .cache(cache)
@@ -1032,8 +1032,7 @@ public final class URLConnectionTest {
   }
 
   /** Test which headers are sent unencrypted to the HTTP proxy. */
-  @Test public void proxyConnectIncludesProxyHeadersOnly()
-      throws IOException, InterruptedException {
+  @Test public void proxyConnectIncludesProxyHeadersOnly() throws Exception {
     RecordingHostnameVerifier hostnameVerifier = new RecordingHostnameVerifier();
 
     server.useHttps(sslClient.socketFactory, true);
@@ -1332,7 +1331,7 @@ public final class URLConnectionTest {
    * This test checks whether connections are gzipped by default. This behavior in not required by
    * the API, so a failure of this test does not imply a bug in the implementation.
    */
-  @Test public void gzipEncodingEnabledByDefault() throws IOException, InterruptedException {
+  @Test public void gzipEncodingEnabledByDefault() throws Exception {
     server.enqueue(new MockResponse()
         .setBody(gzip("ABCABCABC"))
         .addHeader("Content-Encoding: gzip"));
@@ -1518,7 +1517,7 @@ public final class URLConnectionTest {
     assertEquals(0, server.takeRequest().getSequenceNumber()); // Connection is not pooled.
   }
 
-  @Test public void setChunkedStreamingMode() throws IOException, InterruptedException {
+  @Test public void setChunkedStreamingMode() throws Exception {
     server.enqueue(new MockResponse());
 
     String body = "ABCDEFGHIJKLMNOPQ";
@@ -2044,7 +2043,7 @@ public final class URLConnectionTest {
     }
   }
 
-  @Test public void redirectedOnHttps() throws IOException, InterruptedException {
+  @Test public void redirectedOnHttps() throws Exception {
     server.useHttps(sslClient.socketFactory, false);
     server.enqueue(new MockResponse().setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
         .addHeader("Location: /foo")
@@ -2066,7 +2065,7 @@ public final class URLConnectionTest {
     assertEquals("Expected connection reuse", 1, retry.getSequenceNumber());
   }
 
-  @Test public void notRedirectedFromHttpsToHttp() throws IOException, InterruptedException {
+  @Test public void notRedirectedFromHttpsToHttp() throws Exception {
     server.useHttps(sslClient.socketFactory, false);
     server.enqueue(new MockResponse().setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
         .addHeader("Location: http://anyhost/foo")
@@ -2081,7 +2080,7 @@ public final class URLConnectionTest {
     assertEquals("This page has moved!", readAscii(connection.getInputStream(), Integer.MAX_VALUE));
   }
 
-  @Test public void notRedirectedFromHttpToHttps() throws IOException, InterruptedException {
+  @Test public void notRedirectedFromHttpToHttps() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
         .addHeader("Location: https://anyhost/foo")
         .setBody("This page has moved!"));
@@ -2559,7 +2558,7 @@ public final class URLConnectionTest {
     }
   }
 
-  @Test public void setChunkedEncodingAsRequestProperty() throws IOException, InterruptedException {
+  @Test public void setChunkedEncodingAsRequestProperty() throws Exception {
     server.enqueue(new MockResponse());
 
     connection = urlFactory.open(server.url("/").url());
@@ -2572,7 +2571,7 @@ public final class URLConnectionTest {
     assertEquals("ABC", request.getBody().readUtf8());
   }
 
-  @Test public void connectionCloseInRequest() throws IOException, InterruptedException {
+  @Test public void connectionCloseInRequest() throws Exception {
     server.enqueue(new MockResponse()); // server doesn't honor the connection: close header!
     server.enqueue(new MockResponse());
 
@@ -2588,7 +2587,7 @@ public final class URLConnectionTest {
         server.takeRequest().getSequenceNumber());
   }
 
-  @Test public void connectionCloseInResponse() throws IOException, InterruptedException {
+  @Test public void connectionCloseInResponse() throws Exception {
     server.enqueue(new MockResponse().addHeader("Connection: close"));
     server.enqueue(new MockResponse());
 
@@ -2603,7 +2602,7 @@ public final class URLConnectionTest {
         server.takeRequest().getSequenceNumber());
   }
 
-  @Test public void connectionCloseWithRedirect() throws IOException, InterruptedException {
+  @Test public void connectionCloseWithRedirect() throws Exception {
     MockResponse response = new MockResponse()
         .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
         .addHeader("Location: /foo")
@@ -2642,7 +2641,7 @@ public final class URLConnectionTest {
     assertEquals(0, server.takeRequest().getSequenceNumber());
   }
 
-  @Test public void responseCodeDisagreesWithHeaders() throws IOException, InterruptedException {
+  @Test public void responseCodeDisagreesWithHeaders() throws Exception {
     server.enqueue(new MockResponse()
         .setResponseCode(HttpURLConnection.HTTP_NO_CONTENT)
         .setBody("This body is not allowed!"));
@@ -3274,14 +3273,14 @@ public final class URLConnectionTest {
     assertContent("A", connection);
   }
 
-  @Test public void http10SelectedProtocol() throws Exception {
+  @Test public void http10SelectedProtocol() {
     server.enqueue(new MockResponse().setStatus("HTTP/1.0 200 OK"));
     connection = urlFactory.open(server.url("/").url());
     List<String> protocolValues = connection.getHeaderFields().get(SELECTED_PROTOCOL);
     assertEquals(Arrays.asList("http/1.0"), protocolValues);
   }
 
-  @Test public void http11SelectedProtocol() throws Exception {
+  @Test public void http11SelectedProtocol() {
     server.enqueue(new MockResponse().setStatus("HTTP/1.1 200 OK"));
     connection = urlFactory.open(server.url("/").url());
     List<String> protocolValues = connection.getHeaderFields().get(SELECTED_PROTOCOL);
@@ -3289,7 +3288,7 @@ public final class URLConnectionTest {
   }
 
   /** For example, empty Protobuf RPC messages end up as a zero-length POST. */
-  @Test public void zeroLengthPost() throws IOException, InterruptedException {
+  @Test public void zeroLengthPost() throws Exception {
     zeroLengthPayload("POST");
   }
 
@@ -3299,7 +3298,7 @@ public final class URLConnectionTest {
   }
 
   /** For example, creating an Amazon S3 bucket ends up as a zero-length POST. */
-  @Test public void zeroLengthPut() throws IOException, InterruptedException {
+  @Test public void zeroLengthPut() throws Exception {
     zeroLengthPayload("PUT");
   }
 
@@ -3308,8 +3307,7 @@ public final class URLConnectionTest {
     zeroLengthPut();
   }
 
-  private void zeroLengthPayload(String method)
-      throws IOException, InterruptedException {
+  private void zeroLengthPayload(String method) throws Exception {
     server.enqueue(new MockResponse());
     connection = urlFactory.open(server.url("/").url());
     connection.setRequestProperty("Content-Length", "0");
@@ -3345,7 +3343,7 @@ public final class URLConnectionTest {
     assertContent("A", urlFactory.open(server.url("/").url()));
   }
 
-  @Test public void setProtocolsWithoutHttp11() throws Exception {
+  @Test public void setProtocolsWithoutHttp11() {
     try {
       new OkHttpClient.Builder().protocols(Arrays.asList(Protocol.HTTP_2));
       fail();
@@ -3353,7 +3351,7 @@ public final class URLConnectionTest {
     }
   }
 
-  @Test public void setProtocolsWithNull() throws Exception {
+  @Test public void setProtocolsWithNull() {
     try {
       new OkHttpClient.Builder().protocols(Arrays.asList(Protocol.HTTP_1_1, null));
       fail();

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/ThreadInterruptTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/ThreadInterruptTest.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static okhttp3.TestUtil.defaultClient;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class ThreadInterruptTest {
@@ -92,6 +93,9 @@ public final class ThreadInterruptTest {
       }
       fail("Expected thread to be interrupted");
     } catch (InterruptedIOException expected) {
+      // TODO(jwilson): test that we're interrupted once Okio retains interrupted state.
+      //     https://github.com/square/okhttp/issues/3107
+      if (false) assertTrue(Thread.interrupted());
     }
 
     connection.disconnect();
@@ -115,6 +119,9 @@ public final class ThreadInterruptTest {
       }
       fail("Expected thread to be interrupted");
     } catch (InterruptedIOException expected) {
+      // TODO(jwilson): test that we're interrupted once Okio retains interrupted state.
+      //     https://github.com/square/okhttp/issues/3107
+      if (false) assertTrue(Thread.interrupted());
     }
 
     responseBody.close();
@@ -128,7 +135,7 @@ public final class ThreadInterruptTest {
           sleep(delayMillis);
           toInterrupt.interrupt();
         } catch (InterruptedException e) {
-          throw new RuntimeException(e);
+          throw new AssertionError(e);
         }
       }
     };

--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
@@ -1572,7 +1572,7 @@ public final class Http2ConnectionTest {
    * creates more work for the watchdog and waits for that work to be executed. When it is, we know
    * work that preceded this call is complete.
    */
-  private void awaitWatchdogIdle() throws InterruptedException {
+  private void awaitWatchdogIdle() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     AsyncTimeout watchdogJob = new AsyncTimeout() {
       @Override protected void timedOut() {
@@ -1642,7 +1642,7 @@ public final class Http2ConnectionTest {
   private static class RecordingPushObserver implements PushObserver {
     final List<Object> events = new ArrayList<>();
 
-    public synchronized Object takeEvent() throws InterruptedException {
+    public synchronized Object takeEvent() throws Exception {
       while (events.isEmpty()) {
         wait();
       }

--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -868,7 +868,7 @@ public final class HttpOverHttp2Test {
   }
 
   /** Make a call and canceling it as soon as it's accepted by the server. */
-  private void callAndCancel(int expectedSequenceNumber) throws InterruptedException {
+  private void callAndCancel(int expectedSequenceNumber) throws Exception {
     Call call = client.newCall(new Request.Builder()
         .url(server.url("/"))
         .build());
@@ -913,7 +913,7 @@ public final class HttpOverHttp2Test {
     }
   }
 
-  @Test public void recoverFromConnectionNoNewStreamsOnFollowUp() throws InterruptedException {
+  @Test public void recoverFromConnectionNoNewStreamsOnFollowUp() throws Exception {
     server.enqueue(new MockResponse()
         .setResponseCode(401));
     server.enqueue(new MockResponse()

--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/MockHttp2Peer.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/MockHttp2Peer.java
@@ -100,7 +100,7 @@ public final class MockHttp2Peer implements Closeable {
     return writer;
   }
 
-  public InFrame takeFrame() throws InterruptedException {
+  public InFrame takeFrame() throws Exception {
     return inFrames.take();
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -79,7 +79,7 @@ public final class WebSocketHttpTest {
     clientListener.assertExhausted();
   }
 
-  @Test public void textMessage() throws IOException {
+  @Test public void textMessage() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
     WebSocket webSocket = newWebSocket();
 
@@ -90,7 +90,7 @@ public final class WebSocketHttpTest {
     serverListener.assertTextMessage("Hello, WebSockets!");
   }
 
-  @Test public void binaryMessage() throws IOException {
+  @Test public void binaryMessage() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
     WebSocket webSocket = newWebSocket();
 
@@ -101,7 +101,7 @@ public final class WebSocketHttpTest {
     serverListener.assertBinaryMessage(ByteString.of(new byte[] {'H', 'e', 'l', 'l', 'o', '!'}));
   }
 
-  @Test public void nullStringThrows() throws IOException {
+  @Test public void nullStringThrows() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
     WebSocket webSocket = newWebSocket();
 
@@ -114,7 +114,7 @@ public final class WebSocketHttpTest {
     }
   }
 
-  @Test public void nullByteStringThrows() throws IOException {
+  @Test public void nullByteStringThrows() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
     WebSocket webSocket = newWebSocket();
 
@@ -127,7 +127,7 @@ public final class WebSocketHttpTest {
     }
   }
 
-  @Test public void serverMessage() throws IOException {
+  @Test public void serverMessage() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
     newWebSocket();
 
@@ -155,7 +155,7 @@ public final class WebSocketHttpTest {
   }
 
   @Ignore("AsyncCall currently lets runtime exceptions propagate.")
-  @Test public void throwingOnFailLogs() throws InterruptedException {
+  @Test public void throwingOnFailLogs() throws Exception {
     TestLogHandler logs = new TestLogHandler();
     Logger logger = Logger.getLogger(OkHttpClient.class.getName());
     logger.addHandler(logs);
@@ -175,7 +175,7 @@ public final class WebSocketHttpTest {
     logger.removeHandler(logs);
   }
 
-  @Test public void throwingOnMessageClosesImmediatelyAndFails() throws IOException {
+  @Test public void throwingOnMessageClosesImmediatelyAndFails() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
     newWebSocket();
 
@@ -195,7 +195,7 @@ public final class WebSocketHttpTest {
     serverListener.assertExhausted();
   }
 
-  @Test public void throwingOnClosingClosesImmediatelyAndFails() throws IOException {
+  @Test public void throwingOnClosingClosesImmediatelyAndFails() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
     newWebSocket();
 
@@ -348,7 +348,7 @@ public final class WebSocketHttpTest {
         "Expected 'Sec-WebSocket-Accept' header value 'ujmZX4KXZqjwy6vi1aQFH5p4Ygk=' but was 'magic'");
   }
 
-  @Test public void webSocketAndApplicationInterceptors() throws IOException {
+  @Test public void webSocketAndApplicationInterceptors() {
     final AtomicInteger interceptedCount = new AtomicInteger();
 
     client = client.newBuilder()
@@ -374,10 +374,10 @@ public final class WebSocketHttpTest {
     server.close(1000, null);
   }
 
-  @Test public void webSocketAndNetworkInterceptors() throws IOException {
+  @Test public void webSocketAndNetworkInterceptors() {
     client = client.newBuilder()
         .addNetworkInterceptor(new Interceptor() {
-          @Override public Response intercept(Chain chain) throws IOException {
+          @Override public Response intercept(Chain chain) {
             throw new AssertionError(); // Network interceptors don't execute.
           }
         }).build();
@@ -392,7 +392,7 @@ public final class WebSocketHttpTest {
     server.close(1000, null);
   }
 
-  @Test public void overflowOutgoingQueue() throws IOException {
+  @Test public void overflowOutgoingQueue() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
 
     WebSocket webSocket = newWebSocket();
@@ -425,7 +425,7 @@ public final class WebSocketHttpTest {
     serverListener.assertClosed(1001, "");
   }
 
-  @Test public void closeReasonMaximumLength() throws IOException {
+  @Test public void closeReasonMaximumLength() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
 
     String clientReason = repeat('C', 123);
@@ -445,7 +445,7 @@ public final class WebSocketHttpTest {
     serverListener.assertClosed(1000, clientReason);
   }
 
-  @Test public void closeReasonTooLong() throws IOException {
+  @Test public void closeReasonTooLong() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
 
     WebSocket webSocket = newWebSocket();
@@ -470,15 +470,15 @@ public final class WebSocketHttpTest {
     serverListener.assertClosed(1000, "");
   }
 
-  @Test public void wsScheme() throws IOException {
+  @Test public void wsScheme() {
     websocketScheme("ws");
   }
 
-  @Test public void wsUppercaseScheme() throws IOException {
+  @Test public void wsUppercaseScheme() {
     websocketScheme("WS");
   }
 
-  @Test public void wssScheme() throws IOException {
+  @Test public void wssScheme() {
     webServer.useHttps(sslClient.socketFactory, false);
     client = client.newBuilder()
         .sslSocketFactory(sslClient.socketFactory, sslClient.trustManager)
@@ -488,7 +488,7 @@ public final class WebSocketHttpTest {
     websocketScheme("wss");
   }
 
-  @Test public void httpsScheme() throws IOException {
+  @Test public void httpsScheme() {
     webServer.useHttps(sslClient.socketFactory, false);
     client = client.newBuilder()
         .sslSocketFactory(sslClient.socketFactory, sslClient.trustManager)
@@ -498,7 +498,7 @@ public final class WebSocketHttpTest {
     websocketScheme("https");
   }
 
-  @Test public void readTimeoutAppliesToHttpRequest() throws IOException {
+  @Test public void readTimeoutAppliesToHttpRequest() {
     webServer.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.NO_RESPONSE));
 
@@ -513,9 +513,9 @@ public final class WebSocketHttpTest {
    * reading a frame we enable the read timeout. In this test we have the server returning the first
    * byte of a frame but no more frames.
    */
-  @Test public void readTimeoutAppliesWithinFrames() throws IOException {
+  @Test public void readTimeoutAppliesWithinFrames() {
     webServer.setDispatcher(new Dispatcher() {
-      @Override public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+      @Override public MockResponse dispatch(RecordedRequest request) {
         return upgradeResponse(request)
             .setBody(new Buffer().write(ByteString.decodeHex("81"))) // Truncated frame.
             .removeHeader("Content-Length")
@@ -596,7 +596,7 @@ public final class WebSocketHttpTest {
    * responding to pings. The client should give up when attempting to send its 2nd ping, at about
    * 1000 ms.
    */
-  @Test public void unacknowledgedPingFailsConnection() throws Exception {
+  @Test public void unacknowledgedPingFailsConnection() {
     client = client.newBuilder()
         .pingInterval(500, TimeUnit.MILLISECONDS)
         .build();
@@ -625,7 +625,7 @@ public final class WebSocketHttpTest {
   }
 
   /** https://github.com/square/okhttp/issues/2788 */
-  @Test public void clientCancelsIfCloseIsNotAcknowledged() throws Exception {
+  @Test public void clientCancelsIfCloseIsNotAcknowledged() {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
     RealWebSocket webSocket = newWebSocket();
 
@@ -647,7 +647,7 @@ public final class WebSocketHttpTest {
     serverListener.assertClosed(1000, "goodbye");
   }
 
-  @Test public void webSocketsDontTriggerEventListener() throws IOException {
+  @Test public void webSocketsDontTriggerEventListener() {
     RecordingEventListener listener = new RecordingEventListener();
 
     client = client.newBuilder()
@@ -683,7 +683,7 @@ public final class WebSocketHttpTest {
         .setHeader("Sec-WebSocket-Accept", WebSocketProtocol.acceptHeader(key));
   }
 
-  private void websocketScheme(String scheme) throws IOException {
+  private void websocketScheme(String scheme) {
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
 
     Request request = new Request.Builder()

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
@@ -132,6 +132,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
           throw propagate(callFailure);
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt(); // Retain interrupted status.
         throw new InterruptedIOException();
       }
     }
@@ -445,6 +446,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
             lock.wait(); // Wait until the response is returned or the call fails.
           }
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt(); // Retain interrupted status.
           throw new InterruptedIOException();
         }
       }
@@ -634,6 +636,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
             lock.wait(); // Wait until proceed() is called.
           }
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt(); // Retain interrupted status.
           throw new InterruptedIOException();
         }
       }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -307,6 +307,7 @@ public final class Http2Connection implements Closeable {
             Http2Connection.this.wait(); // Wait until we receive a WINDOW_UPDATE.
           }
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt(); // Retain interrupted status.
           throw new InterruptedIOException();
         }
 
@@ -395,13 +396,13 @@ public final class Http2Connection implements Closeable {
   }
 
   /** For testing: sends a ping and waits for a pong. */
-  void writePingAndAwaitPong() throws IOException, InterruptedException {
+  void writePingAndAwaitPong() throws InterruptedException {
     writePing(false, 0x4f4b6f6b /* "OKok" */, 0xf09f8da9 /* donut */);
     awaitPong();
   }
 
   /** For testing: waits until {@code requiredPongCount} pings have been received from the peer. */
-  synchronized void awaitPong() throws IOException, InterruptedException {
+  synchronized void awaitPong() throws InterruptedException {
     while (awaitingPong) {
       wait();
     }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.java
@@ -587,6 +587,7 @@ public final class Http2Stream {
     try {
       wait();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt(); // Retain interrupted status.
       throw new InterruptedIOException();
     }
   }

--- a/okhttp/src/main/java/okhttp3/internal/publicsuffix/PublicSuffixDatabase.java
+++ b/okhttp/src/main/java/okhttp3/internal/publicsuffix/PublicSuffixDatabase.java
@@ -114,6 +114,7 @@ public final class PublicSuffixDatabase {
       try {
         readCompleteLatch.await();
       } catch (InterruptedException ignored) {
+        Thread.currentThread().interrupt(); // Retain interrupted status.
       }
     }
 
@@ -299,7 +300,7 @@ public final class PublicSuffixDatabase {
       }
     } finally {
       if (interrupted) {
-        Thread.currentThread().interrupt();
+        Thread.currentThread().interrupt(); // Retain interrupted status.
       }
     }
   }

--- a/samples/slack/src/main/java/okhttp3/slack/OAuthSessionFactory.java
+++ b/samples/slack/src/main/java/okhttp3/slack/OAuthSessionFactory.java
@@ -76,7 +76,7 @@ public final class OAuthSessionFactory extends Dispatcher implements Closeable {
   }
 
   /** When the browser hits the redirect URL, use the provided code to ask Slack for a session. */
-  @Override public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+  @Override public MockResponse dispatch(RecordedRequest request) {
     HttpUrl requestUrl = mockWebServer.url(request.getPath());
     String code = requestUrl.queryParameter("code");
     String stateString = requestUrl.queryParameter("state");


### PR DESCRIPTION
The drawbacks seem small; the callsite needs to handle interruption anyway
because the thread is prone to interruption.

And the upside is that a single interrupt should now be sufficient to break
out an in-flight OkHttp call.

Note that although we're fixing this, thread interruption is not well tested
in OkHttp. Most users should prefer Call.cancel(), which is well tested and
doesn't rely on the caller to know which threads OkHttp is using to make
the actual HTTP request.

Closes: https://github.com/square/okhttp/issues/3945