### PR TITLE
JDK 11 docker image for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11.0.2-jdk
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Trying to find a way around the error below

```
Mar 24, 2019 3:00:26 PM okhttp3.mockwebserver.MockWebServer$3 execute INFO: MockWebServer[45903] starting to accept connections Exception in thread "MockWebServer" j
java.lang.NoSuchMethodError: sun.security.ssl.SSLSessionImpl.<init>(Lsun/security/ssl/ProtocolVersion;Lsun/security/ssl/CipherSuite;Ljava/util/Collection;Ljava/security/SecureRandom;Ljava/lang/String;IZ)V 
  at sun.security.ssl.ServerHandshaker.clientHello(ServerHandshaker.java:787) a
```

Alternative option for CircleCI would be a custom docker image with Oracle JDK 8?