### PR TITLE
Improvements to the JavaNetAuthenticator

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -1560,10 +1560,9 @@ public final class URLConnectionTest {
   }
 
   private void testAuthenticateWithStreamingPost(StreamingMode streamingMode) throws Exception {
-    MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
+    server.enqueue(new MockResponse().setResponseCode(401)
         .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
-        .setBody("Please authenticate.");
-    server.enqueue(pleaseAuthenticate);
+        .setBody("Please authenticate."));
 
     Authenticator.setDefault(new RecordingAuthenticator());
     urlFactory.setClient(urlFactory.client().newBuilder()
@@ -1694,11 +1693,10 @@ public final class URLConnectionTest {
     int responseCode = proxy ? 407 : 401;
     RecordingAuthenticator authenticator = new RecordingAuthenticator(null);
     Authenticator.setDefault(authenticator);
-    MockResponse pleaseAuthenticate = new MockResponse()
+    server.enqueue(new MockResponse()
         .setResponseCode(responseCode)
         .addHeader(authHeader)
-        .setBody("Please authenticate.");
-    server.enqueue(pleaseAuthenticate);
+        .setBody("Please authenticate."));
 
     if (proxy) {
       urlFactory.setClient(urlFactory.client().newBuilder()
@@ -1881,14 +1879,11 @@ public final class URLConnectionTest {
   }
 
   @Test public void authenticateWithPost() throws Exception {
-    MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
+    // fail auth once...
+    server.enqueue(new MockResponse().setResponseCode(401)
         .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
-        .setBody("Please authenticate.");
-    // fail auth three times...
-    server.enqueue(pleaseAuthenticate);
-    server.enqueue(pleaseAuthenticate);
-    server.enqueue(pleaseAuthenticate);
-    // ...then succeed the fourth time
+        .setBody("Please authenticate."));
+    // ...then succeed the second time
     server.enqueue(new MockResponse().setBody("Successful auth!"));
 
     Authenticator.setDefault(new RecordingAuthenticator());
@@ -1907,25 +1902,20 @@ public final class URLConnectionTest {
     RecordedRequest request = server.takeRequest();
     assertNull(request.getHeader("Authorization"));
 
-    // ...but the three requests that follow include an authorization header
-    for (int i = 0; i < 3; i++) {
-      request = server.takeRequest();
-      assertEquals("POST / HTTP/1.1", request.getRequestLine());
-      assertEquals("Basic " + RecordingAuthenticator.BASE_64_CREDENTIALS,
-          request.getHeader("Authorization"));
-      assertEquals("ABCD", request.getBody().readUtf8());
-    }
+    // ...but the second request that follows includes an authorization header
+    request = server.takeRequest();
+    assertEquals("POST / HTTP/1.1", request.getRequestLine());
+    assertEquals("Basic " + RecordingAuthenticator.BASE_64_CREDENTIALS,
+        request.getHeader("Authorization"));
+    assertEquals("ABCD", request.getBody().readUtf8());
   }
 
   @Test public void authenticateWithGet() throws Exception {
-    MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
+    // fail auth once...
+    server.enqueue(new MockResponse().setResponseCode(401)
         .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
-        .setBody("Please authenticate.");
-    // fail auth three times...
-    server.enqueue(pleaseAuthenticate);
-    server.enqueue(pleaseAuthenticate);
-    server.enqueue(pleaseAuthenticate);
-    // ...then succeed the fourth time
+        .setBody("Please authenticate."));
+    // ...then succeed the second time
     server.enqueue(new MockResponse().setBody("Successful auth!"));
 
     Authenticator.setDefault(new RecordingAuthenticator());
@@ -1939,13 +1929,11 @@ public final class URLConnectionTest {
     RecordedRequest request = server.takeRequest();
     assertNull(request.getHeader("Authorization"));
 
-    // ...but the three requests that follow requests include an authorization header
-    for (int i = 0; i < 3; i++) {
-      request = server.takeRequest();
-      assertEquals("GET / HTTP/1.1", request.getRequestLine());
-      assertEquals("Basic " + RecordingAuthenticator.BASE_64_CREDENTIALS,
-          request.getHeader("Authorization"));
-    }
+    // ...but the second request that follows includes an authorization header
+    request = server.takeRequest();
+    assertEquals("GET / HTTP/1.1", request.getRequestLine());
+    assertEquals("Basic " + RecordingAuthenticator.BASE_64_CREDENTIALS,
+        request.getHeader("Authorization"));
   }
 
   @Test public void authenticateWithCharset() throws Exception {
@@ -1981,14 +1969,11 @@ public final class URLConnectionTest {
 
   /** https://code.google.com/p/android/issues/detail?id=74026 */
   @Test public void authenticateWithGetAndTransparentGzip() throws Exception {
-    MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
+    // fail auth once...
+    server.enqueue(new MockResponse().setResponseCode(401)
         .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
-        .setBody("Please authenticate.");
-    // fail auth three times...
-    server.enqueue(pleaseAuthenticate);
-    server.enqueue(pleaseAuthenticate);
-    server.enqueue(pleaseAuthenticate);
-    // ...then succeed the fourth time
+        .setBody("Please authenticate."));
+    // ...then succeed the second time
     MockResponse successfulResponse = new MockResponse()
         .addHeader("Content-Encoding", "gzip")
         .setBody(gzip("Successful auth!"));
@@ -2005,13 +1990,11 @@ public final class URLConnectionTest {
     RecordedRequest request = server.takeRequest();
     assertNull(request.getHeader("Authorization"));
 
-    // ...but the three requests that follow requests include an authorization header
-    for (int i = 0; i < 3; i++) {
-      request = server.takeRequest();
-      assertEquals("GET / HTTP/1.1", request.getRequestLine());
-      assertEquals("Basic " + RecordingAuthenticator.BASE_64_CREDENTIALS,
-          request.getHeader("Authorization"));
-    }
+    // ...but the second request that follows includes an authorization header
+    request = server.takeRequest();
+    assertEquals("GET / HTTP/1.1", request.getRequestLine());
+    assertEquals("Basic " + RecordingAuthenticator.BASE_64_CREDENTIALS,
+        request.getHeader("Authorization"));
   }
 
   /** https://github.com/square/okhttp/issues/342 */
@@ -3179,10 +3162,9 @@ public final class URLConnectionTest {
   }
 
   @Test public void customBasicAuthenticator() throws Exception {
-    MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
+    server.enqueue(new MockResponse().setResponseCode(401)
         .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
-        .setBody("Please authenticate.");
-    server.enqueue(pleaseAuthenticate);
+        .setBody("Please authenticate."));
     server.enqueue(new MockResponse().setBody("A"));
 
     String credential = Credentials.basic("jesse", "peanutbutter");
@@ -3202,10 +3184,9 @@ public final class URLConnectionTest {
   }
 
   @Test public void customTokenAuthenticator() throws Exception {
-    MockResponse pleaseAuthenticate = new MockResponse().setResponseCode(401)
+    server.enqueue(new MockResponse().setResponseCode(401)
         .addHeader("WWW-Authenticate: Bearer realm=\"oauthed\"")
-        .setBody("Please authenticate.");
-    server.enqueue(pleaseAuthenticate);
+        .setBody("Please authenticate."));
     server.enqueue(new MockResponse().setBody("A"));
 
     RecordingOkAuthenticator authenticator = new RecordingOkAuthenticator("oauthed abc123");

--- a/okhttp-urlconnection/src/test/java/okhttp3/JavaNetAuthenticatorTest.java
+++ b/okhttp-urlconnection/src/test/java/okhttp3/JavaNetAuthenticatorTest.java
@@ -1,0 +1,976 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import org.junit.After;
+import org.junit.Test;
+
+import javax.net.SocketFactory;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+
+import static java.net.HttpURLConnection.HTTP_PROXY_AUTH;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static java.net.InetSocketAddress.createUnresolved;
+import static java.net.Proxy.Type.HTTP;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static okhttp3.Protocol.HTTP_1_1;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class JavaNetAuthenticatorTest {
+  private static JavaNetAuthenticator javaNetAuthenticator = new JavaNetAuthenticator();
+
+  private List<String> challenges;
+  private String realmToAnswer;
+  private boolean proxyAuthenticate;
+
+  private int responseCode;
+  private String authenticateHeaderName;
+  private String authorizationHeaderName;
+  private Proxy proxy = new Proxy(HTTP, createUnresolved("localhost", 80));
+  private Route route = new Route(
+      new Address("localhost",
+          80,
+          Dns.SYSTEM,
+          SocketFactory.getDefault(),
+          null,
+          null,
+          null,
+          Authenticator.NONE,
+          null,
+          Collections.<Protocol>emptyList(),
+          Collections.<ConnectionSpec>emptyList(),
+          ProxySelector.getDefault()),
+      proxy,
+      createUnresolved("localhost", 80));
+
+  private void setup() {
+    if (proxyAuthenticate) {
+      responseCode = HTTP_PROXY_AUTH;
+      authenticateHeaderName = "Proxy-Authenticate";
+      authorizationHeaderName = "Proxy-Authorization";
+    } else {
+      responseCode = HTTP_UNAUTHORIZED;
+      authenticateHeaderName = "WWW-Authenticate";
+      authorizationHeaderName = "Authorization";
+    }
+
+    java.net.Authenticator.setDefault(new java.net.Authenticator() {
+      @Override protected PasswordAuthentication getPasswordAuthentication() {
+        if (realmToAnswer.equals(getRequestingPrompt())) {
+          return new PasswordAuthentication("username", "password".toCharArray());
+        }
+        return null;
+      }
+    });
+  }
+
+  @After public void tearDown() {
+    java.net.Authenticator.setDefault(null);
+  }
+
+  private Response buildResponse(Request request) {
+    Response.Builder responseBuilder = new Response.Builder()
+        .request(request)
+        .protocol(HTTP_1_1)
+        .code(responseCode)
+        .message("");
+    for (String challenge : challenges) {
+      responseBuilder.addHeader(authenticateHeaderName, challenge);
+    }
+    return responseBuilder.build();
+  }
+
+  private void correctAuthenticationHeaderIsSet() throws UnknownHostException {
+    setup();
+    Response response = buildResponse(new Request.Builder().url("http://localhost").build());
+    Request returnedRequest = javaNetAuthenticator.authenticate(route, response);
+
+    assertNotNull(returnedRequest);
+    assertEquals("Basic dXNlcm5hbWU6cGFzc3dvcmQ=", returnedRequest.header(authorizationHeaderName));
+  }
+
+  private void credentialsAreNotRetriedTwiceInARow() throws UnknownHostException {
+    setup();
+    Request request = new Request.Builder()
+        .url("http://localhost")
+        .header(authorizationHeaderName, "Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
+        .build();
+    Response response = buildResponse(request);
+
+    assertNull(javaNetAuthenticator.authenticate(route, response));
+  }
+
+  private void newCredentialsAreTriedIfOthersDidNotWork() throws UnknownHostException {
+    setup();
+    Request request = new Request.Builder()
+        .url("http://localhost")
+        .header(authorizationHeaderName, "wrong credentials")
+        .build();
+    Response response = buildResponse(request);
+    Request returnedRequest = javaNetAuthenticator.authenticate(route, response);
+
+    assertNotNull(returnedRequest);
+    assertEquals("Basic dXNlcm5hbWU6cGFzc3dvcmQ=", returnedRequest.header(authorizationHeaderName));
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet1() throws UnknownHostException {
+    challenges = singletonList(" ,  , Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet2() throws UnknownHostException {
+    challenges = singletonList("Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet3() throws UnknownHostException {
+    challenges = singletonList("Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet4() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet5() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet6() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet7() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet8() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet9() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet10() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet11() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet12() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet13() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet14() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet15() throws UnknownHostException {
+    challenges = singletonList(",Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet16() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,,realm=\"f\\\\\\\"o\\o\"");
+    realmToAnswer = "f\\\"oo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet17() throws UnknownHostException {
+    challenges = asList("Digest", "Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet18() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet19() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet20() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = true;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet21() throws UnknownHostException {
+    challenges = singletonList(" ,  , Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet22() throws UnknownHostException {
+    challenges = singletonList("Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet23() throws UnknownHostException {
+    challenges = singletonList("Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet24() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet25() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet26() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet27() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet28() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet29() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet30() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet31() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet32() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet33() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet34() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet35() throws UnknownHostException {
+    challenges = singletonList(",Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet36() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,,realm=\"f\\\\\\\"o\\o\"");
+    realmToAnswer = "f\\\"oo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet37() throws UnknownHostException {
+    challenges = asList("Digest", "Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet38() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet39() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void correctAuthenticationHeaderIsSet40() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = false;
+    correctAuthenticationHeaderIsSet();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow1() throws UnknownHostException {
+    challenges = singletonList(" ,  , Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow2() throws UnknownHostException {
+    challenges = singletonList("Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow3() throws UnknownHostException {
+    challenges = singletonList("Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow4() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow5() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow6() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow7() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow8() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow9() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow10() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow11() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow12() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow13() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow14() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow15() throws UnknownHostException {
+    challenges = singletonList(",Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow16() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,,realm=\"f\\\\\\\"o\\o\"");
+    realmToAnswer = "f\\\"oo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow17() throws UnknownHostException {
+    challenges = asList("Digest", "Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow18() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow19() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow20() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = true;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow21() throws UnknownHostException {
+    challenges = singletonList(" ,  , Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow22() throws UnknownHostException {
+    challenges = singletonList("Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow23() throws UnknownHostException {
+    challenges = singletonList("Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow24() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow25() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow26() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow27() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow28() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow29() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow30() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow31() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow32() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow33() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow34() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow35() throws UnknownHostException {
+    challenges = singletonList(",Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow36() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,,realm=\"f\\\\\\\"o\\o\"");
+    realmToAnswer = "f\\\"oo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow37() throws UnknownHostException {
+    challenges = asList("Digest", "Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow38() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow39() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void credentialsAreNotRetriedTwiceInARow40() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = false;
+    credentialsAreNotRetriedTwiceInARow();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork1() throws UnknownHostException {
+    challenges = singletonList(" ,  , Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork2() throws UnknownHostException {
+    challenges = singletonList("Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork3() throws UnknownHostException {
+    challenges = singletonList("Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork4() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork5() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork6() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork7() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork8() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork9() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork10() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork11() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork12() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork13() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork14() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork15() throws UnknownHostException {
+    challenges = singletonList(",Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork16() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,,realm=\"f\\\\\\\"o\\o\"");
+    realmToAnswer = "f\\\"oo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork17() throws UnknownHostException {
+    challenges = asList("Digest", "Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork18() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork19() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork20() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = true;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork21() throws UnknownHostException {
+    challenges = singletonList(" ,  , Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork22() throws UnknownHostException {
+    challenges = singletonList("Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork23() throws UnknownHostException {
+    challenges = singletonList("Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork24() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork25() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork26() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork27() throws UnknownHostException {
+    challenges = singletonList("Basic realm = \"foo\",Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork28() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork29() throws UnknownHostException {
+    challenges = singletonList("Digest,Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork30() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork31() throws UnknownHostException {
+    challenges = singletonList("Digest, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork32() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork33() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"foo\"");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork34() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork35() throws UnknownHostException {
+    challenges = singletonList(",Digest,,,, Basic ,,foo=bar,realm=\"f,oo\"");
+    realmToAnswer = "f,oo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork36() throws UnknownHostException {
+    challenges = singletonList("Digest,,,, Basic ,,,realm=\"f\\\\\\\"o\\o\"");
+    realmToAnswer = "f\\\"oo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork37() throws UnknownHostException {
+    challenges = asList("Digest", "Basic realm=foo");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork38() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Digest");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork39() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "foo";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+
+  @Test public void newCredentialsAreTriedIfOthersDidNotWork40() throws UnknownHostException {
+    challenges = asList("Basic realm=foo", "Basic realm=bar");
+    realmToAnswer = "bar";
+    proxyAuthenticate = false;
+    newCredentialsAreTriedIfOthersDidNotWork();
+  }
+}


### PR DESCRIPTION
- do not try to authenticate with the same credentials as in the last request
- instead try credentials for next challenge if any available
- do not calculate things multiple times that only need to be done once per request
- cleaner, more straightforward code
- extensive tests targeting the JavaNetAuthenticator directly, not only in context