### PR TITLE
Remove overlapping package-info.java

### DIFF
--- a/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.java
@@ -22,12 +22,14 @@ import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.util.List;
+import okhttp3.internal.annotations.EverythingIsNonNull;
 
 /**
  * Adapts {@link java.net.Authenticator} to {@link Authenticator}. Configure OkHttp to use {@link
  * java.net.Authenticator} with {@link OkHttpClient.Builder#authenticator} or {@link
  * OkHttpClient.Builder#proxyAuthenticator(Authenticator)}.
  */
+@EverythingIsNonNull
 public final class JavaNetAuthenticator implements Authenticator {
   @Override public Request authenticate(Route route, Response response) throws IOException {
     List<Challenge> challenges = response.challenges();

--- a/okhttp-urlconnection/src/main/java/okhttp3/JavaNetCookieJar.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/JavaNetCookieJar.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import okhttp3.internal.annotations.EverythingIsNonNull;
 import okhttp3.internal.platform.Platform;
 
 import static okhttp3.internal.Util.delimiterOffset;
@@ -29,6 +30,7 @@ import static okhttp3.internal.Util.trimSubstring;
 import static okhttp3.internal.platform.Platform.WARN;
 
 /** A cookie jar that delegates to a {@link java.net.CookieHandler}. */
+@EverythingIsNonNull
 public final class JavaNetCookieJar implements CookieJar {
   private final CookieHandler cookieHandler;
 

--- a/okhttp-urlconnection/src/main/java/okhttp3/OkUrlFactory.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/OkUrlFactory.java
@@ -22,6 +22,7 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 import okhttp3.internal.URLFilter;
+import okhttp3.internal.annotations.EverythingIsNonNull;
 import okhttp3.internal.huc.OkHttpURLConnection;
 import okhttp3.internal.huc.OkHttpsURLConnection;
 
@@ -30,6 +31,7 @@ import okhttp3.internal.huc.OkHttpsURLConnection;
  * upcoming release. Applications that need this should either downgrade to the system's built-in
  * {@link HttpURLConnection} or upgrade to OkHttp's Request/Response API.
  */
+@EverythingIsNonNull
 public final class OkUrlFactory implements URLStreamHandlerFactory, Cloneable {
   private OkHttpClient client;
   private URLFilter urlFilter;

--- a/okhttp-urlconnection/src/main/java/okhttp3/package-info.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/package-info.java
@@ -1,3 +1,0 @@
-/** Support for JDK provider APIs. */
-@okhttp3.internal.annotations.EverythingIsNonNull
-package okhttp3;


### PR DESCRIPTION
Overlaps with okhttp core, triggering build issues. Without causing pain by moving the (public API) class we can only forgo this. 