### PR TITLE
Support SOCKS proxies on older Android versions

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
@@ -31,6 +31,7 @@ import okhttp3.Call;
 import okhttp3.EventListener;
 import okhttp3.HttpUrl;
 import okhttp3.Route;
+import okhttp3.internal.platform.Platform;
 import okhttp3.internal.Util;
 
 /**
@@ -176,7 +177,8 @@ public final class RouteSelector {
           + "; port is out of range");
     }
 
-    if (proxy.type() == Proxy.Type.SOCKS) {
+    if (proxy.type() == Proxy.Type.SOCKS && Platform.get().getSocksVersion() >= 5) {
+      // SOCKS 5 supports DNS resolution at the proxy.
       inetSocketAddresses.add(InetSocketAddress.createUnresolved(socketHost, socketPort));
     } else {
       eventListener.dnsStart(call, socketHost);

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -454,4 +454,12 @@ class AndroidPlatform extends Platform {
       throw new IllegalStateException("No TLS provider", e);
     }
   }
+
+  @Override public int getSocksVersion() {
+    if (Build.VERSION.SDK_INT <= 23) {
+      // Android API 23 and lower only support SOCKS 4, not SOCKS 5.
+      return 4;
+    }
+    return super.getSocksVersion();
+  }
 }

--- a/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
@@ -82,6 +82,12 @@ final class Jdk9Platform extends Platform {
         "clientBuilder.sslSocketFactory(SSLSocketFactory) not supported on JDK 9+");
   }
 
+  @Override public int getSocksVersion() {
+    // This setting controls the default SOCKS version.  See
+    // https://docs.oracle.com/javase/9/docs/api/java/net/doc-files/net-properties.html
+    return Integer.parseInt(System.getProperty("socksProxyVersion", "5"));
+  }
+
   public static Jdk9Platform buildIfSupported() {
     // Find JDK 9 new methods
     try {

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -291,6 +291,12 @@ public class Platform {
   public void configureSslSocketFactory(SSLSocketFactory socketFactory) {
   }
 
+  public int getSocksVersion() {
+    // On JDK 7 and 8, SOCKS 5 is the only supported version.
+    // See https://bugs.openjdk.java.net/browse/JDK-8129444
+    return 5;
+  }
+
   @Override public String toString() {
     return getClass().getSimpleName();
   }


### PR DESCRIPTION
This is currently nonfunctional due to an interaction
between InetAddress.createUnresolved and the SOCKS 4 protocol.

Fixes #2315