### PR TITLE
Fix flaky testRfc2109Response()

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CookiesTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CookiesTest.java
@@ -99,7 +99,7 @@ public class CookiesTest {
     assertThat(cookie.getCommentURL()).isNull();
     assertThat(cookie.getDiscard()).isFalse();
     // Converting to a fixed date can cause rounding!
-    assertThat((double) cookie.getMaxAge()).isCloseTo(60.0, offset(1.0));
+    assertThat((double) cookie.getMaxAge()).isCloseTo(60.0, offset(5.0));
     assertThat(cookie.getPath()).isEqualTo("/path");
     assertThat(cookie.getSecure()).isTrue();
   }


### PR DESCRIPTION
The time delta in the cookie max-age is rounded down, so is at most 59 seconds. Possibly a GC or some other hiccup can occasionally make it lower, so allow some room for error.

Fixes https://github.com/square/okhttp/issues/4733.