### PR TITLE
Introduce EventListener.requestFailed, responseFailed events

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/LoggingEventListener.java
@@ -125,6 +125,11 @@ public final class LoggingEventListener extends EventListener {
   }
 
   @Override
+  public void requestFailed(Call call, IOException ioe) {
+    logWithTime("requestFailed: " + ioe);
+  }
+
+  @Override
   public void responseHeadersStart(Call call) {
     logWithTime("responseHeadersStart");
   }
@@ -142,6 +147,11 @@ public final class LoggingEventListener extends EventListener {
   @Override
   public void responseBodyEnd(Call call, long byteCount) {
     logWithTime("responseBodyEnd: byteCount=" + byteCount);
+  }
+
+  @Override
+  public void responseFailed(Call call, IOException ioe) {
+    logWithTime("responseFailed: " + ioe);
   }
 
   @Override

--- a/okhttp-tests/src/test/java/okhttp3/DuplexTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/DuplexTest.java
@@ -319,7 +319,7 @@ public final class DuplexTest {
         "RequestHeadersStart", "RequestHeadersEnd", "RequestBodyStart", "ResponseHeadersStart",
         "ResponseHeadersEnd", "ResponseBodyStart", "ResponseBodyEnd", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
-        "ResponseBodyEnd", "ConnectionReleased", "CallEnd", "RequestBodyEnd");
+        "ResponseBodyEnd", "ConnectionReleased", "CallEnd", "RequestFailed");
     assertEquals(expectedEvents, listener.recordedEventTypes());
   }
 

--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -38,6 +38,7 @@ import okhttp3.RecordingEventListener.DnsStart;
 import okhttp3.RecordingEventListener.RequestBodyEnd;
 import okhttp3.RecordingEventListener.RequestHeadersEnd;
 import okhttp3.RecordingEventListener.ResponseBodyEnd;
+import okhttp3.RecordingEventListener.ResponseFailed;
 import okhttp3.RecordingEventListener.ResponseHeadersEnd;
 import okhttp3.RecordingEventListener.SecureConnectEnd;
 import okhttp3.RecordingEventListener.SecureConnectStart;
@@ -168,7 +169,8 @@ public final class EventListenerTest {
 
     List<String> expectedEvents = Arrays.asList("CallStart", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
-        "RequestHeadersEnd", "ResponseHeadersStart", "ConnectionReleased", "CallFailed");
+        "RequestHeadersEnd", "ResponseHeadersStart", "ResponseFailed", "ConnectionReleased",
+        "CallFailed");
     assertEquals(expectedEvents, listener.recordedEventTypes());
   }
 
@@ -197,10 +199,10 @@ public final class EventListenerTest {
     List<String> expectedEvents = Arrays.asList("CallStart", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "ResponseBodyStart",
-        "ResponseBodyEnd", "ConnectionReleased", "CallFailed");
+        "ResponseFailed", "ConnectionReleased", "CallFailed");
     assertEquals(expectedEvents, listener.recordedEventTypes());
-    ResponseBodyEnd bodyEnd = listener.removeUpToEvent(ResponseBodyEnd.class);
-    assertEquals(5, bodyEnd.bytesRead);
+    ResponseFailed responseFailed = listener.removeUpToEvent(ResponseFailed.class);
+    assertEquals("unexpected end of stream", responseFailed.ioe.getMessage());
   }
 
   @Test public void canceledCallEventSequence() {
@@ -1052,7 +1054,7 @@ public final class EventListenerTest {
 
     List<String> expectedEvents = Arrays.asList("CallStart", "DnsStart", "DnsEnd", "ConnectStart",
         "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd",
-        "RequestBodyStart", "RequestBodyEnd", "ConnectionReleased", "CallFailed");
+        "RequestBodyStart", "RequestFailed", "ConnectionReleased", "CallFailed");
     assertEquals(expectedEvents, listener.recordedEventTypes());
   }
 

--- a/okhttp/src/main/java/okhttp3/EventListener.java
+++ b/okhttp/src/main/java/okhttp3/EventListener.java
@@ -46,7 +46,7 @@ import javax.annotation.Nullable;
  * events.
  *
  * <p>All event methods must execute fast, without external locking, cannot throw exceptions,
- * attempt to mutate the event parameters, or be reentrant back into the client.
+ * attempt to mutate the event parameters, or be re-entrant back into the client.
  * Any IO - writing to files or network should be done asynchronously.
  */
 public abstract class EventListener {
@@ -211,6 +211,15 @@ public abstract class EventListener {
   }
 
   /**
+   * Invoked when a request fails to be written.
+   *
+   * <p>This method is invoked after {@link #requestHeadersStart} or {@link #requestBodyStart}. Note
+   * that request failures do not necessarily fail the entire call.
+   */
+  public void requestFailed(Call call, IOException ioe) {
+  }
+
+  /**
    * Invoked just prior to receiving response headers.
    *
    * <p>The connection is implicit, and will generally relate to the last
@@ -254,6 +263,15 @@ public abstract class EventListener {
    * <p>This method is always invoked after {@link #requestBodyStart(Call)}.
    */
   public void responseBodyEnd(Call call, long byteCount) {
+  }
+
+  /**
+   * Invoked when a response fails to be read.
+   *
+   * <p>This method is invoked after {@link #responseHeadersStart} or {@link #responseBodyStart}.
+   * Note that response failures do not necessarily fail the entire call.
+   */
+  public void responseFailed(Call call, IOException ioe) {
   }
 
   /**

--- a/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java
@@ -156,6 +156,10 @@ public final class PrintEvents {
       printEvent("requestBodyEnd");
     }
 
+    @Override public void requestFailed(Call call, IOException ioe) {
+      printEvent("requestFailed");
+    }
+
     @Override public void responseHeadersStart(Call call) {
       printEvent("responseHeadersStart");
     }
@@ -170,6 +174,10 @@ public final class PrintEvents {
 
     @Override public void responseBodyEnd(Call call, long byteCount) {
       printEvent("responseBodyEnd");
+    }
+
+    @Override public void responseFailed(Call call, IOException ioe) {
+      printEvent("responseFailed");
     }
 
     @Override public void callEnd(Call call) {

--- a/samples/guide/src/main/java/okhttp3/recipes/PrintEventsNonConcurrent.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/PrintEventsNonConcurrent.java
@@ -131,6 +131,10 @@ public final class PrintEventsNonConcurrent {
       printEvent("requestBodyEnd");
     }
 
+    @Override public void requestFailed(Call call, IOException ioe) {
+      printEvent("requestFailed");
+    }
+
     @Override public void responseHeadersStart(Call call) {
       printEvent("responseHeadersStart");
     }
@@ -145,6 +149,10 @@ public final class PrintEventsNonConcurrent {
 
     @Override public void responseBodyEnd(Call call, long byteCount) {
       printEvent("responseBodyEnd");
+    }
+
+    @Override public void responseFailed(Call call, IOException ioe) {
+      printEvent("responseFailed");
     }
 
     @Override public void callEnd(Call call) {


### PR DESCRIPTION
These replace requestBodyEnd() / responseBodyEnd() in some failure scenarios.
They may also be issued in cases where no event was published previously.