### PR TITLE
RFC: Platform Thoughts

### DIFF
--- a/okhttp/src/main/java/okhttp3/RealCall.kt
+++ b/okhttp/src/main/java/okhttp3/RealCall.kt
@@ -138,7 +138,7 @@ internal class RealCall private constructor(
       } catch (e: IOException) {
         if (signalledCallback) {
           // Do not signal the callback twice!
-          Platform.get().log(INFO, "Callback failure for ${toLoggableString()}", e)
+          client.platform.log(INFO, "Callback failure for ${toLoggableString()}", e)
         } else {
           responseCallback.onFailure(this@RealCall, e)
         }

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.kt
@@ -173,7 +173,9 @@ open class Platform {
     private val logger = Logger.getLogger(OkHttpClient::class.java.name)
 
     @JvmStatic
-    fun get(): Platform = PLATFORM
+    fun get(): Platform {
+      return PLATFORM
+    }
 
     fun alpnProtocolNames(protocols: List<Protocol>) =
         protocols.filter { it != Protocol.HTTP_1_0 }.map { it.toString() }


### PR DESCRIPTION
I'm still assuming Platform is a JVM wide instance, but it seems in almost all cases OkHttpClient is the best way to reference the current platform.  Would make it easier to test different platforms in our tests.

I do wonder whether some control over the choice of Platform should be eventually made into public API, e.g. OkHttp users can't implement a platform but can force downgrade to Platform instead of ConscryptPlatform etc.  Or conversely can force Jdk9Platform to be used. 