### PR TITLE
Fix connection leak on failed WebSocket handshake

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -310,8 +310,6 @@ public final class WebSocketHttpTest {
 
     clientListener.assertFailure(101, null, ProtocolException.class,
         "Expected 'Connection' header value 'Upgrade' but was 'null'");
-
-    // TODO: fix connection leak
   }
 
   @Test public void wrongConnectionHeader() throws IOException {
@@ -324,8 +322,6 @@ public final class WebSocketHttpTest {
 
     clientListener.assertFailure(101, null, ProtocolException.class,
         "Expected 'Connection' header value 'Upgrade' but was 'Downgrade'");
-
-    // TODO: fix connection leak
   }
 
   @Test public void missingUpgradeHeader() throws IOException {
@@ -337,8 +333,6 @@ public final class WebSocketHttpTest {
 
     clientListener.assertFailure(101, null, ProtocolException.class,
         "Expected 'Upgrade' header value 'websocket' but was 'null'");
-
-    // TODO: fix connection leak
   }
 
   @Test public void wrongUpgradeHeader() throws IOException {
@@ -351,8 +345,6 @@ public final class WebSocketHttpTest {
 
     clientListener.assertFailure(101, null, ProtocolException.class,
         "Expected 'Upgrade' header value 'websocket' but was 'Pepsi'");
-
-    // TODO: fix connection leak
   }
 
   @Test public void missingMagicHeader() throws IOException {
@@ -364,8 +356,6 @@ public final class WebSocketHttpTest {
 
     clientListener.assertFailure(101, null, ProtocolException.class,
         "Expected 'Sec-WebSocket-Accept' header value 'ujmZX4KXZqjwy6vi1aQFH5p4Ygk=' but was 'null'");
-
-    // TODO: fix connection leak
   }
 
   @Test public void wrongMagicHeader() throws IOException {
@@ -378,8 +368,6 @@ public final class WebSocketHttpTest {
 
     clientListener.assertFailure(101, null, ProtocolException.class,
         "Expected 'Sec-WebSocket-Accept' header value 'ujmZX4KXZqjwy6vi1aQFH5p4Ygk=' but was 'magic'");
-
-    // TODO: fix connection leak
   }
 
   @Test public void webSocketAndApplicationInterceptors() {

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -192,16 +192,18 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
     call.timeout().clearTimeout();
     call.enqueue(new Callback() {
       @Override public void onResponse(Call call, Response response) {
+        StreamAllocation streamAllocation = Internal.instance.streamAllocation(call);
+
         try {
           checkResponse(response);
         } catch (ProtocolException e) {
           failWebSocket(e, response);
           closeQuietly(response);
+          streamAllocation.streamFailed(e);
           return;
         }
 
         // Promote the HTTP streams into web socket streams.
-        StreamAllocation streamAllocation = Internal.instance.streamAllocation(call);
         streamAllocation.noNewStreams(); // Prevent connection pooling!
         Streams streams = streamAllocation.connection().newWebSocketStreams(streamAllocation);
 


### PR DESCRIPTION
Note that as long as there are leaking tests, I can't commit an assertion that verifies the fix. Since all tests share the same OkHttpClient and ConnectionPool, a leaking test will cause such an assertion to fail for all subsequent tests. To test the fix, I added an assertion locally and ran each fixed test individually.