### PR TITLE
Allow specifying pongTimeout smaller than pingInterval

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java
@@ -738,7 +738,7 @@ public final class MockWebServer extends ExternalResource implements Closeable {
       }
     };
     RealWebSocket webSocket = new RealWebSocket(fancyRequest,
-        response.getWebSocketListener(), new SecureRandom(), 0);
+        response.getWebSocketListener(), new SecureRandom(), 0, 0);
     response.getWebSocketListener().onOpen(webSocket, fancyResponse);
     String name = "MockWebServer WebSocket " + request.getPath();
     webSocket.initReaderAndWriter(name, streams);


### PR DESCRIPTION
Current ping-pong implementation introduced in #3870 for websocket awaits for the next ping to detect the fact that the previous ping got lost. So the worst case for detecting a broken connection is `pingInterval` ms.

This works well for small pingInterval numbers, however if the number is high enough (let's say 15 or more seconds), we'll for 15 seconds instead of ~3-5 which looks more than enough even for mobile networks. This is a real use case for us, and we plan to try raising the pingInterval even more. 

This PR adds the ability to specify a pongTimeout smaller than pingInterval. Example:
pingInterval = 15_000
pongTimeout = 3_000

If pongTimeout is not used, the previous strategy is used. 

This is a draft PR, if I get an approve of the general idea, I'll contribute the same for HTTP/2 and update the javadocs. 
Also, with the whole Kotlin migration, where should the PR be targeted to have a chance to be released before okhttp4?