### PR TITLE
Test for connection leaks in more tests

### DIFF
--- a/okhttp-testing-support/src/main/java/okhttp3/TestUtil.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/TestUtil.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import okhttp3.internal.http2.Header;
 
+import static org.junit.Assert.assertEquals;
+
 public final class TestUtil {
   public static final InetSocketAddress UNREACHABLE_ADDRESS
       = new InetSocketAddress("198.51.100.1", 8080);
@@ -82,5 +84,10 @@ public final class TestUtil {
     Runtime.getRuntime().gc();
     Thread.sleep(100);
     System.runFinalization();
+  }
+
+  public static void ensureAllConnectionsReleased(OkHttpClient client) {
+    client.connectionPool().evictAll();
+    assertEquals(0, client.connectionPool().idleConnectionCount());
   }
 }

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -85,6 +85,7 @@ public final class CacheTest {
   @After public void tearDown() throws Exception {
     ResponseCache.setDefault(null);
     cache.delete();
+    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   /**
@@ -1101,9 +1102,7 @@ public final class CacheTest {
   }
 
   @Test public void conditionalCacheHitIsNotDoublePooled() throws Exception {
-    // Ensure that the (shared) connection pool is in a consistent state.
-    client.connectionPool().evictAll();
-    assertEquals(0, client.connectionPool().idleConnectionCount());
+    TestUtil.ensureAllConnectionsReleased(client);
 
     server.enqueue(new MockResponse()
         .addHeader("ETag: v1")

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -127,9 +127,7 @@ public final class CallTest {
     cache.delete();
     logger.removeHandler(logHandler);
 
-    // Ensure the test has released all connections.
-    client.connectionPool().evictAll();
-    assertEquals(0, client.connectionPool().connectionCount());
+    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   @Test public void get() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
@@ -29,6 +29,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.tls.HandshakeCertificates;
 import okhttp3.tls.HeldCertificate;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -87,6 +88,11 @@ public final class ConnectionCoalescingTest {
     server.useHttps(serverHandshakeCertificates.sslSocketFactory(), false);
 
     url = server.url("/robots.txt");
+  }
+
+  @After
+  public void tearDown() {
+    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   /**

--- a/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
@@ -25,6 +25,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.SocketPolicy;
 import okhttp3.tls.HandshakeCertificates;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -41,6 +42,11 @@ public final class ConnectionReuseTest {
 
   private HandshakeCertificates handshakeCertificates = localhost();
   private OkHttpClient client = defaultClient();
+
+  @After
+  public void tearDown() {
+    TestUtil.ensureAllConnectionsReleased(client);
+  }
 
   @Test public void connectionsAreReused() throws Exception {
     server.enqueue(new MockResponse().setBody("a"));

--- a/okhttp-tests/src/test/java/okhttp3/ConscryptTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConscryptTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import okhttp3.internal.platform.ConscryptPlatform;
 import okhttp3.internal.platform.Platform;
 import org.conscrypt.OpenSSLProvider;
+import org.junit.After;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -41,6 +42,11 @@ public class ConscryptTest {
   };
 
   private OkHttpClient client = buildClient();
+
+  @After
+  public void tearDown() {
+    TestUtil.ensureAllConnectionsReleased(client);
+  }
 
   private OkHttpClient buildClient() {
     ConnectionSpec spec = new ConnectionSpec.Builder(true)

--- a/okhttp-tests/src/test/java/okhttp3/CookiesTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CookiesTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
 import org.junit.Test;
 
 import static java.net.CookiePolicy.ACCEPT_ORIGINAL_SERVER;
@@ -44,6 +45,11 @@ import static org.junit.Assert.fail;
 /** Derived from Android's CookiesTest. */
 public class CookiesTest {
   private OkHttpClient client = defaultClient();
+
+  @After
+  public void tearDown() {
+    TestUtil.ensureAllConnectionsReleased(client);
+  }
 
   @Test
   public void testNetscapeResponse() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import okhttp3.RealCall.AsyncCall;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,6 +41,11 @@ public final class DispatcherTest {
     dispatcher.setMaxRequests(20);
     dispatcher.setMaxRequestsPerHost(10);
     listener.forbidLock(dispatcher);
+  }
+
+  @After
+  public void tearDown() {
+    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   @Test public void maxRequestsZero() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/DuplexTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/DuplexTest.java
@@ -31,6 +31,7 @@ import okhttp3.mockwebserver.internal.duplex.MockDuplexResponseBody;
 import okhttp3.tls.HandshakeCertificates;
 import okio.BufferedSink;
 import okio.BufferedSource;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -53,6 +54,11 @@ public final class DuplexTest {
       .newBuilder()
       .eventListener(listener)
       .build();
+
+  @After
+  public void tearDown() {
+    TestUtil.ensureAllConnectionsReleased(client);
+  }
 
   @Test public void http1DoesntSupportDuplex() throws IOException {
     Call call = client.newCall(new Request.Builder()

--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -100,6 +100,8 @@ public final class EventListenerTest {
     if (socksProxy != null) {
       socksProxy.shutdown();
     }
+
+    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   @Test public void successfulCallEventSequence() throws IOException {

--- a/okhttp-tests/src/test/java/okhttp3/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/InterceptorTest.java
@@ -39,6 +39,7 @@ import okio.GzipSink;
 import okio.Okio;
 import okio.Sink;
 import okio.Source;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,6 +57,11 @@ public final class InterceptorTest {
 
   private OkHttpClient client = defaultClient();
   private RecordingCallback callback = new RecordingCallback();
+
+  @After
+  public void tearDown() {
+    TestUtil.ensureAllConnectionsReleased(client);
+  }
 
   @Test public void applicationInterceptorsCanShortCircuitResponses() throws Exception {
     server.shutdown(); // Accept no connections.

--- a/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okio.BufferedSink;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -41,6 +42,11 @@ public final class WholeOperationTimeoutTest {
   @Rule public final MockWebServer server = new MockWebServer();
 
   private OkHttpClient client = defaultClient();
+
+  @After
+  public void tearDown() {
+    TestUtil.ensureAllConnectionsReleased(client);
+  }
 
   @Test public void defaultConfigIsNoTimeout() throws Exception {
     Request request = new Request.Builder()

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/ThreadInterruptTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/ThreadInterruptTest.java
@@ -31,6 +31,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.TestUtil;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okio.Buffer;
@@ -77,6 +78,7 @@ public final class ThreadInterruptTest {
 
   @After public void tearDown() throws Exception {
     Thread.interrupted(); // Clear interrupted state.
+    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   @Test public void interruptWritingRequestBody() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -149,9 +149,7 @@ public final class HttpOverHttp2Test {
     http2Logger.removeHandler(http2Handler);
     http2Logger.setLevel(previousLevel);
 
-    // Ensure a fresh connection pool for the next test.
-    client.connectionPool().evictAll();
-    assertEquals(0, client.connectionPool().connectionCount());
+    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   @Test public void get() throws Exception {


### PR DESCRIPTION
This will help prevent regressions and point to the leaking test, rather than to a later test that happens to checks for leaks. The change is applied to all tests that have an OkHttpClient member variable.