### PR TITLE
Log handshake in LoggingEventListener

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
@@ -75,7 +75,7 @@ public final class LoggingEventListener extends EventListener {
 
   @Override
   public void secureConnectEnd(Call call, @Nullable Handshake handshake) {
-    logWithTime("secureConnectEnd");
+    logWithTime("secureConnectEnd: " + handshake);
   }
 
   @Override

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
@@ -145,7 +145,11 @@ public final class LoggingEventListenerTest {
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
         .assertLogMatch("secureConnectStart")
-        .assertLogMatch("secureConnectEnd")
+        .assertLogMatch("secureConnectEnd: Handshake\\{"
+            + "tlsVersion=TLS_1_2 "
+            + "cipherSuite=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 "
+            + "peerCertificates=\\[CN=localhost\\] "
+            + "localCertificates=\\[\\]}")
         .assertLogMatch("connectEnd: h2")
         .assertLogMatch(
             "connectionAcquired: Connection\\{"

--- a/okhttp/src/main/java/okhttp3/Handshake.java
+++ b/okhttp/src/main/java/okhttp3/Handshake.java
@@ -158,7 +158,7 @@ public final class Handshake {
   private List<String> names(List<Certificate> certificates) {
     ArrayList<String> strings = new ArrayList<>();
 
-    for (Certificate cert: certificates) {
+    for (Certificate cert : certificates) {
       if (cert instanceof X509Certificate) {
         strings.add(String.valueOf(((X509Certificate) cert).getSubjectDN()));
       } else {

--- a/okhttp/src/main/java/okhttp3/Handshake.java
+++ b/okhttp/src/main/java/okhttp3/Handshake.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -139,5 +140,32 @@ public final class Handshake {
     result = 31 * result + peerCertificates.hashCode();
     result = 31 * result + localCertificates.hashCode();
     return result;
+  }
+
+  @Override public String toString() {
+    return "Handshake{"
+        + "tlsVersion="
+        + tlsVersion
+        + " cipherSuite="
+        + cipherSuite
+        + " peerCertificates="
+        + names(peerCertificates)
+        + " localCertificates="
+        + names(localCertificates)
+        + '}';
+  }
+
+  private List<String> names(List<Certificate> certificates) {
+    ArrayList<String> strings = new ArrayList<>();
+
+    for (Certificate cert: certificates) {
+      if (cert instanceof X509Certificate) {
+        strings.add(String.valueOf(((X509Certificate) cert).getSubjectDN()));
+      } else {
+        strings.add(cert.getType());
+      }
+    }
+
+    return strings;
   }
 }


### PR DESCRIPTION
Adds the handshake details to the LoggingEventListener.

`secureConnectEnd: Handshake{tlsVersion=TLS_1_2 cipherSuite=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 peerCertificates=[CN=localhost] localCertificates=[]}`