### PR TITLE
Test for and fix connection leaks in CallTest

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
@@ -301,14 +301,22 @@ public final class ConnectionReuseTest {
    * https://github.com/square/okhttp/issues/2409
    */
   @Test public void connectionsAreNotReusedIfNetworkInterceptorInterferes() throws Exception {
-    client = client.newBuilder().addNetworkInterceptor(new Interceptor() {
-      @Override public Response intercept(Chain chain) throws IOException {
-        Response response = chain.proceed(chain.request());
-        return response.newBuilder()
-            .body(ResponseBody.create(null, "unrelated response body!"))
-            .build();
-      }
-    }).build();
+    client = client.newBuilder()
+        // Since this test knowingly leaks a connection, avoid using the default shared connection
+        // pool, which should remain clean for subsequent tests.
+        .connectionPool(new ConnectionPool())
+        .addNetworkInterceptor(
+            new Interceptor() {
+              @Override
+              public Response intercept(Chain chain) throws IOException {
+                Response response = chain.proceed(chain.request());
+                return response
+                    .newBuilder()
+                    .body(ResponseBody.create(null, "unrelated response body!"))
+                    .build();
+              }
+            })
+        .build();
 
     server.enqueue(new MockResponse()
         .setResponseCode(301)


### PR DESCRIPTION
Also removed calls to ConnectionPool.evictAll() that are now redundant.