### PR TITLE
Restore tests that now report the correct events.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -2202,18 +2202,16 @@ public final class CallTest {
   public void cancelWhileRequestHeadersAreSent() throws Exception {
     server.enqueue(new MockResponse().setBody("A"));
 
-    EventListener listener =
-        new EventListener() {
-          @Override
-          public void requestHeadersStart(Call call) {
-            try {
-              // Cancel call from another thread to avoid reentrance.
-              cancelLater(call, 0).join();
-            } catch (InterruptedException e) {
-              throw new AssertionError();
-            }
-          }
-        };
+    EventListener listener = new EventListener() {
+      @Override public void requestHeadersStart(Call call) {
+        try {
+          // Cancel call from another thread to avoid reentrance.
+          cancelLater(call, 0).join();
+        } catch (InterruptedException e) {
+          throw new AssertionError();
+        }
+      }
+    };
     client = client.newBuilder().eventListener(listener).build();
 
     Call call = client.newCall(new Request.Builder().url(server.url("/a")).build());

--- a/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
@@ -244,8 +244,8 @@ public final class ConnectionCoalescingTest {
 
     AtomicInteger connectCount = new AtomicInteger();
     EventListener listener = new EventListener() {
-      @Override public void connectStart(Call call, InetSocketAddress inetSocketAddress,
-          Proxy proxy) {
+      @Override public void connectStart(
+          Call call, InetSocketAddress inetSocketAddress, Proxy proxy) {
         connectCount.getAndIncrement();
       }
     };


### PR DESCRIPTION
The change to introduce Transmitter and Exchange has caused us to report
the correct events. Yay!