### PR TITLE
Stream release doesn't always mean call end

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -1103,7 +1103,6 @@ public final class EventListenerTest {
     assertEquals(expectedEvents, listener.recordedEventTypes());
   }
 
-  @Ignore("CallEnd emitted twice")
   @Test
   public void redirectUsingNewConnectionEventSequence() throws IOException {
     MockWebServer otherServer = new MockWebServer();

--- a/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
@@ -257,8 +257,6 @@ public final class WholeOperationTimeoutTest {
     }
   }
 
-  @Ignore(
-      "timeout.exit() is called when the first connection is released but timeout.enter() is not called again")
   @Test
   public void timeoutFollowingRedirectOnNewConnection() throws Exception {
     MockWebServer otherServer = new MockWebServer();

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -343,7 +343,7 @@ public final class StreamAllocation {
     return connection;
   }
 
-  public void release() {
+  public void release(boolean callEnd) {
     Socket socket;
     Connection releasedConnection;
     synchronized (connectionPool) {
@@ -353,9 +353,13 @@ public final class StreamAllocation {
     }
     closeQuietly(socket);
     if (releasedConnection != null) {
-      Internal.instance.timeoutExit(call, null);
+      if (callEnd) {
+        Internal.instance.timeoutExit(call, null);
+      }
       eventListener.connectionReleased(call, releasedConnection);
-      eventListener.callEnd(call);
+      if (callEnd) {
+        eventListener.callEnd(call);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes:
* an issue where call timeout doesn't fire after redirect is followed on a different connection
* https://github.com/square/okhttp/issues/4386

While I think this is the minimal fix, I'm not sure it's the best end state. It may be better to trigger call-end actions in `RetryAndFollowUpInterceptor` instead of passing a flag to `StreamAllocation.release()`. This may be a slightly bigger change and can be done as a follow-up refactoring-only PR.