### PR TITLE
Exercise TLS with no server certificates

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -84,6 +84,7 @@ import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
 import static java.net.CookiePolicy.ACCEPT_ORIGINAL_SERVER;
+import static okhttp3.CipherSuite.TLS_DH_anon_WITH_AES_128_GCM_SHA256;
 import static okhttp3.TestUtil.awaitGarbageCollection;
 import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.tls.internal.TlsUtil.localhost;
@@ -1178,6 +1179,96 @@ public final class CallTest {
       String jvmVersion = System.getProperty("java.specification.version");
       assertEquals("11", jvmVersion);
     }
+  }
+
+  /**
+   * When the server doesn't present any certificates we fail the TLS handshake. This test requires
+   * that the client and server are each configured with a cipher suite that permits the server to
+   * be unauthenticated.
+   */
+  @Test public void tlsSuccessWithNoPeerCertificates() throws Exception {
+    server.enqueue(new MockResponse()
+        .setBody("abc"));
+
+    // The _anon_ cipher suites don't require server certificates.
+    CipherSuite cipherSuite = TLS_DH_anon_WITH_AES_128_GCM_SHA256;
+
+    HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+        .build();
+    client = client.newBuilder()
+        .sslSocketFactory(
+            socketFactoryWithCipherSuite(clientCertificates.sslSocketFactory(), cipherSuite),
+            clientCertificates.trustManager())
+        .connectionSpecs(Arrays.asList(new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .cipherSuites(cipherSuite)
+            .build()))
+        .hostnameVerifier(new RecordingHostnameVerifier())
+        .build();
+
+    HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+        .build();
+    server.useHttps(socketFactoryWithCipherSuite(
+        serverCertificates.sslSocketFactory(), cipherSuite), false);
+
+    Call call = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    Response response = call.execute();
+    assertEquals("abc", response.body().string());
+    assertNull(response.handshake().peerPrincipal());
+    assertEquals(Collections.emptyList(), response.handshake().peerCertificates());
+    assertEquals(cipherSuite, response.handshake().cipherSuite());
+  }
+
+  @Test public void tlsHostnameVerificationFailure() throws Exception {
+    server.enqueue(new MockResponse());
+
+    HeldCertificate serverCertificate = new HeldCertificate.Builder()
+        .commonName("localhost") // Unusued for hostname verification.
+        .addSubjectAlternativeName("wronghostname")
+        .build();
+
+    HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+        .heldCertificate(serverCertificate)
+        .build();
+
+    HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+        .addTrustedCertificate(serverCertificate.certificate())
+        .build();
+
+    client = client.newBuilder()
+        .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager())
+        .build();
+    server.useHttps(serverCertificates.sslSocketFactory(), false);
+
+    executeSynchronously("/")
+        .assertFailureMatches("(?s)Hostname localhost not verified.*");
+  }
+
+  @Test public void tlsHostnameVerificationFailureNoPeerCertificates() throws Exception {
+    server.enqueue(new MockResponse());
+
+    // The _anon_ cipher suites don't require server certificates.
+    CipherSuite cipherSuite = TLS_DH_anon_WITH_AES_128_GCM_SHA256;
+
+    HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+        .build();
+    client = client.newBuilder()
+        .sslSocketFactory(
+            socketFactoryWithCipherSuite(clientCertificates.sslSocketFactory(), cipherSuite),
+            clientCertificates.trustManager())
+        .connectionSpecs(Arrays.asList(new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .cipherSuites(cipherSuite)
+            .build()))
+        .build();
+
+    HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+        .build();
+    server.useHttps(socketFactoryWithCipherSuite(
+        serverCertificates.sslSocketFactory(), cipherSuite), false);
+
+    executeSynchronously("/")
+        .assertFailure("Hostname localhost not verified (no certificates)");
   }
 
   @Test public void cleartextCallsFailWhenCleartextIsDisabled() throws Exception {
@@ -3528,6 +3619,16 @@ public final class CallTest {
         call.cancel();
       }
     }.start();
+  }
+
+  private SSLSocketFactory socketFactoryWithCipherSuite(
+      final SSLSocketFactory sslSocketFactory, final CipherSuite cipherSuite) {
+    return new DelegatingSSLSocketFactory(sslSocketFactory) {
+      @Override protected SSLSocket configureSocket(SSLSocket sslSocket) throws IOException {
+        sslSocket.setEnabledCipherSuites(new String[] { cipherSuite.javaName() });
+        return super.configureSocket(sslSocket);
+      }
+    };
   }
 
   private static class RecordingSSLSocketFactory extends DelegatingSSLSocketFactory {


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/4427