### PR TITLE
Fix flaky HttpOverHttp2Test.emptyDataFrameSentWithEmptyBody

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -1152,9 +1152,13 @@ public final class HttpOverHttp2Test {
     assertThat(firstFrame(logs, "HEADERS"))
         .overridingErrorMessage("header logged")
         .contains("HEADERS       END_HEADERS");
-    assertThat(firstFrame(logs, "DATA"))
-        .overridingErrorMessage("data logged")
-        .contains("0 DATA          END_STREAM");
+    // While MockWebServer waits to read the client's HEADERS frame before sending the response, it
+    // doesn't wait to read the client's DATA frame and may send a DATA frame before the client
+    // does. So we can't assume the client's empty DATA will be logged first.
+    assertThat(countFrames(logs, "FINE: >> 0x00000003     0 DATA          END_STREAM"))
+        .isEqualTo((long) 2);
+    assertThat(countFrames(logs, "FINE: >> 0x00000003     3 DATA          "))
+        .isEqualTo((long) 1);
   }
 
   @Test public void pingsTransmitted() throws Exception {


### PR DESCRIPTION
The test fails when there is a context switch to the MockWebServer thread after the client sends the HEADERS frame but before it sends the DATA frame. The MockWebServer then reads the client's HEADER frame and sends a DATA frame with the response body. As a result, the first DATA frame that is logged is not the expected empty DATA frame sent by the client.

Fixes https://github.com/square/okhttp/issues/4757