### PR TITLE
Fix flaky webSocketAndApplicationInterceptors test

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -376,6 +376,8 @@ public final class WebSocketHttpTest {
 
     WebSocket server = serverListener.assertOpen();
     server.close(1000, null);
+    clientListener.assertClosing(1000, "");
+    clientListener.assertClosed(1000, "");
   }
 
   @Test public void webSocketAndNetworkInterceptors() {


### PR DESCRIPTION
The 'Closing' and 'Closed' events sometimes fire before the test completes. Since they were not consumed by the test, the assertion in tearTown() that all events have been consumed failed.

Fixes https://github.com/square/okhttp/issues/4382.