### PR TITLE
Nullable route annotation

### DIFF
--- a/okhttp/src/main/java/okhttp3/Authenticator.java
+++ b/okhttp/src/main/java/okhttp3/Authenticator.java
@@ -70,6 +70,13 @@ public interface Authenticator {
   /**
    * Returns a request that includes a credential to satisfy an authentication challenge in {@code
    * response}. Returns null if the challenge cannot be satisfied.
+   *
+   * The route is best effort, it currently may not always be provided even when logically
+   * available.  It may also not be provided when an Authenticator is re-used manually in
+   * an application interceptor, e.g. implementing client specific retries.
+   *
+   * @param route The route for evaluating whether to use a proxy.
+   * @param response The response containing the auth challenges to respond to.
    */
-  @Nullable Request authenticate(Route route, Response response) throws IOException;
+  @Nullable Request authenticate(@Nullable Route route, Response response) throws IOException;
 }

--- a/okhttp/src/main/java/okhttp3/Authenticator.java
+++ b/okhttp/src/main/java/okhttp3/Authenticator.java
@@ -75,7 +75,7 @@ public interface Authenticator {
    * available.  It may also not be provided when an Authenticator is re-used manually in
    * an application interceptor, e.g. implementing client specific retries.
    *
-   * @param route The route for evaluating whether to use a proxy.
+   * @param route The route for evaluating how to respond to a challenge e.g. via intranet.
    * @param response The response containing the auth challenges to respond to.
    */
   @Nullable Request authenticate(@Nullable Route route, Response response) throws IOException;


### PR DESCRIPTION
Related to https://github.com/square/okhttp/issues/4238

Currently (by code structure) route may be null when used internally.  In addition as an API for handling authentication challenges, it makes sense that route may not be always available, even though it can be useful when determining when to apply a authentication method.