### PR TITLE
Whole operation timeouts

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.HttpURLConnection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.BufferedSink;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static okhttp3.TestUtil.defaultClient;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class WholeOperationTimeoutTest {
+  /** A large response body. Smaller bodies might successfully read after the socket is closed! */
+  private static final String BIG_ENOUGH_BODY = TestUtil.repeat('a', 64 * 1024);
+
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  private OkHttpClient client = defaultClient();
+
+  @Test public void timeoutWritingRequest() throws Exception {
+    server.enqueue(new MockResponse());
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .post(sleepingRequestBody(500))
+        .build();
+
+    Call call = client.newCall(request);
+    call.timeout().timeout(250, TimeUnit.MILLISECONDS);
+    try {
+      call.execute();
+      fail();
+    } catch (IOException e) {
+      assertTrue(call.isCanceled());
+    }
+  }
+
+  @Test public void timeoutWritingRequestWithEnqueue() throws Exception {
+    server.enqueue(new MockResponse());
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .post(sleepingRequestBody(500))
+        .build();
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+
+    Call call = client.newCall(request);
+    call.timeout().timeout(250, TimeUnit.MILLISECONDS);
+    call.enqueue(new Callback() {
+      @Override public void onFailure(Call call, IOException e) {
+        exceptionRef.set(e);
+        latch.countDown();
+      }
+
+      @Override public void onResponse(Call call, Response response) throws IOException {
+        response.close();
+        latch.countDown();
+      }
+    });
+
+    latch.await();
+    assertTrue(call.isCanceled());
+    assertNotNull(exceptionRef.get());
+  }
+
+  @Test public void timeoutProcessing() throws Exception {
+    server.enqueue(new MockResponse()
+        .setHeadersDelay(500, TimeUnit.MILLISECONDS));
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .build();
+
+    Call call = client.newCall(request);
+    call.timeout().timeout(250, TimeUnit.MILLISECONDS);
+    try {
+      call.execute();
+      fail();
+    } catch (IOException e) {
+      assertTrue(call.isCanceled());
+    }
+  }
+
+  @Test public void timeoutProcessingWithEnqueue() throws Exception {
+    server.enqueue(new MockResponse()
+        .setHeadersDelay(500, TimeUnit.MILLISECONDS));
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .build();
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+
+    Call call = client.newCall(request);
+    call.timeout().timeout(250, TimeUnit.MILLISECONDS);
+    call.enqueue(new Callback() {
+      @Override public void onFailure(Call call, IOException e) {
+        exceptionRef.set(e);
+        latch.countDown();
+      }
+
+      @Override public void onResponse(Call call, Response response) throws IOException {
+        response.close();
+        latch.countDown();
+      }
+    });
+
+    latch.await();
+    assertTrue(call.isCanceled());
+    assertNotNull(exceptionRef.get());
+  }
+
+  @Test public void timeoutReadingResponse() throws Exception {
+    server.enqueue(new MockResponse()
+        .setBody(BIG_ENOUGH_BODY));
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .build();
+
+    Call call = client.newCall(request);
+    call.timeout().timeout(250, TimeUnit.MILLISECONDS);
+    Response response = call.execute();
+    Thread.sleep(500);
+    try {
+      response.body().source().readUtf8();
+      fail();
+    } catch (IOException e) {
+      assertTrue(call.isCanceled());
+    }
+  }
+
+  @Test public void timeoutReadingResponseWithEnqueue() throws Exception {
+    server.enqueue(new MockResponse()
+        .setBody(BIG_ENOUGH_BODY));
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .build();
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+
+    Call call = client.newCall(request);
+    call.timeout().timeout(250, TimeUnit.MILLISECONDS);
+    call.enqueue(new Callback() {
+      @Override public void onFailure(Call call, IOException e) {
+        latch.countDown();
+      }
+
+      @Override public void onResponse(Call call, Response response) throws IOException {
+        try {
+          Thread.sleep(500);
+        } catch (InterruptedException e) {
+          throw new AssertionError();
+        }
+        try {
+          response.body().source().readUtf8();
+          fail();
+        } catch (IOException e) {
+          exceptionRef.set(e);
+        } finally {
+          latch.countDown();
+        }
+      }
+    });
+
+    latch.await();
+    assertTrue(call.isCanceled());
+    assertNotNull(exceptionRef.get());
+  }
+
+  @Test public void singleTimeoutForAllFollowUpRequests() throws Exception {
+    server.enqueue(new MockResponse()
+        .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
+        .setHeader("Location", "/b")
+        .setHeadersDelay(100, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse()
+        .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
+        .setHeader("Location", "/c")
+        .setHeadersDelay(100, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse()
+        .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
+        .setHeader("Location", "/d")
+        .setHeadersDelay(100, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse()
+        .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
+        .setHeader("Location", "/e")
+        .setHeadersDelay(100, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse()
+        .setResponseCode(HttpURLConnection.HTTP_MOVED_TEMP)
+        .setHeader("Location", "/f")
+        .setHeadersDelay(100, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse());
+
+    Request request = new Request.Builder()
+        .url(server.url("/a"))
+        .build();
+
+    Call call = client.newCall(request);
+    call.timeout().timeout(250, TimeUnit.MILLISECONDS);
+    try {
+      call.execute();
+      fail();
+    } catch (IOException e) {
+      assertTrue(call.isCanceled());
+    }
+  }
+
+  @Test public void noTimeout() throws Exception {
+    server.enqueue(new MockResponse()
+        .setHeadersDelay(250, TimeUnit.MILLISECONDS)
+        .setBody(BIG_ENOUGH_BODY));
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .post(sleepingRequestBody(250))
+        .build();
+
+    Call call = client.newCall(request);
+    call.timeout().timeout(1000, TimeUnit.MILLISECONDS);
+    Response response = call.execute();
+    Thread.sleep(250);
+    response.body().source().readUtf8();
+    response.close();
+    assertFalse(call.isCanceled());
+  }
+
+  private RequestBody sleepingRequestBody(final int sleepMillis) {
+    return new RequestBody() {
+      @Override public MediaType contentType() {
+        return MediaType.parse("text/plain");
+      }
+
+      @Override public void writeTo(BufferedSink sink) throws IOException {
+        try {
+          sink.writeUtf8("abc");
+          sink.flush();
+          Thread.sleep(sleepMillis);
+          sink.writeUtf8("def");
+        } catch (InterruptedException e) {
+          throw new InterruptedIOException();
+        }
+      }
+    };
+  }
+}

--- a/okhttp/src/main/java/okhttp3/Call.java
+++ b/okhttp/src/main/java/okhttp3/Call.java
@@ -16,6 +16,7 @@
 package okhttp3;
 
 import java.io.IOException;
+import okio.Timeout;
 
 /**
  * A call is a request that has been prepared for execution. A call can be canceled. As this object
@@ -79,6 +80,12 @@ public interface Call extends Cloneable {
   boolean isExecuted();
 
   boolean isCanceled();
+
+  /**
+   * Returns a timeout that applies to the entire call: writing the request, server processing,
+   * and reading the response.
+   */
+  Timeout timeout();
 
   /**
    * Create a new, identical call to this one which can be enqueued or executed even if this call

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -15,6 +15,7 @@
  */
 package okhttp3;
 
+import java.io.IOException;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.Socket;
@@ -37,11 +38,11 @@ import javax.net.ssl.X509TrustManager;
 import okhttp3.internal.Internal;
 import okhttp3.internal.Util;
 import okhttp3.internal.cache.InternalCache;
-import okhttp3.internal.proxy.NullProxySelector;
 import okhttp3.internal.connection.RealConnection;
 import okhttp3.internal.connection.RouteDatabase;
 import okhttp3.internal.connection.StreamAllocation;
 import okhttp3.internal.platform.Platform;
+import okhttp3.internal.proxy.NullProxySelector;
 import okhttp3.internal.tls.CertificateChainCleaner;
 import okhttp3.internal.tls.OkHostnameVerifier;
 import okhttp3.internal.ws.RealWebSocket;
@@ -185,6 +186,10 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
 
       @Override public StreamAllocation streamAllocation(Call call) {
         return ((RealCall) call).streamAllocation();
+      }
+
+      @Override public @Nullable IOException timeoutExit(Call call, @Nullable IOException e) {
+        return ((RealCall) call).timeoutExit(e);
       }
 
       @Override public Call newWebSocketCall(OkHttpClient client, Request originalRequest) {

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -15,7 +15,9 @@
  */
 package okhttp3.internal;
 
+import java.io.IOException;
 import java.net.Socket;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLSocket;
 import okhttp3.Address;
 import okhttp3.Call;
@@ -72,6 +74,8 @@ public abstract class Internal {
   public abstract boolean isInvalidHttpUrlHost(IllegalArgumentException e);
 
   public abstract StreamAllocation streamAllocation(Call call);
+
+  public abstract @Nullable IOException timeoutExit(Call call, @Nullable IOException e);
 
   public abstract Call newWebSocketCall(OkHttpClient client, Request request);
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -317,8 +317,10 @@ public final class StreamAllocation {
     }
 
     if (e != null) {
+      e = Internal.instance.timeoutExit(call, e);
       eventListener.callFailed(call, e);
     } else if (callEnd) {
+      Internal.instance.timeoutExit(call, null);
       eventListener.callEnd(call);
     }
   }
@@ -351,6 +353,7 @@ public final class StreamAllocation {
     }
     closeQuietly(socket);
     if (releasedConnection != null) {
+      Internal.instance.timeoutExit(call, null);
       eventListener.connectionReleased(call, releasedConnection);
       eventListener.callEnd(call);
     }


### PR DESCRIPTION
Strictly-speaking this change is backwards-incompatible because it adds
a new method to the Call interface. The method returns the call's timeout.

The trickiest part of this is signaling the end of the call, which
occurs after the last byte is consumed of the last follow up request,
or when the call fails. Fortunately this is made easier by borrowing
the sites used by EventListener, which already plots out where calls
end.

https://github.com/square/okhttp/issues/2840