### PR TITLE
Support custom DNS and SOCKS at the same time

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import okhttp3.Address;
 import okhttp3.Call;
+import okhttp3.Dns;
 import okhttp3.EventListener;
 import okhttp3.HttpUrl;
 import okhttp3.Route;
@@ -162,7 +163,10 @@ final class RouteSelector {
           + "; port is out of range");
     }
 
-    if (proxy.type() == Proxy.Type.SOCKS) {
+    if (proxy.type() == Proxy.Type.SOCKS && Dns.SYSTEM.equals(address.dns())) {
+      // SOCKS 5 supports DNS resolution at the proxy, and the caller hasn't overridden
+      // this behavior.  Callers who want SOCKS 4 compatibility on older Java implementations
+      // should set a custom Dns object in OkHttpClient.Builder.
       inetSocketAddresses.add(InetSocketAddress.createUnresolved(socketHost, socketPort));
     } else {
       eventListener.dnsStart(call, socketHost);

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -23,6 +23,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.UnknownHostException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
 import java.security.cert.TrustAnchor;
@@ -77,6 +78,16 @@ class AndroidPlatform extends Platform {
       // see https://issuetracker.google.com/issues/63649622
       if (Build.VERSION.SDK_INT == 26) {
         throw new IOException("Exception in connect", e);
+      } else {
+        throw e;
+      }
+    } catch (UnknownHostException e) {
+      if (address.isUnresolved() && Build.VERSION.SDK_INT <= 23) {
+        IOException ioException = new IOException(
+            "Android M and older throw this exception when a SOCKS proxy is enabled. "
+            + "To resolve this problem, set a custom Dns in OkHttpClient.Builder.");
+        ioException.initCause(e);
+        throw ioException;
       } else {
         throw e;
       }


### PR DESCRIPTION
Currently, setting a SOCKS proxy in OkHttpClient.Builder
silently overrides any custom DNS setting.  This changes
behavior for users who are currently using both settings
in a single Builder, but any such usage is likely already
buggy because the custom DNS setting is being ignored.

This also fixes #2315 (SOCKS 4 support) if users "opt in"
by adding a custom DNS setting in their Builder.