### PR TITLE
Relax handling of Cache-Control: immutable

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheStrategy.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheStrategy.java
@@ -205,9 +205,6 @@ public final class CacheStrategy {
       }
 
       CacheControl responseCaching = cacheResponse.cacheControl();
-      if (responseCaching.immutable()) {
-        return new CacheStrategy(null, cacheResponse);
-      }
 
       long ageMillis = cacheResponseAge();
       long freshMillis = computeFreshnessLifetime();


### PR DESCRIPTION
Previously we were treating this header as if the response would never
change. This was incorrect. The correct behavior according to RFC 8246
is that the 'immutable' directive only applies to conditional requests
made during the freshness lifetime. We don't make conditional requests
during the freshness lifetime, so the entire directive doesn't apply
to us.

https://github.com/square/okhttp/issues/4313