### PR TITLE
Don't log duplex request bodies

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -193,6 +193,8 @@ public final class HttpLoggingInterceptor implements Interceptor {
         logger.log("--> END " + request.method());
       } else if (bodyHasUnknownEncoding(request.headers())) {
         logger.log("--> END " + request.method() + " (encoded body omitted)");
+      } else if (requestBody.isDuplex()) {
+        logger.log("--> END " + request.method() + " (duplex request body omitted)");
       } else {
         Buffer buffer = new Buffer();
         requestBody.writeTo(buffer);


### PR DESCRIPTION
We may want to support these eventually but for now this is
unhelpful because they won't terminate.