### PR TITLE
Remove TLSv1.3 as default

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConscryptTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConscryptTest.java
@@ -45,7 +45,7 @@ public class ConscryptTest {
   private OkHttpClient buildClient() {
     ConnectionSpec spec = new ConnectionSpec.Builder(true)
         .cipherSuites(MANDATORY_CIPHER_SUITES) // Check we are using strong ciphers
-        .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2) // and modern TLS
+        .tlsVersions(TlsVersion.TLS_1_2) // and modern TLS
         .supportsTlsExtensions(true)
         .build();
 

--- a/okhttp/src/main/java/okhttp3/ConnectionSpec.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionSpec.java
@@ -76,14 +76,14 @@ public final class ConnectionSpec {
   /** A secure TLS connection assuming a modern client platform and server. */
   public static final ConnectionSpec RESTRICTED_TLS = new Builder(true)
       .cipherSuites(RESTRICTED_CIPHER_SUITES)
-      .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
+      .tlsVersions(TlsVersion.TLS_1_2)
       .supportsTlsExtensions(true)
       .build();
 
   /** A modern TLS connection with extensions like SNI and ALPN available. */
   public static final ConnectionSpec MODERN_TLS = new Builder(true)
       .cipherSuites(APPROVED_CIPHER_SUITES)
-      .tlsVersions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0)
+      .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0)
       .supportsTlsExtensions(true)
       .build();
 


### PR DESCRIPTION
We specify TLSv1.3, but without any compatible cipher suites.  So makes sense to remove for 3.11 to avoid weirdness as JVMs supporting TLSv1.3 start showing up.  n.b. JDK 11 detects this and strips anyway.