### PR TITLE
Don't filter TE headers out if value is trailers

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/HeadersTest.java
@@ -64,12 +64,26 @@ public final class HeadersTest {
         .header("Connection", "upgrade")
         .header("Upgrade", "websocket")
         .header("Host", "square.com")
+        .header("TE", "gzip")
         .build();
     List<Header> expected = headerEntries(
         ":method", "GET",
         ":path", "/",
         ":authority", "square.com",
         ":scheme", "http");
+    assertEquals(expected, Http2Codec.http2HeadersList(request));
+  }
+
+  @Test public void http2HeadersListDontDropTeIfTrailersHttp2() {
+    Request request = new Request.Builder()
+        .url("http://square.com/")
+        .header("TE", "trailers")
+        .build();
+    List<Header> expected = headerEntries(
+        ":method", "GET",
+        ":path", "/",
+        ":scheme", "http",
+        "te", "trailers");
     assertEquals(expected, Http2Codec.http2HeadersList(request));
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -162,7 +162,8 @@ public final class Http2Codec implements HttpCodec {
     for (int i = 0, size = headers.size(); i < size; i++) {
       // header names must be lowercase.
       ByteString name = ByteString.encodeUtf8(headers.name(i).toLowerCase(Locale.US));
-      if (!HTTP_2_SKIPPED_REQUEST_HEADERS.contains(name.utf8())) {
+      if (!HTTP_2_SKIPPED_REQUEST_HEADERS.contains(name.utf8())
+          || name.utf8().equals(TE) && headers.value(i).equals("trailers")) {
         result.add(new Header(name, headers.value(i)));
       }
     }


### PR DESCRIPTION
part of #4267

https://tools.ietf.org/html/rfc7540#section-8.1.2.2
https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.39