### PR TITLE
Support header redaction in HttpLoggingInterceptor

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -125,8 +125,9 @@ public final class HttpLoggingInterceptor implements Interceptor {
   }
 
   public static class Builder {
-    private Set<String> headersToRedact = new LinkedHashSet();
     private Logger logger = Logger.DEFAULT;
+    private Set<String> headersToRedact = new LinkedHashSet();
+    private Level level = Level.NONE;
 
     public Builder logger(Logger logger) {
       this.logger = logger;
@@ -138,6 +139,11 @@ public final class HttpLoggingInterceptor implements Interceptor {
       return this;
     }
 
+    public Builder level(Level level) {
+      this.level = level;
+      return this;
+    }
+
     public HttpLoggingInterceptor build() {
       return new HttpLoggingInterceptor(this);
     }
@@ -146,6 +152,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
   public HttpLoggingInterceptor(Builder builder) {
     this.headersToRedact = builder.headersToRedact;
     this.logger = builder.logger;
+    this.level = builder.level;
   }
 
   private final Logger logger;

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -19,7 +19,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
@@ -122,18 +121,19 @@ public final class HttpLoggingInterceptor implements Interceptor {
   }
 
   public HttpLoggingInterceptor(Logger logger) {
-    this(logger, Collections.<String>emptyList());
-  }
-
-  public HttpLoggingInterceptor(Logger logger, List<String> headersToRedact) {
-    this.headersToRedact = new TreeSet(String.CASE_INSENSITIVE_ORDER);
-    this.headersToRedact.addAll(headersToRedact);
     this.logger = logger;
   }
 
   private final Logger logger;
 
-  private final Set<String> headersToRedact;
+  private volatile Set<String> headersToRedact = Collections.emptySet();
+
+  public void redactHeader(String name) {
+    Set<String> newHeadersToRedact = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    newHeadersToRedact.addAll(headersToRedact);
+    newHeadersToRedact.add(name);
+    headersToRedact = newHeadersToRedact;
+  }
 
   private volatile Level level = Level.NONE;
 

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -19,6 +19,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Connection;
@@ -135,7 +136,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
     }
 
     public Builder redactHeader(String name) {
-      headersToRedact.add(name.toLowerCase());
+      headersToRedact.add(name.toLowerCase(Locale.US));
       return this;
     }
 
@@ -323,7 +324,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
   private void logHeader(Headers headers, int i) {
     String value =
-        headersToRedact.contains(headers.name(i).toLowerCase()) ? "<redacted>" : headers.value(i);
+        headersToRedact.contains(headers.name(i).toLowerCase(Locale.US)) ? "<redacted>" : headers.value(i);
     logger.log(headers.name(i) + ": " + value);
   }
 

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -324,9 +324,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
   private void logHeader(Headers headers, int i) {
     String value =
-        headersToRedact.contains(headers.name(i).toLowerCase(Locale.US))
-            ? "<redacted>"
-            : headers.value(i);
+        headersToRedact.contains(headers.name(i).toLowerCase(Locale.US)) ? "██" : headers.value(i);
     logger.log(headers.name(i) + ": " + value);
   }
 

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -18,9 +18,10 @@ package okhttp3.logging;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.LinkedHashSet;
-import java.util.Locale;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Connection;
 import okhttp3.Headers;
@@ -121,39 +122,13 @@ public final class HttpLoggingInterceptor implements Interceptor {
   }
 
   public HttpLoggingInterceptor(Logger logger) {
+    this(logger, Collections.<String>emptyList());
+  }
+
+  public HttpLoggingInterceptor(Logger logger, List<String> headersToRedact) {
+    this.headersToRedact = new TreeSet(String.CASE_INSENSITIVE_ORDER);
+    this.headersToRedact.addAll(headersToRedact);
     this.logger = logger;
-    this.headersToRedact = new LinkedHashSet();
-  }
-
-  public static class Builder {
-    private Logger logger = Logger.DEFAULT;
-    private Set<String> headersToRedact = new LinkedHashSet();
-    private Level level = Level.NONE;
-
-    public Builder logger(Logger logger) {
-      this.logger = logger;
-      return this;
-    }
-
-    public Builder redactHeader(String name) {
-      headersToRedact.add(name.toLowerCase(Locale.US));
-      return this;
-    }
-
-    public Builder level(Level level) {
-      this.level = level;
-      return this;
-    }
-
-    public HttpLoggingInterceptor build() {
-      return new HttpLoggingInterceptor(this);
-    }
-  }
-
-  public HttpLoggingInterceptor(Builder builder) {
-    this.headersToRedact = builder.headersToRedact;
-    this.logger = builder.logger;
-    this.level = builder.level;
   }
 
   private final Logger logger;
@@ -323,8 +298,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
   }
 
   private void logHeader(Headers headers, int i) {
-    String value =
-        headersToRedact.contains(headers.name(i).toLowerCase(Locale.US)) ? "██" : headers.value(i);
+    String value = headersToRedact.contains(headers.name(i)) ? "██" : headers.value(i);
     logger.log(headers.name(i) + ": " + value);
   }
 

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -324,7 +324,9 @@ public final class HttpLoggingInterceptor implements Interceptor {
 
   private void logHeader(Headers headers, int i) {
     String value =
-        headersToRedact.contains(headers.name(i).toLowerCase(Locale.US)) ? "<redacted>" : headers.value(i);
+        headersToRedact.contains(headers.name(i).toLowerCase(Locale.US))
+            ? "<redacted>"
+            : headers.value(i);
     logger.log(headers.name(i) + ": " + value);
   }
 

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -780,19 +780,19 @@ public final class HttpLoggingInterceptorTest {
 
     applicationLogs
         .assertLogEqual("--> GET " + url)
-        .assertLogEqual("SeNsItIvE: <redacted>")
+        .assertLogEqual("SeNsItIvE: ██")
         .assertLogEqual("Not-Sensitive: Value")
         .assertLogEqual("--> END GET")
         .assertLogMatch("<-- 200 OK " + url + " \\(\\d+ms\\)")
         .assertLogEqual("Content-Length: 0")
-        .assertLogEqual("SeNsItIvE: <redacted>")
+        .assertLogEqual("SeNsItIvE: ██")
         .assertLogEqual("Not-Sensitive: Value")
         .assertLogEqual("<-- END HTTP")
         .assertNoMoreLogs();
 
     networkLogs
         .assertLogEqual("--> GET " + url + " http/1.1")
-        .assertLogEqual("SeNsItIvE: <redacted>")
+        .assertLogEqual("SeNsItIvE: ██")
         .assertLogEqual("Not-Sensitive: Value")
         .assertLogEqual("Host: " + host)
         .assertLogEqual("Connection: Keep-Alive")
@@ -801,7 +801,7 @@ public final class HttpLoggingInterceptorTest {
         .assertLogEqual("--> END GET")
         .assertLogMatch("<-- 200 OK " + url + " \\(\\d+ms\\)")
         .assertLogEqual("Content-Length: 0")
-        .assertLogEqual("SeNsItIvE: <redacted>")
+        .assertLogEqual("SeNsItIvE: ██")
         .assertLogEqual("Not-Sensitive: Value")
         .assertLogEqual("<-- END HTTP")
         .assertNoMoreLogs();

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -745,6 +745,68 @@ public final class HttpLoggingInterceptorTest {
         .assertNoMoreLogs();
   }
 
+  @Test
+  public void headersAreRedacted() throws Exception {
+    HttpLoggingInterceptor networkInterceptor =
+        new HttpLoggingInterceptor.Builder()
+            .redactHeader("sEnSiTiVe")
+            .logger(networkLogs)
+            .build()
+            .setLevel(Level.HEADERS);
+    HttpLoggingInterceptor applicationInterceptor =
+        new HttpLoggingInterceptor.Builder()
+            .redactHeader("sEnSiTiVe")
+            .logger(applicationLogs)
+            .build()
+            .setLevel(Level.HEADERS);
+
+    client =
+        new OkHttpClient.Builder()
+            .addNetworkInterceptor(networkInterceptor)
+            .addInterceptor(applicationInterceptor)
+            .build();
+
+    server.enqueue(
+        new MockResponse().addHeader("SeNsItIvE", "Value").addHeader("Not-Sensitive", "Value"));
+    Response response =
+        client
+            .newCall(
+                request()
+                    .addHeader("SeNsItIvE", "Value")
+                    .addHeader("Not-Sensitive", "Value")
+                    .build())
+            .execute();
+    response.body().close();
+
+    applicationLogs
+        .assertLogEqual("--> GET " + url)
+        .assertLogEqual("SeNsItIvE: <redacted>")
+        .assertLogEqual("Not-Sensitive: Value")
+        .assertLogEqual("--> END GET")
+        .assertLogMatch("<-- 200 OK " + url + " \\(\\d+ms\\)")
+        .assertLogEqual("Content-Length: 0")
+        .assertLogEqual("SeNsItIvE: <redacted>")
+        .assertLogEqual("Not-Sensitive: Value")
+        .assertLogEqual("<-- END HTTP")
+        .assertNoMoreLogs();
+
+    networkLogs
+        .assertLogEqual("--> GET " + url + " http/1.1")
+        .assertLogEqual("SeNsItIvE: <redacted>")
+        .assertLogEqual("Not-Sensitive: Value")
+        .assertLogEqual("Host: " + host)
+        .assertLogEqual("Connection: Keep-Alive")
+        .assertLogEqual("Accept-Encoding: gzip")
+        .assertLogMatch("User-Agent: okhttp/.+")
+        .assertLogEqual("--> END GET")
+        .assertLogMatch("<-- 200 OK " + url + " \\(\\d+ms\\)")
+        .assertLogEqual("Content-Length: 0")
+        .assertLogEqual("SeNsItIvE: <redacted>")
+        .assertLogEqual("Not-Sensitive: Value")
+        .assertLogEqual("<-- END HTTP")
+        .assertNoMoreLogs();
+  }
+
   private Request.Builder request() {
     return new Request.Builder().url(url);
   }

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.net.ssl.HostnameVerifier;
@@ -748,17 +749,10 @@ public final class HttpLoggingInterceptorTest {
   @Test
   public void headersAreRedacted() throws Exception {
     HttpLoggingInterceptor networkInterceptor =
-        new HttpLoggingInterceptor.Builder()
-            .redactHeader("sEnSiTiVe")
-            .logger(networkLogs)
-            .level(Level.HEADERS)
-            .build();
+        new HttpLoggingInterceptor(networkLogs, Arrays.asList("sEnSiTiVe")).setLevel(Level.HEADERS);
     HttpLoggingInterceptor applicationInterceptor =
-        new HttpLoggingInterceptor.Builder()
-            .redactHeader("sEnSiTiVe")
-            .logger(applicationLogs)
-            .level(Level.HEADERS)
-            .build();
+        new HttpLoggingInterceptor(applicationLogs, Arrays.asList("sEnSiTiVe"))
+            .setLevel(Level.HEADERS);
 
     client =
         new OkHttpClient.Builder()

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -751,14 +751,14 @@ public final class HttpLoggingInterceptorTest {
         new HttpLoggingInterceptor.Builder()
             .redactHeader("sEnSiTiVe")
             .logger(networkLogs)
-            .build()
-            .setLevel(Level.HEADERS);
+            .level(Level.HEADERS)
+            .build();
     HttpLoggingInterceptor applicationInterceptor =
         new HttpLoggingInterceptor.Builder()
             .redactHeader("sEnSiTiVe")
             .logger(applicationLogs)
-            .build()
-            .setLevel(Level.HEADERS);
+            .level(Level.HEADERS)
+            .build();
 
     client =
         new OkHttpClient.Builder()

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -749,10 +749,12 @@ public final class HttpLoggingInterceptorTest {
   @Test
   public void headersAreRedacted() throws Exception {
     HttpLoggingInterceptor networkInterceptor =
-        new HttpLoggingInterceptor(networkLogs, Arrays.asList("sEnSiTiVe")).setLevel(Level.HEADERS);
+        new HttpLoggingInterceptor(networkLogs).setLevel(Level.HEADERS);
+    networkInterceptor.redactHeader("sEnSiTiVe");
+
     HttpLoggingInterceptor applicationInterceptor =
-        new HttpLoggingInterceptor(applicationLogs, Arrays.asList("sEnSiTiVe"))
-            .setLevel(Level.HEADERS);
+        new HttpLoggingInterceptor(applicationLogs).setLevel(Level.HEADERS);
+    applicationInterceptor.redactHeader("sEnSiTiVe");
 
     client =
         new OkHttpClient.Builder()


### PR DESCRIPTION
This implements the enhancement discussed in https://github.com/square/okhttp/issues/3826.