### PR TITLE
Delay loading default ServerSocketFactory until needed

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -132,7 +132,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
       Collections.newSetFromMap(new ConcurrentHashMap<Http2Connection, Boolean>());
   private final AtomicInteger requestCount = new AtomicInteger();
   private long bodyLimit = Long.MAX_VALUE;
-  private ServerSocketFactory serverSocketFactory = ServerSocketFactory.getDefault();
+  private ServerSocketFactory serverSocketFactory;
   private ServerSocket serverSocket;
   private SSLSocketFactory sslSocketFactory;
   private ExecutorService executor;
@@ -358,7 +358,12 @@ public final class MockWebServer extends ExternalResource implements Closeable {
 
     executor = Executors.newCachedThreadPool(Util.threadFactory("MockWebServer", false));
     this.inetSocketAddress = inetSocketAddress;
+
+    if (serverSocketFactory == null) {
+      serverSocketFactory = ServerSocketFactory.getDefault();
+    }
     serverSocket = serverSocketFactory.createServerSocket();
+
     // Reuse if the user specified a port
     serverSocket.setReuseAddress(inetSocketAddress.getPort() != 0);
     serverSocket.bind(inetSocketAddress, 50);


### PR DESCRIPTION
`ServerSocketFactory.getDefault()` will load the default JVM truststore
(typically from jre/lib/security/cacerts) as configured by JSSE
system properties.

However, a typical use case for setting a custom ServerSocketFactory is
that the client application has loaded custom keystore or truststore
material into their JVM, usually by creating a custom SSLContext.

There's strictly no reason to initialize the default ServerSocketFactory
until the mockwebserver has been started, allowing custom settings of the
factory by clients and avoiding the default load attempt during class
construction.

This patch simply moves the initiatlization logic into the private start
method to avoid the premature loading of trust store materials.