### PR TITLE
Increase documentation of HttpUrl.Builder

### DIFF
--- a/okhttp/src/main/java/okhttp3/HttpUrl.kt
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.kt
@@ -832,7 +832,7 @@ class HttpUrl internal constructor(builder: Builder) {
     }
 
     /**
-     * @param scheme either http or https
+     * @param scheme either "http" or "https"
      */
     fun scheme(scheme: String): Builder {
       when {

--- a/okhttp/src/main/java/okhttp3/HttpUrl.kt
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.kt
@@ -754,7 +754,7 @@ class HttpUrl internal constructor(builder: Builder) {
   fun resolve(link: String): HttpUrl? = newBuilder(link)?.build()
 
   /**
-   * Returns a builder based on this URL
+   * Returns a builder based on this URL.
    */
   fun newBuilder(): Builder {
     val result = Builder()
@@ -832,7 +832,7 @@ class HttpUrl internal constructor(builder: Builder) {
     }
 
     /**
-     * @param scheme either "http" or "https"
+     * @param scheme either "http" or "https".
      */
     fun scheme(scheme: String): Builder {
       when {

--- a/okhttp/src/main/java/okhttp3/HttpUrl.kt
+++ b/okhttp/src/main/java/okhttp3/HttpUrl.kt
@@ -753,6 +753,9 @@ class HttpUrl internal constructor(builder: Builder) {
    */
   fun resolve(link: String): HttpUrl? = newBuilder(link)?.build()
 
+  /**
+   * Returns a builder based on this URL
+   */
   fun newBuilder(): Builder {
     val result = Builder()
     result.scheme = scheme
@@ -828,6 +831,9 @@ class HttpUrl internal constructor(builder: Builder) {
       encodedPathSegments.add("") // The default path is '/' which needs a trailing space.
     }
 
+    /**
+     * @param scheme either http or https
+     */
     fun scheme(scheme: String): Builder {
       when {
         scheme.equals("http", ignoreCase = true) -> this.scheme = "http"


### PR DESCRIPTION
Add documentation for the `HttpUrl.newBuilder()` method indicating that initial values are read from the existing URL, and for `HttpUrl.Builder.scheme` indicating the legal values for the `scheme` parameter