### PR TITLE
#3795 Provide unique name for threads

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -518,7 +518,12 @@ public final class Http2Connection implements Closeable {
         writer.windowUpdate(0, windowSize - Settings.DEFAULT_INITIAL_WINDOW_SIZE);
       }
     }
-    new Thread(readerRunnable).start(); // Not a daemon thread.
+    new Thread(
+            readerRunnable,
+            String.format(
+                    "OkHttp Http2Connection@%s",
+                    Integer.toHexString(readerRunnable.hashCode()))
+    ).start(); // Not a daemon thread.
   }
 
   /** Merges {@code settings} into this peer's settings and sends them to the remote peer. */


### PR DESCRIPTION
Decided to use the memory address of the runnable instead of trying to introduce a number to track creations.