### PR TITLE
Fix #4915 nullPointerException caused by realConnection is null

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1ExchangeCodec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1ExchangeCodec.java
@@ -229,8 +229,12 @@ public final class Http1ExchangeCodec implements ExchangeCodec {
       return responseBuilder;
     } catch (EOFException e) {
       // Provide more context if the server ends the stream before sending a response.
+      String address = "unknown";
+      if (realConnection != null) {
+        address = realConnection.route().address().url().redact();
+      }
       throw new IOException("unexpected end of stream on "
-          + realConnection.route().address().url().redact(), e);
+          + address, e);
     }
   }
 


### PR DESCRIPTION
When make an HTTPS connection over an HTTP proxy, the `realConnection` is always set to `null`.
In `RealConnection.java` line 395:
`Http1ExchangeCodec tunnelCodec = new Http1ExchangeCodec(client:null, realConnection:null, source, sink);`
`...`
`Response response = tunnelCodec.readResponseHeaders(false)`

Refer to #4915 NullPointerException in Http1ExchangeCodec.readResponseHeaders() in OkHttp 3.14.0 
