### PR TITLE
CircleCI alternative JDK 8 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:8u171-jdk
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Found an acceptable version, even with alpn-boot and openjdk incompatibilities.