### PR TITLE
Manage releasing connection separately from HTTP framing

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
@@ -272,7 +272,7 @@ public final class WholeOperationTimeoutTest {
     Call call = client.newCall(request);
     call.timeout().timeout(250, TimeUnit.MILLISECONDS);
     try {
-      Response response = call.execute();
+      call.execute();
       fail();
     } catch (IOException e) {
       assertTrue(call.isCanceled());

--- a/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/StreamAllocation.java
@@ -115,7 +115,7 @@ public final class StreamAllocation {
     try {
       RealConnection resultConnection = findHealthyConnection(connectTimeout, readTimeout,
           writeTimeout, pingIntervalMillis, connectionRetryEnabled, doExtensiveHealthChecks);
-      HttpCodec resultCodec = resultConnection.newCodec(client, chain, transmitter);
+      HttpCodec resultCodec = resultConnection.newCodec(client, chain);
 
       synchronized (connectionPool) {
         codec = resultCodec;
@@ -303,11 +303,12 @@ public final class StreamAllocation {
       eventListener.connectionReleased(call, releasedConnection);
     }
 
-    if (e != null) {
+    if (callEnd) {
       e = Internal.instance.timeoutExit(call, e);
+    }
+    if (e != null) {
       eventListener.callFailed(call, e);
     } else if (callEnd) {
-      Internal.instance.timeoutExit(call, null);
       eventListener.callEnd(call);
     }
   }

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpCodec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpCodec.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 import okhttp3.Headers;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import okio.Sink;
+import okio.Source;
 
 /** Encodes HTTP requests and decodes HTTP responses. */
 public interface HttpCodec {
@@ -51,8 +51,9 @@ public interface HttpCodec {
    */
   Response.Builder readResponseHeaders(boolean expectContinue) throws IOException;
 
-  /** Returns a stream that reads the response body. */
-  ResponseBody openResponseBody(Response response) throws IOException;
+  long reportedContentLength(Response response) throws IOException;
+
+  Source openResponseBodySource(Response response) throws IOException;
 
   /** Returns the trailers after the HTTP response. May be empty. */
   Headers trailers() throws IOException;

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
@@ -18,27 +18,23 @@ package okhttp3.internal.http1;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.ProtocolException;
-import javax.annotation.Nullable;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import okhttp3.internal.Internal;
-import okhttp3.internal.Transmitter;
 import okhttp3.internal.Util;
 import okhttp3.internal.connection.RealConnection;
 import okhttp3.internal.http.HttpCodec;
 import okhttp3.internal.http.HttpHeaders;
-import okhttp3.internal.http.RealResponseBody;
 import okhttp3.internal.http.RequestLine;
 import okhttp3.internal.http.StatusLine;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.ForwardingTimeout;
-import okio.Okio;
 import okio.Sink;
 import okio.Source;
 import okio.Timeout;
@@ -83,9 +79,6 @@ public final class Http1Codec implements HttpCodec {
   /** The connection that carries this stream. */
   final RealConnection realConnection;
 
-  /** The transmitter that owns this codec. May be null for HTTPS proxy tunnels. */
-  final @Nullable Transmitter transmitter;
-
   final BufferedSource source;
   final BufferedSink sink;
   int state = STATE_IDLE;
@@ -97,11 +90,10 @@ public final class Http1Codec implements HttpCodec {
    */
   private Headers trailers;
 
-  public Http1Codec(OkHttpClient client, RealConnection realConnection,
-      @Nullable Transmitter transmitter, BufferedSource source, BufferedSink sink) {
+  public Http1Codec(OkHttpClient client, RealConnection realConnection, BufferedSource source,
+      BufferedSink sink) {
     this.client = client;
     this.realConnection = realConnection;
-    this.transmitter = transmitter;
     this.source = source;
     this.sink = sink;
   }
@@ -141,29 +133,36 @@ public final class Http1Codec implements HttpCodec {
     writeRequest(request.headers(), requestLine);
   }
 
-  @Override public ResponseBody openResponseBody(Response response) throws IOException {
-    String contentType = response.header("Content-Type");
-
+  @Override public long reportedContentLength(Response response) {
     if (!HttpHeaders.hasBody(response)) {
-      Source source = newFixedLengthSource(0);
-      return new RealResponseBody(contentType, 0, Okio.buffer(source));
+      return 0L;
     }
 
     if ("chunked".equalsIgnoreCase(response.header("Transfer-Encoding"))) {
-      Source source = newChunkedSource(response.request().url());
-      return new RealResponseBody(contentType, -1L, Okio.buffer(source));
+      return -1L;
+    }
+
+    return HttpHeaders.contentLength(response);
+  }
+
+  @Override public Source openResponseBodySource(Response response) {
+    if (!HttpHeaders.hasBody(response)) {
+      return newFixedLengthSource(0);
+    }
+
+    if ("chunked".equalsIgnoreCase(response.header("Transfer-Encoding"))) {
+      return newChunkedSource(response.request().url());
     }
 
     long contentLength = HttpHeaders.contentLength(response);
     if (contentLength != -1) {
-      Source source = newFixedLengthSource(contentLength);
-      return new RealResponseBody(contentType, contentLength, Okio.buffer(source));
+      return newFixedLengthSource(contentLength);
     }
 
-    return new RealResponseBody(contentType, -1L, Okio.buffer(newUnknownLengthSource()));
+    return newUnknownLengthSource();
   }
 
-  @Override public Headers trailers() throws IOException {
+  @Override public Headers trailers() {
     if (state != STATE_CLOSED) {
       throw new IllegalStateException("too early; can't read the trailers yet");
     }
@@ -222,7 +221,8 @@ public final class Http1Codec implements HttpCodec {
       return responseBuilder;
     } catch (EOFException e) {
       // Provide more context if the server ends the stream before sending a response.
-      throw new IOException("unexpected end of stream on " + transmitter, e);
+      throw new IOException("unexpected end of stream on "
+          + realConnection.route().address().url().redact(), e);
     }
   }
 
@@ -242,33 +242,32 @@ public final class Http1Codec implements HttpCodec {
     return headers.build();
   }
 
-  public Sink newChunkedSink() {
+  private Sink newChunkedSink() {
     if (state != STATE_OPEN_REQUEST_BODY) throw new IllegalStateException("state: " + state);
     state = STATE_WRITING_REQUEST_BODY;
     return new ChunkedSink();
   }
 
-  public Sink newKnownLengthSink() {
+  private Sink newKnownLengthSink() {
     if (state != STATE_OPEN_REQUEST_BODY) throw new IllegalStateException("state: " + state);
     state = STATE_WRITING_REQUEST_BODY;
     return new KnownLengthSink();
   }
 
-  public Source newFixedLengthSource(long length) throws IOException {
+  private Source newFixedLengthSource(long length) {
     if (state != STATE_OPEN_RESPONSE_BODY) throw new IllegalStateException("state: " + state);
     state = STATE_READING_RESPONSE_BODY;
     return new FixedLengthSource(length);
   }
 
-  public Source newChunkedSource(HttpUrl url) throws IOException {
+  private Source newChunkedSource(HttpUrl url) {
     if (state != STATE_OPEN_RESPONSE_BODY) throw new IllegalStateException("state: " + state);
     state = STATE_READING_RESPONSE_BODY;
     return new ChunkedSource(url);
   }
 
-  public Source newUnknownLengthSource() throws IOException {
+  private Source newUnknownLengthSource() {
     if (state != STATE_OPEN_RESPONSE_BODY) throw new IllegalStateException("state: " + state);
-    if (transmitter == null) throw new IllegalStateException("transmitter == null");
     state = STATE_READING_RESPONSE_BODY;
     realConnection.noNewStreams();
     return new UnknownLengthSource();
@@ -284,6 +283,18 @@ public final class Http1Codec implements HttpCodec {
     timeout.setDelegate(Timeout.NONE);
     oldDelegate.clearDeadline();
     oldDelegate.clearTimeout();
+  }
+
+  /**
+   * The response body from a CONNECT should be empty, but if it is not then we should consume it
+   * before proceeding.
+   */
+  public void skipConnectBody(Response response) throws IOException {
+    long contentLength = HttpHeaders.contentLength(response);
+    if (contentLength == -1L) return;
+    Source body = newFixedLengthSource(contentLength);
+    Util.skipAll(body, Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
+    body.close();
   }
 
   /** An HTTP request body. */
@@ -356,7 +367,6 @@ public final class Http1Codec implements HttpCodec {
   private abstract class AbstractSource implements Source {
     protected final ForwardingTimeout timeout = new ForwardingTimeout(source.timeout());
     protected boolean closed;
-    protected long bytesRead = 0;
 
     @Override public Timeout timeout() {
       return timeout;
@@ -364,14 +374,10 @@ public final class Http1Codec implements HttpCodec {
 
     @Override public long read(Buffer sink, long byteCount) throws IOException {
       try {
-        long read = source.read(sink, byteCount);
-        if (read > 0) {
-          bytesRead += read;
-        }
-        return read;
+        return source.read(sink, byteCount);
       } catch (IOException e) {
         realConnection.noNewStreams();
-        responseBodyComplete(e);
+        responseBodyComplete();
         throw e;
       }
     }
@@ -380,16 +386,13 @@ public final class Http1Codec implements HttpCodec {
      * Closes the cache entry and makes the socket available for reuse. This should be invoked when
      * the end of the body has been reached.
      */
-    protected final void responseBodyComplete(IOException e) throws IOException {
+    protected final void responseBodyComplete() {
       if (state == STATE_CLOSED) return;
       if (state != STATE_READING_RESPONSE_BODY) throw new IllegalStateException("state: " + state);
 
       detachTimeout(timeout);
 
       state = STATE_CLOSED;
-      if (transmitter != null) {
-        transmitter.responseBodyComplete(bytesRead, e);
-      }
     }
   }
 
@@ -397,10 +400,10 @@ public final class Http1Codec implements HttpCodec {
   private class FixedLengthSource extends AbstractSource {
     private long bytesRemaining;
 
-    FixedLengthSource(long length) throws IOException {
+    FixedLengthSource(long length) {
       bytesRemaining = length;
       if (bytesRemaining == 0) {
-        responseBodyComplete(null);
+        responseBodyComplete();
       }
     }
 
@@ -411,15 +414,15 @@ public final class Http1Codec implements HttpCodec {
 
       long read = super.read(sink, Math.min(bytesRemaining, byteCount));
       if (read == -1) {
-        realConnection.noNewStreams();
+        realConnection.noNewStreams(); // The server didn't supply the promised content length.
         ProtocolException e = new ProtocolException("unexpected end of stream");
-        responseBodyComplete(e); // The server didn't supply the promised content length.
+        responseBodyComplete();
         throw e;
       }
 
       bytesRemaining -= read;
       if (bytesRemaining == 0) {
-        responseBodyComplete(null);
+        responseBodyComplete();
       }
       return read;
     }
@@ -428,8 +431,8 @@ public final class Http1Codec implements HttpCodec {
       if (closed) return;
 
       if (bytesRemaining != 0 && !Util.discard(this, DISCARD_STREAM_TIMEOUT_MILLIS, MILLISECONDS)) {
-        realConnection.noNewStreams();
-        responseBodyComplete(null);
+        realConnection.noNewStreams(); // Unread bytes remain on the stream.
+        responseBodyComplete();
       }
 
       closed = true;
@@ -459,9 +462,9 @@ public final class Http1Codec implements HttpCodec {
 
       long read = super.read(sink, Math.min(byteCount, bytesRemainingInChunk));
       if (read == -1) {
-        realConnection.noNewStreams();
+        realConnection.noNewStreams(); // The server didn't supply the promised chunk length.
         ProtocolException e = new ProtocolException("unexpected end of stream");
-        responseBodyComplete(e); // The server didn't supply the promised chunk length.
+        responseBodyComplete();
         throw e;
       }
       bytesRemainingInChunk -= read;
@@ -487,15 +490,15 @@ public final class Http1Codec implements HttpCodec {
         hasMoreChunks = false;
         trailers = readHeaders();
         HttpHeaders.receiveHeaders(client.cookieJar(), url, trailers);
-        responseBodyComplete(null);
+        responseBodyComplete();
       }
     }
 
     @Override public void close() throws IOException {
       if (closed) return;
       if (hasMoreChunks && !Util.discard(this, DISCARD_STREAM_TIMEOUT_MILLIS, MILLISECONDS)) {
-        realConnection.noNewStreams();
-        responseBodyComplete(null);
+        realConnection.noNewStreams(); // Unread bytes remain on the stream.
+        responseBodyComplete();
       }
       closed = true;
     }
@@ -504,9 +507,6 @@ public final class Http1Codec implements HttpCodec {
   /** An HTTP message body terminated by the end of the underlying stream. */
   private class UnknownLengthSource extends AbstractSource {
     private boolean inputExhausted;
-
-    UnknownLengthSource() {
-    }
 
     @Override public long read(Buffer sink, long byteCount)
         throws IOException {
@@ -517,7 +517,7 @@ public final class Http1Codec implements HttpCodec {
       long read = super.read(sink, byteCount);
       if (read == -1) {
         inputExhausted = true;
-        responseBodyComplete(null);
+        responseBodyComplete();
         return -1;
       }
       return read;
@@ -526,8 +526,7 @@ public final class Http1Codec implements HttpCodec {
     @Override public void close() throws IOException {
       if (closed) return;
       if (!inputExhausted) {
-        realConnection.noNewStreams();
-        responseBodyComplete(null);
+        responseBodyComplete();
       }
       closed = true;
     }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -27,18 +27,12 @@ import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import okhttp3.internal.Internal;
-import okhttp3.internal.Transmitter;
 import okhttp3.internal.Util;
 import okhttp3.internal.http.HttpCodec;
 import okhttp3.internal.http.HttpHeaders;
-import okhttp3.internal.http.RealResponseBody;
 import okhttp3.internal.http.RequestLine;
 import okhttp3.internal.http.StatusLine;
-import okio.Buffer;
-import okio.ForwardingSource;
-import okio.Okio;
 import okio.Sink;
 import okio.Source;
 
@@ -89,16 +83,13 @@ public final class Http2Codec implements HttpCodec {
       UPGRADE);
 
   private final Interceptor.Chain chain;
-  private final Transmitter transmitter;
   private final Http2Connection connection;
   private volatile Http2Stream stream;
   private final Protocol protocol;
   private volatile boolean canceled;
 
-  public Http2Codec(OkHttpClient client, Interceptor.Chain chain, Transmitter transmitter,
-      Http2Connection connection) {
+  public Http2Codec(OkHttpClient client, Interceptor.Chain chain, Http2Connection connection) {
     this.chain = chain;
-    this.transmitter = transmitter;
     this.connection = connection;
     this.protocol = client.protocols().contains(Protocol.H2_PRIOR_KNOWLEDGE)
         ? Protocol.H2_PRIOR_KNOWLEDGE
@@ -187,11 +178,12 @@ public final class Http2Codec implements HttpCodec {
         .headers(headersBuilder.build());
   }
 
-  @Override public ResponseBody openResponseBody(Response response) throws IOException {
-    String contentType = response.header("Content-Type");
-    long contentLength = HttpHeaders.contentLength(response);
-    Source source = new StreamFinishingSource(stream.getSource());
-    return new RealResponseBody(contentType, contentLength, Okio.buffer(source));
+  @Override public long reportedContentLength(Response response) {
+    return HttpHeaders.contentLength(response);
+  }
+
+  @Override public Source openResponseBodySource(Response response) {
+    return stream.getSource();
   }
 
   @Override public Headers trailers() throws IOException {
@@ -201,38 +193,5 @@ public final class Http2Codec implements HttpCodec {
   @Override public void cancel() {
     canceled = true;
     if (stream != null) stream.closeLater(ErrorCode.CANCEL);
-  }
-
-  class StreamFinishingSource extends ForwardingSource {
-    boolean completed = false;
-    long bytesRead = 0;
-
-    StreamFinishingSource(Source delegate) {
-      super(delegate);
-    }
-
-    @Override public long read(Buffer sink, long byteCount) throws IOException {
-      try {
-        long read = delegate().read(sink, byteCount);
-        if (read > 0) {
-          bytesRead += read;
-        }
-        return read;
-      } catch (IOException e) {
-        endOfInput(e);
-        throw e;
-      }
-    }
-
-    @Override public void close() throws IOException {
-      super.close();
-      endOfInput(null);
-    }
-
-    private void endOfInput(IOException e) {
-      if (completed) return;
-      completed = true;
-      transmitter.responseBodyComplete(bytesRead, e);
-    }
   }
 }


### PR DESCRIPTION
This creates a new class ResponseBodySource that manages events and
connections. It's symmetric with our existing RequestBodySink class.

Continuing to work towards these things having their own lifecycles
that are separate from HTTP framing mechanics.

https://github.com/square/okhttp/issues/4603