### PR TITLE
replacing 'ı' chars with 'i' in the value strings in 'checkValue' method

### DIFF
--- a/okhttp/src/main/java/okhttp3/Headers.java
+++ b/okhttp/src/main/java/okhttp3/Headers.java
@@ -269,8 +269,13 @@ public final class Headers {
     for (int i = 0, length = value.length(); i < length; i++) {
       char c = value.charAt(i);
       if ((c <= '\u001f' && c != '\t') || c >= '\u007f') {
-        throw new IllegalArgumentException(Util.format(
-            "Unexpected char %#04x at %d in %s value: %s", (int) c, i, name, value));
+        if(c == '\u0131'){
+			    value = value.replace('\u0131', '\u0069');
+		    }
+		    else{
+			    throw new IllegalArgumentException(Util.format(
+				    "Unexpected char %#04x at %d in %s value: %s", (int) c, i, name, value));
+		    }
       }
     }
   }


### PR DESCRIPTION
update to solve the exception 'ı' character in user agent "selenium/3.12.0 (java wındows)" in Turkish windows. 
Now Replacing 'ı' character with 'i'.