### PR TITLE
Reverse suppression of connect exceptions

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteExceptionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteExceptionTest.java
@@ -18,6 +18,7 @@ package okhttp3.internal.connection;
 import java.io.IOException;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 public class RouteExceptionTest {
@@ -25,6 +26,7 @@ public class RouteExceptionTest {
   @Test public void getConnectionIOException_single() {
     IOException firstException = new IOException();
     RouteException re = new RouteException(firstException);
+    assertSame(firstException, re.getFirstConnectException());
     assertSame(firstException, re.getLastConnectException());
   }
 
@@ -36,12 +38,13 @@ public class RouteExceptionTest {
     re.addConnectException(secondException);
     re.addConnectException(thirdException);
 
-    IOException connectionIOException = re.getLastConnectException();
-    assertSame(thirdException, connectionIOException);
-    Throwable[] thirdSuppressedExceptions = thirdException.getSuppressed();
-    assertSame(secondException, thirdSuppressedExceptions[0]);
+    IOException connectionIOException = re.getFirstConnectException();
+    assertSame(firstException, connectionIOException);
+    Throwable[] suppressedExceptions = connectionIOException.getSuppressed();
+    assertEquals(2, suppressedExceptions.length);
+    assertSame(secondException, suppressedExceptions[0]);
+    assertSame(thirdException, suppressedExceptions[1]);
 
-    Throwable[] secondSuppressedException = secondException.getSuppressed();
-    assertSame(firstException, secondSuppressedException[0]);
+    assertSame(thirdException, re.getLastConnectException());
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteException.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteException.java
@@ -24,11 +24,17 @@ import static okhttp3.internal.Util.addSuppressedIfPossible;
  * have been made with alternative protocols, none of which were successful.
  */
 public final class RouteException extends RuntimeException {
+  private IOException firstException;
   private IOException lastException;
 
   public RouteException(IOException cause) {
     super(cause);
+    firstException = cause;
     lastException = cause;
+  }
+
+  public IOException getFirstConnectException() {
+    return firstException;
   }
 
   public IOException getLastConnectException() {
@@ -36,7 +42,7 @@ public final class RouteException extends RuntimeException {
   }
 
   public void addConnectException(IOException e) {
-    addSuppressedIfPossible(e, lastException);
+    addSuppressedIfPossible(firstException, e);
     lastException = e;
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.java
@@ -128,7 +128,7 @@ public final class RetryAndFollowUpInterceptor implements Interceptor {
       } catch (RouteException e) {
         // The attempt to connect via a route failed. The request will not have been sent.
         if (!recover(e.getLastConnectException(), streamAllocation, false, request)) {
-          throw e.getLastConnectException();
+          throw e.getFirstConnectException();
         }
         releaseConnection = false;
         continue;


### PR DESCRIPTION
Throw the first exception, with all following exceptions directly connected to the first instead of as a linked list.