### PR TITLE
Fix NPE in HttpLoggingInterceptor when response has no body

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -230,7 +230,7 @@ public final class HttpLoggingInterceptor implements Interceptor {
     long tookMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
 
     ResponseBody responseBody = response.body();
-    long contentLength = responseBody.contentLength();
+    long contentLength = responseBody != null ? responseBody.contentLength() : -1;
     String bodySize = contentLength != -1 ? contentLength + "-byte" : "unknown-length";
     logger.log("<-- "
         + response.code()


### PR DESCRIPTION
When intercepting a WebSocket response.body() returns null