### PR TITLE
Record proxy path also

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.java
@@ -65,7 +65,7 @@ public final class RecordedRequest {
       this.method = requestLine.substring(0, methodEnd);
       String path = requestLine.substring(methodEnd + 1, pathEnd);
       if (!path.startsWith("/")) {
-        path = "/";
+        path = "/" + path;
       }
       this.path = path;
 

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/RecordedRequestTest.java
@@ -5,7 +5,6 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import okhttp3.Headers;
-import okhttp3.HttpUrl;
 import okio.Buffer;
 import org.junit.Test;
 
@@ -30,6 +29,16 @@ public class RecordedRequestTest {
     @Override public int getLocalPort() {
       return port;
     }
+  }
+
+  @Test public void testIPv4Proxy() throws UnknownHostException {
+    Socket socket =
+        new FakeSocket(InetAddress.getByAddress("127.0.0.1", new byte[] { 127, 0, 0, 1 }), 80);
+
+    RecordedRequest request = new RecordedRequest("CONNECT android.com:443 HTTP/1.1", headers,
+        Collections.<Integer>emptyList(), 0, new Buffer(), 0, socket);
+
+    assertEquals("http://127.0.0.1/android.com:443", request.getRequestUrl().toString());
   }
 
   @Test public void testIPv4() throws UnknownHostException {


### PR DESCRIPTION
For proxied requests, record more data to make the request identifiable.