### PR TITLE
Validate the certificate's basic constraints.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
@@ -52,7 +52,7 @@ public final class ConnectionCoalescingTest {
   @Before public void setUp() throws Exception {
     rootCa = new HeldCertificate.Builder()
         .serialNumber(1L)
-        .certificateAuthority(3)
+        .certificateAuthority(0)
         .commonName("root")
         .build();
     certificate = new HeldCertificate.Builder()

--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
@@ -57,12 +57,12 @@ public final class CertificatePinnerChainValidationTest {
   @Test public void pinRootNotPresentInChain() throws Exception {
     HeldCertificate rootCa = new HeldCertificate.Builder()
         .serialNumber(1L)
-        .certificateAuthority(3)
+        .certificateAuthority(1)
         .commonName("root")
         .build();
     HeldCertificate intermediateCa = new HeldCertificate.Builder()
         .issuedBy(rootCa)
-        .certificateAuthority(2)
+        .certificateAuthority(0)
         .serialNumber(2L)
         .commonName("intermediate_ca")
         .build();
@@ -113,12 +113,12 @@ public final class CertificatePinnerChainValidationTest {
   @Test public void pinIntermediatePresentInChain() throws Exception {
     HeldCertificate rootCa = new HeldCertificate.Builder()
         .serialNumber(1L)
-        .certificateAuthority(3)
+        .certificateAuthority(1)
         .commonName("root")
         .build();
     HeldCertificate intermediateCa = new HeldCertificate.Builder()
         .issuedBy(rootCa)
-        .certificateAuthority(2)
+        .certificateAuthority(0)
         .serialNumber(2L)
         .commonName("intermediate_ca")
         .build();
@@ -174,7 +174,7 @@ public final class CertificatePinnerChainValidationTest {
     // Start with a trusted root CA certificate.
     HeldCertificate rootCa = new HeldCertificate.Builder()
         .serialNumber(1L)
-        .certificateAuthority(3)
+        .certificateAuthority(1)
         .commonName("root")
         .build();
 
@@ -183,7 +183,7 @@ public final class CertificatePinnerChainValidationTest {
     // certificate.
     HeldCertificate goodIntermediateCa = new HeldCertificate.Builder()
         .issuedBy(rootCa)
-        .certificateAuthority(2)
+        .certificateAuthority(0)
         .serialNumber(2L)
         .commonName("good_intermediate_ca")
         .build();
@@ -211,7 +211,7 @@ public final class CertificatePinnerChainValidationTest {
     // chain, we may trick the certificate pinner into accepting the rouge certificate.
     HeldCertificate compromisedIntermediateCa = new HeldCertificate.Builder()
         .issuedBy(rootCa)
-        .certificateAuthority(2)
+        .certificateAuthority(0)
         .serialNumber(4L)
         .commonName("bad_intermediate_ca")
         .build();
@@ -249,12 +249,12 @@ public final class CertificatePinnerChainValidationTest {
     // Start with two root CA certificates, one is good and the other is compromised.
     HeldCertificate rootCa = new HeldCertificate.Builder()
         .serialNumber(1L)
-        .certificateAuthority(3)
+        .certificateAuthority(1)
         .commonName("root")
         .build();
     HeldCertificate compromisedRootCa = new HeldCertificate.Builder()
         .serialNumber(2L)
-        .certificateAuthority(3)
+        .certificateAuthority(1)
         .commonName("compromised_root")
         .build();
 
@@ -263,7 +263,7 @@ public final class CertificatePinnerChainValidationTest {
     // certificate.
     HeldCertificate goodIntermediateCa = new HeldCertificate.Builder()
         .issuedBy(rootCa)
-        .certificateAuthority(2)
+        .certificateAuthority(0)
         .serialNumber(3L)
         .commonName("intermediate_ca")
         .build();
@@ -286,7 +286,7 @@ public final class CertificatePinnerChainValidationTest {
     // different set of certificates than the SSL verifier.
     HeldCertificate compromisedIntermediateCa = new HeldCertificate.Builder()
         .issuedBy(compromisedRootCa)
-        .certificateAuthority(2)
+        .certificateAuthority(0)
         .serialNumber(4L)
         .commonName("intermediate_ca")
         .build();

--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
@@ -62,13 +62,13 @@ public final class ClientAuthTest {
   public void setUp() {
     serverRootCa = new HeldCertificate.Builder()
         .serialNumber(1L)
-        .certificateAuthority(3)
+        .certificateAuthority(1)
         .commonName("root")
         .addSubjectAlternativeName("root_ca.com")
         .build();
     serverIntermediateCa = new HeldCertificate.Builder()
         .issuedBy(serverRootCa)
-        .certificateAuthority(2)
+        .certificateAuthority(0)
         .serialNumber(2L)
         .commonName("intermediate_ca")
         .addSubjectAlternativeName("intermediate_ca.com")
@@ -83,13 +83,13 @@ public final class ClientAuthTest {
 
     clientRootCa = new HeldCertificate.Builder()
         .serialNumber(1L)
-        .certificateAuthority(13)
+        .certificateAuthority(1)
         .commonName("root")
         .addSubjectAlternativeName("root_ca.com")
         .build();
     clientIntermediateCa = new HeldCertificate.Builder()
         .issuedBy(serverRootCa)
-        .certificateAuthority(12)
+        .certificateAuthority(0)
         .serialNumber(2L)
         .commonName("intermediate_ca")
         .addSubjectAlternativeName("intermediate_ca.com")

--- a/okhttp-tls/src/main/java/okhttp3/tls/HeldCertificate.java
+++ b/okhttp-tls/src/main/java/okhttp3/tls/HeldCertificate.java
@@ -209,7 +209,7 @@ public final class HeldCertificate {
     private BigInteger serialNumber;
     private KeyPair keyPair;
     private HeldCertificate issuedBy;
-    private int maxIntermediateCas;
+    private int maxIntermediateCas = -1;
     private String keyAlgorithm;
     private int keySize;
 
@@ -309,8 +309,16 @@ public final class HeldCertificate {
     /**
      * Set this certificate to be a signing certificate, with up to {@code maxIntermediateCas}
      * intermediate signing certificates beneath it.
+     *
+     * <p>By default this certificate cannot not sign other certificates. Set this to 0 so this
+     * certificate can sign other certificates (but those certificates cannot themselves sign
+     * certificates). Set this to 1 so this certificate can sign intermediate certificates that can
+     * themselves sign certificates. Add one for each additional layer of intermediates to permit.
      */
     public Builder certificateAuthority(int maxIntermediateCas) {
+      if (maxIntermediateCas < 0) {
+        throw new IllegalArgumentException("maxIntermediateCas < 0: " + maxIntermediateCas);
+      }
       this.maxIntermediateCas = maxIntermediateCas;
       return this;
     }
@@ -372,7 +380,7 @@ public final class HeldCertificate {
           ? "SHA256WithRSAEncryption"
           : "SHA256withECDSA");
 
-      if (maxIntermediateCas > 0) {
+      if (maxIntermediateCas != -1) {
         generator.addExtension(X509Extensions.BasicConstraints, true,
             new BasicConstraints(maxIntermediateCas));
       }


### PR DESCRIPTION
Also fix our calling code to have the smallest path lengths possible.
http://www.ietf.org/rfc/rfc3280.txt