### PR TITLE
Make connection coalescing less special.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
@@ -96,7 +96,7 @@ public final class ConnectionPoolTest {
       Call call = client.newCall(newRequest(addressA));
       Transmitter transmitter = new Transmitter(client, call);
       transmitter.prepareToConnect(call.request());
-      transmitter.acquireConnection(c1, true);
+      transmitter.acquireConnection(c1);
     }
 
     // Running at time 50, the pool returns that nothing can be evicted until time 150.
@@ -195,7 +195,7 @@ public final class ConnectionPoolTest {
       Call call = client.newCall(newRequest(connection.route().address()));
       Transmitter transmitter = new Transmitter(client, call);
       transmitter.prepareToConnect(call.request());
-      transmitter.acquireConnection(connection, true);
+      transmitter.acquireConnection(connection);
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/Transmitter.java
+++ b/okhttp/src/main/java/okhttp3/internal/Transmitter.java
@@ -18,7 +18,6 @@ package okhttp3.internal;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.net.ProtocolException;
-import java.net.Socket;
 import java.net.SocketException;
 import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
@@ -268,16 +267,12 @@ public final class Transmitter {
     return streamAllocation.connection().supportsUrl(url);
   }
 
-  public void acquireConnection(RealConnection connection, boolean reportedAcquired) {
-    streamAllocation.transmitterAcquireConnection(connection, reportedAcquired);
+  public void acquireConnection(RealConnection connection) {
+    streamAllocation.transmitterAcquireConnection(connection);
   }
 
   public RealConnection connection() {
     return streamAllocation.connection();
-  }
-
-  public Socket releaseAndAcquire(RealConnection newConnection) {
-    return streamAllocation.releaseAndAcquire(newConnection);
   }
 
   public void responseBodyComplete(long bytesRead, IOException e) {


### PR DESCRIPTION
Today we have to suppress 'connectionAcquired' events because we attach the
constructed connection and then replace it with the pooled one. This changes
the logic to use separate fields for the connecting connection vs. the
pooled one.