### PR TITLE
Add API to close websocket without sending status code.

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -90,6 +90,18 @@ public final class RealWebSocketTest {
     }
   }
 
+  @Test public void clientCloseWithoutStatus() throws IOException {
+    client.webSocket.close();
+    // This will trigger a close response.
+    assertThat(server.processNextFrame()).isFalse();
+    server.listener.assertClosing(1005, "");
+    server.webSocket.close(1000, "Goodbye!");
+    assertThat(client.processNextFrame()).isFalse();
+    client.listener.assertClosing(1000, "Goodbye!");
+    server.listener.assertClosed(1005, "");
+    client.listener.assertClosed(1000, "Goodbye!");
+  }
+
   @Test public void afterSocketClosedPingFailsWebSocket() throws IOException {
     client2Server.source().close();
     client.webSocket.pong(ByteString.encodeUtf8("Ping!"));

--- a/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketWriterTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/ws/WebSocketWriterTest.java
@@ -278,17 +278,21 @@ public final class WebSocketWriterTest {
     assertData("888760b420bb635d68de0cd84f");
   }
 
-  @Test public void closeWithOnlyReasonThrows() throws IOException {
-    clientWriter.writeClose(0, ByteString.encodeUtf8("Hello"));
-    assertData("888760b420bb60b468de0cd84f");
-  }
-
   @Test public void closeCodeOutOfRangeThrows() throws IOException {
     try {
       clientWriter.writeClose(98724976, ByteString.encodeUtf8("Hello"));
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).isEqualTo("Code must be in range [1000,5000): 98724976");
+    }
+  }
+
+  @Test public void reasonWithEmptyCloseThrows() throws IOException {
+    try {
+      clientWriter.writeClose(0, ByteString.encodeUtf8("Hello"));
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("Close reason must be null when code is 0");
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/WebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/WebSocket.kt
@@ -104,6 +104,16 @@ interface WebSocket {
   fun close(code: Int, reason: String?): Boolean
 
   /**
+   * Attempts to initiate a graceful shutdown of this web socket without sending a status code
+   * or reason. Any already-enqueued messages will be transmitted before the close message is sent
+   * but subsequent calls to [send] will return false and their messages will not be enqueued.
+   *
+   * This returns true if a graceful shutdown was initiated by this call. It returns false if
+   * a graceful shutdown was already underway or if the web socket is already closed or canceled.
+   */
+  fun close(): Boolean
+
+  /**
    * Immediately and violently release resources held by this web socket, discarding any enqueued
    * messages. This does nothing if the web socket has already been closed or canceled.
    */

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.java
@@ -406,12 +406,16 @@ public final class RealWebSocket implements WebSocket, WebSocketReader.FrameCall
     return true;
   }
 
+  @Override public boolean close() {
+    return close(0, null, CANCEL_AFTER_CLOSE_MILLIS);
+  }
+
   @Override public boolean close(int code, String reason) {
+    validateCloseCode(code);
     return close(code, reason, CANCEL_AFTER_CLOSE_MILLIS);
   }
 
   synchronized boolean close(int code, String reason, long cancelAfterCloseMillis) {
-    validateCloseCode(code);
 
     ByteString reasonBytes = null;
     if (reason != null) {

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebSocketWriter.java
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebSocketWriter.java
@@ -93,6 +93,8 @@ final class WebSocketWriter {
     if (code != 0 || reason != null) {
       if (code != 0) {
         validateCloseCode(code);
+      } else if (reason != null) {
+        throw new IllegalArgumentException("Close reason must be null when code is 0");
       }
       Buffer buffer = new Buffer();
       buffer.writeShort(code);


### PR DESCRIPTION
The WebSocket specification allows a close frame to be sent
without a body.  In this case, neither a code or reason are
sent in the frame.  Add a new API, `close()`, which supports
this.