### PR TITLE
Enable passing emptyResponseBody test

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -911,7 +911,6 @@ public final class EventListenerTest {
     assertNotNull(callFailed.ioe);
   }
 
-  @Ignore("the CallEnd event is omitted")
   @Test public void emptyResponseBody() throws IOException {
     server.enqueue(new MockResponse()
         .setBody("")


### PR DESCRIPTION
https://github.com/square/okhttp/commit/30e72340e0c5a74feb347a79621b93d640ded576 fixed the issue of callEnd not being fired.