### PR TITLE
Tests working with JDK12

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
@@ -183,7 +183,7 @@ public final class CertificatePinnerChainValidationTest {
 
   @Test public void unrelatedPinnedLeafCertificateInChain() throws Exception {
     // https://github.com/square/okhttp/issues/4729
-    assumeFalse(getJvmSpecVersion().equals("11"));
+    assumeFalse(getJvmSpecVersion().matches("1[123]"));
 
     // Start with a trusted root CA certificate.
     HeldCertificate rootCa = new HeldCertificate.Builder()
@@ -261,7 +261,7 @@ public final class CertificatePinnerChainValidationTest {
 
   @Test public void unrelatedPinnedIntermediateCertificateInChain() throws Exception {
     // https://github.com/square/okhttp/issues/4729
-    assumeFalse(getJvmSpecVersion().equals("11"));
+    assumeFalse(getJvmSpecVersion().matches("1[123]"));
 
     // Start with two root CA certificates, one is good and the other is compromised.
     HeldCertificate rootCa = new HeldCertificate.Builder()

--- a/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
@@ -200,7 +200,7 @@ public final class ClientAuthTest {
     } catch (SSLHandshakeException expected) {
     } catch (SSLException expected) {
       String jvmVersion = System.getProperty("java.specification.version");
-      assertThat(jvmVersion).isEqualTo("11");
+      assertThat(jvmVersion).matches("1[123]");
     } catch (SocketException expected) {
       assertThat(getPlatformSystemProperty()).isEqualTo("jdk9");
     }
@@ -233,7 +233,7 @@ public final class ClientAuthTest {
   @Test public void invalidClientAuthFails() throws Throwable {
     // TODO https://github.com/square/okhttp/issues/4598
     // StreamReset stream was reset: PROT...
-    assumeFalse(getJvmSpecVersion().equals("11"));
+    assumeFalse(getJvmSpecVersion().matches("1[123]"));
 
     HeldCertificate clientCert2 = new HeldCertificate.Builder()
         .serialNumber(4L)
@@ -256,7 +256,7 @@ public final class ClientAuthTest {
     } catch (SSLException expected) {
       // javax.net.ssl.SSLException: readRecord
       String jvmVersion = System.getProperty("java.specification.version");
-      assertThat(jvmVersion).isEqualTo("11");
+      assertThat(jvmVersion).matches("1[123]");
     } catch (SocketException expected) {
       assertThat(getPlatformSystemProperty()).isEqualTo("jdk9");
     }


### PR DESCRIPTION
```
> Task :okhttp:test

okhttp3.internal.tls.CertificatePinnerChainValidationTest > unrelatedPinnedLeafCertificateInChain FAILED
    java.security.KeyStoreException: Key protection algorithm not found: java.security.KeyStoreException: Certificate chain is not valid
        at java.base/sun.security.pkcs12.PKCS12KeyStore.setKeyEntry(PKCS12KeyStore.java:696)
        at java.base/sun.security.pkcs12.PKCS12KeyStore.engineSetKeyEntry(PKCS12KeyStore.java:593)
        at java.base/sun.security.util.KeyStoreDelegator.engineSetKeyEntry(KeyStoreDelegator.java:111)
        at java.base/java.security.KeyStore.setKeyEntry(KeyStore.java:1167)
        at okhttp3.tls.internal.TlsUtil.newKeyManager(TlsUtil.kt:85)
        at okhttp3.internal.tls.CertificatePinnerChainValidationTest.newServerSocketFactory(CertificatePinnerChainValidationTest.java:352)
        at okhttp3.internal.tls.CertificatePinnerChainValidationTest.unrelatedPinnedLeafCertificateInChain(CertificatePinnerChainValidationTest.java:238)

        Caused by:
        java.security.KeyStoreException: Certificate chain is not valid
            at java.base/sun.security.pkcs12.PKCS12KeyStore.setKeyEntry(PKCS12KeyStore.java:643)
            ... 6 more

okhttp3.internal.tls.CertificatePinnerChainValidationTest > unrelatedPinnedIntermediateCertificateInChain FAILED
    java.security.KeyStoreException: Key protection algorithm not found: java.security.KeyStoreException: Certificate chain is not valid
        at java.base/sun.security.pkcs12.PKCS12KeyStore.setKeyEntry(PKCS12KeyStore.java:696)
        at java.base/sun.security.pkcs12.PKCS12KeyStore.engineSetKeyEntry(PKCS12KeyStore.java:593)
        at java.base/sun.security.util.KeyStoreDelegator.engineSetKeyEntry(KeyStoreDelegator.java:111)
        at java.base/java.security.KeyStore.setKeyEntry(KeyStore.java:1167)
        at okhttp3.tls.internal.TlsUtil.newKeyManager(TlsUtil.kt:85)
        at okhttp3.internal.tls.CertificatePinnerChainValidationTest.newServerSocketFactory(CertificatePinnerChainValidationTest.java:352)
        at okhttp3.internal.tls.CertificatePinnerChainValidationTest.unrelatedPinnedIntermediateCertificateInChain(CertificatePinnerChainValidationTest.java:317)

        Caused by:
        java.security.KeyStoreException: Certificate chain is not valid
            at java.base/sun.security.pkcs12.PKCS12KeyStore.setKeyEntry(PKCS12KeyStore.java:643)
            ... 6 more

okhttp3.internal.tls.ClientAuthTest > invalidClientAuthFails FAILED
    okhttp3.internal.http2.ConnectionShutdownException
        at okhttp3.internal.http2.Http2Connection.newStream(Http2Connection.java:243)
        at okhttp3.internal.http2.Http2Connection.newStream(Http2Connection.java:226)
        at okhttp3.internal.http2.Http2ExchangeCodec.writeRequestHeaders(Http2ExchangeCodec.kt:81)
        at okhttp3.internal.connection.Exchange.writeRequestHeaders(Exchange.java:72)
        at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.java:43)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:117)
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:38)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:117)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:90)
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:117)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:90)
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:84)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:117)
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:117)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:90)
        at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.kt:184)
        at okhttp3.RealCall.execute(RealCall.kt:67)
        at okhttp3.internal.tls.ClientAuthTest.invalidClientAuthFails(ClientAuthTest.java:253)

okhttp3.internal.tls.ClientAuthTest > missingClientAuthFailsForNeeds FAILED
    org.junit.ComparisonFailure: expected:<"1[1]"> but was:<"1[2]">
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at okhttp3.internal.tls.ClientAuthTest.missingClientAuthFailsForNeeds(ClientAuthTest.java:203)

2293 tests completed, 4 failed, 183 skipped
```