### PR TITLE
Allow users to set the encoded value to `filename*` in MultiPart Parts

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
@@ -102,7 +102,7 @@ public final class MultipartBodyTest {
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"files\"\r\n"
         + "Content-Type: multipart/mixed; boundary=BbC04y\r\n"
-        + "Content-Length: 337\r\n"
+        + "Content-Length: 343\r\n"
         + "\r\n"
         + "--BbC04y\r\n"
         + "Content-Disposition: file; filename=\"file1.txt\"\r\n"
@@ -111,12 +111,12 @@ public final class MultipartBodyTest {
         + "\r\n"
         + "... contents of file1.txt ...\r\n"
         + "--BbC04y\r\n"
-        + "Content-Disposition: file; filename=\"file2.gif\"\r\n"
+        + "Content-Disposition: file; filename=\"file2€.gif\"\r\n"
         + "Content-Transfer-Encoding: binary\r\n"
         + "Content-Type: image/gif\r\n"
-        + "Content-Length: 29\r\n"
+        + "Content-Length: 32\r\n"
         + "\r\n"
-        + "... contents of file2.gif ...\r\n"
+        + "... contents of file2€.gif ...\r\n"
         + "--BbC04y--\r\n"
         + "\r\n"
         + "--AaB03x--\r\n";
@@ -131,12 +131,13 @@ public final class MultipartBodyTest {
                     RequestBody.create(
                         MediaType.get("text/plain"), "... contents of file1.txt ..."))
                 .addPart(
-                    Headers.of(
-                        "Content-Disposition", "file; filename=\"file2.gif\"",
-                        "Content-Transfer-Encoding", "binary"),
+                    new Headers.Builder()
+                        .addUnsafeNonAscii("Content-Disposition", "file; filename=\"file2€.gif\"")
+                        .add("Content-Transfer-Encoding", "binary")
+                        .build(),
                     RequestBody.create(
                         MediaType.get("image/gif"),
-                        "... contents of file2.gif ...".getBytes(UTF_8)))
+                        "... contents of file2€.gif ...".getBytes(UTF_8)))
                 .build())
         .build();
 
@@ -144,7 +145,7 @@ public final class MultipartBodyTest {
     assertEquals(MultipartBody.FORM, body.type());
     assertEquals("multipart/form-data; boundary=AaB03x", body.contentType().toString());
     assertEquals(2, body.parts().size());
-    assertEquals(568, body.contentLength());
+    assertEquals(574, body.contentLength());
 
     Buffer buffer = new Buffer();
     body.writeTo(buffer);

--- a/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
@@ -153,6 +153,44 @@ public final class MultipartBodyTest {
     assertEquals(expected, buffer.readUtf8());
   }
 
+  @Test public void acceptAsciiAndUtf8CharsForFilename() throws Exception {
+    String expected = ""
+        + "--AaB03x\r\n"
+        + "Content-Disposition: form-data; name=\"name1\"; filename=\"value.txt\"\r\n"
+        + "Content-Type: text/plain; charset=utf-8\r\n"
+        + "Content-Length: 5\r\n"
+        + "\r\n"
+        + "ASCII\r\n"
+        + "--AaB03x\r\n"
+        + "Content-Disposition: form-data; name=\"name2\"; filename=\"零壱弐参.txt\"\r\n"
+        + "Content-Type: text/plain; charset=utf-8\r\n"
+        + "Content-Length: 5\r\n"
+        + "\r\n"
+        + "UTF-8\r\n"
+        + "--AaB03x\r\n"
+        + "Content-Disposition: form-data; name=\"name3\"; filename=\"Star Fox 零.txt\"\r\n"
+        + "Content-Type: text/plain; charset=utf-8\r\n"
+        + "Content-Length: 26\r\n"
+        + "\r\n"
+        + "Mixture of ASCII and UTF-8\r\n"
+        + "--AaB03x--\r\n";
+
+    MultipartBody body = new MultipartBody.Builder("AaB03x")
+        .setType(MultipartBody.FORM)
+        .addFormDataPart("name1", "value.txt",
+            RequestBody.create(MediaType.get("text/plain; charset=utf-8"), "ASCII"))
+        .addFormDataPart("name2", "零壱弐参.txt",
+            RequestBody.create(MediaType.get("text/plain; charset=utf-8"), "UTF-8"))
+        .addFormDataPart("name3", "Star Fox 零.txt",
+            RequestBody.create(MediaType.get("text/plain; charset=utf-8"),
+                "Mixture of ASCII and UTF-8"))
+        .build();
+
+    Buffer buffer = new Buffer();
+    body.writeTo(buffer);
+    assertEquals(expected, buffer.readUtf8());
+  }
+
   @Test public void stringEscapingIsWeird() throws Exception {
     String expected = ""
         + "--AaB03x\r\n"

--- a/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
@@ -162,28 +162,35 @@ public final class MultipartBodyTest {
         + "\r\n"
         + "ASCII\r\n"
         + "--AaB03x\r\n"
-        + "Content-Disposition: form-data; name=\"name2\"; filename=\"零壱弐参.txt\"\r\n"
+        + "Content-Disposition: form-data; name=\"name2\"; filename=\"零壱弐参.txt\"; filename*=utf-8''%E9%9B%B6%E5%A3%B1%E5%BC%90%E5%8F%82.txt\r\n"
         + "Content-Type: text/plain; charset=utf-8\r\n"
         + "Content-Length: 5\r\n"
         + "\r\n"
         + "UTF-8\r\n"
         + "--AaB03x\r\n"
-        + "Content-Disposition: form-data; name=\"name3\"; filename=\"Star Fox 零.txt\"\r\n"
+        + "Content-Disposition: form-data; name=\"name3\"; filename=\"Star Fox 零.txt\"; filename*=utf-8''Star%20Fox%20%E9%9B%B6.txt\r\n"
         + "Content-Type: text/plain; charset=utf-8\r\n"
         + "Content-Length: 26\r\n"
         + "\r\n"
         + "Mixture of ASCII and UTF-8\r\n"
+        + "--AaB03x\r\n"
+        + "Content-Disposition: form-data; name=\"name4\"; filename*=utf-8''Star%20Fox%20%E9%9B%B6.txt\r\n"
+        + "Content-Type: text/plain; charset=utf-8\r\n"
+        + "Content-Length: 14\r\n"
+        + "\r\n"
+        + "filename* only\r\n"
         + "--AaB03x--\r\n";
 
     MultipartBody body = new MultipartBody.Builder("AaB03x")
         .setType(MultipartBody.FORM)
         .addFormDataPart("name1", "value.txt",
             RequestBody.create(MediaType.get("text/plain; charset=utf-8"), "ASCII"))
-        .addFormDataPart("name2", "零壱弐参.txt",
+        .addFormDataPart("name2", "零壱弐参.txt", "utf-8''%E9%9B%B6%E5%A3%B1%E5%BC%90%E5%8F%82.txt",
             RequestBody.create(MediaType.get("text/plain; charset=utf-8"), "UTF-8"))
-        .addFormDataPart("name3", "Star Fox 零.txt",
-            RequestBody.create(MediaType.get("text/plain; charset=utf-8"),
-                "Mixture of ASCII and UTF-8"))
+        .addFormDataPart("name3", "Star Fox 零.txt", "utf-8''Star%20Fox%20%E9%9B%B6.txt",
+            RequestBody.create(MediaType.get("text/plain; charset=utf-8"), "Mixture of ASCII and UTF-8"))
+        .addFormDataPart("name4", null, "utf-8''Star%20Fox%20%E9%9B%B6.txt",
+            RequestBody.create(MediaType.get("text/plain; charset=utf-8"), "filename* only"))
         .build();
 
     Buffer buffer = new Buffer();

--- a/okhttp/src/main/java/okhttp3/MultipartBody.java
+++ b/okhttp/src/main/java/okhttp3/MultipartBody.java
@@ -244,6 +244,11 @@ public final class MultipartBody extends RequestBody {
     }
 
     public static Part createFormData(String name, @Nullable String filename, RequestBody body) {
+      return createFormData(name, filename, null, body);
+    }
+
+    public static Part createFormData(String name, @Nullable String filename,
+        @Nullable String filenameAsterisk, RequestBody body) {
       if (name == null) {
         throw new NullPointerException("name == null");
       }
@@ -253,6 +258,12 @@ public final class MultipartBody extends RequestBody {
       if (filename != null) {
         disposition.append("; filename=");
         appendQuotedString(disposition, filename);
+      }
+
+      if (filenameAsterisk != null) {
+        disposition.append("; filename*=");
+        // RFC5987 allows the user to set filename* without quotations.
+        disposition.append(filenameAsterisk);
       }
 
       Headers headers = new Headers.Builder()
@@ -324,6 +335,12 @@ public final class MultipartBody extends RequestBody {
     /** Add a form data part to the body. */
     public Builder addFormDataPart(String name, @Nullable String filename, RequestBody body) {
       return addPart(Part.createFormData(name, filename, body));
+    }
+
+    /** Add a form data part to the body. */
+    public Builder addFormDataPart(String name, @Nullable String filename,
+        @Nullable String filenameAsterisk, RequestBody body) {
+      return addPart(Part.createFormData(name, filename, filenameAsterisk, body));
     }
 
     /** Add a part to the body. */

--- a/okhttp/src/main/java/okhttp3/MultipartBody.java
+++ b/okhttp/src/main/java/okhttp3/MultipartBody.java
@@ -255,7 +255,10 @@ public final class MultipartBody extends RequestBody {
         appendQuotedString(disposition, filename);
       }
 
-      return create(Headers.of("Content-Disposition", disposition.toString()), body);
+      Headers headers = new Headers.Builder()
+          .addUnsafeNonAscii("Content-Disposition", disposition.toString())
+          .build();
+      return  create(headers, body);
     }
 
     final @Nullable Headers headers;

--- a/samples/guide/src/main/java/okhttp3/recipes/PostMultipart.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PostMultipart.java
@@ -41,6 +41,9 @@ public final class PostMultipart {
         .addFormDataPart("title", "Square Logo")
         .addFormDataPart("image", "logo-square.png",
             RequestBody.create(MEDIA_TYPE_PNG, new File("website/static/logo-square.png")))
+        .addFormDataPart("image", "スクエアロゴ.png",
+            "utf-8''%E3%82%B9%E3%82%AF%E3%82%A8%E3%82%A2%E3%83%AD%E3%82%B4.png",
+            RequestBody.create(MEDIA_TYPE_PNG, new File("website/static/logo-square.png")))
         .build();
 
     Request request = new Request.Builder()


### PR DESCRIPTION
Cont. #4576 

Currently the user can only set `filename` in MultiPart. [RFC6266](https://tools.ietf.org/html/rfc6266#section-6) says that `filename*` field is used to set the encoding of `filename`. Moreover, as defined in [RFC5987](https://tools.ietf.org/html/rfc5987#section-3.2.2), we don't provide quotations to wrap the `filename*` value.

To improve user exprience, it'd be better to give this option to users.

Useful resources:
- [RFC6266 Appendix D.  Advice on Generating Content-Disposition Header Fields](https://tools.ietf.org/html/rfc6266#appendix-D)
- [Stackoverflow: How to encode the filename parameter of Content-Disposition header in HTTP?](https://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http)