### PR TITLE
Limit the use of regexes in the RFC 7235 challenge parser.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
@@ -26,6 +26,7 @@ import okhttp3.internal.Internal;
 import okhttp3.internal.http.HttpHeaders;
 import okhttp3.internal.http2.Header;
 import okhttp3.internal.http2.Http2Codec;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.util.Collections.emptyList;
@@ -718,7 +719,9 @@ public final class HeadersTest {
         .add("WWW-Authenticate", "Digest,,,, Basic ,,,realm=\"my\\\\\\\\\"r\\ealm\"")
         .build();
 
-    assertEquals(emptyList(), HttpHeaders.parseChallenges(headers, "WWW-Authenticate"));
+    assertEquals(Arrays.asList(
+        new Challenge("Digest", Collections.<String, String>emptyMap())),
+        HttpHeaders.parseChallenges(headers, "WWW-Authenticate"));
   }
 
   @Test public void unescapedDoubleQuoteInQuotedString() {
@@ -726,15 +729,20 @@ public final class HeadersTest {
         .add("WWW-Authenticate", "Digest,,,, Basic ,,,realm=\"my\"realm\"")
         .build();
 
-    assertEquals(emptyList(), HttpHeaders.parseChallenges(headers, "WWW-Authenticate"));
+    assertEquals(Arrays.asList(
+        new Challenge("Digest", Collections.<String, String>emptyMap())),
+        HttpHeaders.parseChallenges(headers, "WWW-Authenticate"));
   }
 
+  @Ignore("TODO(jwilson): reject parameters that use invalid characters")
   @Test public void doubleQuoteInToken() {
     Headers headers = new Headers.Builder()
         .add("WWW-Authenticate", "Digest,,,, Basic ,,,realm=my\"realm")
         .build();
 
-    assertEquals(emptyList(), HttpHeaders.parseChallenges(headers, "WWW-Authenticate"));
+    assertEquals(Arrays.asList(
+        new Challenge("Digest", Collections.<String, String>emptyMap())),
+        HttpHeaders.parseChallenges(headers, "WWW-Authenticate"));
   }
 
   @Test public void token68InsteadOfAuthParams() {
@@ -752,7 +760,9 @@ public final class HeadersTest {
         .add("WWW-Authenticate", "Other abc==, realm=myrealm")
         .build();
 
-    assertEquals(emptyList(), HttpHeaders.parseChallenges(headers, "WWW-Authenticate"));
+    assertEquals(Arrays.asList(
+        new Challenge("Other", singletonMap((String) null, "abc=="))),
+        HttpHeaders.parseChallenges(headers, "WWW-Authenticate"));
   }
 
   @Test public void repeatedAuthParamKey() {

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -3198,7 +3198,7 @@ public final class URLConnectionTest {
     assertEquals(Proxy.NO_PROXY, authenticator.onlyRoute().proxy());
     Response response = authenticator.onlyResponse();
     assertEquals("/private", response.request().url().url().getPath());
-    assertEquals(Arrays.asList(new Challenge("Basic", singletonMap("realm", "protected area"))), response.challenges());
+    assertEquals(Arrays.asList(new Challenge("Basic", "protected area")), response.challenges());
   }
 
   @Test public void customTokenAuthenticator() throws Exception {
@@ -3219,7 +3219,7 @@ public final class URLConnectionTest {
 
     Response response = authenticator.onlyResponse();
     assertEquals("/private", response.request().url().url().getPath());
-    assertEquals(Arrays.asList(new Challenge("Bearer", singletonMap("realm", "oauthed"))), response.challenges());
+    assertEquals(Arrays.asList(new Challenge("Bearer", "oauthed")), response.challenges());
   }
 
   @Test public void authenticateCallsTrackedAsRedirects() throws Exception {

--- a/okhttp/src/main/java/okhttp3/Response.java
+++ b/okhttp/src/main/java/okhttp3/Response.java
@@ -225,16 +225,15 @@ public final class Response implements Closeable {
   }
 
   /**
-   * Returns the RFC 7235 authorization challenges appropriate for this response's code.
-   * If the response code is 401 unauthorized, this returns the "WWW-Authenticate" challenges.
-   * If the response code is 407 proxy unauthorized, this returns the "Proxy-Authenticate"
-   * challenges. Otherwise this returns an empty list of challenges.
-   * <p>
-   * If a challenge uses the {@code token68} variant instead of auth params,
-   * there is exactly one auth param in the challenge at key {@code null}.
-   * Invalid headers and challenges are ignored.
-   * No semantic validation is done, for example that {@code Basic} auth must have a
-   * {@code realm} auth param, this is up to the caller that interprets these challenges.
+   * Returns the RFC 7235 authorization challenges appropriate for this response's code. If the
+   * response code is 401 unauthorized, this returns the "WWW-Authenticate" challenges. If the
+   * response code is 407 proxy unauthorized, this returns the "Proxy-Authenticate" challenges.
+   * Otherwise this returns an empty list of challenges.
+   *
+   * <p>If a challenge uses the {@code token68} variant instead of auth params, there is exactly one
+   * auth param in the challenge at key {@code null}. Invalid headers and challenges are ignored.
+   * No semantic validation is done, for example that {@code Basic} auth must have a {@code realm}
+   * auth param, this is up to the caller that interprets these challenges.
    */
   public List<Challenge> challenges() {
     String responseField;

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.java
@@ -15,15 +15,15 @@
  */
 package okhttp3.internal.http;
 
+import java.io.EOFException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import okhttp3.Challenge;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
@@ -31,52 +31,18 @@ import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
+import okio.Buffer;
+import okio.ByteString;
 
 import static java.net.HttpURLConnection.HTTP_NOT_MODIFIED;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
-import static java.util.Locale.US;
 import static okhttp3.internal.Util.equal;
 import static okhttp3.internal.http.StatusLine.HTTP_CONTINUE;
 
 /** Headers and utilities for internal use by OkHttp. */
 public final class HttpHeaders {
-  // regexes according to RFC 7235
-  private static final String TOKEN_PATTERN_PART = "[!#$%&'*+.^_`|~\\p{Alnum}-]+";
-  private static final String TOKEN68_PATTERN_PART = "[\\p{Alnum}._~+/-]+=*";
-  private static final String OWS_PATTERN_PART = "[ \\t]*";
-  private static final String QUOTED_PAIR_PATTERN_PART = "\\\\([\\t \\p{Graph}\\x80-\\xFF])";
-  private static final String QUOTED_STRING_PATTERN_PART =
-          "\"(?:[\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|" + QUOTED_PAIR_PATTERN_PART + ")*\"";
-  private static final String AUTH_PARAM_PATTERN_PART = TOKEN_PATTERN_PART + OWS_PATTERN_PART + '='
-          + OWS_PATTERN_PART + "(?:" + TOKEN_PATTERN_PART + '|' + QUOTED_STRING_PATTERN_PART + ')';
-  private static final String CHALLENGE_PATTERN_PART = TOKEN_PATTERN_PART + "(?: +(?:"
-          + TOKEN68_PATTERN_PART + "|(?:,|" + AUTH_PARAM_PATTERN_PART + ")(?:" + OWS_PATTERN_PART
-          + ",(?:" + OWS_PATTERN_PART + AUTH_PARAM_PATTERN_PART + ")?)*)?)?";
-  private static final String AUTHENTICATION_HEADER_VALUE_SPLIT_PATTERN_PART =
-          "(?:" + OWS_PATTERN_PART + ',' + OWS_PATTERN_PART + ")+";
-
-  private static final Pattern AUTHENTICATION_HEADER_VALUE_PATTERN = Pattern.compile("^(?:,"
-          + OWS_PATTERN_PART + ")*" + CHALLENGE_PATTERN_PART + "(?:" + OWS_PATTERN_PART + ",(?:"
-          + OWS_PATTERN_PART + CHALLENGE_PATTERN_PART + ")?)*$");
-  private static final Pattern AUTH_SCHEME_PATTERN =
-          Pattern.compile('^' + TOKEN_PATTERN_PART + '$');
-  private static final Pattern AUTH_SCHEME_AND_TOKEN68_PATTERN =
-          Pattern.compile('^' + TOKEN_PATTERN_PART + " +" + TOKEN68_PATTERN_PART + '$');
-  private static final Pattern AUTH_SCHEME_AND_PARAM_PATTERN =
-          Pattern.compile('^' + TOKEN_PATTERN_PART + " +" + AUTH_PARAM_PATTERN_PART + '$');
-  private static final Pattern AUTH_PARAM_PATTERN =
-          Pattern.compile('^' + AUTH_PARAM_PATTERN_PART + '$');
-  private static final Pattern TOKEN_PATTERN = Pattern.compile('^' + TOKEN_PATTERN_PART + '$');
-  private static final Pattern QUOTED_PAIR_PATTERN = Pattern.compile(QUOTED_PAIR_PATTERN_PART);
-
-  private static final Pattern AUTHENTICATION_HEADER_VALUE_SPLIT_PATTERN =
-          Pattern.compile(AUTHENTICATION_HEADER_VALUE_SPLIT_PATTERN_PART);
-  private static final Pattern WHITESPACE_SPLIT_PATTERN = Pattern.compile(" +");
-  private static final Pattern AUTH_PARAM_SPLIT_PATTERN =
-          Pattern.compile(OWS_PATTERN_PART + '=' + OWS_PATTERN_PART);
-  private static final Pattern QUOTED_STRING_AUTH_PARAM_AT_END_PATTERN =
-          Pattern.compile(TOKEN_PATTERN_PART + OWS_PATTERN_PART + '=' + OWS_PATTERN_PART
-                  + QUOTED_STRING_PATTERN_PART + '$');
+  private static final ByteString QUOTED_STRING_DELIMITERS = ByteString.encodeUtf8("\"\\");
+  private static final ByteString TOKEN_DELIMITERS = ByteString.encodeUtf8("\t ,=");
 
   private HttpHeaders() {
   }
@@ -179,104 +145,168 @@ public final class HttpHeaders {
   }
 
   /**
-   * Parse RFC 7235 challenges.
+   * Parse RFC 7235 challenges. This is awkward because we need to look ahead to know how to
+   * interpret a token.
+   *
+   * <p>For example, the first line has a parameter name/value pair and the second line has a single
+   * token68:
+   *
+   * <pre>   {@code
+   *
+   *   WWW-Authenticate: Digest foo=bar
+   *   WWW-Authenticate: Digest foo=
+   * }</pre>
+   *
+   * <p>Similarly, the first line has one challenge and the second line has two challenges:
+   *
+   * <pre>   {@code
+   *
+   *   WWW-Authenticate: Digest ,foo=bar
+   *   WWW-Authenticate: Digest ,foo
+   * }</pre>
    */
-  public static List<Challenge> parseChallenges(Headers responseHeaders, String challengeHeader) {
-    List<Challenge> challenges = new ArrayList<>();
-    List<String> authenticationHeaders = responseHeaders.values(challengeHeader);
-headerLoop:
-    for (String header : authenticationHeaders) {
-      // ignore invalid header value
-      if (!AUTHENTICATION_HEADER_VALUE_PATTERN.matcher(header).matches()) {
+  public static List<Challenge> parseChallenges(Headers responseHeaders, String headerName) {
+    List<Challenge> result = new ArrayList<>();
+    for (int h = 0; h < responseHeaders.size(); h++) {
+      if (headerName.equalsIgnoreCase(responseHeaders.name(h))) {
+        Buffer header = new Buffer().writeUtf8(responseHeaders.value(h));
+        parseChallengeHeader(result, header);
+      }
+    }
+    return result;
+  }
+
+  private static void parseChallengeHeader(List<Challenge> result, Buffer header) {
+    String peek = null;
+
+    while (true) {
+      // Read a scheme name for this challenge if we don't have one already.
+      if (peek == null) {
+        skipWhitespaceAndCommas(header);
+        peek = readToken(header);
+        if (peek == null) return;
+      }
+
+      String schemeName = peek;
+
+      // Read a token68, a sequence of parameters, or nothing.
+      boolean commaPrefixed = skipWhitespaceAndCommas(header);
+      peek = readToken(header);
+      if (peek == null) {
+        if (!header.exhausted()) return; // Expected a token; got something else.
+        result.add(new Challenge(schemeName, Collections.<String, String>emptyMap()));
+        return;
+      }
+
+      int eqCount = skipAll(header, (byte) '=');
+      boolean commaSuffixed = skipWhitespaceAndCommas(header);
+
+      // It's a token68 because there isn't a value after it.
+      if (!commaPrefixed && (commaSuffixed || header.exhausted())) {
+        result.add(new Challenge(schemeName, Collections.singletonMap(
+            (String) null, peek + repeat('=', eqCount))));
+        peek = null;
         continue;
       }
 
-      // needed to properly abort if a header is invalid due to repeated auth param names
-      List<Challenge> headerChallenges = new ArrayList<>();
-
-      String[] challengeParts = AUTHENTICATION_HEADER_VALUE_SPLIT_PATTERN.split(header);
-      String authScheme = null;
-      Map<String, String> authParams = new LinkedHashMap<>();
-      for (int i = 0, j = challengeParts.length; i < j; i++) {
-        String challengePart = challengeParts[i];
-
-        // skip empty parts that can occur as first and last element
-        if (challengePart.isEmpty()) {
-          continue;
+      // It's a series of parameter names and values.
+      Map<String, String> parameters = new LinkedHashMap<>();
+      eqCount += skipAll(header, (byte) '=');
+      while (true) {
+        if (peek == null) {
+          peek = readToken(header);
+          if (skipWhitespaceAndCommas(header)) break; // We peeked a scheme name followed by ','.
+          eqCount = skipAll(header, (byte) '=');
         }
+        if (eqCount == 0) break; // We peeked a scheme name.
+        if (eqCount > 1) return; // Unexpected '=' characters.
+        if (skipWhitespaceAndCommas(header)) return; // Unexpected ','.
 
-        String newAuthScheme = null;
-        String authParam = null;
-        if (AUTH_SCHEME_PATTERN.matcher(challengePart).matches()) {
-          newAuthScheme = challengePart;
-        } else if (AUTH_SCHEME_AND_TOKEN68_PATTERN.matcher(challengePart).matches()) {
-          String[] authSchemeAndToken68 = WHITESPACE_SPLIT_PATTERN.split(challengePart, 2);
-          newAuthScheme = authSchemeAndToken68[0];
-          if (authParams.put(null, authSchemeAndToken68[1]) != null) {
-            // if the regex is correct, this must not happen
-            throw new AssertionError();
-          }
-        } else if (AUTH_SCHEME_AND_PARAM_PATTERN.matcher(challengePart).matches()) {
-          String[] authSchemeAndParam = WHITESPACE_SPLIT_PATTERN.split(challengePart, 2);
-          newAuthScheme = authSchemeAndParam[0];
-          authParam = authSchemeAndParam[1];
-        } else if (AUTH_PARAM_PATTERN.matcher(challengePart).matches()) {
-          authParam = challengePart;
-        } else {
-          // comma in quoted string part got split wrongly
-          StringBuilder patternBuilder = new StringBuilder();
-          patternBuilder.append('^').append(Pattern.quote(challengeParts[0]));
-          for (int i2 = 1; i2 < i; i2++) {
-            patternBuilder
-                    .append(AUTHENTICATION_HEADER_VALUE_SPLIT_PATTERN_PART)
-                    .append(Pattern.quote(challengeParts[i2]));
-          }
-          // if the algorithm has a flaw, the loop will crash with an ArrayIndexOutOfBoundsException
-          // if this happens, the algorithm or overall regex has to be fixed, not the array access
-          Matcher quotedStringAuthParamAtEndMatcher;
-          do {
-            patternBuilder
-                    .append(AUTHENTICATION_HEADER_VALUE_SPLIT_PATTERN_PART)
-                    .append(Pattern.quote(challengeParts[i++]));
-            Matcher matcher = Pattern.compile(patternBuilder.toString()).matcher(header);
-            if (!matcher.find()) {
-              // if the algorithm is flawless, this must not happen
-              throw new AssertionError();
-            }
-            quotedStringAuthParamAtEndMatcher =
-                    QUOTED_STRING_AUTH_PARAM_AT_END_PATTERN.matcher(matcher.group());
-          } while (!quotedStringAuthParamAtEndMatcher.find());
-          authParam = quotedStringAuthParamAtEndMatcher.group();
-        }
-
-        if (newAuthScheme != null) {
-          if (authScheme != null) {
-            headerChallenges.add(new Challenge(authScheme, authParams));
-            authParams.clear();
-          }
-          authScheme = newAuthScheme;
-        }
-
-        if (authParam != null) {
-          String[] authParamPair = AUTH_PARAM_SPLIT_PATTERN.split(authParam, 2);
-          // lower-case to easily check for multiple occurrences
-          String authParamKey = authParamPair[0].toLowerCase(US);
-          String authParamValue = authParamPair[1];
-          if (!TOKEN_PATTERN.matcher(authParamValue).matches()) {
-            authParamValue = authParamValue.substring(1, authParamValue.length() - 1);
-            authParamValue = QUOTED_PAIR_PATTERN.matcher(authParamValue).replaceAll("$1");
-          }
-          if (authParams.put(authParamKey, authParamValue) != null) {
-            // ignore invalid header value
-            // auth param keys must not occur multiple times within one challenge
-            continue headerLoop;
-          }
-        }
+        String parameterValue = !header.exhausted() && header.getByte(0) == '"'
+            ? readQuotedString(header)
+            : readToken(header);
+        if (parameterValue == null) return; // Expected a value.
+        String replaced = parameters.put(peek, parameterValue);
+        peek = null;
+        if (replaced != null) return; // Unexpected duplicate parameter.
+        if (!skipWhitespaceAndCommas(header) && !header.exhausted()) return; // Expected ',' or EOF.
       }
-      headerChallenges.add(new Challenge(authScheme, authParams));
-      challenges.addAll(headerChallenges);
+      result.add(new Challenge(schemeName, parameters));
     }
-    return challenges;
+  }
+
+  /** Returns true if any commas were skipped. */
+  private static boolean skipWhitespaceAndCommas(Buffer buffer) {
+    boolean commaFound = false;
+    while (!buffer.exhausted()) {
+      byte b = buffer.getByte(0);
+      if (b == ',') {
+        buffer.readByte(); // Consume ','.
+        commaFound = true;
+      } else if (b == ' ' || b == '\t') {
+        buffer.readByte(); // Consume space or tab.
+      } else {
+        break;
+      }
+    }
+    return commaFound;
+  }
+
+  private static int skipAll(Buffer buffer, byte b) {
+    int count = 0;
+    while (!buffer.exhausted() && buffer.getByte(0) == b) {
+      count++;
+      buffer.readByte();
+    }
+    return count;
+  }
+
+  /**
+   * Reads a double-quoted string, unescaping quoted pairs like {@code \"} to the 2nd character in
+   * each sequence. Returns the unescaped string, or null if the buffer isn't prefixed with a
+   * double-quoted string.
+   */
+  private static String readQuotedString(Buffer buffer) {
+    if (buffer.readByte() != '\"') throw new IllegalArgumentException();
+    Buffer result = new Buffer();
+    while (true) {
+      long i = buffer.indexOfElement(QUOTED_STRING_DELIMITERS);
+      if (i == -1L) return null; // Unterminated quoted string.
+
+      if (buffer.getByte(i) == '"') {
+        result.write(buffer, i);
+        buffer.readByte(); // Consume '"'.
+        return result.readUtf8();
+      }
+
+      if (buffer.size() == i + 1L) return null; // Dangling escape.
+      result.write(buffer, i);
+      buffer.readByte(); // Consume '\'.
+      result.write(buffer, 1L); // The escaped character.
+    }
+  }
+
+  /**
+   * Consumes and returns a non-empty token, terminating at special characters in {@link
+   * #TOKEN_DELIMITERS}. Returns null if the buffer is empty or prefixed with a delimiter.
+   */
+  private static String readToken(Buffer buffer) {
+    try {
+      long tokenSize = buffer.indexOfElement(TOKEN_DELIMITERS);
+      if (tokenSize == -1L) tokenSize = buffer.size();
+
+      return tokenSize != 0L
+          ? buffer.readUtf8(tokenSize)
+          : null;
+    } catch (EOFException e) {
+      throw new AssertionError();
+    }
+  }
+
+  private static String repeat(char c, int count) {
+    char[] array = new char[count];
+    Arrays.fill(array, c);
+    return new String(array);
   }
 
   public static void receiveHeaders(CookieJar cookieJar, HttpUrl url, Headers headers) {


### PR DESCRIPTION
Creating patterns dynamically to do comma-escaping is pretty awkward.
This is more code but I have more confidence in it.