### PR TITLE
Fix WebSocketRecorder logging

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java
@@ -86,7 +86,7 @@ public final class WebSocketRecorder extends WebSocketListener {
   }
 
   @Override public void onClosing(WebSocket webSocket, int code, String reason) {
-    Platform.get().log(Platform.INFO, "[WS " + name + "] onClose " + code, null);
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onClosing " + code, null);
 
     WebSocketListener delegate = this.delegate;
     if (delegate != null) {
@@ -98,7 +98,7 @@ public final class WebSocketRecorder extends WebSocketListener {
   }
 
   @Override public void onClosed(WebSocket webSocket, int code, String reason) {
-    Platform.get().log(Platform.INFO, "[WS " + name + "] onClose " + code, null);
+    Platform.get().log(Platform.INFO, "[WS " + name + "] onClosed " + code, null);
 
     WebSocketListener delegate = this.delegate;
     if (delegate != null) {


### PR DESCRIPTION
Both WebSocketRecorder.onClosing() and WebSocketRecorder.onClose() currently use the string "onClose":
https://github.com/square/okhttp/blob/775d5d9d5c6a210a49fb6ef5ebfcc47dcbb0865a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java#L88-L89

https://github.com/square/okhttp/blob/775d5d9d5c6a210a49fb6ef5ebfcc47dcbb0865a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketRecorder.java#L100-L101