### PR TITLE
Fail with clear message when missing scheme or host for HttpUrl.Builder.toString.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HttpUrlTest.java
@@ -772,6 +772,18 @@ public final class HttpUrlTest {
     } catch (IllegalStateException expected) {
       assertEquals("scheme == null", expected.getMessage());
     }
+    try {
+      new HttpUrl.Builder().scheme("http").toString();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("host == null", expected.getMessage());
+    }
+    try {
+      new HttpUrl.Builder().host("host").toString();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("scheme == null", expected.getMessage());
+    }
   }
 
   @Test public void minimalUrlComposition() throws Exception {

--- a/okhttp/src/main/java/okhttp3/HttpUrl.java
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.java
@@ -1257,6 +1257,9 @@ public final class HttpUrl {
     }
 
     @Override public String toString() {
+      if (scheme == null) throw new IllegalStateException("scheme == null");
+      if (host == null) throw new IllegalStateException("host == null");
+
       StringBuilder result = new StringBuilder();
       result.append(scheme);
       result.append("://");


### PR DESCRIPTION
ran into a place where I was missing the scheme in a logging call.

before:
missing host:
```
java.lang.NullPointerException
	at okhttp3.HttpUrl$Builder.toString(HttpUrl.java:1273)
	at okhttp3.HttpUrlTest.incompleteUrlComposition(HttpUrlTest.java:775)
```

missing scheme:
```
java.lang.NullPointerException
	at okhttp3.HttpUrl.defaultPort(HttpUrl.java:510)
	at okhttp3.HttpUrl$Builder.effectivePort(HttpUrl.java:1039)
	at okhttp3.HttpUrl$Builder.toString(HttpUrl.java:1285)
	at okhttp3.HttpUrlTest.incompleteUrlComposition(HttpUrlTest.java:782)
```