### PR TITLE
Don't leak a connection if a WebSocket handshake fails

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -51,6 +51,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static okhttp3.TestUtil.defaultClient;
+import static okhttp3.TestUtil.ensureAllConnectionsReleased;
 import static okhttp3.TestUtil.repeat;
 import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.junit.Assert.assertEquals;
@@ -304,6 +305,8 @@ public final class WebSocketHttpTest {
 
     clientListener.assertFailure(101, null, ProtocolException.class,
         "Expected 'Connection' header value 'Upgrade' but was 'null'");
+
+    ensureAllConnectionsReleased(client);
   }
 
   @Test public void wrongConnectionHeader() throws IOException {

--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.java
@@ -152,6 +152,10 @@ public final class Exchange {
     return codec.connection().newWebSocketStreams(this);
   }
 
+  public void webSocketUpgradeFailed() {
+    bodyComplete(-1L, true, true, null);
+  }
+
   public void noNewExchangesOnConnection() {
     codec.connection().noNewExchanges();
   }


### PR DESCRIPTION
I'm not particularly happy with all of the moving parts here. I think
perhaps doing web sockets over duplex is a possible fix here.

Closes: https://github.com/square/okhttp/issues/4658