### PR TITLE
Ensure streams are removed from connection within test lifetime

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -896,8 +896,10 @@ public final class HttpOverHttp2Test {
     Call call = client.newCall(new Request.Builder()
         .url(server.url("/"))
         .build());
+    final CountDownLatch latch = new CountDownLatch(1);
     call.enqueue(new Callback() {
       @Override public void onFailure(Call call1, IOException e) {
+        latch.countDown();
       }
 
       @Override public void onResponse(Call call1, Response response) {
@@ -905,6 +907,7 @@ public final class HttpOverHttp2Test {
     });
     assertEquals(expectedSequenceNumber, server.takeRequest().getSequenceNumber());
     call.cancel();
+    latch.await();
   }
 
   @Test public void noRecoveryFromRefusedStreamWithRetryDisabled() throws Exception {


### PR DESCRIPTION
After the recent fix, if the call is canceled while writing request headers, the stream is eventually removed from the connection. But this is done on a separate thread, and there was previously no guarantee that it would happen before tearDown() is called and the connection pool is evicted, preventing the connection from being evicted before the next test starts.

Together with https://github.com/square/okhttp/pull/4492, this will hopefully fix https://github.com/square/okhttp/issues/4470.