### PR TITLE
Added test to cover header drops with 100-continue

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
@@ -16,6 +16,7 @@
 package okhttp3;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -54,6 +55,23 @@ public final class HeadersTest {
     assertEquals(1, headers.size());
     assertEquals(":version", headers.name(0));
     assertEquals("HTTP/1.1", headers.value(0));
+  }
+
+  @Test public void readNameValueBlockDropsHeadersUpTo100Continue() throws IOException {
+    List<Header> firstHeaderBlock = headerEntries(":status", "100 Continue", "a", "albatross");
+    List<Header> secondHeaderBlock = headerEntries(":status", "200 OK", "b", "balicassiao");
+    List<Header> headerBlock = new ArrayList<>();
+    headerBlock.addAll(firstHeaderBlock);
+    headerBlock.add(null);
+    headerBlock.addAll(secondHeaderBlock);
+
+    Request request = new Request.Builder().url("http://square.com/").build();
+    Response response =
+        Http2Codec.readHttp2HeadersList(headerBlock, Protocol.HTTP_2).request(request).build();
+    Headers headers = response.headers();
+    assertEquals(1, headers.size());
+    assertEquals("b", headers.name(0));
+    assertEquals("balicassiao", headers.value(0));
   }
 
   @Test public void http2HeadersListDropsForbiddenHeadersHttp2() {


### PR DESCRIPTION
It doesn't seem to be cover in `CallTest`