### PR TITLE
Add a LoggingEventListener and use it in okcurl

### DIFF
--- a/okcurl/pom.xml
+++ b/okcurl/pom.xml
@@ -20,6 +20,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>logging-interceptor</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>okhttp-testing-support</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/okcurl/src/main/java/okhttp3/curl/Main.java
+++ b/okcurl/src/main/java/okhttp3/curl/Main.java
@@ -48,6 +48,7 @@ import okhttp3.internal.Util;
 import okhttp3.internal.http.StatusLine;
 import okhttp3.internal.http2.Http2;
 import okhttp3.internal.platform.Platform;
+import okhttp3.logging.LoggingEventListener;
 import okio.BufferedSource;
 import okio.Okio;
 import okio.Sink;
@@ -121,6 +122,11 @@ public class Main extends HelpOption implements Runnable {
   @Option(name = {"-V", "--version"}, description = "Show version number and quit")
   public boolean version;
 
+  @Option(
+      name = {"-v", "--verbose"},
+      description = "Makes " + NAME + " verbose during the operation")
+  public boolean verbose;
+
   @Arguments(title = "url", description = "Remote resource URL")
   public String url;
 
@@ -183,6 +189,9 @@ public class Main extends HelpOption implements Runnable {
       SSLSocketFactory sslSocketFactory = createInsecureSslSocketFactory(trustManager);
       builder.sslSocketFactory(sslSocketFactory, trustManager);
       builder.hostnameVerifier(createInsecureHostnameVerifier());
+    }
+    if (verbose) {
+      builder.eventListenerFactory(LoggingEventListener.Factory.STDOUT);
     }
     return builder.build();
   }

--- a/okcurl/src/main/java/okhttp3/curl/Main.java
+++ b/okcurl/src/main/java/okhttp3/curl/Main.java
@@ -48,6 +48,7 @@ import okhttp3.internal.Util;
 import okhttp3.internal.http.StatusLine;
 import okhttp3.internal.http2.Http2;
 import okhttp3.internal.platform.Platform;
+import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.logging.LoggingEventListener;
 import okio.BufferedSource;
 import okio.Okio;
@@ -191,7 +192,14 @@ public class Main extends HelpOption implements Runnable {
       builder.hostnameVerifier(createInsecureHostnameVerifier());
     }
     if (verbose) {
-      builder.eventListenerFactory(LoggingEventListener.Factory.STDOUT);
+      HttpLoggingInterceptor.Logger logger =
+          new HttpLoggingInterceptor.Logger() {
+            @Override
+            public void log(String message) {
+              System.out.println(message);
+            }
+          };
+      builder.eventListenerFactory(new LoggingEventListener.Factory(logger));
     }
     return builder.build();
   }

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.logging;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.EventListener;
+import okhttp3.Handshake;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.internal.platform.Platform;
+
+import static okhttp3.internal.platform.Platform.INFO;
+
+/**
+ * An OkHttp EventListener, which logs call events. Can be applied as an {@linkplain
+ * OkHttpClient#eventListenerFactory() event listener factory}.
+ *
+ * <p>The format of the logs created by this class should not be considered stable and may change
+ * slightly between releases. If you need a stable logging format, use your own event listener.
+ */
+public final class LoggingEventListener extends EventListener {
+  private final Logger logger;
+  private long startNs;
+
+  private LoggingEventListener(Logger logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public void callStart(Call call) {
+    startNs = System.nanoTime();
+
+    logWithTime("callStart: " + call.request());
+  }
+
+  @Override
+  public void dnsStart(Call call, String domainName) {
+    logWithTime("dnsStart: " + domainName);
+  }
+
+  @Override
+  public void dnsEnd(Call call, String domainName, List<InetAddress> inetAddressList) {
+    logWithTime("dnsEnd: " + inetAddressList);
+  }
+
+  @Override
+  public void connectStart(Call call, InetSocketAddress inetSocketAddress, Proxy proxy) {
+    logWithTime("connectStart: " + inetSocketAddress + " " + proxy);
+  }
+
+  @Override
+  public void secureConnectStart(Call call) {
+    logWithTime("secureConnectStart");
+  }
+
+  @Override
+  public void secureConnectEnd(Call call, @Nullable Handshake handshake) {
+    logWithTime("secureConnectEnd");
+  }
+
+  @Override
+  public void connectEnd(
+      Call call, InetSocketAddress inetSocketAddress, Proxy proxy, @Nullable Protocol protocol) {
+    logWithTime("connectEnd: " + protocol);
+  }
+
+  @Override
+  public void connectFailed(
+      Call call,
+      InetSocketAddress inetSocketAddress,
+      Proxy proxy,
+      @Nullable Protocol protocol,
+      IOException ioe) {
+    logWithTime("connectFailed: " + protocol + " " + ioe);
+  }
+
+  @Override
+  public void connectionAcquired(Call call, Connection connection) {
+    logWithTime("connectionAcquired: " + connection);
+  }
+
+  @Override
+  public void connectionReleased(Call call, Connection connection) {
+    logWithTime("connectionReleased");
+  }
+
+  @Override
+  public void requestHeadersStart(Call call) {
+    logWithTime("requestHeadersStart");
+  }
+
+  @Override
+  public void requestHeadersEnd(Call call, Request request) {
+    logWithTime("requestHeadersEnd");
+  }
+
+  @Override
+  public void requestBodyStart(Call call) {
+    logWithTime("requestBodyStart");
+  }
+
+  @Override
+  public void requestBodyEnd(Call call, long byteCount) {
+    logWithTime("requestBodyEnd: byteCount=" + byteCount);
+  }
+
+  @Override
+  public void responseHeadersStart(Call call) {
+    logWithTime("responseHeadersStart");
+  }
+
+  @Override
+  public void responseHeadersEnd(Call call, Response response) {
+    logWithTime("responseHeadersEnd: " + response);
+  }
+
+  @Override
+  public void responseBodyStart(Call call) {
+    logWithTime("responseBodyStart");
+  }
+
+  @Override
+  public void responseBodyEnd(Call call, long byteCount) {
+    logWithTime("responseBodyEnd: byteCount=" + byteCount);
+  }
+
+  @Override
+  public void callEnd(Call call) {
+    logWithTime("callEnd");
+  }
+
+  @Override
+  public void callFailed(Call call, IOException ioe) {
+    logWithTime("callFailed: " + ioe);
+  }
+
+  private void logWithTime(String message) {
+    long timeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
+    logger.log("[t=" + timeMs + "] " + message);
+  }
+
+  public interface Logger {
+    /** A {@link Logger} that outputs appropriately for the current platform. */
+    Logger DEFAULT =
+        new Logger() {
+          @Override
+          public void log(String message) {
+            Platform.get().log(INFO, message, null);
+          }
+        };
+
+    /** A {@link Logger} that outputs to the standard output stream. */
+    Logger STDOUT = new Logger() {
+      @Override
+      public void log(String message) {
+          System.out.println(message);
+      }
+    };
+
+    void log(String message);
+  }
+
+  public static class Factory implements EventListener.Factory {
+    public static final Factory STDOUT = new Factory(Logger.STDOUT);
+
+    private final Logger logger;
+
+    public Factory() {
+      this(Logger.DEFAULT);
+    }
+
+    public Factory(Logger logger) {
+      this.logger = logger;
+    }
+
+    @Override
+    public EventListener create(Call call) {
+      return new LoggingEventListener(logger);
+    }
+  }
+}

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
@@ -30,9 +30,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.internal.platform.Platform;
-
-import static okhttp3.internal.platform.Platform.INFO;
 
 /**
  * An OkHttp EventListener, which logs call events. Can be applied as an

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Square, Inc.
+ * Copyright (C) 2018 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,10 +42,10 @@ import static okhttp3.internal.platform.Platform.INFO;
  * slightly between releases. If you need a stable logging format, use your own event listener.
  */
 public final class LoggingEventListener extends EventListener {
-  private final Logger logger;
+  private final HttpLoggingInterceptor.Logger logger;
   private long startNs;
 
-  private LoggingEventListener(Logger logger) {
+  private LoggingEventListener(HttpLoggingInterceptor.Logger logger) {
     this.logger = logger;
   }
 
@@ -159,40 +159,17 @@ public final class LoggingEventListener extends EventListener {
 
   private void logWithTime(String message) {
     long timeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
-    logger.log("[t=" + timeMs + "] " + message);
-  }
-
-  public interface Logger {
-    /** A {@link Logger} that outputs appropriately for the current platform. */
-    Logger DEFAULT =
-        new Logger() {
-          @Override
-          public void log(String message) {
-            Platform.get().log(INFO, message, null);
-          }
-        };
-
-    /** A {@link Logger} that outputs to the standard output stream. */
-    Logger STDOUT = new Logger() {
-      @Override
-      public void log(String message) {
-          System.out.println(message);
-      }
-    };
-
-    void log(String message);
+    logger.log("[" + timeMs + " ms] " + message);
   }
 
   public static class Factory implements EventListener.Factory {
-    public static final Factory STDOUT = new Factory(Logger.STDOUT);
-
-    private final Logger logger;
+    private final HttpLoggingInterceptor.Logger logger;
 
     public Factory() {
-      this(Logger.DEFAULT);
+      this(HttpLoggingInterceptor.Logger.DEFAULT);
     }
 
-    public Factory(Logger logger) {
+    public Factory(HttpLoggingInterceptor.Logger logger) {
       this.logger = logger;
     }
 

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
@@ -26,6 +26,7 @@ import okhttp3.Call;
 import okhttp3.Connection;
 import okhttp3.EventListener;
 import okhttp3.Handshake;
+import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -34,8 +35,8 @@ import okhttp3.internal.platform.Platform;
 import static okhttp3.internal.platform.Platform.INFO;
 
 /**
- * An OkHttp EventListener, which logs call events. Can be applied as an {@linkplain
- * OkHttpClient#eventListenerFactory() event listener factory}.
+ * An OkHttp EventListener, which logs call events. Can be applied as an
+ * {@linkplain OkHttpClient#eventListenerFactory() event listener factory}.
  *
  * <p>The format of the logs created by this class should not be considered stable and may change
  * slightly between releases. If you need a stable logging format, use your own event listener.

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -807,7 +807,7 @@ public final class HttpLoggingInterceptorTest {
     return new Request.Builder().url(url);
   }
 
-  private static class LogRecorder implements HttpLoggingInterceptor.Logger {
+  static class LogRecorder implements HttpLoggingInterceptor.Logger {
     private final List<String> logs = new ArrayList<>();
     private int index;
 

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
@@ -61,6 +61,7 @@ public final class LoggingEventListenerTest {
             .eventListenerFactory(loggingEventListenerFactory)
             .sslSocketFactory(
                 handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager())
+            .retryOnConnectionFailure(false)
             .build();
 
     url = server.url("/");
@@ -215,13 +216,8 @@ public final class LoggingEventListenerTest {
         .assertLogMatch("secureConnectStart")
         .assertLogMatch(
             "connectFailed: null javax\\.net\\.ssl\\.SSLProtocolException: Handshake message sequence violation, 1")
-        .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
         .assertLogMatch(
-            "connectFailed: null java.net.ConnectException: Failed to connect to "
-                + url.host()
-                + "/.+")
-        .assertLogMatch(
-            "callFailed: java.net.ConnectException: Failed to connect to " + url.host() + "/.+")
+            "callFailed: javax.net.ssl.SSLProtocolException: Handshake message sequence violation, 1")
         .assertNoMoreLogs();
   }
 

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
@@ -75,17 +75,23 @@ public final class LoggingEventListenerTest {
 
     logRecorder
         .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
-        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
-        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
         .assertLogMatch("connectEnd: http/1.1")
         .assertLogMatch(
-            "connectionAcquired: Connection\\{localhost:.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=none protocol=http/1\\.1\\}")
+            "connectionAcquired: Connection\\{"
+                + url.host()
+                + ":\\d+, proxy=DIRECT hostAddress="
+                + url.host()
+                + "/.+ cipherSuite=none protocol=http/1\\.1\\}")
         .assertLogMatch("requestHeadersStart")
         .assertLogMatch("requestHeadersEnd")
         .assertLogMatch("responseHeadersStart")
         .assertLogMatch(
-            "responseHeadersEnd: Response\\{protocol=http/1\\.1, code=200, message=OK, url=http://localhost.+}")
+            "responseHeadersEnd: Response\\{protocol=http/1\\.1, code=200, message=OK, url="
+                + url
+                + "}")
         .assertLogMatch("responseBodyStart")
         .assertLogMatch("responseBodyEnd: byteCount=6")
         .assertLogMatch("connectionReleased")
@@ -99,20 +105,26 @@ public final class LoggingEventListenerTest {
     client.newCall(request().post(RequestBody.create(PLAIN, "Hello!")).build()).execute();
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=POST, url=" + url +", tags=\\{\\}\\}")
-        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("callStart: Request\\{method=POST, url=" + url + ", tags=\\{\\}\\}")
+        .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
-        .assertLogMatch("connectStart: .+ DIRECT")
+        .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
         .assertLogMatch("connectEnd: http/1.1")
         .assertLogMatch(
-            "connectionAcquired: Connection\\{.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=none protocol=http/1\\.1\\}")
+            "connectionAcquired: Connection\\{"
+                + url.host()
+                + ":\\d+, proxy=DIRECT hostAddress="
+                + url.host()
+                + "/.+ cipherSuite=none protocol=http/1\\.1\\}")
         .assertLogMatch("requestHeadersStart")
         .assertLogMatch("requestHeadersEnd")
         .assertLogMatch("requestBodyStart")
         .assertLogMatch("requestBodyEnd: byteCount=6")
         .assertLogMatch("responseHeadersStart")
         .assertLogMatch(
-            "responseHeadersEnd: Response\\{protocol=http/1\\.1, code=200, message=OK, url=" + url + "}")
+            "responseHeadersEnd: Response\\{protocol=http/1\\.1, code=200, message=OK, url="
+                + url
+                + "}")
         .assertLogMatch("responseBodyStart")
         .assertLogMatch("responseBodyEnd: byteCount=0")
         .assertLogMatch("connectionReleased")
@@ -132,19 +144,23 @@ public final class LoggingEventListenerTest {
 
     logRecorder
         .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
-        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
-        .assertLogMatch("connectStart: .+ DIRECT")
+        .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
         .assertLogMatch("secureConnectStart")
         .assertLogMatch("secureConnectEnd")
         .assertLogMatch("connectEnd: h2")
         .assertLogMatch(
-            "connectionAcquired: Connection\\{.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 protocol=h2\\}")
+            "connectionAcquired: Connection\\{"
+                + url.host()
+                + ":\\d+, proxy=DIRECT hostAddress="
+                + url.host()
+                + "/.+ cipherSuite=.+ protocol=h2}")
         .assertLogMatch("requestHeadersStart")
         .assertLogMatch("requestHeadersEnd")
         .assertLogMatch("responseHeadersStart")
         .assertLogMatch(
-            "responseHeadersEnd: Response\\{protocol=h2, code=200, message=, url=https://localhost.+\\}")
+            "responseHeadersEnd: Response\\{protocol=h2, code=200, message=, url=" + url + "}")
         .assertLogMatch("responseBodyStart")
         .assertLogMatch("responseBodyEnd: byteCount=0")
         .assertLogMatch("connectionReleased")
@@ -174,7 +190,7 @@ public final class LoggingEventListenerTest {
 
     logRecorder
         .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
-        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("callFailed: java.net.UnknownHostException: reason")
         .assertNoMoreLogs();
   }
@@ -193,16 +209,19 @@ public final class LoggingEventListenerTest {
 
     logRecorder
         .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
-        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
-        .assertLogMatch("connectStart: .+ DIRECT")
+        .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
         .assertLogMatch("secureConnectStart")
         .assertLogMatch(
             "connectFailed: null javax\\.net\\.ssl\\.SSLProtocolException: Handshake message sequence violation, 1")
-        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
         .assertLogMatch(
-            "connectFailed: null java.net.ConnectException: Failed to connect to localhost/.+")
-        .assertLogMatch("callFailed: java.net.ConnectException: Failed to connect to localhost/.+")
+            "connectFailed: null java.net.ConnectException: Failed to connect to "
+                + url.host()
+                + "/.+")
+        .assertLogMatch(
+            "callFailed: java.net.ConnectException: Failed to connect to " + url.host() + "/.+")
         .assertNoMoreLogs();
   }
 

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.logging;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import okhttp3.Dns;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import okhttp3.tls.HandshakeCertificates;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static okhttp3.tls.internal.TlsUtil.localhost;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class LoggingEventListenerTest {
+  private static final MediaType PLAIN = MediaType.get("text/plain");
+
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  private final HandshakeCertificates handshakeCertificates = localhost();
+  private final LogRecorder logRecorder = new LogRecorder();
+  private final LoggingEventListener.Factory loggingEventListenerFactory =
+      new LoggingEventListener.Factory(logRecorder);
+  private OkHttpClient client;
+  private HttpUrl url;
+
+  @Before
+  public void setUp() {
+    client =
+        new OkHttpClient.Builder()
+            .eventListenerFactory(loggingEventListenerFactory)
+            .sslSocketFactory(
+                handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager())
+            .build();
+
+    url = server.url("/");
+  }
+
+  @Test
+  public void get() throws Exception {
+    server.enqueue(new MockResponse().setBody("Hello!").setHeader("Content-Type", PLAIN));
+    Response response = client.newCall(request().build()).execute();
+    assertNotNull(response.body());
+    response.body().bytes();
+
+    logRecorder
+        .assertLogMatch("callStart: Request\\{method=GET, url=http://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("dnsEnd: \\[.+\\]")
+        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch("connectEnd: http/1.1")
+        .assertLogMatch(
+            "connectionAcquired: Connection\\{localhost:.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=none protocol=http/1\\.1\\}")
+        .assertLogMatch("requestHeadersStart")
+        .assertLogMatch("requestHeadersEnd")
+        .assertLogMatch("responseHeadersStart")
+        .assertLogMatch(
+            "responseHeadersEnd: Response\\{protocol=http/1\\.1, code=200, message=OK, url=http://localhost.+}")
+        .assertLogMatch("responseBodyStart")
+        .assertLogMatch("responseBodyEnd: byteCount=6")
+        .assertLogMatch("connectionReleased")
+        .assertLogMatch("callEnd")
+        .assertNoMoreLogs();
+  }
+
+  @Test
+  public void post() throws IOException {
+    server.enqueue(new MockResponse());
+    client.newCall(request().post(RequestBody.create(PLAIN, "Hello!")).build()).execute();
+
+    logRecorder
+        .assertLogMatch("callStart: Request\\{method=POST, url=http://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("dnsEnd: \\[.+\\]")
+        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch("connectEnd: http/1.1")
+        .assertLogMatch(
+            "connectionAcquired: Connection\\{localhost:.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=none protocol=http/1\\.1\\}")
+        .assertLogMatch("requestHeadersStart")
+        .assertLogMatch("requestHeadersEnd")
+        .assertLogMatch("requestBodyStart")
+        .assertLogMatch("requestBodyEnd: byteCount=6")
+        .assertLogMatch("responseHeadersStart")
+        .assertLogMatch(
+            "responseHeadersEnd: Response\\{protocol=http/1\\.1, code=200, message=OK, url=http://localhost.+}")
+        .assertLogMatch("responseBodyStart")
+        .assertLogMatch("responseBodyEnd: byteCount=0")
+        .assertLogMatch("connectionReleased")
+        .assertLogMatch("callEnd")
+        .assertNoMoreLogs();
+  }
+
+  @Test
+  public void secureGet() throws Exception {
+    server.useHttps(handshakeCertificates.sslSocketFactory(), false);
+    url = server.url("/");
+
+    server.enqueue(new MockResponse());
+    Response response = client.newCall(request().build()).execute();
+    assertNotNull(response.body());
+    response.body().bytes();
+
+    logRecorder
+        .assertLogMatch("callStart: Request\\{method=GET, url=https://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("dnsEnd: \\[.+\\]")
+        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch("secureConnectStart")
+        .assertLogMatch("secureConnectEnd")
+        .assertLogMatch("connectEnd: h2")
+        .assertLogMatch(
+            "connectionAcquired: Connection\\{localhost:.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 protocol=h2\\}")
+        .assertLogMatch("requestHeadersStart")
+        .assertLogMatch("requestHeadersEnd")
+        .assertLogMatch("responseHeadersStart")
+        .assertLogMatch(
+            "responseHeadersEnd: Response\\{protocol=h2, code=200, message=, url=https://localhost.+\\}")
+        .assertLogMatch("responseBodyStart")
+        .assertLogMatch("responseBodyEnd: byteCount=0")
+        .assertLogMatch("connectionReleased")
+        .assertLogMatch("callEnd")
+        .assertNoMoreLogs();
+  }
+
+  @Test
+  public void dnsFail() throws IOException {
+    client =
+        new OkHttpClient.Builder()
+            .dns(
+                new Dns() {
+                  @Override
+                  public List<InetAddress> lookup(String hostname) throws UnknownHostException {
+                    throw new UnknownHostException("reason");
+                  }
+                })
+            .eventListenerFactory(loggingEventListenerFactory)
+            .build();
+
+    try {
+      client.newCall(request().build()).execute();
+      fail();
+    } catch (UnknownHostException expected) {
+    }
+
+    logRecorder
+        .assertLogMatch("callStart: Request\\{method=GET, url=http://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("callFailed: java.net.UnknownHostException: reason")
+        .assertNoMoreLogs();
+  }
+
+  @Test
+  public void connectFail() {
+    server.useHttps(handshakeCertificates.sslSocketFactory(), false);
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.FAIL_HANDSHAKE));
+    url = server.url("/");
+
+    try {
+      client.newCall(request().build()).execute();
+      fail();
+    } catch (IOException expected) {
+    }
+
+    logRecorder
+        .assertLogMatch("callStart: Request\\{method=GET, url=https://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("dnsStart: localhost")
+        .assertLogMatch("dnsEnd: \\[.+\\]")
+        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch("secureConnectStart")
+        .assertLogMatch(
+            "connectFailed: null javax\\.net\\.ssl\\.SSLProtocolException: Handshake message sequence violation, 1")
+        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch(
+            "connectFailed: null java.net.ConnectException: Failed to connect to localhost/.+")
+        .assertLogMatch("callFailed: java.net.ConnectException: Failed to connect to localhost/.+")
+        .assertNoMoreLogs();
+  }
+
+  private Request.Builder request() {
+    return new Request.Builder().url(url);
+  }
+
+  private static class LogRecorder implements LoggingEventListener.Logger {
+    private final List<String> logs = new ArrayList<>();
+    private int index;
+
+    LogRecorder assertLogMatch(String pattern) {
+      pattern = "\\[t=\\d+] " + pattern;
+      assertTrue("No more messages found", index < logs.size());
+      String actual = logs.get(index++);
+      assertTrue(
+          "<" + actual + "> did not match pattern <" + pattern + ">",
+          Pattern.matches(pattern, actual));
+      return this;
+    }
+
+    void assertNoMoreLogs() {
+      assertEquals("More messages remain: " + logs.subList(index, logs.size()), index, logs.size());
+    }
+
+    @Override
+    public void log(String message) {
+      logs.add(message);
+    }
+  }
+}

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Square, Inc.
+ * Copyright (C) 2018 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package okhttp3.logging;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 import okhttp3.Dns;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -37,9 +35,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static okhttp3.tls.internal.TlsUtil.localhost;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class LoggingEventListenerTest {
@@ -225,27 +221,9 @@ public final class LoggingEventListenerTest {
     return new Request.Builder().url(url);
   }
 
-  private static class LogRecorder implements LoggingEventListener.Logger {
-    private final List<String> logs = new ArrayList<>();
-    private int index;
-
+  private static class LogRecorder extends HttpLoggingInterceptorTest.LogRecorder {
     LogRecorder assertLogMatch(String pattern) {
-      pattern = "\\[t=\\d+] " + pattern;
-      assertTrue("No more messages found", index < logs.size());
-      String actual = logs.get(index++);
-      assertTrue(
-          "<" + actual + "> did not match pattern <" + pattern + ">",
-          Pattern.matches(pattern, actual));
-      return this;
-    }
-
-    void assertNoMoreLogs() {
-      assertEquals("More messages remain: " + logs.subList(index, logs.size()), index, logs.size());
-    }
-
-    @Override
-    public void log(String message) {
-      logs.add(message);
+      return (LogRecorder) super.assertLogMatch("\\[\\d+ ms] " + pattern);
     }
   }
 }

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
@@ -74,7 +74,7 @@ public final class LoggingEventListenerTest {
     response.body().bytes();
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=GET, url=http://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
         .assertLogMatch("dnsStart: localhost")
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: localhost/.+ DIRECT")
@@ -99,20 +99,20 @@ public final class LoggingEventListenerTest {
     client.newCall(request().post(RequestBody.create(PLAIN, "Hello!")).build()).execute();
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=POST, url=http://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=POST, url=" + url +", tags=\\{\\}\\}")
         .assertLogMatch("dnsStart: localhost")
         .assertLogMatch("dnsEnd: \\[.+\\]")
-        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch("connectStart: .+ DIRECT")
         .assertLogMatch("connectEnd: http/1.1")
         .assertLogMatch(
-            "connectionAcquired: Connection\\{localhost:.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=none protocol=http/1\\.1\\}")
+            "connectionAcquired: Connection\\{.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=none protocol=http/1\\.1\\}")
         .assertLogMatch("requestHeadersStart")
         .assertLogMatch("requestHeadersEnd")
         .assertLogMatch("requestBodyStart")
         .assertLogMatch("requestBodyEnd: byteCount=6")
         .assertLogMatch("responseHeadersStart")
         .assertLogMatch(
-            "responseHeadersEnd: Response\\{protocol=http/1\\.1, code=200, message=OK, url=http://localhost.+}")
+            "responseHeadersEnd: Response\\{protocol=http/1\\.1, code=200, message=OK, url=" + url + "}")
         .assertLogMatch("responseBodyStart")
         .assertLogMatch("responseBodyEnd: byteCount=0")
         .assertLogMatch("connectionReleased")
@@ -131,15 +131,15 @@ public final class LoggingEventListenerTest {
     response.body().bytes();
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=GET, url=https://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
         .assertLogMatch("dnsStart: localhost")
         .assertLogMatch("dnsEnd: \\[.+\\]")
-        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch("connectStart: .+ DIRECT")
         .assertLogMatch("secureConnectStart")
         .assertLogMatch("secureConnectEnd")
         .assertLogMatch("connectEnd: h2")
         .assertLogMatch(
-            "connectionAcquired: Connection\\{localhost:.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 protocol=h2\\}")
+            "connectionAcquired: Connection\\{.+, proxy=DIRECT hostAddress=localhost/.+ cipherSuite=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 protocol=h2\\}")
         .assertLogMatch("requestHeadersStart")
         .assertLogMatch("requestHeadersEnd")
         .assertLogMatch("responseHeadersStart")
@@ -173,7 +173,7 @@ public final class LoggingEventListenerTest {
     }
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=GET, url=http://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
         .assertLogMatch("dnsStart: localhost")
         .assertLogMatch("callFailed: java.net.UnknownHostException: reason")
         .assertNoMoreLogs();
@@ -192,10 +192,10 @@ public final class LoggingEventListenerTest {
     }
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=GET, url=https://localhost:.+, tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
         .assertLogMatch("dnsStart: localhost")
         .assertLogMatch("dnsEnd: \\[.+\\]")
-        .assertLogMatch("connectStart: localhost/.+ DIRECT")
+        .assertLogMatch("connectStart: .+ DIRECT")
         .assertLogMatch("secureConnectStart")
         .assertLogMatch(
             "connectFailed: null javax\\.net\\.ssl\\.SSLProtocolException: Handshake message sequence violation, 1")


### PR DESCRIPTION
A basic logger, as discussed in #4315.

To install a `LoggingEventListener` that uses the platform logger:
```
builder.eventListenerFactory(new LoggingEventListener.Factory());
```

The user can also pass a custom Logger:
```
Logger logger = new Logger() {
  @Override
  public void log(String message) {
    ...
  }
};
builder.eventListenerFactory(new LoggingEventListener.Factory(logger));
```

Sample output:
```
$ okcurl -v "https://httpbin.org/redirect-to?status_code=307&url=https://api.twitter.com/robots.txt"

[t=0] callStart: Request{method=GET, url=https://httpbin.org/redirect-to?status_code=307&url=https://api.twitter.com/robots.txt, tags={}}
[t=13] dnsStart: httpbin.org
[t=233] dnsEnd: [httpbin.org/54.174.228.92, httpbin.org/52.4.75.11, httpbin.org/54.173.32.212, httpbin.org/54.152.208.69, httpbin.org/54.172.170.160, httpbin.org/54.165.51.142, httpbin.org/54.209.64.71, httpbin.org/54.164.206.44]
[t=247] connectStart: httpbin.org/54.174.228.92:443 DIRECT
[t=310] secureConnectStart
[t=605] secureConnectEnd
[t=605] connectEnd: http/1.1
[t=606] connectionAcquired: Connection{httpbin.org:443, proxy=DIRECT hostAddress=httpbin.org/54.174.228.92:443 cipherSuite=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 protocol=http/1.1}
[t=607] requestHeadersStart
[t=608] requestHeadersEnd
[t=610] responseHeadersStart
[t=670] responseHeadersEnd: Response{protocol=http/1.1, code=307, message=TEMPORARY REDIRECT, url=https://httpbin.org/redirect-to?status_code=307&url=https://api.twitter.com/robots.txt}
[t=670] responseBodyStart
[t=676] responseBodyEnd: byteCount=0
[t=677] connectionReleased
[t=677] callEnd
[t=677] dnsStart: api.twitter.com
[t=830] dnsEnd: [api.twitter.com/104.244.42.66, api.twitter.com/104.244.42.2, api.twitter.com/104.244.42.130, api.twitter.com/104.244.42.194]
[t=831] connectStart: api.twitter.com/104.244.42.66:443 DIRECT
[t=858] secureConnectStart
[t=993] secureConnectEnd
[t=993] connectEnd: http/1.1
[t=994] connectionAcquired: Connection{api.twitter.com:443, proxy=DIRECT hostAddress=api.twitter.com/104.244.42.66:443 cipherSuite=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 protocol=http/1.1}
[t=994] requestHeadersStart
[t=994] requestHeadersEnd
[t=994] responseHeadersStart
[t=1029] responseHeadersEnd: Response{protocol=http/1.1, code=200, message=OK, url=https://api.twitter.com/robots.txt}
[t=1029] responseBodyStart
[t=1031] responseBodyEnd: byteCount=138
[t=1031] connectionReleased
[t=1031] callEnd
# Used for Google app indexing. See https://developers.google.com/app-indexing/webmasters/server
User-agent: Googlebot
Disallow:

User-agent: *
Disallow: /
```