### PR TITLE
Dump list of events if expected event is not found in test

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
@@ -43,11 +43,15 @@ public final class RecordingEventListener extends EventListener {
    * {@code eventClass} and returns it.
    */
   public <T> T removeUpToEvent(Class<T> eventClass) {
+    List<CallEvent> fullEventSequence = new ArrayList<>(eventSequence);
     Object event = eventSequence.poll();
     while (event != null && !eventClass.isInstance(event)) {
       event = eventSequence.poll();
     }
-    if (event == null) throw new AssertionError();
+    if (event == null) {
+      throw new AssertionError(
+          eventClass.getSimpleName() + " not found. Found " + fullEventSequence + ".");
+    }
     return eventClass.cast(event);
   }
 


### PR DESCRIPTION
This will help debug flaky tests where expected events are sometimes missing. For example: https://travis-ci.org/square/okhttp/jobs/506592764.