### PR TITLE
Fix connection leak if WebSocketListener.onOpen() throws

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -168,8 +168,6 @@ public final class WebSocketHttpTest {
     serverListener.assertOpen();
     serverListener.assertExhausted();
     clientListener.assertFailure(e);
-
-    // TODO: fix connection leak
   }
 
   @Ignore("AsyncCall currently lets runtime exceptions propagate.")

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -207,9 +207,9 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
 
         // Process all web socket messages.
         try {
-          listener.onOpen(RealWebSocket.this, response);
           String name = "OkHttp WebSocket " + request.url().redact();
           initReaderAndWriter(name, streams);
+          listener.onOpen(RealWebSocket.this, response);
           streamAllocation.connection().socket().setSoTimeout(0);
           loopReader();
         } catch (Exception e) {


### PR DESCRIPTION
If WebSocketListener.onOpen() throws, failWebSocket() is responsible for releasing the allocated streams. Specifically it releases this.streams. Previously WebSocketListener.onOpen() was called after the streams were allocated but before they were assigned to this.streams. As a result the streams were not allocated if WebSocketListener.onOpen() threw.

Fixes part of https://github.com/square/okhttp/issues/4515.