### PR TITLE
Use a TestRule to check for connection leaks

### DIFF
--- a/okhttp-sse/src/test/java/okhttp3/internal/sse/EventSourceHttpTest.java
+++ b/okhttp-sse/src/test/java/okhttp3/internal/sse/EventSourceHttpTest.java
@@ -17,6 +17,7 @@ package okhttp3.internal.sse;
 
 import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
+import okhttp3.OkHttpClientTestingRule;
 import okhttp3.Request;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -26,14 +27,14 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.assertEquals;
 
 public final class EventSourceHttpTest {
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
   private final EventSourceRecorder listener = new EventSourceRecorder();
-  private OkHttpClient client = defaultClient();
+  private OkHttpClient client = clientTestingRule.client;
 
   @After public void after() {
     listener.assertExhausted();

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestingRule.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestingRule.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import static okhttp3.TestUtil.defaultClient;
+
+public class OkHttpClientTestingRule implements TestRule {
+  public OkHttpClient client = defaultClient();
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return statement(base);
+  }
+
+  private Statement statement(final Statement base) {
+    return new Statement() {
+      public void evaluate() throws Throwable {
+        try {
+          base.evaluate();
+        } finally {
+          TestUtil.ensureAllConnectionsReleased(client);
+        }
+      }
+    };
+  }
+}

--- a/okhttp-tests/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CacheTest.java
@@ -51,7 +51,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AT_END;
 import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.junit.Assert.assertEquals;
@@ -67,6 +66,7 @@ public final class CacheTest {
   @Rule public MockWebServer server = new MockWebServer();
   @Rule public MockWebServer server2 = new MockWebServer();
   @Rule public InMemoryFileSystem fileSystem = new InMemoryFileSystem();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
   private final HandshakeCertificates handshakeCertificates = localhost();
   private OkHttpClient client;
@@ -76,7 +76,7 @@ public final class CacheTest {
   @Before public void setUp() throws Exception {
     server.setProtocolNegotiationEnabled(false);
     cache = new Cache(new File("/cache/"), Integer.MAX_VALUE, fileSystem);
-    client = defaultClient().newBuilder()
+    client = clientTestingRule.client.newBuilder()
         .cache(cache)
         .cookieJar(new JavaNetCookieJar(cookieManager))
         .build();
@@ -85,7 +85,6 @@ public final class CacheTest {
   @After public void tearDown() throws Exception {
     ResponseCache.setDefault(null);
     cache.delete();
-    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   /**

--- a/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionCoalescingTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.fail;
 
 public final class ConnectionCoalescingTest {
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
   private OkHttpClient client;
 
@@ -81,6 +82,7 @@ public final class ConnectionCoalescingTest {
         .sslSocketFactory(
             handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager())
         .build();
+    clientTestingRule.client = client;
 
     HandshakeCertificates serverHandshakeCertificates = new HandshakeCertificates.Builder()
         .heldCertificate(certificate)
@@ -88,11 +90,6 @@ public final class ConnectionCoalescingTest {
     server.useHttps(serverHandshakeCertificates.sslSocketFactory(), false);
 
     url = server.url("/robots.txt");
-  }
-
-  @After
-  public void tearDown() {
-    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   /**

--- a/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/ConnectionReuseTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
-import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -39,14 +38,10 @@ import static org.junit.Assert.fail;
 public final class ConnectionReuseTest {
   @Rule public final TestRule timeout = new Timeout(30_000);
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
   private HandshakeCertificates handshakeCertificates = localhost();
-  private OkHttpClient client = defaultClient();
-
-  @After
-  public void tearDown() {
-    TestUtil.ensureAllConnectionsReleased(client);
-  }
+  private OkHttpClient client = clientTestingRule.client;
 
   @Test public void connectionsAreReused() throws Exception {
     server.enqueue(new MockResponse().setBody("a"));

--- a/okhttp-tests/src/test/java/okhttp3/CookiesTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CookiesTest.java
@@ -32,10 +32,10 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static java.net.CookiePolicy.ACCEPT_ORIGINAL_SERVER;
-import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -44,12 +44,9 @@ import static org.junit.Assert.fail;
 
 /** Derived from Android's CookiesTest. */
 public class CookiesTest {
-  private OkHttpClient client = defaultClient();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
-  @After
-  public void tearDown() {
-    TestUtil.ensureAllConnectionsReleased(client);
-  }
+  private OkHttpClient client = clientTestingRule.client;
 
   @Test
   public void testNetscapeResponse() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/DispatcherTest.java
@@ -17,22 +17,24 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import okhttp3.RealCall.AsyncCall;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class DispatcherTest {
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
+
   RecordingExecutor executor = new RecordingExecutor();
   RecordingCallback callback = new RecordingCallback();
   RecordingWebSocketListener webSocketListener = new RecordingWebSocketListener();
   Dispatcher dispatcher = new Dispatcher(executor);
   RecordingEventListener listener = new RecordingEventListener();
-  OkHttpClient client = defaultClient().newBuilder()
+  OkHttpClient client = clientTestingRule.client.newBuilder()
       .dispatcher(dispatcher)
       .eventListener(listener)
       .build();
@@ -41,11 +43,6 @@ public final class DispatcherTest {
     dispatcher.setMaxRequests(20);
     dispatcher.setMaxRequestsPerHost(10);
     listener.forbidLock(dispatcher);
-  }
-
-  @After
-  public void tearDown() {
-    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   @Test public void maxRequestsZero() throws Exception {

--- a/okhttp-tests/src/test/java/okhttp3/DuplexTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/DuplexTest.java
@@ -38,7 +38,6 @@ import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
 import static junit.framework.TestCase.assertTrue;
-import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -47,18 +46,14 @@ import static org.junit.Assert.fail;
 public final class DuplexTest {
   @Rule public final TestRule timeout = new Timeout(30_000, TimeUnit.MILLISECONDS);
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
   private final RecordingEventListener listener = new RecordingEventListener();
   private HandshakeCertificates handshakeCertificates = localhost();
-  private OkHttpClient client = defaultClient()
+  private OkHttpClient client = clientTestingRule.client
       .newBuilder()
       .eventListener(listener)
       .build();
-
-  @After
-  public void tearDown() {
-    TestUtil.ensureAllConnectionsReleased(client);
-  }
 
   @Test public void http1DoesntSupportDuplex() throws IOException {
     Call call = client.newCall(new Request.Builder()

--- a/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/EventListenerTest.java
@@ -62,7 +62,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
-import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.either;
@@ -80,15 +79,16 @@ import static org.junit.Assume.assumeThat;
 public final class EventListenerTest {
   public static final Matcher<Response> anyResponse = CoreMatchers.any(Response.class);
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
   private final RecordingEventListener listener = new RecordingEventListener();
   private final HandshakeCertificates handshakeCertificates = localhost();
 
-  private OkHttpClient client;
+  private OkHttpClient client = clientTestingRule.client;
   private SocksProxy socksProxy;
 
   @Before public void setUp() {
-    client = defaultClient().newBuilder()
+    client = clientTestingRule.client.newBuilder()
         .eventListener(listener)
         .build();
 
@@ -100,8 +100,6 @@ public final class EventListenerTest {
     if (socksProxy != null) {
       socksProxy.shutdown();
     }
-
-    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   @Test public void successfulCallEventSequence() throws IOException {

--- a/okhttp-tests/src/test/java/okhttp3/InterceptorTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/InterceptorTest.java
@@ -43,7 +43,6 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -54,14 +53,10 @@ import static org.junit.Assert.fail;
 
 public final class InterceptorTest {
   @Rule public MockWebServer server = new MockWebServer();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
-  private OkHttpClient client = defaultClient();
+  private OkHttpClient client = clientTestingRule.client;
   private RecordingCallback callback = new RecordingCallback();
-
-  @After
-  public void tearDown() {
-    TestUtil.ensureAllConnectionsReleased(client);
-  }
 
   @Test public void applicationInterceptorsCanShortCircuitResponses() throws Exception {
     server.shutdown(); // Accept no connections.

--- a/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/URLConnectionTest.java
@@ -88,7 +88,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.internal.http.StatusLine.HTTP_PERM_REDIRECT;
 import static okhttp3.internal.http.StatusLine.HTTP_TEMP_REDIRECT;
 import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST;
@@ -114,9 +113,10 @@ public final class URLConnectionTest {
   @Rule public final MockWebServer server = new MockWebServer();
   @Rule public final MockWebServer server2 = new MockWebServer();
   @Rule public final TemporaryFolder tempDir = new TemporaryFolder();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
   private HandshakeCertificates handshakeCertificates = localhost();
-  private OkHttpClient client = defaultClient();
+  private OkHttpClient client = clientTestingRule.client;
   private @Nullable Cache cache;
 
   @Before public void setUp() {

--- a/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/WholeOperationTimeoutTest.java
@@ -28,7 +28,6 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -40,13 +39,9 @@ public final class WholeOperationTimeoutTest {
   private static final String BIG_ENOUGH_BODY = TestUtil.repeat('a', 64 * 1024);
 
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
-  private OkHttpClient client = defaultClient();
-
-  @After
-  public void tearDown() {
-    TestUtil.ensureAllConnectionsReleased(client);
-  }
+  private OkHttpClient client = clientTestingRule.client;
 
   @Test public void defaultConfigIsNoTimeout() throws Exception {
     Request request = new Request.Builder()

--- a/okhttp-tests/src/test/java/okhttp3/internal/http/CancelTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http/CancelTest.java
@@ -28,6 +28,7 @@ import okhttp3.DelegatingServerSocketFactory;
 import okhttp3.DelegatingSocketFactory;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
+import okhttp3.OkHttpClientTestingRule;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -36,12 +37,13 @@ import okhttp3.mockwebserver.MockWebServer;
 import okio.Buffer;
 import okio.BufferedSink;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
-import static okhttp3.TestUtil.defaultClient;
 import static org.junit.Assert.fail;
 
 public final class CancelTest {
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
   // The size of the socket buffers in bytes.
   private static final int SOCKET_BUFFER_SIZE = 256 * 1024;
@@ -61,7 +63,7 @@ public final class CancelTest {
             return serverSocket;
           }
         });
-    client = defaultClient().newBuilder()
+    client = clientTestingRule.client.newBuilder()
         .socketFactory(new DelegatingSocketFactory(SocketFactory.getDefault()) {
           @Override protected Socket configureSocket(Socket socket) throws IOException {
             socket.setSendBufferSize(SOCKET_BUFFER_SIZE);

--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -40,6 +40,7 @@ import okhttp3.Headers;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
+import okhttp3.OkHttpClientTestingRule;
 import okhttp3.Protocol;
 import okhttp3.RecordingCookieJar;
 import okhttp3.RecordingHostnameVerifier;
@@ -77,7 +78,6 @@ import org.junit.runners.Parameterized.Parameters;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static okhttp3.TestUtil.defaultClient;
 import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertArrayEquals;
@@ -101,6 +101,7 @@ public final class HttpOverHttp2Test {
 
   @Rule public final TemporaryFolder tempDir = new TemporaryFolder();
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public final OkHttpClientTestingRule clientTestingRule = new OkHttpClientTestingRule();
 
   private OkHttpClient client;
   private Cache cache;
@@ -115,14 +116,14 @@ public final class HttpOverHttp2Test {
     this.protocol = protocol;
   }
 
-  private static OkHttpClient buildH2PriorKnowledgeClient() {
-    return defaultClient().newBuilder()
+  private OkHttpClient buildH2PriorKnowledgeClient() {
+    return clientTestingRule.client.newBuilder()
         .protocols(Arrays.asList(Protocol.H2_PRIOR_KNOWLEDGE))
         .build();
   }
 
-  private static OkHttpClient buildHttp2Client() {
-    return defaultClient().newBuilder()
+  private OkHttpClient buildHttp2Client() {
+    return clientTestingRule.client.newBuilder()
         .protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1))
         .sslSocketFactory(
             handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager())
@@ -148,8 +149,6 @@ public final class HttpOverHttp2Test {
     Authenticator.setDefault(null);
     http2Logger.removeHandler(http2Handler);
     http2Logger.setLevel(previousLevel);
-
-    TestUtil.ensureAllConnectionsReleased(client);
   }
 
   @Test public void get() throws Exception {


### PR DESCRIPTION
This implements the suggestion in https://github.com/square/okhttp/pull/4677.

I'm not very happy with the result and I personally prefer it not to be merged, at least not as-is: The problem is that many tests use this pattern to overwrite the `client` field:
```
client = client.newBuilder()
      ...
      .build();
```
Since updating `OkHttpClientTestingRule.client` after every instance of this would be tedious, `OkHttpClientTestingRule` will apply its checks to the original `OkHttpClient`. This is usually OK since the original and new `OkHttpClient` instances share most of the fields, but since some fields do differ, the result is inconsistent.
