### PR TITLE
Fix race condition in RecordingHostnameVerifier

### DIFF
--- a/okhttp-testing-support/src/main/java/okhttp3/RecordingHostnameVerifier.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/RecordingHostnameVerifier.java
@@ -24,7 +24,7 @@ public final class RecordingHostnameVerifier implements HostnameVerifier {
   public final List<String> calls = new ArrayList<>();
 
   @Override
-  public boolean verify(String hostname, SSLSession session) {
+  public synchronized boolean verify(String hostname, SSLSession session) {
     calls.add("verify " + hostname);
     return true;
   }


### PR DESCRIPTION
When connections are established concurrently, verify() sometimes throws a `java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0` because of unsynchronized access to the `calls` list.