### PR TITLE
Allow users to set UTF-8 characters in Multipart Parts when they use addFormDataPart(...)

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
@@ -188,6 +188,10 @@ public final class MultipartBodyTest {
     Buffer buffer = new Buffer();
     body.writeTo(buffer);
     assertEquals(expected, buffer.readUtf8());
+    assertEquals(489, body.contentLength());
+    assertEquals("form-data; name=\"name1\"; filename=\"value.txt\"", body.part(0).headers.value(0));
+    assertEquals("form-data; name=\"name2\"; filename=\"零壱弐参.txt\"", body.part(1).headers.value(0));
+    assertEquals("form-data; name=\"name3\"; filename=\"Star Fox 零.txt\"", body.part(2).headers.value(0));
   }
 
   @Test public void stringEscapingIsWeird() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
@@ -102,7 +102,7 @@ public final class MultipartBodyTest {
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"files\"\r\n"
         + "Content-Type: multipart/mixed; boundary=BbC04y\r\n"
-        + "Content-Length: 343\r\n"
+        + "Content-Length: 337\r\n"
         + "\r\n"
         + "--BbC04y\r\n"
         + "Content-Disposition: file; filename=\"file1.txt\"\r\n"
@@ -111,12 +111,12 @@ public final class MultipartBodyTest {
         + "\r\n"
         + "... contents of file1.txt ...\r\n"
         + "--BbC04y\r\n"
-        + "Content-Disposition: file; filename=\"file2€.gif\"\r\n"
+        + "Content-Disposition: file; filename=\"file2.gif\"\r\n"
         + "Content-Transfer-Encoding: binary\r\n"
         + "Content-Type: image/gif\r\n"
-        + "Content-Length: 32\r\n"
+        + "Content-Length: 29\r\n"
         + "\r\n"
-        + "... contents of file2€.gif ...\r\n"
+        + "... contents of file2.gif ...\r\n"
         + "--BbC04y--\r\n"
         + "\r\n"
         + "--AaB03x--\r\n";
@@ -131,13 +131,12 @@ public final class MultipartBodyTest {
                     RequestBody.create(
                         MediaType.get("text/plain"), "... contents of file1.txt ..."))
                 .addPart(
-                    new Headers.Builder()
-                        .addUnsafeNonAscii("Content-Disposition", "file; filename=\"file2€.gif\"")
-                        .add("Content-Transfer-Encoding", "binary")
-                        .build(),
+                    Headers.of(
+                        "Content-Disposition", "file; filename=\"file2.gif\"",
+                        "Content-Transfer-Encoding", "binary"),
                     RequestBody.create(
                         MediaType.get("image/gif"),
-                        "... contents of file2€.gif ...".getBytes(UTF_8)))
+                        "... contents of file2.gif ...".getBytes(UTF_8)))
                 .build())
         .build();
 
@@ -145,7 +144,7 @@ public final class MultipartBodyTest {
     assertEquals(MultipartBody.FORM, body.type());
     assertEquals("multipart/form-data; boundary=AaB03x", body.contentType().toString());
     assertEquals(2, body.parts().size());
-    assertEquals(574, body.contentLength());
+    assertEquals(568, body.contentLength());
 
     Buffer buffer = new Buffer();
     body.writeTo(buffer);

--- a/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
@@ -102,7 +102,7 @@ public final class MultipartBodyTest {
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"files\"\r\n"
         + "Content-Type: multipart/mixed; boundary=BbC04y\r\n"
-        + "Content-Length: 337\r\n"
+        + "Content-Length: 343\r\n"
         + "\r\n"
         + "--BbC04y\r\n"
         + "Content-Disposition: file; filename=\"file1.txt\"\r\n"
@@ -111,12 +111,12 @@ public final class MultipartBodyTest {
         + "\r\n"
         + "... contents of file1.txt ...\r\n"
         + "--BbC04y\r\n"
-        + "Content-Disposition: file; filename=\"file2.gif\"\r\n"
+        + "Content-Disposition: file; filename=\"file2€.gif\"\r\n"
         + "Content-Transfer-Encoding: binary\r\n"
         + "Content-Type: image/gif\r\n"
-        + "Content-Length: 29\r\n"
+        + "Content-Length: 32\r\n"
         + "\r\n"
-        + "... contents of file2.gif ...\r\n"
+        + "... contents of file2€.gif ...\r\n"
         + "--BbC04y--\r\n"
         + "\r\n"
         + "--AaB03x--\r\n";
@@ -131,12 +131,13 @@ public final class MultipartBodyTest {
                     RequestBody.create(
                         MediaType.get("text/plain"), "... contents of file1.txt ..."))
                 .addPart(
-                    Headers.of(
-                        "Content-Disposition", "file; filename=\"file2.gif\"",
-                        "Content-Transfer-Encoding", "binary"),
+                    new Headers.Builder()
+                        .addUnsafeNonAscii("Content-Disposition", "file; filename=\"file2€.gif\"")
+                        .add("Content-Transfer-Encoding", "binary")
+                        .build(),
                     RequestBody.create(
                         MediaType.get("image/gif"),
-                        "... contents of file2.gif ...".getBytes(UTF_8)))
+                        "... contents of file2€.gif ...".getBytes(UTF_8)))
                 .build())
         .build();
 
@@ -144,7 +145,7 @@ public final class MultipartBodyTest {
     assertEquals(MultipartBody.FORM, body.type());
     assertEquals("multipart/form-data; boundary=AaB03x", body.contentType().toString());
     assertEquals(2, body.parts().size());
-    assertEquals(568, body.contentLength());
+    assertEquals(574, body.contentLength());
 
     Buffer buffer = new Buffer();
     body.writeTo(buffer);

--- a/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
@@ -153,6 +153,44 @@ public final class MultipartBodyTest {
     assertEquals(expected, buffer.readUtf8());
   }
 
+  @Test public void acceptAsciiAndUtf8CharsForFilename() throws Exception {
+    String expected = ""
+        + "--AaB03x\r\n"
+        + "Content-Disposition: form-data; name=\"name1\"; filename=\"value.txt\"\r\n"
+        + "Content-Type: text/plain; charset=utf-8\r\n"
+        + "Content-Length: 5\r\n"
+        + "\r\n"
+        + "ASCII\r\n"
+        + "--AaB03x\r\n"
+        + "Content-Disposition: form-data; name=\"name2\"; filename=\"零壱弐参.txt\"\r\n"
+        + "Content-Type: text/plain; charset=utf-8\r\n"
+        + "Content-Length: 5\r\n"
+        + "\r\n"
+        + "UTF-8\r\n"
+        + "--AaB03x\r\n"
+        + "Content-Disposition: form-data; name=\"name3\"; filename=\"Star Fox 零.txt\"\r\n"
+        + "Content-Type: text/plain; charset=utf-8\r\n"
+        + "Content-Length: 26\r\n"
+        + "\r\n"
+        + "Mixture of ASCII and UTF-8\r\n"
+        + "--AaB03x--\r\n";
+
+    MultipartBody body = new MultipartBody.Builder("AaB03x")
+        .setType(MultipartBody.FORM)
+        .addFormDataPart("name1", "value.txt",
+            RequestBody.create(MediaType.get("text/plain; charset=utf-8"), "ASCII"))
+        .addFormDataPart("name2", "零壱弐参.txt",
+            RequestBody.create(MediaType.get("text/plain; charset=utf-8"), "UTF-8"))
+        .addFormDataPart("name3", "Star Fox 零.txt",
+            RequestBody.create(MediaType.get("text/plain; charset=utf-8"),
+                "Mixture of ASCII and UTF-8"))
+        .build();
+
+    Buffer buffer = new Buffer();
+    body.writeTo(buffer);
+    assertEquals(expected, buffer.readUtf8());
+  }
+
   @Test public void stringEscapingIsWeird() throws Exception {
     String expected = ""
         + "--AaB03x\r\n"

--- a/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
@@ -152,7 +152,7 @@ public final class MultipartBodyTest {
     assertEquals(expected, buffer.readUtf8());
   }
 
-  @Test public void acceptAsciiAndUtf8CharsForFilename() throws Exception {
+  @Test public void acceptsAsciiAndUtf8CharsForFilename() throws Exception {
     String expected = ""
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"name1\"; filename=\"value.txt\"\r\n"

--- a/okhttp/src/main/java/okhttp3/MultipartBody.java
+++ b/okhttp/src/main/java/okhttp3/MultipartBody.java
@@ -255,7 +255,10 @@ public final class MultipartBody extends RequestBody {
         appendQuotedString(disposition, filename);
       }
 
-      return create(Headers.of("Content-Disposition", disposition.toString()), body);
+      Headers headers = new Headers.Builder()
+          .addUnsafeNonAscii("Content-Disposition", disposition.toString())
+          .build();
+      return  create(headers, body);
     }
 
     final @Nullable Headers headers;


### PR DESCRIPTION
Closes #4564 

Currently the user is not allowed to set Non-ASCII characters to `filename` when calling [addFormDataPart(...)](https://github.com/square/okhttp/blob/parent-3.12.1/okhttp/src/main/java/okhttp3/MultipartBody.java#L323-L325). When `addFormDataPart(...)` calls [Part.createFormData(...)](https://github.com/square/okhttp/blob/parent-3.12.1/okhttp/src/main/java/okhttp3/MultipartBody.java#L247-L260), [Headers.of(...)](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/Headers.java#L236), which rejects Non-ASCII characters, is executed. By employing `Headers.Builder` with [addUnsafeNonAscii(...)](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/Headers.java#L332-L335) when calling `Part.createFormData(...)`, users can set Non-ASCII characters.