### PR TITLE
Enforce full-call timeouts on SSE setup

### DIFF
--- a/okhttp-sse/src/test/java/okhttp3/internal/sse/EventSourceHttpTest.java
+++ b/okhttp-sse/src/test/java/okhttp3/internal/sse/EventSourceHttpTest.java
@@ -72,9 +72,9 @@ public final class EventSourceHttpTest {
     listener.assertFailure(null);
   }
 
-  @Test public void callTimeoutIsNotApplied() throws Exception {
+  @Test public void fullCallTimeoutDoesNotApplyOnceConnected() throws Exception {
     client = client.newBuilder()
-        .callTimeout(100, TimeUnit.MILLISECONDS)
+        .callTimeout(250, TimeUnit.MILLISECONDS)
         .build();
 
     server.enqueue(new MockResponse()
@@ -89,6 +89,20 @@ public final class EventSourceHttpTest {
     listener.assertOpen();
     listener.assertEvent(null, null, "hey");
     listener.assertClose();
+  }
+
+  @Test public void fullCallTimeoutAppliesToSetup() throws Exception {
+    client = client.newBuilder()
+        .callTimeout(250, TimeUnit.MILLISECONDS)
+        .build();
+
+    server.enqueue(new MockResponse()
+        .setHeadersDelay(500, TimeUnit.MILLISECONDS)
+        .setHeader("content-type", "text/event-stream")
+        .setBody("data: hey\n\n"));
+
+    newEventSource();
+    listener.assertFailure("timeout");
   }
 
   private EventSource newEventSource() {

--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.java
@@ -147,6 +147,10 @@ public final class Exchange {
     return codec.trailers();
   }
 
+  public void timeoutEarlyExit() {
+    transmitter.timeoutEarlyExit();
+  }
+
   public RealWebSocket.Streams newWebSocketStreams() throws SocketException {
     transmitter.timeoutEarlyExit();
     return codec.connection().newWebSocketStreams(this);


### PR DESCRIPTION
Once the response headers are received we go back to not having
any timeout enforced.

Closes: https://github.com/square/okhttp/issues/4646