### PR TITLE
ConscryptPlatform no longer overrides engine socket preference

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/platform/ConscryptPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/ConscryptPlatform.java
@@ -112,11 +112,4 @@ public class ConscryptPlatform extends Platform {
       return null;
     }
   }
-
-  @Override
-  public void configureSslSocketFactory(SSLSocketFactory socketFactory) {
-    if (Conscrypt.isConscrypt(socketFactory)) {
-      Conscrypt.setUseEngineSocket(socketFactory, true);
-    }
-  }
 }


### PR DESCRIPTION
This change allows OkHttp consumers to configure whether to use
the engine socket externally.