### PR TITLE
CircleCI testing with JDK 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:9.0.4-jdk
 
     working_directory: ~/repo
 


### PR DESCRIPTION
The aim is to get a stable build in CircleCI, then follow up with similar features the Travis matrix build in later PRs.  I don't think I've introduced these incompatibilities, more a perfect storm of

 - CircleCI changing build setup e.g. docker images for JVM, OpenJDK usage
 - Gradle changing profile setup