### PR TITLE
Handle security exception when testing if conscrypt should be used

### DIFF
--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
@@ -29,7 +29,6 @@ import java.net.Proxy;
 import java.net.SocketPermission;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.security.AccessControlException;
 import java.security.Permission;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,6 +52,7 @@ import okhttp3.Response;
 import okhttp3.internal.Internal;
 import okhttp3.internal.JavaNetHeaders;
 import okhttp3.internal.URLFilter;
+import okhttp3.internal.Util;
 import okhttp3.internal.Version;
 import okhttp3.internal.http.HttpDate;
 import okhttp3.internal.http.HttpHeaders;
@@ -415,13 +415,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
   }
 
   private String defaultUserAgent() {
-    String agent = null;
-    try {
-      agent = System.getProperty("http.agent");
-    } catch (AccessControlException ex) {
-      Platform.get().log(WARN, "Cannot read the http.agent property", ex);
-    }
-
+    String agent = Util.getSystemProperty("http.agent", null);
     return agent != null ? toHumanReadableAscii(agent) : Version.userAgent();
   }
 

--- a/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
+++ b/okhttp-urlconnection/src/main/java/okhttp3/internal/huc/OkHttpURLConnection.java
@@ -29,6 +29,7 @@ import java.net.Proxy;
 import java.net.SocketPermission;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.security.AccessControlException;
 import java.security.Permission;
 import java.util.Arrays;
 import java.util.Collections;
@@ -414,7 +415,13 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
   }
 
   private String defaultUserAgent() {
-    String agent = System.getProperty("http.agent");
+    String agent = null;
+    try {
+      agent = System.getProperty("http.agent");
+    } catch (AccessControlException ex) {
+      Platform.get().log(WARN, "Cannot read the http.agent property", ex);
+    }
+
     return agent != null ? toHumanReadableAscii(agent) : Version.userAgent();
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -26,6 +26,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
+import java.security.AccessControlException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.util.ArrayList;
@@ -690,5 +691,19 @@ public final class Util {
       result.add(new Header(headers.name(i), headers.value(i)));
     }
     return result;
+  }
+
+  /**
+   * Returns the system property, or defaultValue if the system property is null or
+   * cannot be read (e.g. because of security policy restrictions).
+   */
+  public static String getSystemProperty(String key, @Nullable String defaultValue) {
+    final String value;
+    try {
+      value = System.getProperty(key);
+    } catch (AccessControlException ex) {
+      return defaultValue;
+    }
+    return value != null ? value : defaultValue;
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.security.AccessControlException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.util.ArrayList;
@@ -75,10 +76,10 @@ import okio.Buffer;
  * <p>Supported on Android 6.0+ via {@code NetworkSecurityPolicy}.
  */
 public class Platform {
+  private static final Logger logger = Logger.getLogger(OkHttpClient.class.getName());
   private static final Platform PLATFORM = findPlatform();
   public static final int INFO = 4;
   public static final int WARN = 5;
-  private static final Logger logger = Logger.getLogger(OkHttpClient.class.getName());
 
   public static Platform get() {
     return PLATFORM;
@@ -187,8 +188,12 @@ public class Platform {
 
   public static boolean isConscryptPreferred() {
     // mainly to allow tests to run cleanly
-    if ("conscrypt".equals(System.getProperty("okhttp.platform"))) {
-      return true;
+    try {
+      if ("conscrypt".equals(System.getProperty("okhttp.platform"))) {
+        return true;
+      }
+    } catch (AccessControlException ex) {
+      logger.log(Level.WARNING, "Cannot read the okhttp.platform property", ex);
     }
 
     // check if Provider manually installed

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -272,7 +272,13 @@ public class Platform {
   }
 
   public SSLContext getSSLContext() {
-    String jvmVersion = System.getProperty("java.specification.version");
+    String jvmVersion = null;
+    try {
+      jvmVersion = System.getProperty("java.specification.version");
+    } catch (AccessControlException ex) {
+      logger.log(Level.WARNING, "Cannot read the java.specification.version property", ex);
+    }
+
     if ("1.7".equals(jvmVersion)) {
       try {
         // JDK 1.7 (public version) only support > TLSv1 with named protocols


### PR DESCRIPTION
In some containers or environments, a security policy may prevent reading unknown system properties.

As a result, `Platform#isConscryptPreferred()` is throwing an exception when running OkHttp in our container - because `okhttp.platform` is not on the whitelist of System Properties which are allowed to be read.

This pull request adds handling for such exceptions so that `OkHttpClient` initialization doesn't fail.