### PR TITLE
Test to confirm OkHttp doesn't loop when a request body throws.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -3553,6 +3553,30 @@ public final class CallTest {
     }
   }
 
+  @Test public void requestBodyThrowsUnrelatedToNetwork() throws Exception {
+    server.enqueue(new MockResponse());
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .post(new RequestBody() {
+          @Override public @Nullable MediaType contentType() {
+            return null;
+          }
+
+          @Override public void writeTo(BufferedSink sink) throws IOException {
+            throw new IOException("boom");
+          }
+        })
+        .build();
+
+    executeSynchronously(request).assertFailure("boom");
+  }
+
+  @Test public void requestBodyThrowsUnrelatedToNetwork_HTTP2() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+    requestBodyThrowsUnrelatedToNetwork();
+  }
+
   private void makeFailingCall() {
     RequestBody requestBody = new RequestBody() {
       @Override public MediaType contentType() {


### PR DESCRIPTION
Test to reproduce the issue discussed here:
https://github.com/square/okhttp/pull/4523