### PR TITLE
Hook up japicmp for all stable artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ buildscript {
 plugins {
   id 'ru.vyarus.animalsniffer' version '1.5.0'
   id 'com.github.johnrengelman.shadow' version '4.0.1'
+  id 'me.champeau.gradle.japicmp' version '0.2.6'
 }
 
 allprojects {
@@ -152,3 +153,22 @@ def alpnBootVersionForPatchVersion(String javaVersion, int patchVersion) {
       throw new IllegalStateException("Unexpected Java version: ${javaVersion}")
   }
 }
+
+/**
+ * Returns a .jar file for the golden version of this project.
+ * https://github.com/Visistema/Groovy1/blob/ba5eb9b2f19ca0cc8927359ce414c4e1974b7016/gradle/binarycompatibility.gradle#L48
+ */
+ext.baselineJar = { project, version ->
+  def group = project.property("GROUP")
+  def artifactId = project.property("POM_ARTIFACT_ID")
+  try {
+    String jarFile = "$artifactId-${version}.jar"
+    project.group = 'virtual_group_for_japicmp' // Prevent it from resolving the current version.
+    def dependency = project.dependencies.create("$group:$artifactId:$version@jar")
+    return project.configurations.detachedConfiguration(dependency).files
+        .find { (it.name == jarFile) }
+  } finally {
+    project.group = group
+  }
+}
+ext.baselineVersion = "3.14.0"

--- a/mockwebserver/build.gradle
+++ b/mockwebserver/build.gradle
@@ -14,3 +14,15 @@ dependencies {
   testImplementation project(':okhttp-tls')
   testImplementation deps.assertj
 }
+
+apply plugin: 'me.champeau.gradle.japicmp'
+task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask, dependsOn: 'jar') {
+  oldClasspath = files(baselineJar(project, baselineVersion))
+  newClasspath = files(jar.archivePath)
+  onlyBinaryIncompatibleModified = true
+  failOnModification = true
+  txtOutputFile = file("$buildDir/reports/japi.txt")
+  ignoreMissingClasses = true
+  includeSynthetic = true
+}
+check.dependsOn(japicmp)

--- a/okhttp-logging-interceptor/build.gradle
+++ b/okhttp-logging-interceptor/build.gradle
@@ -17,3 +17,15 @@ dependencies {
   testImplementation project(':okhttp-tls')
   testImplementation deps.assertj
 }
+
+apply plugin: 'me.champeau.gradle.japicmp'
+task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask, dependsOn: 'jar') {
+  oldClasspath = files(baselineJar(project, baselineVersion))
+  newClasspath = files(jar.archivePath)
+  onlyBinaryIncompatibleModified = true
+  failOnModification = true
+  txtOutputFile = file("$buildDir/reports/japi.txt")
+  ignoreMissingClasses = true
+  includeSynthetic = true
+}
+check.dependsOn(japicmp)

--- a/okhttp-logging-interceptor/gradle.properties
+++ b/okhttp-logging-interceptor/gradle.properties
@@ -1,3 +1,3 @@
-POM_ARTIFACT_ID=okhttp-logging-interceptor
-POM_NAME=okhttp-logging-interceptor
+POM_ARTIFACT_ID=logging-interceptor
+POM_NAME=logging-interceptor
 POM_PACKAGING=jar

--- a/okhttp-tls/build.gradle
+++ b/okhttp-tls/build.gradle
@@ -16,3 +16,15 @@ dependencies {
   testImplementation deps.junit
   testImplementation deps.assertj
 }
+
+apply plugin: 'me.champeau.gradle.japicmp'
+task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask, dependsOn: 'jar') {
+  oldClasspath = files(baselineJar(project, baselineVersion))
+  newClasspath = files(jar.archivePath)
+  onlyBinaryIncompatibleModified = true
+  failOnModification = true
+  txtOutputFile = file("$buildDir/reports/japi.txt")
+  ignoreMissingClasses = true
+  includeSynthetic = true
+}
+check.dependsOn(japicmp)

--- a/okhttp-urlconnection/build.gradle
+++ b/okhttp-urlconnection/build.gradle
@@ -17,3 +17,15 @@ dependencies {
   testImplementation deps.junit
   testImplementation deps.assertj
 }
+
+apply plugin: 'me.champeau.gradle.japicmp'
+task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask, dependsOn: 'jar') {
+  oldClasspath = files(baselineJar(project, baselineVersion))
+  newClasspath = files(jar.archivePath)
+  onlyBinaryIncompatibleModified = true
+  failOnModification = true
+  txtOutputFile = file("$buildDir/reports/japi.txt")
+  ignoreMissingClasses = true
+  includeSynthetic = true
+}
+check.dependsOn(japicmp)

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -31,3 +31,15 @@ dependencies {
   testImplementation deps.junit
   testImplementation deps.assertj
 }
+
+apply plugin: 'me.champeau.gradle.japicmp'
+task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask, dependsOn: 'jar') {
+  oldClasspath = files(baselineJar(project, baselineVersion))
+  newClasspath = files(jar.archivePath)
+  onlyBinaryIncompatibleModified = true
+  failOnModification = true
+  txtOutputFile = file("$buildDir/reports/japi.txt")
+  ignoreMissingClasses = true
+  includeSynthetic = true
+}
+check.dependsOn(japicmp)


### PR DESCRIPTION
This excludes okhttp-sse and okhttp-dnsoverhttps