### PR TITLE
feat: add request date in logs

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -159,6 +159,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
       requestStartMessage += " (" + requestBody.contentLength() + "-byte body)";
     }
     logger.log(requestStartMessage);
+    logger.log("Request date : " + new Date());
 
     if (logHeaders) {
       if (hasRequestBody) {


### PR DESCRIPTION
If call fails with an exception, there is no date to get proper traceability