### PR TITLE
Include 'timeout' in exceptions when that's the root cause

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
@@ -77,6 +77,7 @@ public final class WholeOperationTimeoutTest {
       call.execute();
       fail();
     } catch (IOException e) {
+      assertEquals("timeout", e.getMessage());
       assertTrue(call.isCanceled());
     }
   }
@@ -125,6 +126,7 @@ public final class WholeOperationTimeoutTest {
       call.execute();
       fail();
     } catch (IOException e) {
+      assertEquals("timeout", e.getMessage());
       assertTrue(call.isCanceled());
     }
   }
@@ -175,6 +177,7 @@ public final class WholeOperationTimeoutTest {
       response.body().source().readUtf8();
       fail();
     } catch (IOException e) {
+      assertEquals("timeout", e.getMessage());
       assertTrue(call.isCanceled());
     }
   }
@@ -252,6 +255,7 @@ public final class WholeOperationTimeoutTest {
       call.execute();
       fail();
     } catch (IOException e) {
+      assertEquals("timeout", e.getMessage());
       assertTrue(call.isCanceled());
     }
   }
@@ -275,6 +279,7 @@ public final class WholeOperationTimeoutTest {
       call.execute();
       fail();
     } catch (IOException e) {
+      assertEquals("timeout", e.getMessage());
       assertTrue(call.isCanceled());
     }
   }

--- a/okhttp/src/main/java/okhttp3/RealCall.java
+++ b/okhttp/src/main/java/okhttp3/RealCall.java
@@ -236,7 +236,7 @@ final class RealCall implements Call {
         originalRequest, this, client.connectTimeoutMillis(),
         client.readTimeoutMillis(), client.writeTimeoutMillis());
 
-    IOException ioException = null;
+    boolean calledNoMoreExchanges = false;
     try {
       Response response = chain.proceed(originalRequest);
       if (transmitter.isCanceled()) {
@@ -245,10 +245,12 @@ final class RealCall implements Call {
       }
       return response;
     } catch (IOException e) {
-      ioException = e;
-      throw e;
+      calledNoMoreExchanges = true;
+      throw transmitter.noMoreExchanges(e);
     } finally {
-      transmitter.noMoreExchanges(ioException);
+      if (!calledNoMoreExchanges) {
+        transmitter.noMoreExchanges(null);
+      }
     }
   }
 }


### PR DESCRIPTION
I'm not particularly happy with the way this code looks, but I like
the result. Otherwise exceptions are like these:

  * stream was reset: CANCEL
  * Socket closed
  * Canceled