### PR TITLE
Fixup HeldCertificate so that it's worthy of production use.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -1086,8 +1086,8 @@ public final class CallTest {
     client = client.newBuilder()
         .hostnameVerifier(new RecordingHostnameVerifier())
         .dns(new SingleInetAddressDns())
-        // opt-in to fallback to COMPATIBLE_TLS
-        .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
+        // Attempt RESTRICTED_TLS then fall back to MODERN_TLS.
+        .connectionSpecs(Arrays.asList(ConnectionSpec.RESTRICTED_TLS, ConnectionSpec.MODERN_TLS))
         .sslSocketFactory(suppressTlsFallbackClientSocketFactory(), tlsNode.trustManager())
         .build();
 
@@ -1110,8 +1110,8 @@ public final class CallTest {
         new RecordingSSLSocketFactory(tlsNode.sslSocketFactory());
     client = client.newBuilder()
         .sslSocketFactory(clientSocketFactory, tlsNode.trustManager())
-        // opt-in to fallback to COMPATIBLE_TLS
-        .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
+        // Attempt RESTRICTED_TLS then fall back to MODERN_TLS.
+        .connectionSpecs(Arrays.asList(ConnectionSpec.RESTRICTED_TLS, ConnectionSpec.MODERN_TLS))
         .hostnameVerifier(new RecordingHostnameVerifier())
         .dns(new SingleInetAddressDns())
         .build();
@@ -1137,7 +1137,8 @@ public final class CallTest {
 
     client = client.newBuilder()
         .hostnameVerifier(new RecordingHostnameVerifier())
-        .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
+        // Attempt RESTRICTED_TLS then fall back to MODERN_TLS.
+        .connectionSpecs(Arrays.asList(ConnectionSpec.RESTRICTED_TLS, ConnectionSpec.MODERN_TLS))
         .sslSocketFactory(suppressTlsFallbackClientSocketFactory(), tlsNode.trustManager())
         .build();
 

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -691,7 +691,8 @@ public final class URLConnectionTest {
 
     urlFactory.setClient(urlFactory.client().newBuilder()
         .hostnameVerifier(new RecordingHostnameVerifier())
-        .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
+        // Attempt RESTRICTED_TLS then fall back to MODERN_TLS.
+        .connectionSpecs(Arrays.asList(ConnectionSpec.RESTRICTED_TLS, ConnectionSpec.MODERN_TLS))
         .sslSocketFactory(suppressTlsFallbackClientSocketFactory(), tlsNode.trustManager())
         .build());
     connection = urlFactory.open(server.url("/foo").url());
@@ -703,7 +704,7 @@ public final class URLConnectionTest {
 
     RecordedRequest fallbackRequest = server.takeRequest();
     assertEquals("GET /foo HTTP/1.1", fallbackRequest.getRequestLine());
-    assertEquals(TlsVersion.TLS_1_0, fallbackRequest.getTlsVersion());
+    assertEquals(TlsVersion.TLS_1_2, fallbackRequest.getTlsVersion());
   }
 
   @Test public void connectViaHttpsWithSSLFallbackFailuresRecorded() throws Exception {

--- a/okhttp-tls/src/test/java/okhttp3/tls/HeldCertificateTest.java
+++ b/okhttp-tls/src/test/java/okhttp3/tls/HeldCertificateTest.java
@@ -142,6 +142,7 @@ public class HeldCertificateTest {
         .keyPair(publicKey, privateKey)
         .commonName("cash.app")
         .validityInterval(0L, 1_000L)
+        .rsa2048()
         .build();
 
     assertEquals(heldCertificate.certificatePem(), ""
@@ -191,5 +192,35 @@ public class HeldCertificateTest {
         + "LidU7mIE65swMM5/RNhS4aFjez/MwxFNOHaxc9VgCwYPXCLOtdf7AVovdyG0XWgb\n"
         + "UXH+NyxKwboE\n"
         + "-----END PRIVATE KEY-----\n");
+  }
+
+  @Test public void ecdsaSignedByRsa() {
+    HeldCertificate root = new HeldCertificate.Builder()
+        .certificateAuthority(0)
+        .rsa2048()
+        .build();
+    HeldCertificate leaf = new HeldCertificate.Builder()
+        .certificateAuthority(0)
+        .ecdsa256()
+        .issuedBy(root)
+        .build();
+
+    assertEquals("SHA256WITHRSA", root.certificate().getSigAlgName());
+    assertEquals("SHA256WITHRSA", leaf.certificate().getSigAlgName());
+  }
+
+  @Test public void rsaSignedByEcdsa() {
+    HeldCertificate root = new HeldCertificate.Builder()
+        .certificateAuthority(0)
+        .ecdsa256()
+        .build();
+    HeldCertificate leaf = new HeldCertificate.Builder()
+        .certificateAuthority(0)
+        .rsa2048()
+        .issuedBy(root)
+        .build();
+
+    assertEquals("SHA256WITHECDSA", root.certificate().getSigAlgName());
+    assertEquals("SHA256WITHECDSA", leaf.certificate().getSigAlgName());
   }
 }

--- a/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
+++ b/okhttp-urlconnection/src/test/java/okhttp3/UrlConnectionCacheTest.java
@@ -85,7 +85,7 @@ public final class UrlConnectionCacheTest {
   private Cache cache;
   private final CookieManager cookieManager = new CookieManager();
 
-  @Before public void setUp() throws Exception {
+  @Before public void setUp() {
     server.setProtocolNegotiationEnabled(false);
     cache = new Cache(new File("/cache/"), Integer.MAX_VALUE, fileSystem);
     urlFactory = new OkUrlFactory(new OkHttpClient.Builder()
@@ -99,7 +99,7 @@ public final class UrlConnectionCacheTest {
     cache.delete();
   }
 
-  @Test public void responseCacheAccessWithOkHttpMember() throws IOException {
+  @Test public void responseCacheAccessWithOkHttpMember() {
     assertSame(cache, urlFactory.client().cache());
   }
 
@@ -264,7 +264,8 @@ public final class UrlConnectionCacheTest {
     assumeFalse(getPlatform().equals("jdk9"));
 
     server.useHttps(tlsNode.sslSocketFactory(), false);
-    server.enqueue(new MockResponse().addHeader("Last-Modified: " + formatDate(-1, TimeUnit.HOURS))
+    server.enqueue(new MockResponse()
+        .addHeader("Last-Modified: " + formatDate(-1, TimeUnit.HOURS))
         .addHeader("Expires: " + formatDate(1, TimeUnit.HOURS))
         .setBody("ABC"));
 
@@ -413,7 +414,7 @@ public final class UrlConnectionCacheTest {
     testServerPrematureDisconnect(TransferKind.CHUNKED);
   }
 
-  @Test public void serverDisconnectsPrematurelyWithNoLengthHeaders() throws IOException {
+  @Test public void serverDisconnectsPrematurelyWithNoLengthHeaders() {
     // Intentionally empty. This case doesn't make sense because there's no
     // such thing as a premature disconnect when the disconnect itself
     // indicates the end of the data stream.
@@ -1806,8 +1807,7 @@ public final class UrlConnectionCacheTest {
 
   enum TransferKind {
     CHUNKED() {
-      @Override void setBody(MockResponse response, Buffer content, int chunkSize)
-          throws IOException {
+      @Override void setBody(MockResponse response, Buffer content, int chunkSize) {
         response.setChunkedBody(content, chunkSize);
       }
     },


### PR DESCRIPTION
This changes the default from the insecure 1024-bit RSA to a secure 256-bit ECDSA
key. It adds a new option to use RSA keys for interoperating with older clients.