### PR TITLE
Fix exception message

### DIFF
--- a/okhttp/src/main/java/okhttp3/RequestBody.java
+++ b/okhttp/src/main/java/okhttp3/RequestBody.java
@@ -102,7 +102,7 @@ public abstract class RequestBody {
 
   /** Returns a new request body that transmits the content of {@code file}. */
   public static RequestBody create(final @Nullable MediaType contentType, final File file) {
-    if (file == null) throw new NullPointerException("content == null");
+    if (file == null) throw new NullPointerException("file == null");
 
     return new RequestBody() {
       @Override public @Nullable MediaType contentType() {


### PR DESCRIPTION
Just a minor change.
The param name is `file` - not content.
This may leads to confusing when observed in logs.

Another solution - to match with the other methods - would be to change the param name to `content` 🤷‍♂️ 
Please give me a hint when we should do it like this 👍 