### PR TITLE
Assert connection pool eviction in HttpOverHttp2Test.tearDown()

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -150,6 +150,7 @@ public final class HttpOverHttp2Test {
     http2Logger.setLevel(previousLevel);
 
     client.connectionPool().evictAll();
+    assertEquals(0, client.connectionPool().connectionCount());
   }
 
   @Test public void get() throws Exception {


### PR DESCRIPTION
While investigating https://github.com/square/okhttp/issues/4470, I noticed there are sometimes connections left in the pool after calling ConnectionPool.evictAll() in HttpOverHttp2Test.tearDown(). As a result, tests that assume the connection pool is initially empty can appear flaky while the blame is in previous tests, making it hard to debug, and possibly hiding a connection leak bug.

So far I've noticed the new assertion fails (very rarely) when tearing down these tests:
* recoverFromMultipleCancelReusesConnection
* emptyDataFrameSentWithEmptyBody
* gzippedResponseBody

This change may increase flakiness in the short term, but will make it easier to debug, by blaming the right tests.