### PR TITLE
Run cron schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,31 @@ jobs:
 
 workflows:
   version: 2
-  build-check-and-test:
+  commit:
+    jobs:
+      - dependencies
+      - checkjdk8:
+          requires:
+            - dependencies
+          filters:
+            branches:
+              ignore: master
+      - testjdk8:
+          requires:
+            - dependencies
+      - testjdk11:
+          requires:
+            - dependencies
+          filters:
+            branches:
+              only: master
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: master
     jobs:
       - dependencies
       - checkjdk8:


### PR DESCRIPTION
- Run build at midnight with checks and all JVM/platforms tests
- On PR run only checks and JDK8 tests
- On master commit, run all JVM/platforms tests

Logic is that checks shouldn't suddenly break, no point running on every master build.  Flush out those once a day.

On PRs avoid breaking checks, but don't generally worry about all platforms since this is the most delay sensitive thing we do.

On master commit, run all platforms to build record of flaky tests.