### PR TITLE
Change contributing guide in repo to match wiki

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,14 @@ sure your code compiles by running `mvn clean verify`. Checkstyle failures
 during compilation indicate errors in your style and can be viewed in the
 `checkstyle-result.xml` file.
 
+Some general advice
+
+- Don’t change public API lightly, avoid if possible, and include your reasoning in the PR if essential.  It causes pain for developers who use OkHttp and sometimes runtime errors.
+- Favour a working external library if appropriate.  There are many examples of OkHttp libraries that can sit on top or hook in via existing APIs.
+- Get working code on a personal branch with tests before you submit a PR.
+- OkHttp is a small and light dependency.  Don't introduce new dependencies or major new functionality.
+- OkHttp targets the intersection of RFC correct *and* widely implemented.  Incorrect implementations that are very widely implemented e.g. a bug in Apache, Nginx, Google, Firefox should also be handled.
+
 Before your code can be accepted into the project you must also sign the
 [Individual Contributor License Agreement (CLA)][1].
 


### PR DESCRIPTION
We could link, but much simpler to have each be standalone to ensure it gets read.