### PR TITLE
Fix EventListener events for expect-continue.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -1186,4 +1186,25 @@ public final class EventListenerTest {
     List<String> expectedEvents = Arrays.asList("CallStart", "CallEnd");
     assertEquals(expectedEvents, listener.recordedEventTypes());
   }
+
+  /** Response headers start, then the entire request body, then response headers end. */
+  @Test public void expectContinueStartsResponseHeadersEarly() throws Exception {
+    server.enqueue(new MockResponse()
+        .setSocketPolicy(SocketPolicy.EXPECT_CONTINUE));
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .header("Expect", "100-continue")
+        .post(RequestBody.create(MediaType.get("text/plain"), "abc"))
+        .build();
+
+    Call call = client.newCall(request);
+    call.execute();
+
+    List<String> expectedEvents = Arrays.asList("CallStart", "DnsStart", "DnsEnd", "ConnectStart",
+        "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd",
+        "ResponseHeadersStart", "RequestBodyStart", "RequestBodyEnd", "ResponseHeadersEnd",
+        "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
+    assertEquals(expectedEvents, listener.recordedEventTypes());
+  }
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.java
@@ -97,10 +97,12 @@ public final class Exchange {
     }
   }
 
-  public @Nullable Response.Builder readResponseHeaders(
-      boolean expectContinue) throws IOException {
+  public void responseHeadersStart() {
+    eventListener.responseHeadersStart(call);
+  }
+
+  public @Nullable Response.Builder readResponseHeaders(boolean expectContinue) throws IOException {
     try {
-      eventListener.responseHeadersStart(call);
       Response.Builder result = codec.readResponseHeaders(expectContinue);
       if (result != null) {
         Internal.instance.initExchange(result, this);


### PR DESCRIPTION
We were calling responseHeadersStart() multiple times.