### PR TITLE
Fix the name of a TLSv1.3 cipher suite, TLS_AES_128_CCM_8_SHA256

### DIFF
--- a/okhttp-tests/src/main/java/okhttp3/TestTls13Request.java
+++ b/okhttp-tests/src/main/java/okhttp3/TestTls13Request.java
@@ -15,7 +15,7 @@ public class TestTls13Request {
       CipherSuite.TLS_AES_256_GCM_SHA384,
       CipherSuite.TLS_CHACHA20_POLY1305_SHA256,
       CipherSuite.TLS_AES_128_CCM_SHA256,
-      CipherSuite.TLS_AES_256_CCM_8_SHA256
+      CipherSuite.TLS_AES_128_CCM_8_SHA256
   };
 
   /**

--- a/okhttp/src/main/java/okhttp3/CipherSuite.java
+++ b/okhttp/src/main/java/okhttp3/CipherSuite.java
@@ -398,7 +398,7 @@ public final class CipherSuite {
   public static final CipherSuite TLS_AES_256_GCM_SHA384 = init("TLS_AES_256_GCM_SHA384", 0x1302);
   public static final CipherSuite TLS_CHACHA20_POLY1305_SHA256 = init("TLS_CHACHA20_POLY1305_SHA256", 0x1303);
   public static final CipherSuite TLS_AES_128_CCM_SHA256 = init("TLS_AES_128_CCM_SHA256", 0x1304);
-  public static final CipherSuite TLS_AES_256_CCM_8_SHA256 = init("TLS_AES_256_CCM_8_SHA256", 0x1305);
+  public static final CipherSuite TLS_AES_128_CCM_8_SHA256 = init("TLS_AES_128_CCM_8_SHA256", 0x1305);
 
   final String javaName;
 

--- a/okhttp/src/main/java/okhttp3/ConnectionSpec.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionSpec.java
@@ -54,7 +54,7 @@ public final class ConnectionSpec {
       CipherSuite.TLS_AES_256_GCM_SHA384,
       CipherSuite.TLS_CHACHA20_POLY1305_SHA256,
       CipherSuite.TLS_AES_128_CCM_SHA256,
-      CipherSuite.TLS_AES_256_CCM_8_SHA256,
+      CipherSuite.TLS_AES_128_CCM_8_SHA256,
 
       CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
       CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
@@ -73,7 +73,7 @@ public final class ConnectionSpec {
       CipherSuite.TLS_AES_256_GCM_SHA384,
       CipherSuite.TLS_CHACHA20_POLY1305_SHA256,
       CipherSuite.TLS_AES_128_CCM_SHA256,
-      CipherSuite.TLS_AES_256_CCM_8_SHA256,
+      CipherSuite.TLS_AES_128_CCM_8_SHA256,
 
       CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
       CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,


### PR DESCRIPTION
I think we made either a transcription error or grabbed a suite
from an earlier version of the spec.