### PR TITLE
Fail recoverFromCancelReusesConnection() on unexpected response

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -900,6 +900,7 @@ public final class HttpOverHttp2Test {
       }
 
       @Override public void onResponse(Call call1, Response response) {
+        fail();
       }
     });
     assertEquals(expectedSequenceNumber, server.takeRequest().getSequenceNumber());


### PR DESCRIPTION
This may help nail down the sporadic timeouts in this test (https://github.com/square/okhttp/issues/4633).