### PR TITLE
Fix memory leak in MockWebServer when using ALPN

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -496,6 +496,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
           if (protocolNegotiationEnabled) {
             String protocolString = Platform.get().getSelectedProtocol(sslSocket);
             protocol = protocolString != null ? Protocol.get(protocolString) : Protocol.HTTP_1_1;
+            Platform.get().afterHandshake(sslSocket);
           }
           openClientSockets.remove(raw);
         } else if (protocols.contains(Protocol.H2_PRIOR_KNOWLEDGE)) {


### PR DESCRIPTION
Since Platform.afterHandshake() was never called, SSLSockets were not removed from ALPN's Map and could not be freed.