### PR TITLE
Run nightly job at less loaded time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "4 1 * * *"
           filters:
             branches:
               only: master


### PR DESCRIPTION
Was running at midnight, had 36 minute schedule delay.  Scheduled for just after 1pm at random minute.

https://circleci.com/build-insights/gh/square/okhttp/master

![image](https://user-images.githubusercontent.com/231923/55603470-c4b33080-5762-11e9-9ba7-53c197e51f96.png)
