### PR TITLE
Don't fail the build if dependencies aren't available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,11 @@ before_install:
   - echo "MAVEN_OPTS='-Dmaven.repo.local=$HOME/.m2/repository -Xmx1g -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS'" > ~/.mavenrc
 
 install:
-  - ./mvnw dependency:resolve -B
+  - ./mvnw dependency:resolve -B || true
 
 script:
-  - ./mvnw checkstyle:check -B
-  - ./mvnw test -B
-  - ./mvnw javadoc:jar source:jar -B
+  - ./mvnw -DskipTests package checkstyle:check -B
+  - ./mvnw test javadoc:jar source:jar -B
 
 after_success:
   - .buildscript/deploy_snapshot.sh


### PR DESCRIPTION
This causes us to fail if our own snapshots are missing. I wasn't able to
get the normal Maven options to do this, including  -DexcludeGroupIds=com.squareup.okhttp3
and -DexcludeTransitive=true which I expected to work but don't.

My expectation is that if dependencies aren't available, the build will soon
fail anyway.