### PR TITLE
Allow different types of response caches to be used

### DIFF
--- a/okhttp-android-support/src/main/java/okhttp3/AndroidShimResponseCache.java
+++ b/okhttp-android-support/src/main/java/okhttp3/AndroidShimResponseCache.java
@@ -58,7 +58,7 @@ public class AndroidShimResponseCache extends ResponseCache {
   @Override public CacheResponse get(URI uri, String requestMethod,
       Map<String, List<String>> requestHeaders) throws IOException {
     Request okRequest = JavaApiConverter.createOkRequest(uri, requestMethod, requestHeaders);
-    Response okResponse = delegate.internalCache.get(okRequest);
+    Response okResponse = delegate.internalCache().get(okRequest);
     if (okResponse == null) {
       return null;
     }
@@ -73,7 +73,7 @@ public class AndroidShimResponseCache extends ResponseCache {
       return null;
     }
     okhttp3.internal.cache.CacheRequest okCacheRequest =
-        delegate.internalCache.put(okResponse);
+        delegate.internalCache().put(okResponse);
     if (okCacheRequest == null) {
       return null;
     }

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/TestDohMain.java
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/TestDohMain.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import okhttp3.Cache;
+import okhttp3.CacheProvider;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 
@@ -64,7 +65,7 @@ public class TestDohMain {
     } finally {
       bootstrapClient.connectionPool().evictAll();
       bootstrapClient.dispatcher().executorService().shutdownNow();
-      Cache cache = bootstrapClient.cache();
+      CacheProvider cache = bootstrapClient.cache();
       if (cache != null) {
         cache.close();
       }

--- a/okhttp/src/main/java/okhttp3/CacheProvider.java
+++ b/okhttp/src/main/java/okhttp3/CacheProvider.java
@@ -1,0 +1,58 @@
+package okhttp3;
+
+import okhttp3.internal.cache.CacheRequest;
+import okhttp3.internal.cache.InternalCache;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.Iterator;
+
+public abstract class CacheProvider implements Closeable, Flushable {
+
+    @Nullable
+    abstract Response get(Request request);
+
+    @Nullable
+    abstract CacheRequest put(Response response);
+
+    public abstract void delete() throws IOException;
+
+    /**
+     * Deletes all values stored in the cache. In-flight writes to the cache will complete
+     * normally, but the corresponding responses will not be stored.
+     */
+    public abstract void evictAll() throws IOException;
+
+    /**
+     * Returns an iterator over the URLs in this cache. This iterator doesn't throw {@code
+     * ConcurrentModificationException}, but if new responses are added while iterating, their URLs
+     * will not be returned. If existing responses are evicted during iteration, they will be
+     * absent (unless they were already returned).
+     *
+     * <p>The iterator supports {@linkplain Iterator#remove}. Removing a URL from the iterator
+     * evicts the corresponding response from the cache. Use this to evict selected responses.
+     */
+    public abstract Iterator<String> urls() throws IOException;
+
+    public abstract int writeAbortCount();
+
+    public abstract int writeSuccessCount();
+
+    public abstract long size() throws IOException;
+
+    /**
+     * Max size of the cache (in bytes).
+     */
+    public abstract long maxSize();
+
+    public abstract int networkCount();
+
+    public abstract int hitCount();
+
+    public abstract int requestCount();
+
+    abstract InternalCache internalCache();
+
+}

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.java
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.java
@@ -191,7 +191,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
   final EventListener.Factory eventListenerFactory;
   final ProxySelector proxySelector;
   final CookieJar cookieJar;
-  final @Nullable Cache cache;
+  final @Nullable CacheProvider cache;
   final @Nullable InternalCache internalCache;
   final SocketFactory socketFactory;
   final SSLSocketFactory sslSocketFactory;
@@ -321,12 +321,12 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     return cookieJar;
   }
 
-  public @Nullable Cache cache() {
+  public @Nullable CacheProvider cache() {
     return cache;
   }
 
   @Nullable InternalCache internalCache() {
-    return cache != null ? cache.internalCache : internalCache;
+    return cache != null ? cache.internalCache() : internalCache;
   }
 
   public Dns dns() {
@@ -437,7 +437,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     EventListener.Factory eventListenerFactory;
     ProxySelector proxySelector;
     CookieJar cookieJar;
-    @Nullable Cache cache;
+    @Nullable CacheProvider cache;
     @Nullable InternalCache internalCache;
     SocketFactory socketFactory;
     @Nullable SSLSocketFactory sslSocketFactory;
@@ -713,7 +713,7 @@ public class OkHttpClient implements Cloneable, Call.Factory, WebSocket.Factory 
     }
 
     /** Sets the response cache to be used to read and write cached responses. */
-    public Builder cache(@Nullable Cache cache) {
+    public Builder cache(@Nullable CacheProvider cache) {
       this.cache = cache;
       this.internalCache = null;
       return this;


### PR DESCRIPTION
Refactor so that you can provide your own custom response cache
instead of the the default filesystem-based cache.