### PR TITLE
Don't call callEnd() twice when application interceptors proceed twice.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionPoolTest.java
@@ -88,8 +88,8 @@ public final class ConnectionPoolTest {
           .build();
       Call call = client.newCall(newRequest(addressA));
       Transmitter transmitter = new Transmitter(client, call);
-      transmitter.newStreamAllocation(addressA);
-      transmitter.acquire(c1, true);
+      transmitter.prepareToConnect(call.request());
+      transmitter.acquireConnection(c1, true);
     }
 
     // Running at time 50, the pool returns that nothing can be evicted until time 150.
@@ -186,8 +186,8 @@ public final class ConnectionPoolTest {
           .build();
       Call call = client.newCall(newRequest(connection.route().address()));
       Transmitter transmitter = new Transmitter(client, call);
-      transmitter.newStreamAllocation(call.request());
-      transmitter.acquire(connection, true);
+      transmitter.prepareToConnect(call.request());
+      transmitter.acquireConnection(connection, true);
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -110,17 +110,20 @@ public final class ConnectionPool {
   }
 
   /**
-   * Acquires a recycled connection to {@code address} for {@code streamAllocation}. If non-null
-   * {@code route} is the resolved route for a connection.
+   * Attempts to acquire a recycled connection to {@code address} for {@code transmitter}. If
+   * non-null {@code route} is the resolved route for a connection. Returns true if a connection was
+   * acquired.
    */
-  void acquire(Address address, Transmitter transmitter, @Nullable Route route) {
+  boolean transmitterAcquirePooledConnection(
+      Address address, Transmitter transmitter, @Nullable Route route) {
     assert (Thread.holdsLock(this));
     for (RealConnection connection : connections) {
       if (connection.isEligible(address, route)) {
-        transmitter.acquire(connection, true);
-        return;
+        transmitter.acquireConnection(connection, true);
+        return true;
       }
     }
+    return false;
   }
 
   /**

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -149,9 +149,9 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
         return pool.connectionBecameIdle(connection);
       }
 
-      @Override public void acquire(ConnectionPool pool, Address address,
-          Transmitter transmitter, @Nullable Route route) {
-        pool.acquire(address, transmitter, route);
+      @Override public boolean transmitterAcquirePooledConnection(
+          ConnectionPool pool, Address address, Transmitter transmitter, @Nullable Route route) {
+        return pool.transmitterAcquirePooledConnection(address, transmitter, route);
       }
 
       @Override public boolean equalsNonHost(Address a, Address b) {

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -259,6 +259,10 @@ final class RealCall implements Call {
         originalRequest, this, client.connectTimeoutMillis(),
         client.readTimeoutMillis(), client.writeTimeoutMillis());
 
-    return chain.proceed(originalRequest);
+    try {
+      return chain.proceed(originalRequest);
+    } finally {
+      transmitter.noMoreStreamsOnCall();
+    }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -51,8 +51,8 @@ public abstract class Internal {
 
   public abstract void setCache(OkHttpClient.Builder builder, InternalCache internalCache);
 
-  public abstract void acquire(ConnectionPool pool, Address address,
-      Transmitter transmitter, @Nullable Route route);
+  public abstract boolean transmitterAcquirePooledConnection(
+      ConnectionPool pool, Address address, Transmitter transmitter, @Nullable Route route);
 
   public abstract boolean equalsNonHost(Address a, Address b);
 

--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -678,4 +678,11 @@ public final class Util {
     }
     return value != null ? value : defaultValue;
   }
+
+  /** Returns true if an HTTP request for {@code a} and {@code b} can reuse a connection. */
+  public static boolean sameConnection(HttpUrl a, HttpUrl b) {
+    return a.host().equals(b.host())
+        && a.port() == b.port()
+        && a.scheme().equals(b.scheme());
+  }
 }


### PR DESCRIPTION
I'm working towards reducing the role StreamAllocation plays.

https://github.com/square/okhttp/issues/4603