### PR TITLE
changed readme of the mockwerserver to point to parent readme

### DIFF
--- a/mockwebserver/README.md
+++ b/mockwebserver/README.md
@@ -140,20 +140,7 @@ server.setDispatcher(dispatcher);
 
 ### Download
 
-Get MockWebServer via Maven:
-```xml
-<dependency>
-  <groupId>com.squareup.okhttp3</groupId>
-  <artifactId>mockwebserver</artifactId>
-  <version>(insert latest version)</version>
-  <scope>test</scope>
-</dependency>
-```
-
-or via Gradle 
-```groovy
-testImplementation 'com.squareup.okhttp3:mockwebserver:(insert latest version)'
-```
+See [the parent readme](../README.md#MockWebServer).
 
 ### License
 


### PR DESCRIPTION
There are two copies of download instructions for mockwebserver. In the MockWebServer folder and in a parent folder.
The one in parent folder has latest version, the one in server's folder asks to use last version for version number, which confuses me (where can I get one?).
Added reference to parent readme, to have single point of truth and up to date version in one place and avoid confusion.