### PR TITLE
Prepare to fold StreamAllocation and Transmitter

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -87,7 +87,6 @@ import static okhttp3.CipherSuite.TLS_DH_anon_WITH_AES_128_GCM_SHA256;
 import static okhttp3.TestUtil.awaitGarbageCollection;
 import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.internal.platform.PlatformTest.getJvmSpecVersion;
-import static okhttp3.internal.platform.PlatformTest.getPlatform;
 import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -1065,8 +1064,7 @@ public final class CallTest {
     executeSynchronously("/")
         .assertFailure(IOException.class)
         .assertFailureMatches("stream was reset: CANCEL",
-            "unexpected end of stream on Connection.*"
-                + server.getHostName() + ":" + server.getPort() + ".*");
+            "unexpected end of stream on " + server.url("/").redact());
   }
 
   @Test public void recoverWhenRetryOnConnectionFailureIsFalse_HTTP2() throws Exception {
@@ -2117,7 +2115,7 @@ public final class CallTest {
         .setBody("I'm not even supposed to be here today."));
 
     executeSynchronously("/")
-        .assertFailureMatches(".*unexpected end of stream on Connection.*");
+        .assertFailureMatches(".*unexpected end of stream on " + server.url("/").redact());
   }
 
   private String stringFill(char fillChar, int length) {

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -42,7 +42,6 @@ import okhttp3.internal.Util;
 import okhttp3.internal.cache.InternalCache;
 import okhttp3.internal.connection.RealConnection;
 import okhttp3.internal.connection.RouteDatabase;
-import okhttp3.internal.connection.StreamAllocation;
 import okhttp3.internal.platform.Platform;
 import okhttp3.internal.proxy.NullProxySelector;
 import okhttp3.internal.tls.CertificateChainCleaner;
@@ -151,8 +150,8 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       }
 
       @Override public void acquire(ConnectionPool pool, Address address,
-          StreamAllocation streamAllocation, @Nullable Route route) {
-        pool.acquire(address, streamAllocation, route);
+          Transmitter transmitter, @Nullable Route route) {
+        pool.acquire(address, transmitter, route);
       }
 
       @Override public boolean equalsNonHost(Address a, Address b) {
@@ -160,8 +159,8 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
       }
 
       @Override public @Nullable Socket deduplicate(
-          ConnectionPool pool, Address address, StreamAllocation streamAllocation) {
-        return pool.deduplicate(address, streamAllocation);
+          ConnectionPool pool, Address address, Transmitter transmitter) {
+        return pool.deduplicate(address, transmitter);
       }
 
       @Override public void put(ConnectionPool pool, RealConnection connection) {

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -31,7 +31,6 @@ import okhttp3.Route;
 import okhttp3.internal.cache.InternalCache;
 import okhttp3.internal.connection.RealConnection;
 import okhttp3.internal.connection.RouteDatabase;
-import okhttp3.internal.connection.StreamAllocation;
 
 /**
  * Escalate internal APIs in {@code okhttp3} so they can be used from OkHttp's implementation
@@ -53,12 +52,12 @@ public abstract class Internal {
   public abstract void setCache(OkHttpClient.Builder builder, InternalCache internalCache);
 
   public abstract void acquire(ConnectionPool pool, Address address,
-      StreamAllocation streamAllocation, @Nullable Route route);
+      Transmitter transmitter, @Nullable Route route);
 
   public abstract boolean equalsNonHost(Address a, Address b);
 
   public abstract @Nullable Socket deduplicate(
-      ConnectionPool pool, Address address, StreamAllocation streamAllocation);
+      ConnectionPool pool, Address address, Transmitter transmitter);
 
   public abstract void put(ConnectionPool pool, RealConnection connection);
 

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -29,8 +29,8 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.internal.Internal;
+import okhttp3.internal.Transmitter;
 import okhttp3.internal.Util;
-import okhttp3.internal.connection.StreamAllocation;
 import okhttp3.internal.http.HttpCodec;
 import okhttp3.internal.http.HttpHeaders;
 import okhttp3.internal.http.RealResponseBody;
@@ -89,16 +89,16 @@ public final class Http2Codec implements HttpCodec {
       UPGRADE);
 
   private final Interceptor.Chain chain;
-  final StreamAllocation streamAllocation;
+  private final Transmitter transmitter;
   private final Http2Connection connection;
   private volatile Http2Stream stream;
   private final Protocol protocol;
   private volatile boolean canceled;
 
-  public Http2Codec(OkHttpClient client, Interceptor.Chain chain, StreamAllocation streamAllocation,
+  public Http2Codec(OkHttpClient client, Interceptor.Chain chain, Transmitter transmitter,
       Http2Connection connection) {
     this.chain = chain;
-    this.streamAllocation = streamAllocation;
+    this.transmitter = transmitter;
     this.connection = connection;
     this.protocol = client.protocols().contains(Protocol.H2_PRIOR_KNOWLEDGE)
         ? Protocol.H2_PRIOR_KNOWLEDGE
@@ -232,7 +232,7 @@ public final class Http2Codec implements HttpCodec {
     private void endOfInput(IOException e) {
       if (completed) return;
       completed = true;
-      streamAllocation.streamFinished(false, Http2Codec.this, bytesRead, e);
+      transmitter.streamFinished(false, bytesRead, e);
     }
   }
 }


### PR DESCRIPTION
This is a mechanical refactoring that changes all code that directly
accesses a StreamAllocation to instead access a Transmitter. The
next step is to combine StreamAllocation and Transmitter into
a single class.