### PR TITLE
Avoid errorprone in JDK12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,7 @@ subprojects { project ->
     options.errorprone {
       check("MissingFail", CheckSeverity.ERROR)
       check("MissingOverride", CheckSeverity.ERROR)
+      enabled = JavaVersion.current() < JavaVersion.VERSION_11
     }
   }
 


### PR DESCRIPTION
Because

```
> Task :okhttp:compileJava
/Users/yuri/workspace/okhttp/okhttp/src/main/java/okhttp3/internal/Util.java:233: error: An unhandled exception was thrown by the Error Prone static analysis plugin.
          break;
          ^
     Please report this at https://github.com/google/error-prone/issues/new and include the following:

     error-prone version: 2.3.3
     BugPattern: Finally
     Stack Trace:
     java.lang.NoSuchFieldError: com/sun/tools/javac/tree/JCTree$JCBreak.label
        at com.google.errorprone.bugpatterns.Finally$FinallyJumpMatcher.<init>(Finally.java:171)
        at com.google.errorprone.bugpatterns.Finally.matchBreak(Finally.java:79)
        at com.google.errorprone.scanner.ErrorProneScanner$$Lambda$634.00000000315E1010.process(Unknown Source)
        at com.google.errorprone.scanner.ErrorProneScanner.processMatchers(ErrorProneScanner.java:433)
        at com.google.errorprone.scanner.ErrorProneScanner.visitBreak(ErrorProneScanner.java:513)
        at com.google.errorprone.scanner.ErrorProneScanner.visitBreak(ErrorProneScanner.java:150)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCBreak.accept(JCTree.java:1577)
        at jdk.compiler/com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:82)
```