### PR TITLE
Don't specify Okio as a testImplementation

### DIFF
--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -30,7 +30,6 @@ dependencies {
   compileOnly deps.jsr305
   compileOnly deps.animalSniffer
 
-  testImplementation deps.okio
   testImplementation project(':okhttp-testing-support')
   testImplementation project(':okhttp-tls')
   testImplementation project(':okhttp-urlconnection')


### PR DESCRIPTION
This causes the generated pom.xml file to scope that dependency wrong.

    <dependency>
      <groupId>com.squareup.okio</groupId>
      <artifactId>okio</artifactId>
      <version>2.2.2</version>
      <scope>test</scope>
    </dependency>