### PR TITLE
Remove duplicate connection pool eviction code

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -149,6 +149,7 @@ public final class HttpOverHttp2Test {
     http2Logger.removeHandler(http2Handler);
     http2Logger.setLevel(previousLevel);
 
+    // Ensure a fresh connection pool for the next test.
     client.connectionPool().evictAll();
     assertEquals(0, client.connectionPool().connectionCount());
   }
@@ -754,10 +755,6 @@ public final class HttpOverHttp2Test {
   }
 
   @Test public void cancelWithStreamNotCompleted() throws Exception {
-    // Ensure that the (shared) connection pool is in a consistent state.
-    client.connectionPool().evictAll();
-    assertEquals(0, client.connectionPool().connectionCount());
-
     server.enqueue(new MockResponse()
         .setBody("abc"));
     server.enqueue(new MockResponse()
@@ -1341,9 +1338,6 @@ public final class HttpOverHttp2Test {
     assumeTrue(protocol == Protocol.HTTP_2);
 
     server.useHttps(handshakeCertificates.sslSocketFactory(), true);
-
-    // Force a fresh connection pool for the test.
-    client.connectionPool().evictAll();
 
     final QueueDispatcher queueDispatcher = new QueueDispatcher();
     queueDispatcher.enqueueResponse(new MockResponse()


### PR DESCRIPTION
tearDown() takes care of this.