### PR TITLE
Add missing license header to CacheControl.java

### DIFF
--- a/okhttp/src/main/java/okhttp3/CacheControl.java
+++ b/okhttp/src/main/java/okhttp3/CacheControl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okhttp3;
 
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
I'm not sure what should be the year.