### PR TITLE
Remove default cipher suites: TLS_AES_128_CCM_SHA256, TLS_AES_128_CCM_8_SHA256

### DIFF
--- a/okhttp/src/main/java/okhttp3/ConnectionSpec.java
+++ b/okhttp/src/main/java/okhttp3/ConnectionSpec.java
@@ -49,13 +49,12 @@ public final class ConnectionSpec {
 
   // Most secure but generally supported list.
   private static final CipherSuite[] RESTRICTED_CIPHER_SUITES = new CipherSuite[] {
-      // TLSv1.3
+      // TLSv1.3.
       CipherSuite.TLS_AES_128_GCM_SHA256,
       CipherSuite.TLS_AES_256_GCM_SHA384,
       CipherSuite.TLS_CHACHA20_POLY1305_SHA256,
-      CipherSuite.TLS_AES_128_CCM_SHA256,
-      CipherSuite.TLS_AES_128_CCM_8_SHA256,
 
+      // TLSv1.0, TLSv1.1, TLSv1.2.
       CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
       CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
       CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
@@ -64,17 +63,15 @@ public final class ConnectionSpec {
       CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
   };
 
-  // This is nearly equal to the cipher suites supported in Chrome 51, current as of 2016-05-25.
-  // All of these suites are available on Android 7.0; earlier releases support a subset of these
-  // suites. https://github.com/square/okhttp/issues/1972
+  // This is nearly equal to the cipher suites supported in Chrome 72, current as of 2019-02-24.
+  // See https://tinyurl.com/okhttp-cipher-suites for availability.
   private static final CipherSuite[] APPROVED_CIPHER_SUITES = new CipherSuite[] {
-      // TLSv1.3
+      // TLSv1.3.
       CipherSuite.TLS_AES_128_GCM_SHA256,
       CipherSuite.TLS_AES_256_GCM_SHA384,
       CipherSuite.TLS_CHACHA20_POLY1305_SHA256,
-      CipherSuite.TLS_AES_128_CCM_SHA256,
-      CipherSuite.TLS_AES_128_CCM_8_SHA256,
 
+      // TLSv1.0, TLSv1.1, TLSv1.2.
       CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
       CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
       CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
@@ -83,8 +80,7 @@ public final class ConnectionSpec {
       CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 
       // Note that the following cipher suites are all on HTTP/2's bad cipher suites list. We'll
-      // continue to include them until better suites are commonly available. For example, none
-      // of the better cipher suites listed above shipped with Android 4.4 or Java 7.
+      // continue to include them until better suites are commonly available.
       CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
       CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
       CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,


### PR DESCRIPTION
As far as I know we never would have used these anyway, as they're
not available on Android, Java, or Conscrypt.

They aren't enabled by default in either Firefox or Chrome.

Closes: https://github.com/square/okhttp/issues/3865