### PR TITLE
Make Http2Codec.stream volatile

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -91,7 +91,7 @@ public final class Http2Codec implements HttpCodec {
   private final Interceptor.Chain chain;
   final StreamAllocation streamAllocation;
   private final Http2Connection connection;
-  private Http2Stream stream;
+  private volatile Http2Stream stream;
   private final Protocol protocol;
   private volatile boolean canceled;
 


### PR DESCRIPTION
It can be referenced from multiple threads.

I think there is still a thread safety issue with the Http2Stream class.