### PR TITLE
Fix flaky WebSocketHttpTest.webSocketAndNetworkInterceptors

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -405,8 +405,6 @@ public final class WebSocketHttpTest {
 
     WebSocket webSocket = newWebSocket();
     clientListener.assertOpen();
-    webSocket.close(1000, null);
-
     WebSocket server = serverListener.assertOpen();
 
     closeWebSockets(webSocket, server);


### PR DESCRIPTION
close() is already called on the client WebSocket in closeWebSockets().