### PR TITLE
Fix flaky DuplexTest.duplexWithRedirect

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/internal/duplex/MockDuplexResponseBody.java
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/internal/duplex/MockDuplexResponseBody.java
@@ -17,6 +17,7 @@ package okhttp3.mockwebserver.internal.duplex;
 
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -63,9 +64,14 @@ public final class MockDuplexResponseBody implements DuplexResponseBody {
   }
 
   public MockDuplexResponseBody sendResponse(String s) {
+    return sendResponse(s, new CountDownLatch(0));
+  }
+
+    public MockDuplexResponseBody sendResponse(String s, CountDownLatch responseSent) {
     actions.add((request, requestBody, responseBody) -> {
       responseBody.writeUtf8(s);
       responseBody.flush();
+      responseSent.countDown();
     });
     return this;
   }

--- a/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
+++ b/okhttp-tests/src/test/java/okhttp3/RecordingEventListener.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class RecordingEventListener extends EventListener {
+public class RecordingEventListener extends EventListener {
   final Deque<CallEvent> eventSequence = new ConcurrentLinkedDeque<>();
 
   final List<Object> forbiddenLocks = new ArrayList<>();


### PR DESCRIPTION
The test is flaky because the server sometimes acts on the 301 response and resets the stream before the action added by MockDuplexResponseBody.sendResponse() is executed. This action then fails because it tries to write to a reset stream. mockDuplexResponseBody.awaitSuccess() then throws and fails the test.

The change enforces the de-facto sequence on most runs, where the 301 response is handled only after the Duplex response is sent.

Fixes https://github.com/square/okhttp/issues/4743