### PR TITLE
MockWebserver fix for IPv6 addresses

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
@@ -78,7 +78,7 @@ public final class RecordedRequest {
       }
 
       int port = socket.getLocalPort();
-      this.requestUrl = HttpUrl.get(String.format("%s://%s:%s%s", scheme, hostname, port, path));
+      this.requestUrl = HttpUrl.parse(String.format("%s://%s:%s%s", scheme, hostname, port, path));
     } else {
       this.requestUrl = null;
       this.method = null;

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
@@ -63,11 +63,11 @@ public final class RecordedRequest {
       int methodEnd = requestLine.indexOf(' ');
       int pathEnd = requestLine.indexOf(' ', methodEnd + 1);
       this.method = requestLine.substring(0, methodEnd);
-      if (this.method.equals("CONNECT")) {
-        this.path = "/";
-      } else {
-        this.path = requestLine.substring(methodEnd + 1, pathEnd);
+      String path = requestLine.substring(methodEnd + 1, pathEnd);
+      if (!path.startsWith("/")) {
+        path = "/";
       }
+      this.path = path;
 
       String scheme = socket instanceof SSLSocket ? "https" : "http";
       InetAddress inetAddress = socket.getInetAddress();

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
@@ -63,7 +63,11 @@ public final class RecordedRequest {
       int methodEnd = requestLine.indexOf(' ');
       int pathEnd = requestLine.indexOf(' ', methodEnd + 1);
       this.method = requestLine.substring(0, methodEnd);
-      this.path = requestLine.substring(methodEnd + 1, pathEnd);
+      if (this.method.equals("CONNECT")) {
+        this.path = "/";
+      } else {
+        this.path = requestLine.substring(methodEnd + 1, pathEnd);
+      }
 
       String scheme = socket instanceof SSLSocket ? "https" : "http";
       InetAddress inetAddress = socket.getInetAddress();

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
@@ -17,6 +17,8 @@
 package okhttp3.mockwebserver;
 
 import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.Socket;
 import java.util.List;
 import javax.net.ssl.SSLSocket;
@@ -64,9 +66,15 @@ public final class RecordedRequest {
       this.path = requestLine.substring(methodEnd + 1, pathEnd);
 
       String scheme = socket instanceof SSLSocket ? "https" : "http";
-      String hostname = socket.getInetAddress().getHostName();
+      InetAddress inetAddress = socket.getInetAddress();
+
+      String hostname = inetAddress.getHostName();
+      if (inetAddress instanceof Inet6Address) {
+        hostname = "[" + hostname + "]";
+      }
+
       int port = socket.getLocalPort();
-      this.requestUrl = HttpUrl.parse(String.format("%s://%s:%s%s", scheme, hostname, port, path));
+      this.requestUrl = HttpUrl.get(String.format("%s://%s:%s%s", scheme, hostname, port, path));
     } else {
       this.requestUrl = null;
       this.method = null;

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
@@ -78,6 +78,7 @@ public final class RecordedRequest {
       }
 
       int port = socket.getLocalPort();
+      // Allow null in failure case to allow for testing bad requests
       this.requestUrl = HttpUrl.parse(String.format("%s://%s:%s%s", scheme, hostname, port, path));
     } else {
       this.requestUrl = null;

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
@@ -27,7 +27,7 @@ public class RecordedRequestTest {
       return inetAddress;
     }
 
-    @Override public int getPort() {
+    @Override public int getLocalPort() {
       return port;
     }
   }

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
@@ -40,7 +40,7 @@ public class RecordedRequestTest {
         new RecordedRequest("GET / HTTP/1.1", headers, Collections.<Integer>emptyList(), 0,
             new Buffer(), 0, socket);
 
-    assertEquals(HttpUrl.get("http://127.0.0.1:80"), request.getRequestUrl());
+    assertEquals("http://127.0.0.1/", request.getRequestUrl().toString());
   }
 
   @Test public void testIPv6() throws UnknownHostException {
@@ -51,6 +51,6 @@ public class RecordedRequestTest {
         new RecordedRequest("GET / HTTP/1.1", headers, Collections.<Integer>emptyList(), 0,
             new Buffer(), 0, socket);
 
-    assertEquals(HttpUrl.get("http://[0:0:0:0:0:0:0:1]:80"), request.getRequestUrl());
+    assertEquals("http://[::1]/", request.getRequestUrl().toString());
   }
 }

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
@@ -44,7 +44,7 @@ public class RecordedRequestTest {
   }
 
   @Test public void testIPv6() throws UnknownHostException {
-    Socket socket = new FakeSocket(InetAddress.getByAddress("0:0:0:0:0:0:0:1",
+    Socket socket = new FakeSocket(InetAddress.getByAddress("::1",
         new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 80);
 
     RecordedRequest request =

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
@@ -1,0 +1,56 @@
+package okhttp3.mockwebserver;
+
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okio.Buffer;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RecordedRequestTest {
+  Headers headers = new Headers.Builder().build();
+
+  private class FakeSocket extends Socket {
+    private InetAddress inetAddress;
+    private int port;
+
+    private FakeSocket(InetAddress inetAddress, int port) {
+      this.inetAddress = inetAddress;
+      this.port = port;
+    }
+
+    @Override public InetAddress getInetAddress() {
+      return inetAddress;
+    }
+
+    @Override public int getPort() {
+      return port;
+    }
+  }
+
+  @Test public void testIPv4() throws UnknownHostException {
+    Socket socket =
+        new FakeSocket(InetAddress.getByAddress("127.0.0.1", new byte[] { 127, 0, 0, 1 }), 80);
+
+    RecordedRequest request =
+        new RecordedRequest("GET / HTTP/1.1", headers, Collections.<Integer>emptyList(), 0,
+            new Buffer(), 0, socket);
+
+    assertEquals(HttpUrl.get("http://127.0.0.1:80"), request.getRequestUrl());
+  }
+
+  @Test public void testIPv6() throws UnknownHostException {
+    Socket socket = new FakeSocket(InetAddress.getByAddress("0:0:0:0:0:0:0:1",
+        new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 80);
+
+    RecordedRequest request =
+        new RecordedRequest("GET / HTTP/1.1", headers, Collections.<Integer>emptyList(), 0,
+            new Buffer(), 0, socket);
+
+    assertEquals(HttpUrl.get("http://[0:0:0:0:0:0:0:1]:80"), request.getRequestUrl());
+  }
+}


### PR DESCRIPTION
surround IPv6 addresses with [] to make a valid URI

https://github.com/square/okhttp/issues/4225