### PR TITLE
Restore support for custom trust managers on Android

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -35,7 +35,9 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.internal.Util;
 import okhttp3.internal.tls.BasicCertificateChainCleaner;
+import okhttp3.internal.tls.BasicTrustRootIndex;
 import okhttp3.internal.tls.CertificateChainCleaner;
+import okhttp3.internal.tls.TrustRootIndex;
 import okio.Buffer;
 
 /**
@@ -168,7 +170,7 @@ public class Platform {
   }
 
   public CertificateChainCleaner buildCertificateChainCleaner(X509TrustManager trustManager) {
-    return new BasicCertificateChainCleaner(trustManager.getAcceptedIssuers());
+    return new BasicCertificateChainCleaner(buildTrustRootIndex(trustManager));
   }
 
   public CertificateChainCleaner buildCertificateChainCleaner(SSLSocketFactory sslSocketFactory) {
@@ -271,6 +273,10 @@ public class Platform {
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalStateException("No TLS provider", e);
     }
+  }
+
+  public TrustRootIndex buildTrustRootIndex(X509TrustManager trustManager) {
+    return new BasicTrustRootIndex(trustManager.getAcceptedIssuers());
   }
 
   public void configureSslSocketFactory(SSLSocketFactory socketFactory) {

--- a/okhttp/src/main/java/okhttp3/internal/tls/BasicTrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/BasicTrustRootIndex.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.tls;
+
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.security.auth.x500.X500Principal;
+
+/** A simple index that of trusted root certificates that have been loaded into memory. */
+public final class BasicTrustRootIndex implements TrustRootIndex {
+  private final Map<X500Principal, Set<X509Certificate>> subjectToCaCerts;
+
+  public BasicTrustRootIndex(X509Certificate... caCerts) {
+    subjectToCaCerts = new LinkedHashMap<>();
+    for (X509Certificate caCert : caCerts) {
+      X500Principal subject = caCert.getSubjectX500Principal();
+      Set<X509Certificate> subjectCaCerts = subjectToCaCerts.get(subject);
+      if (subjectCaCerts == null) {
+        subjectCaCerts = new LinkedHashSet<>(1);
+        subjectToCaCerts.put(subject, subjectCaCerts);
+      }
+      subjectCaCerts.add(caCert);
+    }
+  }
+
+  @Override public X509Certificate findByIssuerAndSignature(X509Certificate cert) {
+    X500Principal issuer = cert.getIssuerX500Principal();
+    Set<X509Certificate> subjectCaCerts = subjectToCaCerts.get(issuer);
+    if (subjectCaCerts == null) return null;
+
+    for (X509Certificate caCert : subjectCaCerts) {
+      PublicKey publicKey = caCert.getPublicKey();
+      try {
+        cert.verify(publicKey);
+        return caCert;
+      } catch (Exception ignored) {
+      }
+    }
+
+    return null;
+  }
+
+  @Override public boolean equals(Object other) {
+    if (other == this) return true;
+    return other instanceof okhttp3.internal.tls.BasicTrustRootIndex
+        && ((okhttp3.internal.tls.BasicTrustRootIndex) other).subjectToCaCerts.equals(
+        subjectToCaCerts);
+  }
+
+  @Override public int hashCode() {
+    return subjectToCaCerts.hashCode();
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/tls/CertificateChainCleaner.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/CertificateChainCleaner.java
@@ -42,6 +42,6 @@ public abstract class CertificateChainCleaner {
   }
 
   public static CertificateChainCleaner get(X509Certificate... caCerts) {
-    return new BasicCertificateChainCleaner(caCerts);
+    return new BasicCertificateChainCleaner(new BasicTrustRootIndex(caCerts));
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/tls/TrustRootIndex.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/TrustRootIndex.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.tls;
+
+import java.security.cert.X509Certificate;
+
+public interface TrustRootIndex {
+  /** Returns the trusted CA certificate that signed {@code cert}. */
+  X509Certificate findByIssuerAndSignature(X509Certificate cert);
+}


### PR DESCRIPTION
I took this away because I thought it was only useful for Android versions
we've since dropped. But it turns out it's also necessary when there's a
custom TrustManager in use.

Closes: https://github.com/square/okhttp/issues/4592