### PR TITLE
Provide better exceptions when the shared HTTP/2 stream fails

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -932,7 +932,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
       if (peekedResponse.getSocketPolicy() == RESET_STREAM_AT_START) {
         try {
           dispatchBookkeepingRequest(sequenceNumber.getAndIncrement(), socket);
-          stream.close(ErrorCode.fromHttp2(peekedResponse.getHttp2ErrorCode()));
+          stream.close(ErrorCode.fromHttp2(peekedResponse.getHttp2ErrorCode()), null);
           return;
         } catch (InterruptedException e) {
           throw new AssertionError(e);
@@ -1064,7 +1064,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
           duplexResponseBody.onRequest(request, source, sink);
         }
       } else if (!outFinished) {
-        stream.close(ErrorCode.NO_ERROR);
+        stream.close(ErrorCode.NO_ERROR, null);
       }
     }
 

--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -1309,11 +1309,7 @@ public final class CallTest {
   }
 
   @Test public void matchingPinnedCertificate() throws Exception {
-    // TODO https://github.com/square/okhttp/issues/4598
-//    java.util.NoSuchElementException
-//    at java.base/java.util.ArrayDeque.removeFirst(ArrayDeque.java:363)
-//    at okhttp3.internal.tls.BasicCertificateChainCleaner.clean(BasicCertificateChainCleaner.java:58)
-//    at okhttp3.CertificatePinner.check(CertificatePinner.java:166)
+    // TODO https://github.com/square/okhttp/issues/4703
     assumeFalse(getJvmSpecVersion().equals("11"));
 
     enableTls();

--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
@@ -57,11 +57,7 @@ public final class CertificatePinnerChainValidationTest {
 
   /** The pinner should pull the root certificate from the trust manager. */
   @Test public void pinRootNotPresentInChain() throws Exception {
-    // TODO https://github.com/square/okhttp/issues/4598
-//    java.util.NoSuchElementException
-//    at java.base/java.util.ArrayDeque.removeFirst(ArrayDeque.java:363)
-//    at okhttp3.internal.tls.BasicCertificateChainCleaner.clean(BasicCertificateChainCleaner.java:58)
-//    at okhttp3.CertificatePinner.check(CertificatePinner.java:166)
+    // TODO https://github.com/square/okhttp/issues/4703
     assumeFalse(getJvmSpecVersion().equals("11"));
 
     HeldCertificate rootCa = new HeldCertificate.Builder()
@@ -121,11 +117,7 @@ public final class CertificatePinnerChainValidationTest {
 
   /** The pinner should accept an intermediate from the server's chain. */
   @Test public void pinIntermediatePresentInChain() throws Exception {
-    // TODO https://github.com/square/okhttp/issues/4598
-//    java.util.NoSuchElementException
-//    at java.base/java.util.ArrayDeque.removeFirst(ArrayDeque.java:363)
-//    at okhttp3.internal.tls.BasicCertificateChainCleaner.clean(BasicCertificateChainCleaner.java:58)
-//    at okhttp3.CertificatePinner.check(CertificatePinner.java:166)
+    // TODO https://github.com/square/okhttp/issues/4703
     assumeFalse(getJvmSpecVersion().equals("11"));
 
     HeldCertificate rootCa = new HeldCertificate.Builder()

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.java
@@ -607,7 +607,7 @@ public final class RealConnection extends Http2Connection.Listener implements Co
 
   /** Refuse incoming streams. */
   @Override public void onStream(Http2Stream stream) throws IOException {
-    stream.close(ErrorCode.REFUSED_STREAM);
+    stream.close(ErrorCode.REFUSED_STREAM, null);
   }
 
   /** When settings are received, adjust the allocation limit. */

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import okhttp3.Headers;
 import okhttp3.internal.NamedRunnable;
 import okhttp3.internal.Util;
@@ -323,7 +324,7 @@ public final class Http2Connection implements Closeable {
           try {
             writeSynReset(streamId, errorCode);
           } catch (IOException e) {
-            failConnection();
+            failConnection(e);
           }
         }
       });
@@ -344,7 +345,7 @@ public final class Http2Connection implements Closeable {
               try {
                 writer.windowUpdate(streamId, unacknowledgedBytesRead);
               } catch (IOException e) {
-                failConnection();
+                failConnection(e);
               }
             }
           });
@@ -378,7 +379,7 @@ public final class Http2Connection implements Closeable {
         awaitingPong = true;
       }
       if (failedDueToMissingPong) {
-        failConnection();
+        failConnection(null);
         return;
       }
     }
@@ -386,7 +387,7 @@ public final class Http2Connection implements Closeable {
     try {
       writer.ping(reply, payload1, payload2);
     } catch (IOException e) {
-      failConnection();
+      failConnection(e);
     }
   }
 
@@ -432,17 +433,15 @@ public final class Http2Connection implements Closeable {
    * Closes this connection. This cancels all open streams and unanswered pings. It closes the
    * underlying input and output streams and shuts down internal executor services.
    */
-  @Override public void close() throws IOException {
-    close(ErrorCode.NO_ERROR, ErrorCode.CANCEL);
+  @Override public void close() {
+    close(ErrorCode.NO_ERROR, ErrorCode.CANCEL, null);
   }
 
-  void close(ErrorCode connectionCode, ErrorCode streamCode) throws IOException {
+  void close(ErrorCode connectionCode, ErrorCode streamCode, @Nullable IOException cause) {
     assert (!Thread.holdsLock(this));
-    IOException thrown = null;
     try {
       shutdown(connectionCode);
-    } catch (IOException e) {
-      thrown = e;
+    } catch (IOException ignored) {
     }
 
     Http2Stream[] streamsToClose = null;
@@ -456,9 +455,8 @@ public final class Http2Connection implements Closeable {
     if (streamsToClose != null) {
       for (Http2Stream stream : streamsToClose) {
         try {
-          stream.close(streamCode);
-        } catch (IOException e) {
-          if (thrown != null) thrown = e;
+          stream.close(streamCode, cause);
+        } catch (IOException ignored) {
         }
       }
     }
@@ -466,29 +464,22 @@ public final class Http2Connection implements Closeable {
     // Close the writer to release its resources (such as deflaters).
     try {
       writer.close();
-    } catch (IOException e) {
-      if (thrown == null) thrown = e;
+    } catch (IOException ignored) {
     }
 
     // Close the socket to break out the reader thread, which will clean up after itself.
     try {
       socket.close();
-    } catch (IOException e) {
-      thrown = e;
+    } catch (IOException ignored) {
     }
 
     // Release the threads.
     writerExecutor.shutdown();
     pushExecutor.shutdown();
-
-    if (thrown != null) throw thrown;
   }
 
-  private void failConnection() {
-    try {
-      close(ErrorCode.PROTOCOL_ERROR, ErrorCode.PROTOCOL_ERROR);
-    } catch (IOException ignored) {
-    }
+  private void failConnection(@Nullable IOException e) {
+    close(ErrorCode.PROTOCOL_ERROR, ErrorCode.PROTOCOL_ERROR, e);
   }
 
   /**
@@ -603,6 +594,7 @@ public final class Http2Connection implements Closeable {
     @Override protected void execute() {
       ErrorCode connectionErrorCode = ErrorCode.INTERNAL_ERROR;
       ErrorCode streamErrorCode = ErrorCode.INTERNAL_ERROR;
+      IOException errorException = null;
       try {
         reader.readConnectionPreface(this);
         while (reader.nextFrame(false, this)) {
@@ -610,13 +602,11 @@ public final class Http2Connection implements Closeable {
         connectionErrorCode = ErrorCode.NO_ERROR;
         streamErrorCode = ErrorCode.CANCEL;
       } catch (IOException e) {
+        errorException = e;
         connectionErrorCode = ErrorCode.PROTOCOL_ERROR;
         streamErrorCode = ErrorCode.PROTOCOL_ERROR;
       } finally {
-        try {
-          close(connectionErrorCode, streamErrorCode);
-        } catch (IOException ignored) {
-        }
+        close(connectionErrorCode, streamErrorCode, errorException);
         Util.closeQuietly(reader);
       }
     }
@@ -675,7 +665,7 @@ public final class Http2Connection implements Closeable {
                 Platform.get().log(
                     INFO, "Http2Connection.Listener failure for " + connectionName, e);
                 try {
-                  newStream.close(ErrorCode.PROTOCOL_ERROR);
+                  newStream.close(ErrorCode.PROTOCOL_ERROR, e);
                 } catch (IOException ignored) {
                 }
               }
@@ -740,7 +730,7 @@ public final class Http2Connection implements Closeable {
             try {
               writer.applyAndAckSettings(peerSettings);
             } catch (IOException e) {
-              failConnection();
+              failConnection(e);
             }
           }
         });
@@ -928,7 +918,7 @@ public final class Http2Connection implements Closeable {
   public abstract static class Listener {
     public static final Listener REFUSE_INCOMING_STREAMS = new Listener() {
       @Override public void onStream(Http2Stream stream) throws IOException {
-        stream.close(REFUSED_STREAM);
+        stream.close(REFUSED_STREAM, null);
       }
     };
 

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Reader.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Reader.java
@@ -16,6 +16,7 @@
 package okhttp3.internal.http2;
 
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
@@ -93,7 +94,7 @@ final class Http2Reader implements Closeable {
   public boolean nextFrame(boolean requireSettings, Handler handler) throws IOException {
     try {
       source.require(9); // Frame header size
-    } catch (IOException e) {
+    } catch (EOFException e) {
       return false; // This might be a normal socket close.
     }
 


### PR DESCRIPTION
Previously we always provided a generic StreamResetException. Now we provide
the exception that triggered the stream to be closed, if any.