### PR TITLE
[WIP] Async DNS

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/AsyncDnsTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/AsyncDnsTest.java
@@ -40,24 +40,6 @@ public class AsyncDnsTest {
     assertEquals(Arrays.asList(address("2.3.4.5"), address("3.4.5.6")), result);
   }
 
-  //@Test public void cancel() {
-  //  MockDnsCache.when("cancel.do").thenAnswer(() -> {
-  //    try {
-  //      Thread.sleep(2000);
-  //    } catch (InterruptedException e) {
-  //      Thread.currentThread().interrupt();
-  //    }
-  //    return null;
-  //  });
-  //
-  //  final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
-  //  final CompletableFuture<List<InetAddress>> future = dns.lookupAsync("cancel.do");
-  //  if (!future.isDone())
-  //    future.cancel(true);
-  //  else
-  //    fail("Should not be done");
-  //}
-
   @Test(expected = TimeoutException.class) public void timeout() throws Exception {
     MockDnsCache.when("timeout.do").thenAnswer(() -> {
       try {

--- a/okhttp-tests/src/test/java/okhttp3/AsyncDnsTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/AsyncDnsTest.java
@@ -1,0 +1,67 @@
+package okhttp3;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javafx.util.Duration;
+import org.junit.After;
+import org.junit.Test;
+import sun.net.util.IPAddressUtil;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+public class AsyncDnsTest {
+
+  private static final ExecutorService executor = Executors.newCachedThreadPool();
+
+  @Test public void getOne() throws Exception {
+    //MockDnsCache.when("a.bc", "1.2.3.4");
+    MockDnsCache.when("a.bc", "1.2.3.4");
+
+    final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
+    final List<InetAddress> result = dns.lookupAsync("a.bc").get(5, TimeUnit.SECONDS);
+    assertEquals(singletonList(address("1.2.3.4")), result);
+  }
+
+  @Test public void getMulti() throws Exception {
+    //MockDnsCache.when("b.cd", "2.3.4.5", "3.4.5.6");
+    MockDnsCache.when("b.cd", "2.3.4.5", "3.4.5.6");
+
+    final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
+    final List<InetAddress> result = dns.lookupAsync("b.cd").get(5, TimeUnit.SECONDS);
+    result.sort(new InetAdressComparator());
+
+    assertEquals(Arrays.asList(address("2.3.4.5"), address("3.4.5.6")), result);
+  }
+  
+  @After public void clearDnsCache() {
+    MockDnsCache.clear();
+  }
+
+  private static InetAddress address(String host) {
+    try {
+      return InetAddress.getByName(host);
+    } catch (UnknownHostException e) {
+      // impossible for IP addresses
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static final class InetAdressComparator implements Comparator<InetAddress> {
+    @Override
+    public int compare(InetAddress address1, InetAddress address2) {
+      return address1.getHostName().compareTo(address2.getHostName());
+    }
+  }
+
+}

--- a/okhttp-tests/src/test/java/okhttp3/AsyncDnsTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/AsyncDnsTest.java
@@ -1,51 +1,83 @@
 package okhttp3;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import javafx.util.Duration;
+import java.util.concurrent.TimeoutException;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
-import sun.net.util.IPAddressUtil;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class AsyncDnsTest {
 
   private static final ExecutorService executor = Executors.newCachedThreadPool();
 
   @Test public void getOne() throws Exception {
-    //MockDnsCache.when("a.bc", "1.2.3.4");
-    MockDnsCache.when("a.bc", "1.2.3.4");
+    MockDnsCache.when("a.bc").thenReturn("1.2.3.4");
 
     final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
-    final List<InetAddress> result = dns.lookupAsync("a.bc").get(5, TimeUnit.SECONDS);
+    final List<InetAddress> result = dns.lookupAsync("a.bc").get(10, TimeUnit.SECONDS);
     assertEquals(singletonList(address("1.2.3.4")), result);
   }
 
   @Test public void getMulti() throws Exception {
-    //MockDnsCache.when("b.cd", "2.3.4.5", "3.4.5.6");
-    MockDnsCache.when("b.cd", "2.3.4.5", "3.4.5.6");
+    MockDnsCache.when("b.cd").thenReturn("2.3.4.5", "3.4.5.6");
 
     final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
-    final List<InetAddress> result = dns.lookupAsync("b.cd").get(5, TimeUnit.SECONDS);
+    final List<InetAddress> result = dns.lookupAsync("b.cd").get(10, TimeUnit.SECONDS);
     result.sort(new InetAdressComparator());
 
     assertEquals(Arrays.asList(address("2.3.4.5"), address("3.4.5.6")), result);
   }
+
+  @Test public void cancel() {
+    MockDnsCache.when("cancel.do").thenAnswer(() -> {
+      try {
+        Thread.sleep(2000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return null;
+    });
+
+    final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
+    final CompletableFuture<List<InetAddress>> future = dns.lookupAsync("cancel.do");
+    if (!future.isDone())
+      future.cancel(true);
+    else
+      fail("Should not be done");
+  }
+
+  @Test(expected = TimeoutException.class) public void timeout() throws Exception {
+    MockDnsCache.when("timeout.do").thenAnswer(() -> {
+      try {
+        Thread.sleep(2000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return null;
+    });
+
+    final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
+    dns.lookupAsync("b.cd").get(4, TimeUnit.SECONDS);
+  }
   
   @After public void clearDnsCache() {
     MockDnsCache.clear();
+  }
+
+  @AfterClass public static void shutdownExecutor() {
+    executor.shutdownNow();
   }
 
   private static InetAddress address(String host) {

--- a/okhttp-tests/src/test/java/okhttp3/AsyncDnsTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/AsyncDnsTest.java
@@ -40,28 +40,28 @@ public class AsyncDnsTest {
     assertEquals(Arrays.asList(address("2.3.4.5"), address("3.4.5.6")), result);
   }
 
-  @Test public void cancel() {
-    MockDnsCache.when("cancel.do").thenAnswer(() -> {
-      try {
-        Thread.sleep(2000);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-      return null;
-    });
-
-    final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
-    final CompletableFuture<List<InetAddress>> future = dns.lookupAsync("cancel.do");
-    if (!future.isDone())
-      future.cancel(true);
-    else
-      fail("Should not be done");
-  }
+  //@Test public void cancel() {
+  //  MockDnsCache.when("cancel.do").thenAnswer(() -> {
+  //    try {
+  //      Thread.sleep(2000);
+  //    } catch (InterruptedException e) {
+  //      Thread.currentThread().interrupt();
+  //    }
+  //    return null;
+  //  });
+  //
+  //  final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
+  //  final CompletableFuture<List<InetAddress>> future = dns.lookupAsync("cancel.do");
+  //  if (!future.isDone())
+  //    future.cancel(true);
+  //  else
+  //    fail("Should not be done");
+  //}
 
   @Test(expected = TimeoutException.class) public void timeout() throws Exception {
     MockDnsCache.when("timeout.do").thenAnswer(() -> {
       try {
-        Thread.sleep(2000);
+        Thread.sleep(4000);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }
@@ -69,7 +69,7 @@ public class AsyncDnsTest {
     });
 
     final AsyncDns dns = new AsyncDns.Builder().executor(executor).build();
-    dns.lookupAsync("b.cd").get(4, TimeUnit.SECONDS);
+    dns.lookupAsync("timeout.do").get(2, TimeUnit.SECONDS);
   }
   
   @After public void clearDnsCache() {

--- a/okhttp-tests/src/test/java/okhttp3/MockDnsCache.java
+++ b/okhttp-tests/src/test/java/okhttp3/MockDnsCache.java
@@ -2,16 +2,13 @@ package okhttp3;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javafx.util.Duration;
@@ -19,22 +16,11 @@ import sun.net.util.IPAddressUtil;
 
 final class MockDnsCache {
   // TODO is synchronization required for access/update?
-  //private static LinkedHashMap mockPositiveCache;
-  //private static Map<String, StubImpl> stubs = new HashMap<>();
-
-  private static Map<String, Object> positiveCache;
+  private static Map<String, ?> mockPositiveCache;
+  private static Map<String, StubImpl> stubs = new HashMap<>();
 
   static {
     try {
-      ////final LinkedHashMap test2 = new LinkedHashMap();
-      //final Field testField = MockDnsCache.class.getDeclaredField("test");
-      //System.out.println(testField.getDeclaringClass());
-      ////System.out.println(testField.getDeclaringClass());
-      ////System.out.println(test2.getClass());
-      ////final boolean assignableFrom = testField.getDeclaringClass().isAssignableFrom(test2.getClass());
-      ////
-      ////System.out.println(assignableFrom);
-
       final Field addressCacheField = InetAddress.class.getDeclaredField("addressCache");
       addressCacheField.setAccessible(true);
       final Object addressCache = addressCacheField.get(InetAddress.class);
@@ -45,30 +31,19 @@ final class MockDnsCache {
 
       final Field cacheField = addressCache.getClass().getDeclaredField("cache");
       cacheField.setAccessible(true);
-      positiveCache = (Map<String, Object>) cacheField.get(addressCache);
 
-      //when(positiveCache.get("a")).thenAnswer(x -> {
-      //  throw new RuntimeException("faked");
-      //});
-
-      //mockPositiveCache = new MockMap(positiveCache, stubs);
-      //mockPositiveCache = new LinkedHashMap();
-      //
-      //cacheField.set(mockPositiveCache, addressCache);
+      Map<String, ?> positiveCache = (Map<String, ?>) cacheField.get(addressCache);
+      mockPositiveCache = new MockLinkedHashMap(positiveCache, stubs);
+      cacheField.set(addressCache, mockPositiveCache);
     } catch (Exception e) {
       throw new AssertionError(e);
     }
   }
 
-  //static Stub when(String host) {
-  //  final StubImpl stub = new StubImpl(host);
-  //  stubs.put(host, stub);
-  //  return stub;
-  //}
-
-  static void when(String host, String... ips) {
-    final Object dnsEntry = createCacheEntry(host, ips);
-    positiveCache.put(host, dnsEntry);
+  static Stub when(String host) {
+    final StubImpl stub = new StubImpl(host);
+    stubs.put(host, stub);
+    return stub;
   }
 
   private static Object createCacheEntry(String host, String[] ips) {
@@ -77,7 +52,7 @@ final class MockDnsCache {
       final Constructor<?> ctor = clazz.getDeclaredConstructors()[0];
       ctor.setAccessible(true);
 
-      final InetAddress[] addresses = Arrays.asList(ips).stream()
+      final InetAddress[] addresses = Arrays.stream(ips)
           .map(IPAddressUtil::textToNumericFormatV4)
           .map(bytes -> getByAddress(host, bytes))
           .collect(Collectors.toList())
@@ -92,8 +67,7 @@ final class MockDnsCache {
   }
 
   static void clear() {
-    //mockPositiveCache.clear();
-    positiveCache.clear();
+    mockPositiveCache.clear();
   }
 
   private static InetAddress getByAddress(String host, byte[] bytes) {
@@ -126,11 +100,11 @@ final class MockDnsCache {
     }
   }
 
-    public static final class MockMap extends LinkedHashMap {
-      private final Map<String, Object> delegate;
+    public static final class MockLinkedHashMap extends LinkedHashMap<String, Object> {
+      private final Map<String, ?> delegate;
       private final Map<String, StubImpl> stubs;
 
-      private MockMap(Map<String, Object> delegate, Map<String, StubImpl> stubs) {
+      private MockLinkedHashMap(Map<String, ?> delegate, Map<String, StubImpl> stubs) {
         this.delegate = delegate;
         this.stubs = stubs;
       }
@@ -143,13 +117,5 @@ final class MockDnsCache {
         return delegate.get(key);
       }
     }
-
-  //static class ValueStub implements Stub {
-  //  final Object value;
-  //
-  //  ValueStub(Object value) {
-  //    this.value = value;
-  //  }
-  //}
 
 }

--- a/okhttp-tests/src/test/java/okhttp3/MockDnsCache.java
+++ b/okhttp-tests/src/test/java/okhttp3/MockDnsCache.java
@@ -1,0 +1,155 @@
+package okhttp3;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javafx.util.Duration;
+import sun.net.util.IPAddressUtil;
+
+final class MockDnsCache {
+  // TODO is synchronization required for access/update?
+  //private static LinkedHashMap mockPositiveCache;
+  //private static Map<String, StubImpl> stubs = new HashMap<>();
+
+  private static Map<String, Object> positiveCache;
+
+  static {
+    try {
+      ////final LinkedHashMap test2 = new LinkedHashMap();
+      //final Field testField = MockDnsCache.class.getDeclaredField("test");
+      //System.out.println(testField.getDeclaringClass());
+      ////System.out.println(testField.getDeclaringClass());
+      ////System.out.println(test2.getClass());
+      ////final boolean assignableFrom = testField.getDeclaringClass().isAssignableFrom(test2.getClass());
+      ////
+      ////System.out.println(assignableFrom);
+
+      final Field addressCacheField = InetAddress.class.getDeclaredField("addressCache");
+      addressCacheField.setAccessible(true);
+      final Object addressCache = addressCacheField.get(InetAddress.class);
+
+      final Method cacheInit = InetAddress.class.getDeclaredMethod("cacheInitIfNeeded");
+      cacheInit.setAccessible(true);
+      cacheInit.invoke(addressCache);
+
+      final Field cacheField = addressCache.getClass().getDeclaredField("cache");
+      cacheField.setAccessible(true);
+      positiveCache = (Map<String, Object>) cacheField.get(addressCache);
+
+      //when(positiveCache.get("a")).thenAnswer(x -> {
+      //  throw new RuntimeException("faked");
+      //});
+
+      //mockPositiveCache = new MockMap(positiveCache, stubs);
+      //mockPositiveCache = new LinkedHashMap();
+      //
+      //cacheField.set(mockPositiveCache, addressCache);
+    } catch (Exception e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  //static Stub when(String host) {
+  //  final StubImpl stub = new StubImpl(host);
+  //  stubs.put(host, stub);
+  //  return stub;
+  //}
+
+  static void when(String host, String... ips) {
+    final Object dnsEntry = createCacheEntry(host, ips);
+    positiveCache.put(host, dnsEntry);
+  }
+
+  private static Object createCacheEntry(String host, String[] ips) {
+    try {
+      final Class<?> clazz = Class.forName("java.net.InetAddress$CacheEntry");
+      final Constructor<?> ctor = clazz.getDeclaredConstructors()[0];
+      ctor.setAccessible(true);
+
+      final InetAddress[] addresses = Arrays.asList(ips).stream()
+          .map(IPAddressUtil::textToNumericFormatV4)
+          .map(bytes -> getByAddress(host, bytes))
+          .collect(Collectors.toList())
+          .toArray(new InetAddress[ips.length]);
+
+      final Duration expirationSeconds = Duration.seconds(10);
+      final long expirationTime = System.currentTimeMillis() + (long) expirationSeconds.toMillis();
+      return ctor.newInstance(addresses, expirationTime);
+    } catch (Exception e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  static void clear() {
+    //mockPositiveCache.clear();
+    positiveCache.clear();
+  }
+
+  private static InetAddress getByAddress(String host, byte[] bytes) {
+    try {
+      return InetAddress.getByAddress(host, bytes);
+    } catch (UnknownHostException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  interface Stub {
+    void thenAnswer(Supplier<?> answer);
+    void thenReturn(String... ips);
+  }
+
+  private static final class StubImpl implements Stub {
+    private final String host;
+    private Supplier<?> answer;
+
+    public StubImpl(String host) {
+      this.host = host;
+    }
+
+    @Override public void thenAnswer(Supplier<?> answer) {
+      this.answer = answer;
+    }
+
+    @Override public void thenReturn(String... ips) {
+      answer = () -> createCacheEntry(host, ips);
+    }
+  }
+
+    public static final class MockMap extends LinkedHashMap {
+      private final Map<String, Object> delegate;
+      private final Map<String, StubImpl> stubs;
+
+      private MockMap(Map<String, Object> delegate, Map<String, StubImpl> stubs) {
+        this.delegate = delegate;
+        this.stubs = stubs;
+      }
+
+      @Override public Object get(Object key) {
+        final StubImpl stub = stubs.get(key);
+        if (stub != null)
+          return stub.answer.get();
+
+        return delegate.get(key);
+      }
+    }
+
+  //static class ValueStub implements Stub {
+  //  final Object value;
+  //
+  //  ValueStub(Object value) {
+  //    this.value = value;
+  //  }
+  //}
+
+}

--- a/okhttp-tests/src/test/java/okhttp3/internal/connection/AsyncRouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/connection/AsyncRouteSelectorTest.java
@@ -1,0 +1,28 @@
+package okhttp3.internal.connection;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import okhttp3.AsyncDns;
+import okhttp3.Dns;
+import org.junit.AfterClass;
+
+public final class AsyncRouteSelectorTest extends RouteSelectorTest {
+
+  private static final ExecutorService executor = Executors.newCachedThreadPool();
+
+  private final AsyncDns asyncDns;
+
+  public AsyncRouteSelectorTest() {
+    super();
+    asyncDns = new AsyncDns.Builder().executor(executor).dns(dns).build();
+  }
+
+  @AfterClass public static void shutdownExecutor() {
+    executor.shutdownNow();
+  }
+
+  @Override protected Dns getTestDns() {
+    return asyncDns;
+  }
+
+}

--- a/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteSelectorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/connection/RouteSelectorTest.java
@@ -33,6 +33,7 @@ import javax.net.ssl.SSLSocketFactory;
 import okhttp3.Address;
 import okhttp3.Authenticator;
 import okhttp3.ConnectionSpec;
+import okhttp3.Dns;
 import okhttp3.EventListener;
 import okhttp3.FakeDns;
 import okhttp3.Protocol;
@@ -51,7 +52,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public final class RouteSelectorTest {
+public class RouteSelectorTest {
   public final List<ConnectionSpec> connectionSpecs = Util.immutableList(
       ConnectionSpec.MODERN_TLS,
       ConnectionSpec.COMPATIBLE_TLS,
@@ -75,7 +76,7 @@ public final class RouteSelectorTest {
 
   private final Authenticator authenticator = Authenticator.NONE;
   private final List<Protocol> protocols = Arrays.asList(Protocol.HTTP_1_1);
-  private final FakeDns dns = new FakeDns();
+  protected final FakeDns dns = new FakeDns();
   private final RecordingProxySelector proxySelector = new RecordingProxySelector();
   private RouteDatabase routeDatabase = new RouteDatabase();
 
@@ -449,12 +450,17 @@ public final class RouteSelectorTest {
 
   /** Returns an address that's without an SSL socket factory or hostname verifier. */
   private Address httpAddress() {
-    return new Address(uriHost, uriPort, dns, socketFactory, null, null, null, authenticator, null,
+    return new Address(uriHost, uriPort, getTestDns(), socketFactory, null, null, null, authenticator, null,
         protocols, connectionSpecs, proxySelector);
   }
 
   private Address httpsAddress() {
-    return new Address(uriHost, uriPort, dns, socketFactory, sslSocketFactory,
+    return new Address(uriHost, uriPort, getTestDns(), socketFactory, sslSocketFactory,
         hostnameVerifier, null, authenticator, null, protocols, connectionSpecs, proxySelector);
   }
+
+  protected Dns getTestDns() {
+    return dns;
+  }
+
 }

--- a/okhttp/src/main/java/okhttp3/AsyncDns.java
+++ b/okhttp/src/main/java/okhttp3/AsyncDns.java
@@ -12,15 +12,17 @@ import javax.annotation.Nullable;
 final class AsyncDns implements Dns {
 
   private final ExecutorService executor;
+  private final Dns dns;
 
   AsyncDns(Builder builder) {
     this.executor = builder.executor;
+    this.dns = builder.dns;
   }
 
   public CompletableFuture<List<InetAddress>> lookupAsync(String hostName) {
     return CompletableFuture.supplyAsync(() -> {
       try {
-        return Dns.SYSTEM.lookup(hostName);
+        return dns.lookup(hostName);
       } catch (UnknownHostException e) {
         throw new CompletionException(e);
       }
@@ -44,6 +46,7 @@ final class AsyncDns implements Dns {
 
   public static final class Builder {
     @Nullable ExecutorService executor = null;
+    Dns dns = Dns.SYSTEM;
 
     public AsyncDns build() {
       return new AsyncDns(this);
@@ -51,6 +54,11 @@ final class AsyncDns implements Dns {
 
     public Builder executor(ExecutorService executor) {
       this.executor = executor;
+      return this;
+    }
+
+    public Builder dns(Dns dns) {
+      this.dns = dns;
       return this;
     }
   }

--- a/okhttp/src/main/java/okhttp3/AsyncDns.java
+++ b/okhttp/src/main/java/okhttp3/AsyncDns.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 
-final class AsyncDns implements Dns {
+public final class AsyncDns implements Dns {
 
   private final ExecutorService executor;
   private final Dns dns;

--- a/okhttp/src/main/java/okhttp3/AsyncDns.java
+++ b/okhttp/src/main/java/okhttp3/AsyncDns.java
@@ -1,0 +1,58 @@
+package okhttp3;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
+
+final class AsyncDns implements Dns {
+
+  private final ExecutorService executor;
+
+  AsyncDns(Builder builder) {
+    this.executor = builder.executor;
+  }
+
+  public CompletableFuture<List<InetAddress>> lookupAsync(String hostName) {
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        return Dns.SYSTEM.lookup(hostName);
+      } catch (UnknownHostException e) {
+        throw new CompletionException(e);
+      }
+    }, executor);
+  }
+
+  public @Override List<InetAddress> lookup(String hostname) throws UnknownHostException {
+    CompletableFuture<List<InetAddress>> future = lookupAsync(hostname);
+    try {
+      return future.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted waiting for DNS resolution");
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof UnknownHostException)
+        throw (UnknownHostException) e.getCause();
+
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static final class Builder {
+    @Nullable ExecutorService executor = null;
+
+    public AsyncDns build() {
+      return new AsyncDns(this);
+    }
+
+    public Builder executor(ExecutorService executor) {
+      this.executor = executor;
+      return this;
+    }
+  }
+
+}

--- a/okhttp/src/main/java/okhttp3/internal/connection/AsyncRouteState.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/AsyncRouteState.java
@@ -1,0 +1,167 @@
+package okhttp3.internal.connection;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import okhttp3.Address;
+import okhttp3.AsyncDns;
+import okhttp3.Call;
+import okhttp3.EventListener;
+import okhttp3.Route;
+
+public class AsyncRouteState implements RouteState {
+
+  private final Address address;
+  private final AsyncDns asyncDns;
+
+  private CompletableFuture<List<InetSocketAddress>> futureInetSocketAddresses;
+
+  private CompletableFuture<AllRoutes> futureComputedRoutes;
+
+  private AllRoutes computedRoutes;
+
+  public AsyncRouteState(Address address) {
+    this.address = address;
+    this.asyncDns = (AsyncDns) address.dns();
+  }
+
+  @Override public boolean hasPostponedRoutes() {
+    if (futureComputedRoutes.isDone()) {
+      AllRoutes allRoutes = launderedGetComputedRoutes();
+      return !allRoutes.postponedRoutes.isEmpty();
+    }
+
+    return false;
+  }
+
+  private AllRoutes launderedGetComputedRoutes() {
+    try {
+      return getComputedRoutes();
+    } catch (IOException e) {
+      if (e instanceof UnknownHostException)
+        throw new UnknownHostRuntimeException(e);
+
+      throw new RuntimeException(e);
+    }
+  }
+
+  private AllRoutes getComputedRoutes() throws IOException {
+    try {
+      if (computedRoutes == null)
+        computedRoutes = futureComputedRoutes.get();
+
+      return computedRoutes;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return AllRoutes.EMPTY;
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException)
+        throw (IOException) cause;
+
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override public void addPostponedRoutes() throws IOException {
+    if (futureComputedRoutes.isDone()) {
+      AllRoutes allRoutes = getComputedRoutes();
+      List<Route> routes = allRoutes.routes;
+      List<Route> postponedRoutes = allRoutes.postponedRoutes;
+      routes.addAll(postponedRoutes);
+      postponedRoutes.clear();
+    }
+  }
+
+  @Override public void initComputedRoutes() {
+    computedRoutes = null;
+  }
+
+  @Override public boolean hasComputedRoutes() throws IOException {
+    if (futureComputedRoutes.isDone()) {
+      AllRoutes allRoutes = getComputedRoutes();
+      return !allRoutes.routes.isEmpty();
+    }
+
+    return false;
+  }
+
+  @Override public RouteSelector.Selection getComputedRouteSelection() throws IOException {
+    if (futureComputedRoutes.isDone()) {
+      AllRoutes allRoutes = getComputedRoutes();
+      return new RouteSelector.Selection(allRoutes.routes);
+    }
+
+    throw new IOException("Asynchronous DNS lookup not yet completed");
+  }
+
+  @Override
+  public void computeRoutes(Proxy proxy, RouteDatabase routeDatabase) {
+    futureComputedRoutes = futureInetSocketAddresses.thenApply(inetSocketAddresses -> {
+      List<Route> postponedRoutes = new ArrayList<>();
+      List<Route> routes = new ArrayList<>();
+
+      for (int i = 0, size = inetSocketAddresses.size(); i < size; i++) {
+        Route route = new Route(address, proxy, inetSocketAddresses.get(i));
+        if (routeDatabase.shouldPostpone(route)) {
+          postponedRoutes.add(route);
+        } else {
+          routes.add(route);
+        }
+      }
+
+      return new AllRoutes(routes, postponedRoutes);
+    });
+  }
+
+  @Override public void resetAddresses() {
+    futureInetSocketAddresses = null;
+    // futureComputedRoutes = null;
+  }
+
+  @Override public void addUnresolvedAddress(String socketHost, int socketPort) {
+    List<InetSocketAddress> addresses =
+        Collections.singletonList(InetSocketAddress.createUnresolved(socketHost, socketPort));
+    futureInetSocketAddresses = CompletableFuture.completedFuture(addresses);
+  }
+
+  @Override public void addAddresses(String socketHost, int socketPort, Call call,
+      EventListener eventListener) throws IOException {
+    eventListener.dnsStart(call, socketHost);
+
+    // Try each address for best behavior in mixed IPv4/IPv6 environments.
+    CompletableFuture<List<InetAddress>> futureAddresses = asyncDns.lookupAsync(socketHost);
+    futureInetSocketAddresses = futureAddresses
+        .thenApply(addresses -> {
+          eventListener.dnsEnd(call, socketHost, addresses);
+          return addresses;
+        })
+        .thenApply(addresses ->
+          addresses.stream()
+              .map(inetAddress -> new InetSocketAddress(inetAddress, socketPort))
+              .collect(Collectors.toList())
+        );
+  }
+
+  private static final class AllRoutes {
+    private static final AllRoutes EMPTY =
+        new AllRoutes(Collections.emptyList(), Collections.emptyList());
+
+    final List<Route> routes;
+    final List<Route> postponedRoutes;
+
+    private AllRoutes(List<Route> routes, List<Route> postponedRoutes) {
+      this.routes = routes;
+      this.postponedRoutes = postponedRoutes;
+    }
+  }
+
+}

--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteState.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteState.java
@@ -1,0 +1,33 @@
+package okhttp3.internal.connection;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.util.List;
+import okhttp3.Address;
+import okhttp3.Call;
+import okhttp3.EventListener;
+import okhttp3.Route;
+import okhttp3.internal.connection.RouteSelector.Selection;
+
+interface RouteState {
+
+  boolean hasPostponedRoutes();
+
+  void addPostponedRoutes() throws IOException;
+
+  void initComputedRoutes();
+
+  boolean hasComputedRoutes() throws IOException;
+
+  Selection getComputedRouteSelection() throws IOException;
+
+  void computeRoutes(Proxy proxy, RouteDatabase routeDatabase);
+
+  void resetAddresses();
+
+  void addUnresolvedAddress(String socketHost, int socketPort);
+
+  void addAddresses(String socketHost, int socketPort,
+      Call call, EventListener eventListener) throws IOException;
+
+}

--- a/okhttp/src/main/java/okhttp3/internal/connection/SyncRouteState.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/SyncRouteState.java
@@ -1,0 +1,91 @@
+package okhttp3.internal.connection;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import okhttp3.Address;
+import okhttp3.Call;
+import okhttp3.EventListener;
+import okhttp3.Route;
+import okhttp3.internal.connection.RouteSelector.Selection;
+
+final class SyncRouteState implements RouteState {
+
+  private final Address address;
+
+  /* State for negotiating the next socket address to use. */
+  private List<InetSocketAddress> inetSocketAddresses = Collections.emptyList();
+
+  /* State for negotiating failed routes */
+  private List<Route> postponedRoutes = new ArrayList<>();
+
+  List<Route> computedRoutes;
+
+  public SyncRouteState(Address address) {
+    this.address = address;
+  }
+
+  @Override public boolean hasPostponedRoutes() {
+    return !postponedRoutes.isEmpty();
+  }
+
+  @Override public void addPostponedRoutes() {
+    computedRoutes.addAll(postponedRoutes);
+    postponedRoutes.clear();
+  }
+
+  @Override public void initComputedRoutes() {
+    computedRoutes = new ArrayList<>();
+  }
+
+  @Override public boolean hasComputedRoutes() {
+    return !computedRoutes.isEmpty();
+  }
+
+  public Selection getComputedRouteSelection() {
+    return new Selection(computedRoutes);
+  }
+
+  @Override public void computeRoutes(Proxy proxy, RouteDatabase routeDatabase) {
+    for (int i = 0, size = inetSocketAddresses.size(); i < size; i++) {
+      Route route = new Route(address, proxy, inetSocketAddresses.get(i));
+      if (routeDatabase.shouldPostpone(route)) {
+        postponedRoutes.add(route);
+      } else {
+        computedRoutes.add(route);
+      }
+    }
+  }
+
+  @Override public void resetAddresses() {
+    inetSocketAddresses = new ArrayList<>();
+  }
+
+  @Override public void addUnresolvedAddress(String socketHost, int socketPort) {
+    inetSocketAddresses.add(InetSocketAddress.createUnresolved(socketHost, socketPort));
+  }
+
+  @Override public void addAddresses(String socketHost, int socketPort,
+      Call call, EventListener eventListener) throws IOException {
+    eventListener.dnsStart(call, socketHost);
+
+    // Try each address for best behavior in mixed IPv4/IPv6 environments.
+    List<InetAddress> addresses = address.dns().lookup(socketHost);
+    if (addresses.isEmpty()) {
+      throw new UnknownHostException(address.dns() + " returned no addresses for " + socketHost);
+    }
+
+    eventListener.dnsEnd(call, socketHost, addresses);
+
+    for (int i = 0, size = addresses.size(); i < size; i++) {
+      InetAddress inetAddress = addresses.get(i);
+      inetSocketAddresses.add(new InetSocketAddress(inetAddress, socketPort));
+    }
+  }
+
+}

--- a/okhttp/src/main/java/okhttp3/internal/connection/UnknownHostRuntimeException.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/UnknownHostRuntimeException.java
@@ -1,0 +1,7 @@
+package okhttp3.internal.connection;
+
+final class UnknownHostRuntimeException extends RuntimeException {
+  public UnknownHostRuntimeException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
I've been working on #95 and wanted to share progress with it and get some guidance on next steps.

As per #95 I started by looking into Call/Callback to see if DNS requests could be represented using them but these classes are specific to HTTP calls, so I discarded that option. I was also not convinced about adding DnsCall/DnsCallback.

So, instead I've worked backwards by starting first with an async DNS implementation (`AsyncDns`) and a unit test for it (`AsyncDnsTest` and `MockDnsCache`). I've made `AsyncDns` a subclass of `Dns` to make it easier to plug it in. It currently delegates to a given DNS implementation wrapping calls around `CompletableFuture.supplyAsync()` and configurable executor (as suggested in #95, it should be the IO pool). 

Then to try integrate the async DNS implementation I've decided to separate route state in `RouteSelector` into two implementations `SyncRouteState` and `AsyncRouteState` of `RouteState` interface. The former for sync DNS implementations and the latter for async DNS implementations. This interface is a bit clunky at the moment, so should be considered WIP as there are bigger problems to tackle first. 

`AsyncRouteState` just keeps track of the async lookup future and replies accordingly. The key aspect comes when `Selection` needs to be built. If the future is not complete when the `Selection` needs to be built, it throws an `IOException` indicating the async DNS lookup is not done. My rationale here is that this would eventually bubble up to `RetryAndFollowUpInterceptor` and it'd retry. Of course the retry would need to be slightly different since you'd want to just use the same connection and retry the logic all the way to selecting the route.

I wanted to find out from OkHttp developers if this is the right approach? This is not yet implemented and there are no end-to-end tests for async DNS, but before working on those I wanted to verify that this is a valid approach that can work with the current APIs.

On top of `AsyncDnsTest` I've developed a `AsyncRouteSelectorTest` test that extends `RouteSelectorTest` and uses `AsyncDns`. This test randomly fails because there are times when async DNS has not completed (to be expected), but I'm hoping to use the test to verify that if `AsyncRouteState` works as expected. For that, I'm planning to modify the test so that async DNS completes in time.

Once `AsyncRouteSelectorTest` works (with the assumption that async DNS always completes in time for the selection router `next()` to be called), I was planning to work on at least two end-to-end tests: one that verifies that an async DNS implementation that replies in time of router selection being queried works, and another where the DNS implementation is slow and see if retry logic

Summarising, still TODOs:
- Hook IO executor thread pool into AsyncDns (needs investigating).
- End-to-end async DNS test where async DNS completes in time first time.
- End-to-end async DNS test with slow async DNS and retries.
- Cancel an async DNS call if the HTTP `Call` instance is cancelled.
- End-to-end async DNS test with slow async DNS and cancel.
- Calls that timeout should cancel async DNS calls.