### PR TITLE
Optimize local build and test speed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,9 @@ subprojects { project ->
       exceptionFormat = 'full'
     }
   }
+  tasks.withType(Test) {
+    maxParallelForks = (int) (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
+  }
 
   if (platform == "jdk8alpn") {
     // Add alpn-boot on Java 8 so we can use HTTP/2 without a stable API.

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=square
 POM_DEVELOPER_NAME=Square, Inc.
+
+org.gradle.parallel=true
+org.gradle.configureondemand=true


### PR DESCRIPTION
Every time run follow command to test:
```
./gradlew clean
./gradlew build --scan
```

**Before optimization:**
1: 
Total time:**3m 57.810s** 
Test  time:**1m 56.745s**
[build scan1 link](https://scans.gradle.com/s/qho63mol6nxt4/performance/build)

2:
Total time: 3m 49.231s
Test  time: 1m 52.649s
[build scan2 link](https://scans.gradle.com/s/qnc6scwa5upx6/performance/build)

**After optimization:**
3: 
Total time:**2m 31.598s** 
Test  time:**1m 13.944s**
[build scan3 link](https://scans.gradle.com/s/emo3pamzfuaus/performance/build)

4:
Total time: 2m 17.954s
Test  time: 1m 14.917s
[build scan4 link](https://scans.gradle.com/s/b3gdbs5xdswlo/performance/build)

It seems that it can significantly speed up the local compilation and test speed.
But not sure if there are side effects on` continuous-integration`.
Refet to:
[Improving the Performance of Gradle Builds](https://guides.gradle.org/performance/)

