### PR TITLE
Upgrade to Okio 1.17.1.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/duplex/DuplexRequestBody.java
+++ b/okhttp/src/main/java/okhttp3/internal/duplex/DuplexRequestBody.java
@@ -73,17 +73,7 @@ public final class DuplexRequestBody extends RequestBody implements Callback {
   }
 
   public void foldSink(Sink requestBodyOut) throws IOException {
-    // TODO: replace with okio Pipe#fold when released
-    Thread thread = new Thread("duplex folder thingy") {
-      @Override public void run() {
-        try (BufferedSink requestBody = Okio.buffer(requestBodyOut)) {
-          requestBody.writeAll(pipe.source());
-        } catch (IOException e) {
-          e.printStackTrace(); // TODO: actual fold should fix this.
-        }
-      }
-    };
-    thread.start();
+    pipe.fold(requestBodyOut);
   }
 
   @Override public synchronized void onFailure(Call call, IOException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <java.version>1.8</java.version>
     <moshi.version>1.8.0</moshi.version>
     <jnr-unixsocket.version>0.21</jnr-unixsocket.version>
-    <okio.version>1.16.0</okio.version>
+    <okio.version>1.17.1</okio.version>
     <conscrypt.version>1.4.2</conscrypt.version>
 
     <!-- Test Dependencies -->


### PR DESCRIPTION
Use the new Pipe.fold() method to hook up the duplex sink.