### PR TITLE
Initial refactoring towards a Transmitter abstraction

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -35,13 +35,14 @@ import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import okhttp3.internal.DeferredTrailers;
 import okhttp3.internal.Internal;
+import okhttp3.internal.Transmitter;
 import okhttp3.internal.Util;
 import okhttp3.internal.cache.InternalCache;
 import okhttp3.internal.connection.RealConnection;
 import okhttp3.internal.connection.RouteDatabase;
 import okhttp3.internal.connection.StreamAllocation;
-import okhttp3.internal.http.HttpCodec;
 import okhttp3.internal.platform.Platform;
 import okhttp3.internal.proxy.NullProxySelector;
 import okhttp3.internal.tls.CertificateChainCleaner;
@@ -184,8 +185,8 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
         return e.getMessage().startsWith(HttpUrl.Builder.INVALID_HOST);
       }
 
-      @Override public StreamAllocation streamAllocation(Call call) {
-        return ((RealCall) call).streamAllocation();
+      @Override public Transmitter transmitter(Call call) {
+        return ((RealCall) call).transmitter();
       }
 
       @Override public @Nullable IOException timeoutExit(Call call, @Nullable IOException e) {
@@ -196,8 +197,9 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
         return RealCall.newRealCall(client, originalRequest, true);
       }
 
-      @Override public void initCodec(Response.Builder responseBuilder, HttpCodec httpCodec) {
-        responseBuilder.initCodec(httpCodec);
+      @Override public void initDeferredTrailers(
+          Response.Builder responseBuilder, DeferredTrailers deferredTrailers) {
+        responseBuilder.initDeferredTrailers(deferredTrailers);
       }
     };
   }

--- a/okhttp/src/main/java/okhttp3/Response.java
+++ b/okhttp/src/main/java/okhttp3/Response.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
-import okhttp3.internal.http.HttpCodec;
+import okhttp3.internal.DeferredTrailers;
 import okhttp3.internal.http.HttpHeaders;
 import okio.Buffer;
 import okio.BufferedSource;
@@ -54,7 +54,7 @@ public final class Response implements Closeable {
   final @Nullable Response priorResponse;
   final long sentRequestAtMillis;
   final long receivedResponseAtMillis;
-  final @Nullable HttpCodec httpCodec;
+  final @Nullable DeferredTrailers deferredTrailers;
 
   private volatile @Nullable CacheControl cacheControl; // Lazily initialized.
 
@@ -71,7 +71,7 @@ public final class Response implements Closeable {
     this.priorResponse = builder.priorResponse;
     this.sentRequestAtMillis = builder.sentRequestAtMillis;
     this.receivedResponseAtMillis = builder.receivedResponseAtMillis;
-    this.httpCodec = builder.httpCodec;
+    this.deferredTrailers = builder.deferredTrailers;
   }
 
   /**
@@ -144,7 +144,7 @@ public final class Response implements Closeable {
    * before the entire HTTP response body has been consumed.
    */
   public Headers trailers() throws IOException {
-    return httpCodec.trailers();
+    return deferredTrailers.trailers();
   }
 
   /**
@@ -314,7 +314,7 @@ public final class Response implements Closeable {
     @Nullable Response priorResponse;
     long sentRequestAtMillis;
     long receivedResponseAtMillis;
-    @Nullable HttpCodec httpCodec;
+    @Nullable DeferredTrailers deferredTrailers;
 
     public Builder() {
       headers = new Headers.Builder();
@@ -333,7 +333,7 @@ public final class Response implements Closeable {
       this.priorResponse = response.priorResponse;
       this.sentRequestAtMillis = response.sentRequestAtMillis;
       this.receivedResponseAtMillis = response.receivedResponseAtMillis;
-      this.httpCodec = response.httpCodec;
+      this.deferredTrailers = response.deferredTrailers;
     }
 
     public Builder request(Request request) {
@@ -441,8 +441,8 @@ public final class Response implements Closeable {
       return this;
     }
 
-    void initCodec(HttpCodec httpCodec) {
-      this.httpCodec = httpCodec;
+    void initDeferredTrailers(DeferredTrailers deferredTrailers) {
+      this.deferredTrailers = deferredTrailers;
     }
 
     public Response build() {

--- a/okhttp/src/main/java/okhttp3/internal/DeferredTrailers.java
+++ b/okhttp/src/main/java/okhttp3/internal/DeferredTrailers.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import java.io.IOException;
+import okhttp3.Headers;
+
+public interface DeferredTrailers {
+  /** Call this only after the HTTP response body has been exhausted. */
+  Headers trailers() throws IOException;
+}

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -32,7 +32,6 @@ import okhttp3.internal.cache.InternalCache;
 import okhttp3.internal.connection.RealConnection;
 import okhttp3.internal.connection.RouteDatabase;
 import okhttp3.internal.connection.StreamAllocation;
-import okhttp3.internal.http.HttpCodec;
 
 /**
  * Escalate internal APIs in {@code okhttp3} so they can be used from OkHttp's implementation
@@ -74,12 +73,12 @@ public abstract class Internal {
 
   public abstract boolean isInvalidHttpUrlHost(IllegalArgumentException e);
 
-  public abstract StreamAllocation streamAllocation(Call call);
+  public abstract Transmitter transmitter(Call call);
 
   public abstract @Nullable IOException timeoutExit(Call call, @Nullable IOException e);
 
   public abstract Call newWebSocketCall(OkHttpClient client, Request request);
 
-  public abstract void initCodec(
-      Response.Builder responseBuilder, HttpCodec httpCodec);
+  public abstract void initDeferredTrailers(
+      Response.Builder responseBuilder, DeferredTrailers deferredTrailers);
 }

--- a/okhttp/src/main/java/okhttp3/internal/Transmitter.java
+++ b/okhttp/src/main/java/okhttp3/internal/Transmitter.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal;
+
+import java.io.IOException;
+import java.net.SocketException;
+import javax.annotation.Nullable;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
+import okhttp3.Address;
+import okhttp3.Call;
+import okhttp3.CertificatePinner;
+import okhttp3.EventListener;
+import okhttp3.Handshake;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.Route;
+import okhttp3.internal.connection.RealConnection;
+import okhttp3.internal.connection.StreamAllocation;
+import okhttp3.internal.http.HttpCodec;
+import okhttp3.internal.ws.RealWebSocket;
+import okio.Sink;
+
+/**
+ * Bridge between OkHttp's application and network layers. This class exposes high-level application
+ * layer primitives: connections, requests, responses, and streams.
+ */
+public final class Transmitter {
+  public final OkHttpClient client;
+  public final Call call;
+  public final EventListener eventListener;
+
+  private @Nullable Object callStackTrace;
+
+  private volatile boolean canceled;
+  private volatile StreamAllocation streamAllocation;
+
+  public Transmitter(OkHttpClient client, Call call) {
+    this.client = client;
+    this.call = call;
+    this.eventListener = client.eventListenerFactory().create(call);
+  }
+
+  public void setCallStackTrace(@Nullable Object callStackTrace) {
+    this.callStackTrace = callStackTrace;
+  }
+
+  public void newStreamAllocation(Request request) {
+    this.streamAllocation = new StreamAllocation(client.connectionPool(),
+        createAddress(request.url()), call, eventListener, callStackTrace);
+  }
+
+  private Address createAddress(HttpUrl url) {
+    SSLSocketFactory sslSocketFactory = null;
+    HostnameVerifier hostnameVerifier = null;
+    CertificatePinner certificatePinner = null;
+    if (url.isHttps()) {
+      sslSocketFactory = client.sslSocketFactory();
+      hostnameVerifier = client.hostnameVerifier();
+      certificatePinner = client.certificatePinner();
+    }
+
+    return new Address(url.host(), url.port(), client.dns(), client.socketFactory(),
+        sslSocketFactory, hostnameVerifier, certificatePinner, client.proxyAuthenticator(),
+        client.proxy(), client.protocols(), client.connectionSpecs(), client.proxySelector());
+  }
+
+  /**
+   * Immediately closes the socket connection if it's currently held. Use this to interrupt an
+   * in-flight request from any thread. It's the caller's responsibility to close the request body
+   * and response body streams; otherwise resources may be leaked.
+   *
+   * <p>This method is safe to be called concurrently, but provides limited guarantees. If a
+   * transport layer connection has been established (such as a HTTP/2 stream) that is terminated.
+   * Otherwise if a socket connection is being established, that is terminated.
+   */
+  public void cancel() {
+    canceled = true;
+    StreamAllocation streamAllocation = this.streamAllocation;
+    if (streamAllocation != null) streamAllocation.cancel();
+  }
+
+  public boolean isCanceled() {
+    return canceled;
+  }
+
+  public void streamFailed(@Nullable IOException e) {
+    streamAllocation.streamFailed(e);
+  }
+
+  public void noNewStreams() {
+    streamAllocation.noNewStreams();
+  }
+
+  public RealWebSocket.Streams newWebSocketStreams() {
+    return streamAllocation.connection().newWebSocketStreams(streamAllocation);
+  }
+
+  public void socketTimeout(int timeout) throws SocketException {
+    streamAllocation.connection().socket().setSoTimeout(timeout);
+  }
+
+  /** Returns the connection that carries the allocated stream. */
+  public RealConnection newStream(Interceptor.Chain chain, boolean doExtensiveHealthChecks) {
+    streamAllocation.newStream(client, chain, doExtensiveHealthChecks);
+    return streamAllocation.connection();
+  }
+
+  public Handshake handshake() {
+    return streamAllocation.connection().handshake();
+  }
+
+  public boolean isConnectionMultiplexed() {
+    return streamAllocation.connection().isMultiplexed();
+  }
+
+  public void releaseStreamAllocation(boolean callEnd) {
+    streamAllocation.release(callEnd);
+  }
+
+  public boolean hasMoreRoutes() {
+    return streamAllocation.hasMoreRoutes();
+  }
+
+  public Route route() {
+    return streamAllocation.route();
+  }
+
+  public boolean hasCodec() {
+    return streamAllocation != null && streamAllocation.codec() != null;
+  }
+
+  public void callStart() {
+    eventListener.callStart(call);
+  }
+
+  public void callFailed(IOException e) {
+    eventListener.callFailed(call, e);
+  }
+
+  public void writeRequestHeaders(Request request) throws IOException {
+    eventListener.requestHeadersStart(call);
+    streamAllocation.codec().writeRequestHeaders(request);
+    eventListener.requestHeadersEnd(call, request);
+  }
+
+  public Sink createRequestBody(Request request, long contentLength) {
+    eventListener.requestBodyStart(call);
+    return streamAllocation.codec().createRequestBody(request, contentLength);
+  }
+
+  public void requestBodyEnd(long byteCount) {
+    eventListener.requestBodyEnd(call, byteCount);
+  }
+
+  public void flushRequest() throws IOException {
+    streamAllocation.codec().flushRequest();
+  }
+
+  public void finishRequest() throws IOException {
+    streamAllocation.codec().finishRequest();
+  }
+
+  public Response.Builder readResponseHeaders(boolean expectContinue) throws IOException {
+    eventListener.responseHeadersStart(call);
+    return streamAllocation.codec().readResponseHeaders(expectContinue);
+  }
+
+  public void responseHeadersEnd(Response response) {
+    eventListener.responseHeadersEnd(call, response);
+  }
+
+  public ResponseBody openResponseBody(Response response) throws IOException {
+    streamAllocation.eventListener.responseBodyStart(streamAllocation.call);
+    return streamAllocation.codec().openResponseBody(response);
+  }
+
+  public DeferredTrailers deferredTrailers() {
+    return new DeferredTrailers() {
+      HttpCodec codec = streamAllocation.codec();
+
+      @Override public Headers trailers() throws IOException {
+        return codec.trailers();
+      }
+    };
+  }
+
+  public boolean supportsUrl(HttpUrl url) {
+    return streamAllocation.connection().supportsUrl(url);
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/connection/ConnectInterceptor.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ConnectInterceptor.java
@@ -21,7 +21,7 @@ import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.internal.http.HttpCodec;
+import okhttp3.internal.Transmitter;
 import okhttp3.internal.http.RealInterceptorChain;
 
 /** Opens a connection to the target server and proceeds to the next interceptor. */
@@ -35,13 +35,12 @@ public final class ConnectInterceptor implements Interceptor {
   @Override public Response intercept(Chain chain) throws IOException {
     RealInterceptorChain realChain = (RealInterceptorChain) chain;
     Request request = realChain.request();
-    StreamAllocation streamAllocation = realChain.streamAllocation();
+    Transmitter transmitter = realChain.transmitter();
 
     // We need the network to satisfy this request. Possibly for validating a conditional GET.
     boolean doExtensiveHealthChecks = !request.method().equals("GET");
-    HttpCodec httpCodec = streamAllocation.newStream(client, chain, doExtensiveHealthChecks);
-    RealConnection connection = streamAllocation.connection();
+    RealConnection connection = transmitter.newStream(chain, doExtensiveHealthChecks);
 
-    return realChain.proceed(request, streamAllocation, httpCodec, connection);
+    return realChain.proceed(request, transmitter, connection);
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -20,6 +20,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.net.Socket;
 import java.util.List;
+import javax.annotation.Nullable;
 import okhttp3.Address;
 import okhttp3.Call;
 import okhttp3.Connection;
@@ -428,7 +429,7 @@ public final class StreamAllocation {
     }
   }
 
-  public void streamFailed(IOException e) {
+  public void streamFailed(@Nullable IOException e) {
     Socket socket;
     Connection releasedConnection;
     boolean noNewStreams = false;

--- a/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.java
@@ -18,46 +18,45 @@ package okhttp3.internal.http;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import okhttp3.Call;
 import okhttp3.Connection;
-import okhttp3.EventListener;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.internal.Transmitter;
 import okhttp3.internal.connection.RealConnection;
-import okhttp3.internal.connection.StreamAllocation;
 
 import static okhttp3.internal.Util.checkDuration;
 
 /**
  * A concrete interceptor chain that carries the entire interceptor chain: all application
  * interceptors, the OkHttp core, all network interceptors, and finally the network caller.
+ *
+ * <p>If the chain is for an application interceptor then {@link #connection} must be null.
+ * Otherwise it is for a network interceptor and {@link #connection} must be non-null.
  */
 public final class RealInterceptorChain implements Interceptor.Chain {
   private final List<Interceptor> interceptors;
-  private final StreamAllocation streamAllocation;
-  private final HttpCodec httpCodec;
-  private final RealConnection connection;
+  private final Transmitter transmitter;
+  private final @Nullable RealConnection connection;
   private final int index;
   private final Request request;
   private final Call call;
-  private final EventListener eventListener;
   private final int connectTimeout;
   private final int readTimeout;
   private final int writeTimeout;
   private int calls;
 
-  public RealInterceptorChain(List<Interceptor> interceptors, StreamAllocation streamAllocation,
-      HttpCodec httpCodec, RealConnection connection, int index, Request request, Call call,
-      EventListener eventListener, int connectTimeout, int readTimeout, int writeTimeout) {
+  public RealInterceptorChain(List<Interceptor> interceptors, Transmitter transmitter,
+      @Nullable RealConnection connection, int index, Request request, Call call,
+      int connectTimeout, int readTimeout, int writeTimeout) {
     this.interceptors = interceptors;
+    this.transmitter = transmitter;
     this.connection = connection;
-    this.streamAllocation = streamAllocation;
-    this.httpCodec = httpCodec;
     this.index = index;
     this.request = request;
     this.call = call;
-    this.eventListener = eventListener;
     this.connectTimeout = connectTimeout;
     this.readTimeout = readTimeout;
     this.writeTimeout = writeTimeout;
@@ -73,8 +72,8 @@ public final class RealInterceptorChain implements Interceptor.Chain {
 
   @Override public Interceptor.Chain withConnectTimeout(int timeout, TimeUnit unit) {
     int millis = checkDuration("timeout", timeout, unit);
-    return new RealInterceptorChain(interceptors, streamAllocation, httpCodec, connection, index,
-        request, call, eventListener, millis, readTimeout, writeTimeout);
+    return new RealInterceptorChain(interceptors, transmitter, connection, index, request, call,
+        millis, readTimeout, writeTimeout);
   }
 
   @Override public int readTimeoutMillis() {
@@ -83,8 +82,8 @@ public final class RealInterceptorChain implements Interceptor.Chain {
 
   @Override public Interceptor.Chain withReadTimeout(int timeout, TimeUnit unit) {
     int millis = checkDuration("timeout", timeout, unit);
-    return new RealInterceptorChain(interceptors, streamAllocation, httpCodec, connection, index,
-        request, call, eventListener, connectTimeout, millis, writeTimeout);
+    return new RealInterceptorChain(interceptors, transmitter, connection, index, request, call,
+        connectTimeout, millis, writeTimeout);
   }
 
   @Override public int writeTimeoutMillis() {
@@ -93,24 +92,16 @@ public final class RealInterceptorChain implements Interceptor.Chain {
 
   @Override public Interceptor.Chain withWriteTimeout(int timeout, TimeUnit unit) {
     int millis = checkDuration("timeout", timeout, unit);
-    return new RealInterceptorChain(interceptors, streamAllocation, httpCodec, connection, index,
-        request, call, eventListener, connectTimeout, readTimeout, millis);
+    return new RealInterceptorChain(interceptors, transmitter, connection, index, request, call,
+        connectTimeout, readTimeout, millis);
   }
 
-  public StreamAllocation streamAllocation() {
-    return streamAllocation;
-  }
-
-  public HttpCodec httpStream() {
-    return httpCodec;
+  public Transmitter transmitter() {
+    return transmitter;
   }
 
   @Override public Call call() {
     return call;
-  }
-
-  public EventListener eventListener() {
-    return eventListener;
   }
 
   @Override public Request request() {
@@ -118,36 +109,35 @@ public final class RealInterceptorChain implements Interceptor.Chain {
   }
 
   @Override public Response proceed(Request request) throws IOException {
-    return proceed(request, streamAllocation, httpCodec, connection);
+    return proceed(request, transmitter, connection);
   }
 
-  public Response proceed(Request request, StreamAllocation streamAllocation, HttpCodec httpCodec,
-      RealConnection connection) throws IOException {
+  public Response proceed(Request request, Transmitter transmitter, RealConnection connection)
+      throws IOException {
     if (index >= interceptors.size()) throw new AssertionError();
 
     calls++;
 
     // If we already have a stream, confirm that the incoming request will use it.
-    if (this.httpCodec != null && !this.connection.supportsUrl(request.url())) {
+    if (this.connection != null && !this.transmitter.supportsUrl(request.url())) {
       throw new IllegalStateException("network interceptor " + interceptors.get(index - 1)
           + " must retain the same host and port");
     }
 
     // If we already have a stream, confirm that this is the only call to chain.proceed().
-    if (this.httpCodec != null && calls > 1) {
+    if (this.connection != null && calls > 1) {
       throw new IllegalStateException("network interceptor " + interceptors.get(index - 1)
           + " must call proceed() exactly once");
     }
 
     // Call the next interceptor in the chain.
-    RealInterceptorChain next = new RealInterceptorChain(interceptors, streamAllocation, httpCodec,
-        connection, index + 1, request, call, eventListener, connectTimeout, readTimeout,
-        writeTimeout);
+    RealInterceptorChain next = new RealInterceptorChain(interceptors, transmitter, connection,
+        index + 1, request, call, connectTimeout, readTimeout, writeTimeout);
     Interceptor interceptor = interceptors.get(index);
     Response response = interceptor.intercept(next);
 
     // Confirm that the next interceptor made its required call to chain.proceed().
-    if (httpCodec != null && index + 1 < interceptors.size() && next.calls != 1) {
+    if (connection != null && index + 1 < interceptors.size() && next.calls != 1) {
       throw new IllegalStateException("network interceptor " + interceptor
           + " must call proceed() exactly once");
     }

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
@@ -137,7 +137,6 @@ public final class Http1Codec implements HttpCodec {
   }
 
   @Override public ResponseBody openResponseBody(Response response) throws IOException {
-    streamAllocation.eventListener.responseBodyStart(streamAllocation.call);
     String contentType = response.header("Content-Type");
 
     if (!HttpHeaders.hasBody(response)) {

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -188,7 +188,6 @@ public final class Http2Codec implements HttpCodec {
   }
 
   @Override public ResponseBody openResponseBody(Response response) throws IOException {
-    streamAllocation.eventListener.responseBodyStart(streamAllocation.call);
     String contentType = response.header("Content-Type");
     long contentLength = HttpHeaders.contentLength(response);
     Source source = new StreamFinishingSource(stream.getSource());

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -153,7 +153,7 @@ class AndroidPlatform extends Platform {
     }
   }
 
-  @Override public Object getStackTraceForCloseable(String closer) {
+  @Override public @Nullable Object getStackTraceForCloseable(String closer) {
     return closeGuard.createAndOpen(closer);
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.java
@@ -144,7 +144,7 @@ public class Platform {
    * should be used specifically for {@link java.io.Closeable} objects and in conjunction with
    * {@link #logCloseableLeak(String, Object)}.
    */
-  public Object getStackTraceForCloseable(String closer) {
+  public @Nullable Object getStackTraceForCloseable(String closer) {
     if (logger.isLoggable(Level.FINE)) {
       return new Throwable(closer); // These are expensive to allocate.
     }


### PR DESCRIPTION
Currently this just moves all calls into StreamAllocation, RealConnection, and
HttpCodec into a new Transmitter type.

In follow-up I'll try to improve the API boundaries of this new type, possibly
by combining it with StreamAllocation. The ultimate goal is that it should be
very obvious from inspection that we don't leak connections and that we don't
miss any events.

https://github.com/square/okhttp/issues/4603