### PR TITLE
3.14.x branch fix for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ install:
   - ./mvnw dependency:resolve -B || true
 
 script:
+  - ./mvnw install -DskipTests
   - ./mvnw checkstyle:check -B
   - ./mvnw test -B
-  - ./mvnw javadoc:jar source:jar -B || true
+  - ./mvnw javadoc:jar source:jar -B
 
 after_success:
   - .buildscript/deploy_snapshot.sh


### PR DESCRIPTION
Fixes build on development versions by installing the okhttp-testing-support jar locally

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.691 s
[INFO] Finished at: 2019-04-24T20:23:16+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project okhttp-testing-support: Could not resolve dependencies for project com.squareup.okhttp3:okhttp-testing-support:jar:3.14.2-SNAPSHOT: Could not find artifact com.squareup.okhttp3:okhttp:jar:3.14.2-SNAPSHOT in sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots) -> [Help 1]
```