### PR TITLE
Switch to Arrays.copyOf for expanding array

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/Util.java
+++ b/okhttp/src/main/java/okhttp3/internal/Util.java
@@ -311,8 +311,7 @@ public final class Util {
   }
 
   public static String[] concat(String[] array, String value) {
-    String[] result = new String[array.length + 1];
-    System.arraycopy(array, 0, result, 0, array.length);
+    String[] result = Arrays.copyOf(array, array.length + 1);
     result[result.length - 1] = value;
     return result;
   }


### PR DESCRIPTION
This is an intrinsic in the JVM so it should have better performance.