### PR TITLE
Use the build cache in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,14 @@
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 version: 2.1
 jobs:
-  dependencies:
+  compile:
     docker:
       - image: circleci/openjdk:8u171-jdk
 
     working_directory: ~/repo
 
     environment:
-      JVM_OPTS: -Xmx1g
+      JVM_OPTS: -Xmx768m
       TERM: dumb
 
     steps:
@@ -16,19 +16,21 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "build.gradle" }}
-            - v1-dependencies-
+            - v3-{{ checksum "build.gradle" }}-{{ .Branch }}
+            - v3-{{ checksum "build.gradle" }}-master
+            - v3-{{ checksum "build.gradle" }}
 
       - run:
           name: dependencies
-          command: ./gradlew downloadDependencies
+          command: ./gradlew --parallel --build-cache downloadDependencies testClasses
           environment:
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Xmx1G
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=3 -Xmx768m
 
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: v1-dependencies-{{ checksum "build.gradle" }}
+            - ~/.gradle/wrapper
+          key: v3-{{ checksum "build.gradle" }}-{{ .Branch }}
 
   checkjdk8:
     docker:
@@ -45,14 +47,15 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "build.gradle" }}
-            - v1-dependencies-
+            - v3-{{ checksum "build.gradle" }}-{{ .Branch }}
+            - v3-{{ checksum "build.gradle" }}-master
+            - v3-{{ checksum "build.gradle" }}
 
       - run:
           name: Run checks
-          command: ./gradlew check -x test
+          command: ./gradlew --parallel --build-cache check -x test
           environment:
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Xmx1G
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=3 -Xmx1G
 
       - run:
           name: Save gradle reports
@@ -80,14 +83,22 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "build.gradle" }}
-            - v1-dependencies-
+            - v3-{{ checksum "build.gradle" }}-{{ .Branch }}-testjdk8
+            - v3-{{ checksum "build.gradle" }}-{{ .Branch }}
+            - v3-{{ checksum "build.gradle" }}-master
+            - v3-{{ checksum "build.gradle" }}
 
       - run:
           name: test
-          command: ./gradlew test
+          command: ./gradlew --parallel --build-cache test
           environment:
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Xmx1G
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=3 -Xmx1G
+
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+            - ~/.gradle/wrapper
+          key: v3-{{ checksum "build.gradle" }}-{{ .Branch }}-testjdk8
 
       - run:
           name: Save test results
@@ -126,14 +137,22 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "build.gradle" }}
-            - v1-dependencies-
+            - v3-{{ checksum "build.gradle" }}-{{ .Branch }}-testjdk11
+            - v3-{{ checksum "build.gradle" }}-{{ .Branch }}
+            - v3-{{ checksum "build.gradle" }}-master
+            - v3-{{ checksum "build.gradle" }}
 
       - run:
           name: test
-          command: ./gradlew test
+          command: ./gradlew --build-cache --parallel test
           environment:
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Xmx1G
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=3 -Xmx1G
+
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+            - ~/.gradle/wrapper
+          key: v3-{{ checksum "build.gradle" }}-{{ .Branch }}-testjdk11
 
       - run:
           name: Save test results
@@ -161,13 +180,13 @@ workflows:
   version: 2
   build-check-and-test:
     jobs:
-      - dependencies
+      - compile
       - checkjdk8:
           requires:
-            - dependencies
+            - compile
       - testjdk8:
           requires:
-            - dependencies
+            - compile
       - testjdk11:
           requires:
-            - dependencies
+            - compile


### PR DESCRIPTION
TL;DR it probably saves a minute per build on average, and we could debug to improve.

Aggressive build caching within gradle and circleci.  Not sure we want this, it makes re-running a flaky test potentially awkward. It should be safe, but ultimately we want any snapshot or tagged release publishing step to do a fresh build I assume.

Normal: 5:40
https://circleci.com/workflow-run/7c6cd465-9609-41bd-b63c-d98334c9a027
![image](https://user-images.githubusercontent.com/231923/55360744-2eb2a800-54cd-11e9-86a5-30e2cb4aed17.png)

Cache First Run: 5:41
https://circleci.com/workflow-run/a69206f5-ef50-415b-ba90-b0f97fefa33b
![image](https://user-images.githubusercontent.com/231923/55360769-3d00c400-54cd-11e9-9a95-2deae816257f.png)

Second Run: 4:53
https://circleci.com/workflow-run/0a782b8a-5db8-4f4b-b76d-9792d9fef0fd
![image](https://user-images.githubusercontent.com/231923/55360831-69b4db80-54cd-11e9-9581-4f1c05c8ce61.png)

