### PR TITLE
Make separate IPv4 and IPv6 requests for DNS over HTTPS

### DIFF
--- a/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsOverHttps.java
+++ b/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsOverHttps.java
@@ -36,6 +36,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.internal.Util;
 import okhttp3.internal.platform.Platform;
 import okhttp3.internal.publicsuffix.PublicSuffixDatabase;
 import okio.ByteString;
@@ -226,7 +227,7 @@ public class DnsOverHttps implements Dns {
     unknownHostException.initCause(failure);
 
     for (int i = 1; i < failures.size(); i++) {
-      unknownHostException.addSuppressed(failures.get(i));
+      Util.addSuppressedIfPossible(unknownHostException, failures.get(i));
     }
 
     throw unknownHostException;

--- a/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsOverHttps.java
+++ b/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsOverHttps.java
@@ -16,7 +16,6 @@
 package okhttp3.dnsoverhttps;
 
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;

--- a/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsOverHttps.java
+++ b/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsOverHttps.java
@@ -304,11 +304,13 @@ public class DnsOverHttps implements Dns {
     @Nullable HttpUrl url = null;
     boolean includeIPv6 = true;
     boolean post = false;
-    MediaType contentType = DNS_MESSAGE;
     Dns systemDns = Dns.SYSTEM;
     @Nullable List<InetAddress> bootstrapDnsHosts = null;
     boolean resolvePrivateAddresses = false;
     boolean resolvePublicAddresses = true;
+
+    public Builder() {
+    }
 
     public DnsOverHttps build() {
       return new DnsOverHttps(this);
@@ -331,11 +333,6 @@ public class DnsOverHttps implements Dns {
 
     public Builder post(boolean post) {
       this.post = post;
-      return this;
-    }
-
-    public Builder contentType(MediaType contentType) {
-      this.contentType = contentType;
       return this;
     }
 

--- a/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsRecordCodec.java
+++ b/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsRecordCodec.java
@@ -91,7 +91,6 @@ class DnsRecordCodec {
 
     final int questionCount = buf.readShort() & 0xffff;
     final int answerCount = buf.readShort() & 0xffff;
-    //System.out.println(answerCount);
     buf.readShort(); // authority record count
     buf.readShort(); // additional record count
 
@@ -108,8 +107,6 @@ class DnsRecordCodec {
       buf.readShort(); // class
       final long ttl = buf.readInt() & 0xffffffffL; // ttl
       final int length = buf.readShort() & 0xffff;
-
-      //System.out.println(type);
 
       if (type == TYPE_A || type == TYPE_AAAA) {
         byte[] bytes = new byte[length];

--- a/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsRecordCodec.java
+++ b/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsRecordCodec.java
@@ -31,20 +31,20 @@ import okio.Utf8;
 class DnsRecordCodec {
   private static final byte SERVFAIL = 2;
   private static final byte NXDOMAIN = 3;
-  private static final int TYPE_A = 0x0001;
-  private static final int TYPE_AAAA = 0x001c;
+  public static final int TYPE_A = 0x0001;
+  public static final int TYPE_AAAA = 0x001c;
   private static final int TYPE_PTR = 0x000c;
   private static final Charset ASCII = Charset.forName("ASCII");
 
   private DnsRecordCodec() {
   }
 
-  public static ByteString encodeQuery(String host, boolean includeIPv6) {
+  public static ByteString encodeQuery(String host, int type) {
     Buffer buf = new Buffer();
 
     buf.writeShort(0); // query id
     buf.writeShort(256); // flags with recursion
-    buf.writeShort(includeIPv6 ? 2 : 1); // question count
+    buf.writeShort(1); // question count
     buf.writeShort(0); // answerCount
     buf.writeShort(0); // authorityResourceCount
     buf.writeShort(0); // additional
@@ -62,14 +62,8 @@ class DnsRecordCodec {
     nameBuf.writeByte(0); // end
 
     nameBuf.copyTo(buf, 0, nameBuf.size());
-    buf.writeShort(TYPE_A);
+    buf.writeShort(type);
     buf.writeShort(1); // CLASS_IN
-
-    if (includeIPv6) {
-      nameBuf.copyTo(buf, 0, nameBuf.size());
-      buf.writeShort(TYPE_AAAA);
-      buf.writeShort(1); // CLASS_IN
-    }
 
     return buf.readByteString();
   }
@@ -97,6 +91,7 @@ class DnsRecordCodec {
 
     final int questionCount = buf.readShort() & 0xffff;
     final int answerCount = buf.readShort() & 0xffff;
+    //System.out.println(answerCount);
     buf.readShort(); // authority record count
     buf.readShort(); // additional record count
 
@@ -113,6 +108,8 @@ class DnsRecordCodec {
       buf.readShort(); // class
       final long ttl = buf.readInt() & 0xffffffffL; // ttl
       final int length = buf.readShort() & 0xffff;
+
+      //System.out.println(type);
 
       if (type == TYPE_A || type == TYPE_AAAA) {
         byte[] bytes = new byte[length];

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.java
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import okhttp3.Cache;
 import okhttp3.Dns;
@@ -82,18 +84,20 @@ public class DnsOverHttpsTest {
 
     List<InetAddress> result = dns.lookup("google.com");
 
-    assertEquals(asList(address("157.240.1.18"), address("2a03:2880:f029:11:face:b00c:0:2")),
-        result);
+    assertEquals(2, result.size());
+    assertTrue(result.contains(address("157.240.1.18")));
+    assertTrue(result.contains(address("2a03:2880:f029:11:face:b00c:0:2")));
 
-    RecordedRequest recordedRequestIpv4 = server.takeRequest();
-    assertEquals("GET", recordedRequestIpv4.getMethod());
-    assertEquals("/lookup?ct&dns=AAABAAABAAAAAAAABmdvb2dsZQNjb20AAAEAAQ",
-        recordedRequestIpv4.getPath());
+    RecordedRequest request1 = server.takeRequest();
+    assertEquals("GET", request1.getMethod());
 
-    RecordedRequest recordedRequestIpv6 = server.takeRequest();
-    assertEquals("GET", recordedRequestIpv6.getMethod());
-    assertEquals("/lookup?ct&dns=AAABAAABAAAAAAAABmdvb2dsZQNjb20AABwAAQ",
-        recordedRequestIpv6.getPath());
+    RecordedRequest request2 = server.takeRequest();
+    assertEquals("GET", request2.getMethod());
+
+    assertEquals(new HashSet<>(
+            Arrays.asList("/lookup?ct&dns=AAABAAABAAAAAAAABmdvb2dsZQNjb20AAAEAAQ",
+                "/lookup?ct&dns=AAABAAABAAAAAAAABmdvb2dsZQNjb20AABwAAQ")),
+        new LinkedHashSet<>(Arrays.asList(request1.getPath(), request2.getPath())));
   }
 
   @Test public void failure() throws Exception {

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.java
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -44,9 +45,8 @@ public class DnsOverHttpsTest {
   @Rule public final MockWebServer server = new MockWebServer();
 
   private final OkHttpClient bootstrapClient =
-      new OkHttpClient.Builder().protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1))
-          .build();
-  private final Dns dns = buildLocalhost(bootstrapClient);
+      new OkHttpClient.Builder().protocols(asList(Protocol.HTTP_2, Protocol.HTTP_1_1)).build();
+  private Dns dns = buildLocalhost(bootstrapClient, false);
 
   @Before public void setUp() {
     server.setProtocols(bootstrapClient.protocols());
@@ -64,24 +64,36 @@ public class DnsOverHttpsTest {
 
     RecordedRequest recordedRequest = server.takeRequest();
     assertEquals("GET", recordedRequest.getMethod());
-    assertEquals("/lookup?ct&dns=AAABAAACAAAAAAAABmdvb2dsZQNjb20AAAEAAQZnb29nbGUDY29t"
-        + "AAAcAAE", recordedRequest.getPath());
+    assertEquals("/lookup?ct&dns=AAABAAABAAAAAAAABmdvb2dsZQNjb20AAAEAAQ",
+        recordedRequest.getPath());
   }
 
   @Test public void getIpv6() throws Exception {
+    server.enqueue(dnsResponse(
+        "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c00050001"
+            + "00000a6d000603617069c012c0300005000100000cde000c04737461720463313072c012c04200010"
+            + "0010000003b00049df00112"));
     server.enqueue(dnsResponse(
         "0000818000010003000000000567726170680866616365626f6f6b03636f6d00001c0001c00c00050001"
             + "00000a1b000603617069c012c0300005000100000b1f000c04737461720463313072c012c042001c0"
             + "0010000003b00102a032880f0290011faceb00c00000002"));
 
+    dns = buildLocalhost(bootstrapClient, true);
+
     List<InetAddress> result = dns.lookup("google.com");
 
-    assertEquals(singletonList(address("2a03:2880:f029:11:face:b00c:0:2")), result);
+    assertEquals(asList(address("157.240.1.18"), address("2a03:2880:f029:11:face:b00c:0:2")),
+        result);
 
-    RecordedRequest recordedRequest = server.takeRequest();
-    assertEquals("GET", recordedRequest.getMethod());
-    assertEquals("/lookup?ct&dns=AAABAAACAAAAAAAABmdvb2dsZQNjb20AAAEAAQZnb29nbGUDY29t"
-        + "AAAcAAE", recordedRequest.getPath());
+    RecordedRequest recordedRequestIpv4 = server.takeRequest();
+    assertEquals("GET", recordedRequestIpv4.getMethod());
+    assertEquals("/lookup?ct&dns=AAABAAABAAAAAAAABmdvb2dsZQNjb20AAAEAAQ",
+        recordedRequestIpv4.getPath());
+
+    RecordedRequest recordedRequestIpv6 = server.takeRequest();
+    assertEquals("GET", recordedRequestIpv6.getMethod());
+    assertEquals("/lookup?ct&dns=AAABAAABAAAAAAAABmdvb2dsZQNjb20AABwAAQ",
+        recordedRequestIpv6.getPath());
   }
 
   @Test public void failure() throws Exception {
@@ -100,8 +112,8 @@ public class DnsOverHttpsTest {
 
     RecordedRequest recordedRequest = server.takeRequest();
     assertEquals("GET", recordedRequest.getMethod());
-    assertEquals("/lookup?ct&dns=AAABAAACAAAAAAAABmdvb2dsZQNjb20AAAEAAQZnb29nbGUDY29t"
-        + "AAAcAAE", recordedRequest.getPath());
+    assertEquals("/lookup?ct&dns=AAABAAABAAAAAAAABmdvb2dsZQNjb20AAAEAAQ",
+        recordedRequest.getPath());
   }
 
   @Test public void failOnExcessiveResponse() {
@@ -145,13 +157,12 @@ public class DnsOverHttpsTest {
   @Test public void usesCache() throws Exception {
     Cache cache = new Cache(new File("./target/DnsOverHttpsTest.cache"), 100 * 1024);
     OkHttpClient cachedClient = bootstrapClient.newBuilder().cache(cache).build();
-    DnsOverHttps cachedDns = buildLocalhost(cachedClient);
+    DnsOverHttps cachedDns = buildLocalhost(cachedClient, false);
 
     server.enqueue(dnsResponse(
         "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c00050001"
             + "00000a6d000603617069c012c0300005000100000cde000c04737461720463313072c012c04200010"
-            + "0010000003b00049df00112")
-        .setHeader("cache-control", "private, max-age=298"));
+            + "0010000003b00049df00112").setHeader("cache-control", "private, max-age=298"));
 
     List<InetAddress> result = cachedDns.lookup("google.com");
 
@@ -159,23 +170,26 @@ public class DnsOverHttpsTest {
 
     RecordedRequest recordedRequest = server.takeRequest();
     assertEquals("GET", recordedRequest.getMethod());
-    assertEquals("/lookup?ct&dns=AAABAAACAAAAAAAABmdvb2dsZQNjb20AAAEAAQZnb29nbGUDY29t"
-        + "AAAcAAE", recordedRequest.getPath());
+    assertEquals("/lookup?ct&dns=AAABAAABAAAAAAAABmdvb2dsZQNjb20AAAEAAQ",
+        recordedRequest.getPath());
 
     result = cachedDns.lookup("google.com");
     assertEquals(singletonList(address("157.240.1.18")), result);
   }
 
   private MockResponse dnsResponse(String s) {
-    return new MockResponse()
-        .setBody(new Buffer().write(ByteString.decodeHex(s)))
+    return new MockResponse().setBody(new Buffer().write(ByteString.decodeHex(s)))
         .addHeader("content-type", "application/dns-message")
         .addHeader("content-length", s.length() / 2);
   }
 
-  private DnsOverHttps buildLocalhost(OkHttpClient bootstrapClient) {
+  private DnsOverHttps buildLocalhost(OkHttpClient bootstrapClient, boolean includeIPv6) {
     HttpUrl url = server.url("/lookup?ct");
-    return new DnsOverHttps.Builder().client(bootstrapClient).resolvePrivateAddresses(true).url(url).build();
+    return new DnsOverHttps.Builder().client(bootstrapClient)
+        .includeIPv6(includeIPv6)
+        .resolvePrivateAddresses(true)
+        .url(url)
+        .build();
   }
 
   private static InetAddress address(String host) {

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsRecordCodecTest.java
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsRecordCodecTest.java
@@ -22,24 +22,26 @@ import java.util.List;
 import okio.ByteString;
 import org.junit.Test;
 
+import static okhttp3.dnsoverhttps.DnsRecordCodec.TYPE_A;
+import static okhttp3.dnsoverhttps.DnsRecordCodec.TYPE_AAAA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class DnsRecordCodecTest {
   @Test public void testGoogleDotComEncoding() {
-    String encoded = encodeQuery("google.com", false);
+    String encoded = encodeQuery("google.com", TYPE_A);
 
     assertEquals("AAABAAABAAAAAAAABmdvb2dsZQNjb20AAAEAAQ", encoded);
   }
 
-  private String encodeQuery(String host, boolean includeIpv6) {
-    return DnsRecordCodec.encodeQuery(host, includeIpv6).base64Url().replace("=", "");
+  private String encodeQuery(String host, int type) {
+    return DnsRecordCodec.encodeQuery(host, type).base64Url().replace("=", "");
   }
 
   @Test public void testGoogleDotComEncodingWithIPv6() {
-    String encoded = encodeQuery("google.com", true);
+    String encoded = encodeQuery("google.com", TYPE_AAAA);
 
-    assertEquals("AAABAAACAAAAAAAABmdvb2dsZQNjb20AAAEAAQZnb29nbGUDY29tAAAcAAE", encoded);
+    assertEquals("AAABAAABAAAAAAAABmdvb2dsZQNjb20AABwAAQ", encoded);
   }
 
   @Test public void testGoogleDotComDecodingFromCloudflare() throws Exception {


### PR DESCRIPTION
while technically inside the spec, in practice multiple DNS questions must be asked in different messages.  So make two calls instead of one.