### PR TITLE
Parallelize tests based on available processors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - openjdk11
 
 script:
- - ./gradlew check
+ - ./gradlew check --parallel
 
 after_success:
   - .buildscript/deploy_snapshot.sh

--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ subprojects { project ->
     jvmArgs += "-Dlistener=okhttp3.testing.InstallUncaughtExceptionHandlerListener"
     jvmArgs += "-Dokhttp.platform=$platform"
 
+    maxParallelForks Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     testLogging {
       exceptionFormat = 'full'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ subprojects { project ->
     jvmArgs += "-Dlistener=okhttp3.testing.InstallUncaughtExceptionHandlerListener"
     jvmArgs += "-Dokhttp.platform=$platform"
 
-    maxParallelForks Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    maxParallelForks Runtime.runtime.availableProcessors() * 2
     testLogging {
       exceptionFormat = 'full'
     }


### PR DESCRIPTION
This brings down `:okhttp:test` (the biggest bottle neck) time on my local machine from ~2m11s to ~39s.

Build scans:
* Without parallelization: https://scans.gradle.com/s/nmjkdjflng4o4
* With parallelization: https://scans.gradle.com/s/3oebsmkfwetiy