### PR TITLE
Travis CI builds in JDK 8 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: java
 
 jdk:
   - oraclejdk8
-  - openjdk8
-  - openjdk11
 
 script:
  - ./gradlew check


### PR DESCRIPTION
No need to build all here given progress towards CircleCI.