### PR TITLE
Log full exception on test failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,10 @@ subprojects { project ->
   test {
     jvmArgs += "-Dlistener=okhttp3.testing.InstallUncaughtExceptionHandlerListener"
     jvmArgs += "-Dokhttp.platform=platform"
+
+    testLogging {
+      exceptionFormat = 'full'
+    }
   }
 
   // Add alpn-boot on Java 8 so we can use HTTP/2 without a stable API.


### PR DESCRIPTION
Too little information is logged today when tests fail in CI. This makes logging a little more verbose.

Before:
```
okhttp3.internal.ws.RealWebSocketTest > unexpectedPongsDoNotInterfereWithFailureDetection FAILED
    java.lang.AssertionError at RealWebSocketTest.java:349
```

After:
```
okhttp3.internal.ws.RealWebSocketTest > unexpectedPongsDoNotInterfereWithFailureDetection FAILED
    java.lang.AssertionError:
    Expecting:
      <1928.0>
    to be close to:
      <1500.0>
    by less than <250.0> but difference was <428.0>.
    (a difference of exactly <250.0> being considered valid)
        at okhttp3.internal.ws.RealWebSocketTest.unexpectedPongsDoNotInterfereWithFailureDetection(RealWebSocketTest.java:349)
```