### PR TITLE
Fix correctness of WebSocketReader reserved flags test

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketReaderTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketReaderTest.java
@@ -42,7 +42,7 @@ public final class WebSocketReaderTest {
   }
 
   @Test public void controlFramesMustBeFinal() throws IOException {
-    data.write(ByteString.decodeHex("0a00")); // Empty ping.
+    data.write(ByteString.decodeHex("0a00")); // Empty pong.
     try {
       clientReader.processNextFrame();
       fail();
@@ -52,7 +52,7 @@ public final class WebSocketReaderTest {
   }
 
   @Test public void reservedFlagsAreUnsupported() throws IOException {
-    data.write(ByteString.decodeHex("9a00")); // Empty ping, flag 1 set.
+    data.write(ByteString.decodeHex("ca00")); // Empty pong, flag 1 set.
     try {
       clientReader.processNextFrame();
       fail();
@@ -60,7 +60,7 @@ public final class WebSocketReaderTest {
       assertThat(e.getMessage()).isEqualTo("Reserved flags are unsupported.");
     }
     data.clear();
-    data.write(ByteString.decodeHex("aa00")); // Empty ping, flag 2 set.
+    data.write(ByteString.decodeHex("aa00")); // Empty pong, flag 2 set.
     try {
       clientReader.processNextFrame();
       fail();
@@ -68,7 +68,7 @@ public final class WebSocketReaderTest {
       assertThat(e.getMessage()).isEqualTo("Reserved flags are unsupported.");
     }
     data.clear();
-    data.write(ByteString.decodeHex("ca00")); // Empty ping, flag 3 set.
+    data.write(ByteString.decodeHex("9a00")); // Empty pong, flag 3 set.
     try {
       clientReader.processNextFrame();
       fail();


### PR DESCRIPTION
Minor correction to the `WebSocketReaderTest.reservedFlagsAreUnsupported()`.

For all 3 hex codes, `a` is pong, not ping.
`0xca00 is 0b11001010`, rsv1 flag is set
`0xaa00 is 0b10101010`, rsv2 flag is set
`0x9a00 is 0b10011010`, rsv3 flag is set

https://tools.ietf.org/html/rfc6455#section-5.2