### PR TITLE
Remove the hpacktests module by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
     <module>okhttp-testing-support</module>
     <module>okhttp-tls</module>
     <module>okhttp-urlconnection</module>
-    <module>okhttp-hpacktests</module>
 
     <module>okhttp-logging-interceptor</module>
 


### PR DESCRIPTION
We don't change the code this exercises enough to pay for the build
time and complexity it adds.