### PR TITLE
Get trailers working for HTTP/1

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockResponse.java
@@ -212,7 +212,7 @@ public final class MockResponse implements Cloneable {
       bytesOut.write(body, chunkSize);
       bytesOut.writeUtf8("\r\n");
     }
-    bytesOut.writeUtf8("0\r\n\r\n"); // Last chunk + empty trailer + CRLF.
+    bytesOut.writeUtf8("0\r\n"); // Last chunk. Trailers follow!
 
     this.body = bytesOut;
     return this;

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -519,7 +519,7 @@ public final class CacheTest {
     BufferedSource bodySource = get(server.url("/")).body().source();
     assertEquals("ABCDE", bodySource.readUtf8Line());
     try {
-      bodySource.readUtf8Line();
+      bodySource.readUtf8(21);
       fail("This implementation silently ignored a truncated HTTP body.");
     } catch (IOException expected) {
     } finally {
@@ -2577,18 +2577,17 @@ public final class CacheTest {
   }
 
   enum TransferKind {
-    CHUNKED() {
-      @Override void setBody(MockResponse response, Buffer content, int chunkSize)
-          throws IOException {
+    CHUNKED {
+      @Override void setBody(MockResponse response, Buffer content, int chunkSize) {
         response.setChunkedBody(content, chunkSize);
       }
     },
-    FIXED_LENGTH() {
+    FIXED_LENGTH {
       @Override void setBody(MockResponse response, Buffer content, int chunkSize) {
         response.setBody(content);
       }
     },
-    END_OF_STREAM() {
+    END_OF_STREAM {
       @Override void setBody(MockResponse response, Buffer content, int chunkSize) {
         response.setBody(content);
         response.setSocketPolicy(DISCONNECT_AT_END);

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -3485,8 +3485,7 @@ public final class CallTest {
     assertEquals(1L, called.get());
   }
 
-  // Coming soon
-  @Test @Ignore public void clientReadsHeadersDataTrailersHttp1ChunkedTransferEncoding() throws IOException {
+  @Test public void clientReadsHeadersDataTrailersHttp1ChunkedTransferEncoding() throws Exception {
     MockResponse mockResponse = new MockResponse()
         .clearHeaders()
         .addHeader("h1", "v1")

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -910,11 +910,11 @@ public final class URLConnectionTest {
 
   @Test public void contentDisagreesWithChunkedHeaderBodyTooShort() throws IOException {
     MockResponse mockResponse = new MockResponse();
-    mockResponse.setChunkedBody("abcde", 5);
+    mockResponse.setChunkedBody("abcdefg", 5);
 
     Buffer truncatedBody = new Buffer();
     Buffer fullBody = mockResponse.getBody();
-    truncatedBody.write(fullBody, fullBody.indexOf((byte) 'e'));
+    truncatedBody.write(fullBody, 4);
     mockResponse.setBody(truncatedBody);
 
     mockResponse.clearHeaders();
@@ -924,9 +924,9 @@ public final class URLConnectionTest {
     server.enqueue(mockResponse);
 
     try {
-      readAscii(urlFactory.open(server.url("/").url()).getInputStream(), 5);
+      readAscii(urlFactory.open(server.url("/").url()).getInputStream(), 7);
       fail();
-    } catch (ProtocolException expected) {
+    } catch (IOException expected) {
     }
   }
 
@@ -3743,7 +3743,7 @@ public final class URLConnectionTest {
   }
 
   enum TransferKind {
-    CHUNKED() {
+    CHUNKED {
       @Override void setBody(MockResponse response, Buffer content, int chunkSize) {
         response.setChunkedBody(content, chunkSize);
       }
@@ -3752,7 +3752,7 @@ public final class URLConnectionTest {
         connection.setChunkedStreamingMode(5);
       }
     },
-    FIXED_LENGTH() {
+    FIXED_LENGTH {
       @Override void setBody(MockResponse response, Buffer content, int chunkSize) {
         response.setBody(content);
       }
@@ -3761,7 +3761,7 @@ public final class URLConnectionTest {
         connection.setFixedLengthStreamingMode(contentLength);
       }
     },
-    END_OF_STREAM() {
+    END_OF_STREAM {
       @Override void setBody(MockResponse response, Buffer content, int chunkSize) {
         response.setBody(content);
         response.setSocketPolicy(DISCONNECT_AT_END);


### PR DESCRIPTION
The most awkward part of this is the changes to the way MockResponse
handled chunked encoding. It used to consider trailers a part of its
chunked response; now it does not.