### PR TITLE
Split ConnectionPool API from implementation

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -42,6 +42,7 @@ import okhttp3.RecordingEventListener.ResponseHeadersEnd;
 import okhttp3.RecordingEventListener.SecureConnectEnd;
 import okhttp3.RecordingEventListener.SecureConnectStart;
 import okhttp3.internal.DoubleInetAddressDns;
+import okhttp3.internal.Internal;
 import okhttp3.internal.RecordingOkAuthenticator;
 import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.mockwebserver.MockResponse;
@@ -91,7 +92,7 @@ public final class EventListenerTest {
         .eventListener(listener)
         .build();
 
-    listener.forbidLock(client.connectionPool());
+    listener.forbidLock(Internal.instance.realConnectionPool(client.connectionPool()));
     listener.forbidLock(client.dispatcher());
   }
 

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.java
@@ -16,26 +16,8 @@
  */
 package okhttp3;
 
-import java.lang.ref.Reference;
-import java.net.Socket;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.Executor;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
-import okhttp3.internal.Transmitter;
-import okhttp3.internal.Transmitter.TransmitterReference;
-import okhttp3.internal.Util;
-import okhttp3.internal.connection.RealConnection;
-import okhttp3.internal.connection.RouteDatabase;
-import okhttp3.internal.platform.Platform;
-
-import static okhttp3.internal.Util.closeQuietly;
+import okhttp3.internal.connection.RealConnectionPool;
 
 /**
  * Manages reuse of HTTP and HTTP/2 connections for reduced network latency. HTTP requests that
@@ -43,38 +25,7 @@ import static okhttp3.internal.Util.closeQuietly;
  * of which connections to keep open for future use.
  */
 public final class ConnectionPool {
-  /**
-   * Background threads are used to cleanup expired connections. There will be at most a single
-   * thread running per connection pool. The thread pool executor permits the pool itself to be
-   * garbage collected.
-   */
-  private static final Executor executor = new ThreadPoolExecutor(0 /* corePoolSize */,
-      Integer.MAX_VALUE /* maximumPoolSize */, 60L /* keepAliveTime */, TimeUnit.SECONDS,
-      new SynchronousQueue<>(), Util.threadFactory("OkHttp ConnectionPool", true));
-
-  /** The maximum number of idle connections for each address. */
-  private final int maxIdleConnections;
-  private final long keepAliveDurationNs;
-  private final Runnable cleanupRunnable = () -> {
-    while (true) {
-      long waitNanos = cleanup(System.nanoTime());
-      if (waitNanos == -1) return;
-      if (waitNanos > 0) {
-        long waitMillis = waitNanos / 1000000L;
-        waitNanos -= (waitMillis * 1000000L);
-        synchronized (ConnectionPool.this) {
-          try {
-            ConnectionPool.this.wait(waitMillis, (int) waitNanos);
-          } catch (InterruptedException ignored) {
-          }
-        }
-      }
-    }
-  };
-
-  private final Deque<RealConnection> connections = new ArrayDeque<>();
-  final RouteDatabase routeDatabase = new RouteDatabase();
-  boolean cleanupRunning;
+  final RealConnectionPool delegate;
 
   /**
    * Create a new connection pool with tuning parameters appropriate for a single-user application.
@@ -86,195 +37,21 @@ public final class ConnectionPool {
   }
 
   public ConnectionPool(int maxIdleConnections, long keepAliveDuration, TimeUnit timeUnit) {
-    this.maxIdleConnections = maxIdleConnections;
-    this.keepAliveDurationNs = timeUnit.toNanos(keepAliveDuration);
-
-    // Put a floor on the keep alive duration, otherwise cleanup will spin loop.
-    if (keepAliveDuration <= 0) {
-      throw new IllegalArgumentException("keepAliveDuration <= 0: " + keepAliveDuration);
-    }
+    this.delegate = new RealConnectionPool(maxIdleConnections, keepAliveDuration, timeUnit);
   }
 
   /** Returns the number of idle connections in the pool. */
-  public synchronized int idleConnectionCount() {
-    int total = 0;
-    for (RealConnection connection : connections) {
-      if (connection.transmitters.isEmpty()) total++;
-    }
-    return total;
+  public int idleConnectionCount() {
+    return delegate.idleConnectionCount();
   }
 
   /** Returns total number of connections in the pool. */
-  public synchronized int connectionCount() {
-    return connections.size();
-  }
-
-  /**
-   * Attempts to acquire a recycled connection to {@code address} for {@code transmitter}. If
-   * non-null {@code route} is the resolved route for a connection. Returns true if a connection was
-   * acquired.
-   */
-  boolean transmitterAcquirePooledConnection(
-      Address address, Transmitter transmitter, @Nullable Route route) {
-    assert (Thread.holdsLock(this));
-    for (RealConnection connection : connections) {
-      if (connection.isEligible(address, route)) {
-        transmitter.acquireConnection(connection, true);
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Replaces the connection held by {@code streamAllocation} with a shared connection if possible.
-   * This recovers when multiple multiplexed connections are created concurrently.
-   */
-  @Nullable Socket deduplicate(Address address, Transmitter transmitter) {
-    assert (Thread.holdsLock(this));
-    for (RealConnection connection : connections) {
-      if (connection.isEligible(address, null)
-          && connection.isMultiplexed()
-          && connection != transmitter.connection()) {
-        return transmitter.releaseAndAcquire(connection);
-      }
-    }
-    return null;
-  }
-
-  void put(RealConnection connection) {
-    assert (Thread.holdsLock(this));
-    if (!cleanupRunning) {
-      cleanupRunning = true;
-      executor.execute(cleanupRunnable);
-    }
-    connections.add(connection);
-  }
-
-  /**
-   * Notify this pool that {@code connection} has become idle. Returns true if the connection has
-   * been removed from the pool and should be closed.
-   */
-  boolean connectionBecameIdle(RealConnection connection) {
-    assert (Thread.holdsLock(this));
-    if (connection.noNewStreams || maxIdleConnections == 0) {
-      connections.remove(connection);
-      return true;
-    } else {
-      notifyAll(); // Awake the cleanup thread: we may have exceeded the idle connection limit.
-      return false;
-    }
+  public int connectionCount() {
+    return delegate.connectionCount();
   }
 
   /** Close and remove all idle connections in the pool. */
   public void evictAll() {
-    List<RealConnection> evictedConnections = new ArrayList<>();
-    synchronized (this) {
-      for (Iterator<RealConnection> i = connections.iterator(); i.hasNext(); ) {
-        RealConnection connection = i.next();
-        if (connection.transmitters.isEmpty()) {
-          connection.noNewStreams = true;
-          evictedConnections.add(connection);
-          i.remove();
-        }
-      }
-    }
-
-    for (RealConnection connection : evictedConnections) {
-      closeQuietly(connection.socket());
-    }
-  }
-
-  /**
-   * Performs maintenance on this pool, evicting the connection that has been idle the longest if
-   * either it has exceeded the keep alive limit or the idle connections limit.
-   *
-   * <p>Returns the duration in nanos to sleep until the next scheduled call to this method. Returns
-   * -1 if no further cleanups are required.
-   */
-  long cleanup(long now) {
-    int inUseConnectionCount = 0;
-    int idleConnectionCount = 0;
-    RealConnection longestIdleConnection = null;
-    long longestIdleDurationNs = Long.MIN_VALUE;
-
-    // Find either a connection to evict, or the time that the next eviction is due.
-    synchronized (this) {
-      for (Iterator<RealConnection> i = connections.iterator(); i.hasNext(); ) {
-        RealConnection connection = i.next();
-
-        // If the connection is in use, keep searching.
-        if (pruneAndGetAllocationCount(connection, now) > 0) {
-          inUseConnectionCount++;
-          continue;
-        }
-
-        idleConnectionCount++;
-
-        // If the connection is ready to be evicted, we're done.
-        long idleDurationNs = now - connection.idleAtNanos;
-        if (idleDurationNs > longestIdleDurationNs) {
-          longestIdleDurationNs = idleDurationNs;
-          longestIdleConnection = connection;
-        }
-      }
-
-      if (longestIdleDurationNs >= this.keepAliveDurationNs
-          || idleConnectionCount > this.maxIdleConnections) {
-        // We've found a connection to evict. Remove it from the list, then close it below (outside
-        // of the synchronized block).
-        connections.remove(longestIdleConnection);
-      } else if (idleConnectionCount > 0) {
-        // A connection will be ready to evict soon.
-        return keepAliveDurationNs - longestIdleDurationNs;
-      } else if (inUseConnectionCount > 0) {
-        // All connections are in use. It'll be at least the keep alive duration 'til we run again.
-        return keepAliveDurationNs;
-      } else {
-        // No connections, idle or in use.
-        cleanupRunning = false;
-        return -1;
-      }
-    }
-
-    closeQuietly(longestIdleConnection.socket());
-
-    // Cleanup again immediately.
-    return 0;
-  }
-
-  /**
-   * Prunes any leaked transmitters and then returns the number of remaining live transmitters on
-   * {@code connection}. Transmitters are leaked if the connection is tracking them but the
-   * application code has abandoned them. Leak detection is imprecise and relies on garbage
-   * collection.
-   */
-  private int pruneAndGetAllocationCount(RealConnection connection, long now) {
-    List<Reference<Transmitter>> references = connection.transmitters;
-    for (int i = 0; i < references.size(); ) {
-      Reference<Transmitter> reference = references.get(i);
-
-      if (reference.get() != null) {
-        i++;
-        continue;
-      }
-
-      // We've discovered a leaked transmitter. This is an application bug.
-      TransmitterReference transmitterRef = (TransmitterReference) reference;
-      String message = "A connection to " + connection.route().address().url()
-          + " was leaked. Did you forget to close a response body?";
-      Platform.get().logCloseableLeak(message, transmitterRef.callStackTrace);
-
-      references.remove(i);
-      connection.noNewStreams = true;
-
-      // If this was the last allocation, the connection is eligible for immediate eviction.
-      if (references.isEmpty()) {
-        connection.idleAtNanos = now - keepAliveDurationNs;
-        return 0;
-      }
-    }
-
-    return references.size();
+    delegate.evictAll();
   }
 }

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -40,8 +40,7 @@ import okhttp3.internal.Internal;
 import okhttp3.internal.Transmitter;
 import okhttp3.internal.Util;
 import okhttp3.internal.cache.InternalCache;
-import okhttp3.internal.connection.RealConnection;
-import okhttp3.internal.connection.RouteDatabase;
+import okhttp3.internal.connection.RealConnectionPool;
 import okhttp3.internal.platform.Platform;
 import okhttp3.internal.proxy.NullProxySelector;
 import okhttp3.internal.tls.CertificateChainCleaner;
@@ -144,31 +143,12 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
         builder.setInternalCache(internalCache);
       }
 
-      @Override public boolean connectionBecameIdle(
-          ConnectionPool pool, RealConnection connection) {
-        return pool.connectionBecameIdle(connection);
-      }
-
-      @Override public boolean transmitterAcquirePooledConnection(
-          ConnectionPool pool, Address address, Transmitter transmitter, @Nullable Route route) {
-        return pool.transmitterAcquirePooledConnection(address, transmitter, route);
+      @Override public RealConnectionPool realConnectionPool(ConnectionPool connectionPool) {
+        return connectionPool.delegate;
       }
 
       @Override public boolean equalsNonHost(Address a, Address b) {
         return a.equalsNonHost(b);
-      }
-
-      @Override public @Nullable Socket deduplicate(
-          ConnectionPool pool, Address address, Transmitter transmitter) {
-        return pool.deduplicate(address, transmitter);
-      }
-
-      @Override public void put(ConnectionPool pool, RealConnection connection) {
-        pool.put(connection);
-      }
-
-      @Override public RouteDatabase routeDatabase(ConnectionPool connectionPool) {
-        return connectionPool.routeDatabase;
       }
 
       @Override public int code(Response.Builder responseBuilder) {

--- a/okhttp/src/main/java/okhttp3/internal/Internal.java
+++ b/okhttp/src/main/java/okhttp3/internal/Internal.java
@@ -16,7 +16,6 @@
 package okhttp3.internal;
 
 import java.io.IOException;
-import java.net.Socket;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSocket;
 import okhttp3.Address;
@@ -27,10 +26,8 @@ import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.Route;
 import okhttp3.internal.cache.InternalCache;
-import okhttp3.internal.connection.RealConnection;
-import okhttp3.internal.connection.RouteDatabase;
+import okhttp3.internal.connection.RealConnectionPool;
 
 /**
  * Escalate internal APIs in {@code okhttp3} so they can be used from OkHttp's implementation
@@ -51,19 +48,9 @@ public abstract class Internal {
 
   public abstract void setCache(OkHttpClient.Builder builder, InternalCache internalCache);
 
-  public abstract boolean transmitterAcquirePooledConnection(
-      ConnectionPool pool, Address address, Transmitter transmitter, @Nullable Route route);
+  public abstract RealConnectionPool realConnectionPool(ConnectionPool connectionPool);
 
   public abstract boolean equalsNonHost(Address a, Address b);
-
-  public abstract @Nullable Socket deduplicate(
-      ConnectionPool pool, Address address, Transmitter transmitter);
-
-  public abstract void put(ConnectionPool pool, RealConnection connection);
-
-  public abstract boolean connectionBecameIdle(ConnectionPool pool, RealConnection connection);
-
-  public abstract RouteDatabase routeDatabase(ConnectionPool connectionPool);
 
   public abstract int code(Response.Builder responseBuilder);
 

--- a/okhttp/src/main/java/okhttp3/internal/Transmitter.java
+++ b/okhttp/src/main/java/okhttp3/internal/Transmitter.java
@@ -87,8 +87,9 @@ public final class Transmitter {
     }
 
     this.request = request;
-    this.streamAllocation = new StreamAllocation(this, client.connectionPool(),
-        createAddress(request.url()), call, eventListener, callStackTrace);
+    this.streamAllocation = new StreamAllocation(this,
+        Internal.instance.realConnectionPool(client.connectionPool()), createAddress(request.url()),
+        call, eventListener, callStackTrace);
   }
 
   private Address createAddress(HttpUrl url) {

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -40,7 +40,6 @@ import okhttp3.Address;
 import okhttp3.Call;
 import okhttp3.CertificatePinner;
 import okhttp3.Connection;
-import okhttp3.ConnectionPool;
 import okhttp3.ConnectionSpec;
 import okhttp3.EventListener;
 import okhttp3.Handshake;
@@ -79,7 +78,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
   private static final String NPE_THROW_WITH_NULL = "throw with null exception";
   private static final int MAX_TUNNEL_ATTEMPTS = 21;
 
-  private final ConnectionPool connectionPool;
+  private final RealConnectionPool connectionPool;
   private final Route route;
 
   // The fields below are initialized by connect() and never reassigned.
@@ -117,13 +116,13 @@ public final class RealConnection extends Http2Connection.Listener implements Co
   /** Nanotime timestamp when {@code allocations.size()} reached zero. */
   public long idleAtNanos = Long.MAX_VALUE;
 
-  public RealConnection(ConnectionPool connectionPool, Route route) {
+  public RealConnection(RealConnectionPool connectionPool, Route route) {
     this.connectionPool = connectionPool;
     this.route = route;
   }
 
   public static RealConnection testConnection(
-      ConnectionPool connectionPool, Route route, Socket socket, long idleAtNanos) {
+      RealConnectionPool connectionPool, Route route, Socket socket, long idleAtNanos) {
     RealConnection result = new RealConnection(connectionPool, route);
     result.socket = socket;
     result.idleAtNanos = idleAtNanos;

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.java
@@ -1,0 +1,263 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package okhttp3.internal.connection;
+
+import java.lang.ref.Reference;
+import java.net.Socket;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import okhttp3.Address;
+import okhttp3.Route;
+import okhttp3.internal.Transmitter;
+import okhttp3.internal.Transmitter.TransmitterReference;
+import okhttp3.internal.Util;
+import okhttp3.internal.platform.Platform;
+
+import static okhttp3.internal.Util.closeQuietly;
+
+public final class RealConnectionPool {
+  /**
+   * Background threads are used to cleanup expired connections. There will be at most a single
+   * thread running per connection pool. The thread pool executor permits the pool itself to be
+   * garbage collected.
+   */
+  private static final Executor executor = new ThreadPoolExecutor(0 /* corePoolSize */,
+      Integer.MAX_VALUE /* maximumPoolSize */, 60L /* keepAliveTime */, TimeUnit.SECONDS,
+      new SynchronousQueue<>(), Util.threadFactory("OkHttp ConnectionPool", true));
+
+  /** The maximum number of idle connections for each address. */
+  private final int maxIdleConnections;
+  private final long keepAliveDurationNs;
+  private final Runnable cleanupRunnable = () -> {
+    while (true) {
+      long waitNanos = cleanup(System.nanoTime());
+      if (waitNanos == -1) return;
+      if (waitNanos > 0) {
+        long waitMillis = waitNanos / 1000000L;
+        waitNanos -= (waitMillis * 1000000L);
+        synchronized (RealConnectionPool.this) {
+          try {
+            RealConnectionPool.this.wait(waitMillis, (int) waitNanos);
+          } catch (InterruptedException ignored) {
+          }
+        }
+      }
+    }
+  };
+
+  private final Deque<RealConnection> connections = new ArrayDeque<>();
+  final RouteDatabase routeDatabase = new RouteDatabase();
+  boolean cleanupRunning;
+
+  public RealConnectionPool(int maxIdleConnections, long keepAliveDuration, TimeUnit timeUnit) {
+    this.maxIdleConnections = maxIdleConnections;
+    this.keepAliveDurationNs = timeUnit.toNanos(keepAliveDuration);
+
+    // Put a floor on the keep alive duration, otherwise cleanup will spin loop.
+    if (keepAliveDuration <= 0) {
+      throw new IllegalArgumentException("keepAliveDuration <= 0: " + keepAliveDuration);
+    }
+  }
+
+  public synchronized int idleConnectionCount() {
+    int total = 0;
+    for (RealConnection connection : connections) {
+      if (connection.transmitters.isEmpty()) total++;
+    }
+    return total;
+  }
+
+  public synchronized int connectionCount() {
+    return connections.size();
+  }
+
+  /**
+   * Attempts to acquire a recycled connection to {@code address} for {@code transmitter}. If
+   * non-null {@code route} is the resolved route for a connection. Returns true if a connection was
+   * acquired.
+   */
+  boolean transmitterAcquirePooledConnection(
+      Address address, Transmitter transmitter, @Nullable Route route) {
+    assert (Thread.holdsLock(this));
+    for (RealConnection connection : connections) {
+      if (connection.isEligible(address, route)) {
+        transmitter.acquireConnection(connection, true);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Replaces the connection held by {@code streamAllocation} with a shared connection if possible.
+   * This recovers when multiple multiplexed connections are created concurrently.
+   */
+  @Nullable Socket deduplicate(Address address, Transmitter transmitter) {
+    assert (Thread.holdsLock(this));
+    for (RealConnection connection : connections) {
+      if (connection.isEligible(address, null)
+          && connection.isMultiplexed()
+          && connection != transmitter.connection()) {
+        return transmitter.releaseAndAcquire(connection);
+      }
+    }
+    return null;
+  }
+
+  void put(RealConnection connection) {
+    assert (Thread.holdsLock(this));
+    if (!cleanupRunning) {
+      cleanupRunning = true;
+      executor.execute(cleanupRunnable);
+    }
+    connections.add(connection);
+  }
+
+  /**
+   * Notify this pool that {@code connection} has become idle. Returns true if the connection has
+   * been removed from the pool and should be closed.
+   */
+  boolean connectionBecameIdle(RealConnection connection) {
+    assert (Thread.holdsLock(this));
+    if (connection.noNewStreams || maxIdleConnections == 0) {
+      connections.remove(connection);
+      return true;
+    } else {
+      notifyAll(); // Awake the cleanup thread: we may have exceeded the idle connection limit.
+      return false;
+    }
+  }
+
+  public void evictAll() {
+    List<RealConnection> evictedConnections = new ArrayList<>();
+    synchronized (this) {
+      for (Iterator<RealConnection> i = connections.iterator(); i.hasNext(); ) {
+        RealConnection connection = i.next();
+        if (connection.transmitters.isEmpty()) {
+          connection.noNewStreams = true;
+          evictedConnections.add(connection);
+          i.remove();
+        }
+      }
+    }
+
+    for (RealConnection connection : evictedConnections) {
+      closeQuietly(connection.socket());
+    }
+  }
+
+  /**
+   * Performs maintenance on this pool, evicting the connection that has been idle the longest if
+   * either it has exceeded the keep alive limit or the idle connections limit.
+   *
+   * <p>Returns the duration in nanos to sleep until the next scheduled call to this method. Returns
+   * -1 if no further cleanups are required.
+   */
+  long cleanup(long now) {
+    int inUseConnectionCount = 0;
+    int idleConnectionCount = 0;
+    RealConnection longestIdleConnection = null;
+    long longestIdleDurationNs = Long.MIN_VALUE;
+
+    // Find either a connection to evict, or the time that the next eviction is due.
+    synchronized (this) {
+      for (Iterator<RealConnection> i = connections.iterator(); i.hasNext(); ) {
+        RealConnection connection = i.next();
+
+        // If the connection is in use, keep searching.
+        if (pruneAndGetAllocationCount(connection, now) > 0) {
+          inUseConnectionCount++;
+          continue;
+        }
+
+        idleConnectionCount++;
+
+        // If the connection is ready to be evicted, we're done.
+        long idleDurationNs = now - connection.idleAtNanos;
+        if (idleDurationNs > longestIdleDurationNs) {
+          longestIdleDurationNs = idleDurationNs;
+          longestIdleConnection = connection;
+        }
+      }
+
+      if (longestIdleDurationNs >= this.keepAliveDurationNs
+          || idleConnectionCount > this.maxIdleConnections) {
+        // We've found a connection to evict. Remove it from the list, then close it below (outside
+        // of the synchronized block).
+        connections.remove(longestIdleConnection);
+      } else if (idleConnectionCount > 0) {
+        // A connection will be ready to evict soon.
+        return keepAliveDurationNs - longestIdleDurationNs;
+      } else if (inUseConnectionCount > 0) {
+        // All connections are in use. It'll be at least the keep alive duration 'til we run again.
+        return keepAliveDurationNs;
+      } else {
+        // No connections, idle or in use.
+        cleanupRunning = false;
+        return -1;
+      }
+    }
+
+    closeQuietly(longestIdleConnection.socket());
+
+    // Cleanup again immediately.
+    return 0;
+  }
+
+  /**
+   * Prunes any leaked transmitters and then returns the number of remaining live transmitters on
+   * {@code connection}. Transmitters are leaked if the connection is tracking them but the
+   * application code has abandoned them. Leak detection is imprecise and relies on garbage
+   * collection.
+   */
+  private int pruneAndGetAllocationCount(RealConnection connection, long now) {
+    List<Reference<Transmitter>> references = connection.transmitters;
+    for (int i = 0; i < references.size(); ) {
+      Reference<Transmitter> reference = references.get(i);
+
+      if (reference.get() != null) {
+        i++;
+        continue;
+      }
+
+      // We've discovered a leaked transmitter. This is an application bug.
+      TransmitterReference transmitterRef = (TransmitterReference) reference;
+      String message = "A connection to " + connection.route().address().url()
+          + " was leaked. Did you forget to close a response body?";
+      Platform.get().logCloseableLeak(message, transmitterRef.callStackTrace);
+
+      references.remove(i);
+      connection.noNewStreams = true;
+
+      // If this was the last allocation, the connection is eligible for immediate eviction.
+      if (references.isEmpty()) {
+        connection.idleAtNanos = now - keepAliveDurationNs;
+        return 0;
+      }
+    }
+
+    return references.size();
+  }
+}


### PR DESCRIPTION
Our 'Internal' trampoline really gets in the way with this one. Just
move the actual implementation code into its own type so there isn't
as much indirection.

Unfortunately we can't easily make RealConnectionPool extend from
ConnectionPool because otherwise we'd be open to any user-provided
connection pools and our API isn't that complete yet.