### PR TITLE
Don't rely on BouncyCastle algorithms for certificate building.

### DIFF
--- a/okhttp-tls/src/main/java/okhttp3/tls/HeldCertificate.java
+++ b/okhttp-tls/src/main/java/okhttp3/tls/HeldCertificate.java
@@ -400,8 +400,7 @@ public final class HeldCertificate {
       }
 
       try {
-        X509Certificate certificate = generator.generateX509Certificate(
-            signedByKeyPair.getPrivate());
+        X509Certificate certificate = generator.generate(signedByKeyPair.getPrivate());
         return new HeldCertificate(heldKeyPair, certificate);
       } catch (GeneralSecurityException e) {
         throw new AssertionError(e);


### PR DESCRIPTION
We want the system default crypto provider to do it.

Potential fix for https://github.com/square/okhttp/issues/4443