### PR TITLE
Fix source compatibility for some Kotlin callsites.

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -183,7 +183,7 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
         logger.log("--> END ${request.method()}")
       } else if (bodyHasUnknownEncoding(request.headers())) {
         logger.log("--> END ${request.method()} (encoded body omitted)")
-      } else if (requestBody.isDuplex) {
+      } else if (requestBody.isDuplex()) {
         logger.log("--> END ${request.method()} (duplex request body omitted)")
       } else {
         val buffer = Buffer()

--- a/okhttp/src/main/java/okhttp3/Authenticator.kt
+++ b/okhttp/src/main/java/okhttp3/Authenticator.kt
@@ -115,5 +115,13 @@ interface Authenticator {
         return null
       }
     }
+
+    // This lambda conversion is for Kotlin callers expecting a Java SAM (single-abstract-method).
+    @JvmName("-deprecated_Authenticator")
+    inline operator fun invoke(
+      crossinline block: (route: Route?, response: Response) -> Request?
+    ): Authenticator = object: Authenticator {
+      override fun authenticate(route: Route?, response: Response) = block(route, response)
+    }
   }
 }

--- a/okhttp/src/main/java/okhttp3/Call.kt
+++ b/okhttp/src/main/java/okhttp3/Call.kt
@@ -74,9 +74,9 @@ interface Call : Cloneable {
    * Returns true if this call has been either [executed][execute] or [enqueued][enqueue]. It is an
    * error to execute a call more than once.
    */
-  val isExecuted: Boolean
+  fun isExecuted(): Boolean
 
-  val isCanceled: Boolean
+  fun isCanceled(): Boolean
 
   /**
    * Returns a timeout that spans the entire call: resolving DNS, connecting, writing the request

--- a/okhttp/src/main/java/okhttp3/Dispatcher.kt
+++ b/okhttp/src/main/java/okhttp3/Dispatcher.kt
@@ -112,6 +112,11 @@ class Dispatcher constructor() {
     this.idleCallback = idleCallback
   }
 
+  // This lambda conversion is for Kotlin callers expecting a Java SAM (single-abstract-method).
+  @JvmName("-deprecated_setIdleCallback")
+  inline fun setIdleCallback(crossinline idleCallback: () -> Unit) =
+      setIdleCallback(Runnable { idleCallback() })
+
   internal fun enqueue(call: AsyncCall) {
     synchronized(this) {
       readyAsyncCalls.add(call)

--- a/okhttp/src/main/java/okhttp3/Dns.kt
+++ b/okhttp/src/main/java/okhttp3/Dns.kt
@@ -54,5 +54,13 @@ interface Dns {
         }
       }
     }
+
+    // This lambda conversion is for Kotlin callers expecting a Java SAM (single-abstract-method).
+    @JvmName("-deprecated_Dns")
+    inline operator fun invoke(
+      crossinline block: (String) -> List<InetAddress>
+    ): Dns = object : Dns {
+      override fun lookup(hostname: String): List<InetAddress> = block(hostname)
+    }
   }
 }

--- a/okhttp/src/main/java/okhttp3/EventListener.kt
+++ b/okhttp/src/main/java/okhttp3/EventListener.kt
@@ -346,6 +346,16 @@ abstract class EventListener {
      * from this method.**
      */
     fun create(call: Call): EventListener
+
+    companion object {
+      // This lambda conversion is for Kotlin callers expecting a Java SAM (single-abstract-method).
+      @JvmName("-deprecated_Factory")
+      inline operator fun invoke(
+        crossinline block: (call: Call) -> EventListener
+      ): Factory = object : Factory {
+        override fun create(call: Call) = block(call)
+      }
+    }
   }
 
   companion object {

--- a/okhttp/src/main/java/okhttp3/Interceptor.kt
+++ b/okhttp/src/main/java/okhttp3/Interceptor.kt
@@ -27,6 +27,16 @@ interface Interceptor {
   @Throws(IOException::class)
   fun intercept(chain: Chain): Response
 
+  companion object {
+    // This lambda conversion is for Kotlin callers expecting a Java SAM (single-abstract-method).
+    @JvmName("-deprecated_Interceptor")
+    inline operator fun invoke(
+      crossinline block: (chain: Chain) -> Response
+    ): Interceptor = object: Interceptor {
+      override fun intercept(chain: Chain) = block(chain)
+    }
+  }
+
   interface Chain {
     fun request(): Request
 

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.kt
@@ -755,6 +755,16 @@ open class OkHttpClient internal constructor(
       interceptors += interceptor
     }
 
+    // This lambda conversion is for Kotlin callers expecting a Java SAM (single-abstract-method).
+    @JvmName("-deprecated_addInterceptor")
+    inline fun addInterceptor(
+      crossinline interceptor: (chain: Interceptor.Chain) -> Response
+    ) = apply {
+      addInterceptor(object : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response = interceptor(chain)
+      })
+    }
+
     /**
      * Returns a modifiable list of interceptors that observe a single network request and response.
      * These interceptors must call [Interceptor.Chain.proceed] exactly once: it is an error for a
@@ -764,6 +774,16 @@ open class OkHttpClient internal constructor(
 
     fun addNetworkInterceptor(interceptor: Interceptor) = apply {
       networkInterceptors += interceptor
+    }
+
+    // This lambda conversion is for Kotlin callers expecting a Java SAM (single-abstract-method).
+    @JvmName("-deprecated_addNetworkInterceptor")
+    inline fun addNetworkInterceptor(
+      crossinline interceptor: (chain: Interceptor.Chain) -> Response
+    ) = apply {
+      addInterceptor(object : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response = interceptor(chain)
+      })
     }
 
     /**
@@ -784,6 +804,14 @@ open class OkHttpClient internal constructor(
      */
     fun eventListenerFactory(eventListenerFactory: EventListener.Factory) = apply {
       this.eventListenerFactory = eventListenerFactory
+    }
+
+    // This lambda conversion is for Kotlin callers expecting a Java SAM (single-abstract-method).
+    @JvmName("-deprecated_eventListenerFactory")
+    inline fun eventListenerFactory(crossinline block: (call: Call) -> EventListener) = apply {
+      eventListenerFactory(object : EventListener.Factory {
+        override fun create(call: Call) = block(call)
+      })
     }
 
     fun build(): OkHttpClient = OkHttpClient(this)

--- a/okhttp/src/main/java/okhttp3/RequestBody.kt
+++ b/okhttp/src/main/java/okhttp3/RequestBody.kt
@@ -72,7 +72,7 @@ abstract class RequestBody {
    *
    * [grpc]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
    */
-  open val isDuplex: Boolean = false
+  open fun isDuplex(): Boolean = false
 
   /**
    * Returns true if this body expects at most one call to [writeTo] and can be transmitted
@@ -86,7 +86,7 @@ abstract class RequestBody {
    * (HTTP 401 and 407), or a retryable server failure (HTTP 503 with a `Retry-After: 0`
    * header).
    */
-  open val isOneShot: Boolean = false
+  open fun isOneShot(): Boolean = false
 
   companion object {
 

--- a/okhttp/src/test/java/okhttp3/KotlinSourceCompatibilityTest.kt
+++ b/okhttp/src/test/java/okhttp3/KotlinSourceCompatibilityTest.kt
@@ -62,6 +62,8 @@ import javax.net.ssl.SSLSocketFactory
     "ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE",
     "DEPRECATION",
     "RedundantExplicitType",
+    "RedundantLambdaArrow",
+    "UNUSED_ANONYMOUS_PARAMETER",
     "UNUSED_VALUE",
     "UNUSED_VARIABLE",
     "VARIABLE_WITH_REDUNDANT_INITIALIZER"
@@ -97,9 +99,10 @@ class KotlinSourceCompatibilityTest {
 
   @Test @Ignore
   fun authenticator() {
-    val authenticator = object : Authenticator {
+    var authenticator: Authenticator = object : Authenticator {
       override fun authenticate(route: Route?, response: Response): Request? = TODO()
     }
+    authenticator = Authenticator { route: Route?, response: Response -> TODO() }
   }
 
   @Test @Ignore
@@ -160,8 +163,8 @@ class KotlinSourceCompatibilityTest {
       override fun execute(): Response = TODO()
       override fun enqueue(responseCallback: Callback) = TODO()
       override fun cancel() = TODO()
-      override val isExecuted: Boolean get() = TODO()
-      override val isCanceled: Boolean get() = TODO()
+      override fun isExecuted(): Boolean = TODO()
+      override fun isCanceled(): Boolean = TODO()
       override fun timeout(): Timeout = TODO()
       override fun clone(): Call = TODO()
     }
@@ -312,6 +315,7 @@ class KotlinSourceCompatibilityTest {
     dispatcher.setIdleCallback(object : Runnable {
       override fun run() = TODO()
     })
+    dispatcher.setIdleCallback { TODO() }
     val queuedCalls: List<Call> = dispatcher.queuedCalls()
     val runningCalls: List<Call> = dispatcher.runningCalls()
     val queuedCallsCount: Int = dispatcher.queuedCallsCount()
@@ -321,9 +325,11 @@ class KotlinSourceCompatibilityTest {
 
   @Test @Ignore
   fun dns() {
-    val dns = object : Dns {
+    var dns: Dns = object : Dns {
       override fun lookup(hostname: String): List<InetAddress> = TODO()
     }
+    dns = Dns { it: String -> TODO() }
+
     val system: Dns = Dns.SYSTEM
   }
 
@@ -381,9 +387,10 @@ class KotlinSourceCompatibilityTest {
 
   @Test @Ignore
   fun eventListenerBuilder() {
-    val builder = object : EventListener.Factory {
+    var builder: EventListener.Factory = object : EventListener.Factory {
       override fun create(call: Call): EventListener = TODO()
     }
+    builder = EventListener.Factory { it: Call -> TODO() }
   }
 
   @Test @Ignore
@@ -394,7 +401,7 @@ class KotlinSourceCompatibilityTest {
     val name: String = formBody.name(0)
     val encodedValue: String = formBody.encodedValue(0)
     val value: String = formBody.value(0)
-    val contentType: MediaType = formBody.contentType()
+    val contentType: MediaType? = formBody.contentType()
     val contentLength: Long = formBody.contentLength()
     formBody.writeTo(Buffer())
     val requestBody: RequestBody = formBody
@@ -570,9 +577,10 @@ class KotlinSourceCompatibilityTest {
 
   @Test @Ignore
   fun interceptor() {
-    val interceptor = object : Interceptor {
+    var interceptor: Interceptor = object : Interceptor {
       override fun intercept(chain: Interceptor.Chain): Response = TODO()
     }
+    interceptor = Interceptor { it: Interceptor.Chain -> TODO() }
   }
 
   @Test @Ignore
@@ -683,14 +691,17 @@ class KotlinSourceCompatibilityTest {
     builder = builder.addInterceptor(object : Interceptor {
       override fun intercept(chain: Interceptor.Chain): Response = TODO()
     })
+    builder = builder.addInterceptor { it: Interceptor.Chain -> TODO() }
     val networkInterceptors: List<Interceptor> = builder.networkInterceptors()
     builder = builder.addNetworkInterceptor(object : Interceptor {
       override fun intercept(chain: Interceptor.Chain): Response = TODO()
     })
+    builder = builder.addNetworkInterceptor { it: Interceptor.Chain -> TODO() }
     builder = builder.eventListener(EventListener.NONE)
     builder = builder.eventListenerFactory(object : EventListener.Factory {
       override fun create(call: Call): EventListener = TODO()
     })
+    builder = builder.eventListenerFactory { it: Call -> TODO() }
     val client: OkHttpClient = builder.build()
   }
 
@@ -749,8 +760,8 @@ class KotlinSourceCompatibilityTest {
     var requestBody: RequestBody = object : RequestBody() {
       override fun contentType(): MediaType? = TODO()
       override fun contentLength(): Long = TODO()
-      override val isDuplex: Boolean get() = TODO()
-      override val isOneShot: Boolean get() = TODO()
+      override fun isDuplex(): Boolean = TODO()
+      override fun isOneShot(): Boolean = TODO()
       override fun writeTo(sink: BufferedSink) = TODO()
     }
     requestBody = RequestBody.create(null, "")


### PR DESCRIPTION
We had a problem where boolean vals needed to be reverted back to
boolean funs. I'd like to go back to vals later, but supporting existing
source patterns is more important.

We also had a problem where single abstract method types (SAM types)
could be supplied as lambas when calling into Java but not when calling
into Kotlin.

I found these by pointing KotlinSourceCompatibilityTest at the OkHttp

Get there like this:
```
  git co 7eb897ab2e223632b3316bf46a15d37307a3d3b6^
  git co 7eb897ab2e223632b3316bf46a15d37307a3d3b6 okhttp/build.gradle
  git co 7eb897ab2e223632b3316bf46a15d37307a3d3b6 build.gradle
```