### PR TITLE
Permit multipart filenames to contain non-ascii characters

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/MultipartBodyTest.java
@@ -271,4 +271,25 @@ public final class MultipartBodyTest {
     assertEquals(Headers.of("Foo", "Bar"), part1.headers());
     assertEquals("Baz", part1Buffer.readUtf8());
   }
+
+  @Test public void nonAsciiFilename() throws Exception {
+    String expected = ""
+        + "--AaB03x\r\n"
+        + "Content-Disposition: form-data; name=\"attachment\"; filename=\"resumé.pdf\"\r\n"
+        + "Content-Type: application/pdf; charset=utf-8\r\n"
+        + "Content-Length: 17\r\n"
+        + "\r\n"
+        + "Jesse’s Resumé\r\n"
+        + "--AaB03x--\r\n";
+
+    MultipartBody body = new MultipartBody.Builder("AaB03x")
+        .setType(MultipartBody.FORM)
+        .addFormDataPart("attachment", "resumé.pdf",
+            RequestBody.create(MediaType.parse("application/pdf"), "Jesse’s Resumé"))
+        .build();
+
+    Buffer buffer = new Buffer();
+    body.writeTo(buffer);
+    assertEquals(expected, buffer.readUtf8());
+  }
 }

--- a/okhttp/src/main/java/okhttp3/MultipartBody.java
+++ b/okhttp/src/main/java/okhttp3/MultipartBody.java
@@ -256,7 +256,11 @@ public final class MultipartBody extends RequestBody {
         appendQuotedString(disposition, filename);
       }
 
-      return create(Headers.of("Content-Disposition", disposition.toString()), body);
+      Headers headers = new Headers.Builder()
+          .addUnsafeNonAscii("Content-Disposition", disposition.toString())
+          .build();
+
+      return create(headers, body);
     }
 
     final @Nullable Headers headers;


### PR DESCRIPTION
This commit is partially cherry-picked to include only relevant part of the fix