### PR TITLE
Revert license year

### DIFF
--- a/okhttp/src/main/java/okhttp3/Address.kt
+++ b/okhttp/src/main/java/okhttp3/Address.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 The Android Open Source Project
+ * Copyright (C) 2012 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okhttp/src/main/java/okhttp3/Challenge.kt
+++ b/okhttp/src/main/java/okhttp3/Challenge.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Square, Inc.
+ * Copyright (C) 2014 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/okhttp/src/main/java/okhttp3/Handshake.kt
+++ b/okhttp/src/main/java/okhttp3/Handshake.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Square, Inc.
+ * Copyright (C) 2013 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
I mistakenly updated the license year. Apologies!
Here are the previous files for ease of review:
[Address](https://github.com/square/okhttp/pull/4787/files#diff-78b52ad46ac301e325752067fa23cb55L2)
[Challenge](https://github.com/square/okhttp/pull/4802/files#diff-1dc7b1d5ec3edac544524a21685bc421L2)
[Handshake](https://github.com/square/okhttp/pull/4799/files#diff-a6724faeb78a8bff6be65107ece8adefL2) 