### PR TITLE
Handle stream exceptions in Transmitter

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -165,6 +165,7 @@ public final class WebSocketHttpTest {
     newWebSocket();
 
     serverListener.assertOpen();
+    serverListener.assertFailure(EOFException.class);
     serverListener.assertExhausted();
     clientListener.assertFailure(e);
   }

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -111,7 +111,7 @@ final class RealCall implements Call {
   }
 
   private void captureCallStackTrace() {
-    transmitter.setCallStackTrace(
+    transmitter.initCallStackTrace(
         Platform.get().getStackTraceForCloseable("response.body().close()"));
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteSelector.java
@@ -105,20 +105,6 @@ public final class RouteSelector {
     return new Selection(routes);
   }
 
-  /**
-   * Clients should invoke this method when they encounter a connectivity failure on a connection
-   * returned by this route selector.
-   */
-  public void connectFailed(Route failedRoute, IOException failure) {
-    if (failedRoute.proxy().type() != Proxy.Type.DIRECT && address.proxySelector() != null) {
-      // Tell the proxy selector when we fail to connect on a fresh connection.
-      address.proxySelector().connectFailed(
-          address.url().uri(), failedRoute.proxy().address(), failure);
-    }
-
-    routeDatabase.failed(failedRoute);
-  }
-
   /** Prepares the proxy servers to try. */
   private void resetNextProxy(HttpUrl url, Proxy proxy) {
     if (proxy != null) {

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpCodec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpCodec.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import okhttp3.Headers;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.internal.connection.RealConnection;
 import okio.Sink;
 import okio.Source;
 
@@ -30,6 +31,9 @@ public interface HttpCodec {
    * connection.
    */
   int DISCARD_STREAM_TIMEOUT_MILLIS = 100;
+
+  /** Returns the connection that carries this codec. */
+  RealConnection connection();
 
   /** Returns an output stream where the request body can be streamed. */
   Sink createRequestBody(Request request, long contentLength);

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
@@ -98,6 +98,10 @@ public final class Http1Codec implements HttpCodec {
     this.sink = sink;
   }
 
+  @Override public RealConnection connection() {
+    return realConnection;
+  }
+
   @Override public Sink createRequestBody(Request request, long contentLength) {
     if ("chunked".equalsIgnoreCase(request.header("Transfer-Encoding"))) {
       // Stream a request body of unknown length.

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Codec.java
@@ -29,6 +29,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.internal.Internal;
 import okhttp3.internal.Util;
+import okhttp3.internal.connection.RealConnection;
 import okhttp3.internal.http.HttpCodec;
 import okhttp3.internal.http.HttpHeaders;
 import okhttp3.internal.http.RequestLine;
@@ -83,17 +84,24 @@ public final class Http2Codec implements HttpCodec {
       UPGRADE);
 
   private final Interceptor.Chain chain;
+  private final RealConnection realConnection;
   private final Http2Connection connection;
   private volatile Http2Stream stream;
   private final Protocol protocol;
   private volatile boolean canceled;
 
-  public Http2Codec(OkHttpClient client, Interceptor.Chain chain, Http2Connection connection) {
+  public Http2Codec(OkHttpClient client, RealConnection realConnection, Interceptor.Chain chain,
+      Http2Connection connection) {
+    this.realConnection = realConnection;
     this.chain = chain;
     this.connection = connection;
     this.protocol = client.protocols().contains(Protocol.H2_PRIOR_KNOWLEDGE)
         ? Protocol.H2_PRIOR_KNOWLEDGE
         : Protocol.HTTP_2;
+  }
+
+  @Override public RealConnection connection() {
+    return realConnection;
   }
 
   @Override public Sink createRequestBody(Request request, long contentLength) {

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -201,7 +201,6 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
         }
 
         // Promote the HTTP streams into web socket streams.
-        transmitter.noNewStreamsOnConnection();
         Streams streams = transmitter.newWebSocketStreams();
 
         // Process all web socket messages.


### PR DESCRIPTION
This changes failure recovery to only attempt when the failure
occurs when OkHttp is doing I/O. If a failure is triggered by
something else (such as a bad RequestBody or Interceptor) then
that failure will not be retried.

https://github.com/square/okhttp/issues/4603