### PR TITLE
Adopt idiomatic Kotlin in Handshake

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.kt
@@ -16,15 +16,16 @@
 
 package okhttp3.mockwebserver
 
-import java.io.IOException
-import java.net.Inet6Address
-import java.net.Socket
-import javax.net.ssl.SSLSocket
 import okhttp3.Handshake
+import okhttp3.Handshake.Companion.handshake
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.TlsVersion
 import okio.Buffer
+import java.io.IOException
+import java.net.Inet6Address
+import java.net.Socket
+import javax.net.ssl.SSLSocket
 
 /** An HTTP request that came into the mock web server.  */
 class RecordedRequest(
@@ -62,12 +63,12 @@ class RecordedRequest(
 
   /** Returns the connection's TLS version or null if the connection doesn't use SSL.  */
   val tlsVersion: TlsVersion?
-    get() = handshake?.tlsVersion()
+    get() = handshake?.tlsVersion
 
   init {
     if (socket is SSLSocket) {
       try {
-        this.handshake = Handshake.get(socket.session)
+        this.handshake = socket.session.handshake()
       } catch (e: IOException) {
         throw IllegalArgumentException(e)
       }

--- a/okhttp/src/main/java/okhttp3/Cache.kt
+++ b/okhttp/src/main/java/okhttp3/Cache.kt
@@ -603,10 +603,10 @@ class Cache internal constructor(
 
       if (isHttps) {
         sink.writeByte('\n'.toInt())
-        sink.writeUtf8(handshake!!.cipherSuite().javaName()).writeByte('\n'.toInt())
-        writeCertList(sink, handshake.peerCertificates())
-        writeCertList(sink, handshake.localCertificates())
-        sink.writeUtf8(handshake.tlsVersion().javaName()).writeByte('\n'.toInt())
+        sink.writeUtf8(handshake!!.cipherSuite.javaName()).writeByte('\n'.toInt())
+        writeCertList(sink, handshake.peerCertificates)
+        writeCertList(sink, handshake.localCertificates)
+        sink.writeUtf8(handshake.tlsVersion.javaName()).writeByte('\n'.toInt())
       }
       sink.close()
     }

--- a/okhttp/src/main/java/okhttp3/Handshake.kt
+++ b/okhttp/src/main/java/okhttp3/Handshake.kt
@@ -24,50 +24,96 @@ import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSession
 
 /**
- * A record of a TLS handshake. For HTTPS clients, the client is *local* and the remote server
- * is its *peer*.
+ * A record of a TLS handshake. For HTTPS clients, the client is *local* and the remote server is
+ * its *peer*.
  *
- * This value object describes a completed handshake. Use [ConnectionSpec] to set policy
- * for new handshakes.
+ * This value object describes a completed handshake. Use [ConnectionSpec] to set policy for new
+ * handshakes.
  */
-data class Handshake private constructor(
-  private val tlsVersion: TlsVersion,
-  private val cipherSuite: CipherSuite,
-  private val peerCertificates: List<Certificate>,
-  private val localCertificates: List<Certificate>
-) {
-
+class Handshake private constructor(
   /**
    * Returns the TLS version used for this connection. This value wasn't tracked prior to OkHttp
    * 3.0. For responses cached by preceding versions this returns [TlsVersion.SSL_3_0].
    */
-  fun tlsVersion() = tlsVersion
+  @get:JvmName("tlsVersion") val tlsVersion: TlsVersion,
 
   /** Returns the cipher suite used for the connection. */
-  fun cipherSuite() = cipherSuite
+  @get:JvmName("cipherSuite") val cipherSuite: CipherSuite,
 
   /** Returns a possibly-empty list of certificates that identify the remote peer. */
+  @get:JvmName("peerCertificates") val peerCertificates: List<Certificate>,
+
+  /** Returns a possibly-empty list of certificates that identify this peer. */
+  @get:JvmName("localCertificates") val localCertificates: List<Certificate>
+) {
+
+  @JvmName("-deprecated_tlsVersion")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "tlsVersion"),
+      level = DeprecationLevel.WARNING)
+  fun tlsVersion() = tlsVersion
+
+  @JvmName("-deprecated_cipherSuite")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "cipherSuite"),
+      level = DeprecationLevel.WARNING)
+  fun cipherSuite() = cipherSuite
+
+  @JvmName("-deprecated_peerCertificates")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "peerCertificates"),
+      level = DeprecationLevel.WARNING)
   fun peerCertificates() = peerCertificates
 
   /** Returns the remote peer's principle, or null if that peer is anonymous. */
-  fun peerPrincipal(): Principal? {
-    return if (peerCertificates.isNotEmpty()) {
-      (peerCertificates[0] as X509Certificate).subjectX500Principal
-    } else {
-      null
-    }
-  }
+  @get:JvmName("peerPrincipal")
+  val peerPrincipal: Principal?
+    get() = (peerCertificates.firstOrNull() as? X509Certificate)?.subjectX500Principal
 
-  /** Returns a possibly-empty list of certificates that identify this peer. */
+  @JvmName("-deprecated_peerPrincipal")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "peerPrincipal"),
+      level = DeprecationLevel.WARNING)
+  fun peerPrincipal() = peerPrincipal
+
+  @JvmName("-deprecated_localCertificates")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "localCertificates"),
+      level = DeprecationLevel.WARNING)
   fun localCertificates() = localCertificates
 
   /** Returns the local principle, or null if this peer is anonymous. */
-  fun localPrincipal(): Principal? {
-    return if (localCertificates.isNotEmpty()) {
-      (localCertificates[0] as X509Certificate).subjectX500Principal
-    } else {
-      null
-    }
+  @get:JvmName("localPrincipal")
+  val localPrincipal: Principal?
+    get() = (localCertificates.firstOrNull() as? X509Certificate)?.subjectX500Principal
+
+  @JvmName("-deprecated_localPrincipal")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "localPrincipal"),
+      level = DeprecationLevel.WARNING)
+  fun localPrincipal() = localPrincipal
+
+  override fun equals(other: Any?): Boolean {
+    return other is Handshake &&
+        other.tlsVersion == tlsVersion &&
+        other.cipherSuite == cipherSuite &&
+        other.peerCertificates == peerCertificates &&
+        other.localCertificates == localCertificates
+  }
+
+  override fun hashCode(): Int {
+    var result = 17
+    result = 31 * result + tlsVersion.hashCode()
+    result = 31 * result + cipherSuite.hashCode()
+    result = 31 * result + peerCertificates.hashCode()
+    result = 31 * result + localCertificates.hashCode()
+    return result
   }
 
   override fun toString(): String {
@@ -87,20 +133,21 @@ data class Handshake private constructor(
   companion object {
     @Throws(IOException::class)
     @JvmStatic
-    fun get(session: SSLSession): Handshake {
-      val cipherSuiteString = checkNotNull(session.cipherSuite) { "cipherSuite == null" }
+    @JvmName("get")
+    fun SSLSession.handshake(): Handshake {
+      val cipherSuiteString = checkNotNull(cipherSuite) { "cipherSuite == null" }
       if ("SSL_NULL_WITH_NULL_NULL" == cipherSuiteString) {
         throw IOException("cipherSuite == SSL_NULL_WITH_NULL_NULL")
       }
       val cipherSuite = CipherSuite.forJavaName(cipherSuiteString)
 
-      val tlsVersionString = session.protocol ?: throw IllegalStateException("tlsVersion == null")
+      val tlsVersionString = checkNotNull(protocol) { "tlsVersion == null" }
       if ("NONE" == tlsVersionString) throw IOException("tlsVersion == NONE")
       val tlsVersion = TlsVersion.forJavaName(tlsVersionString)
 
       val peerCertificates: Array<Certificate>? = try {
-        session.peerCertificates
-      } catch (ignored: SSLPeerUnverifiedException) {
+        peerCertificates
+      } catch (_: SSLPeerUnverifiedException) {
         null
       }
 
@@ -110,7 +157,7 @@ data class Handshake private constructor(
         emptyList()
       }
 
-      val localCertificates = session.localCertificates
+      val localCertificates = localCertificates
       val localCertificatesList = if (localCertificates != null) {
         Util.immutableList(*localCertificates)
       } else {
@@ -119,6 +166,14 @@ data class Handshake private constructor(
 
       return Handshake(tlsVersion, cipherSuite, peerCertificatesList, localCertificatesList)
     }
+
+    @Throws(IOException::class)
+    @JvmName("-deprecated_get")
+    @Deprecated(
+        message = "moved to extension function",
+        replaceWith = ReplaceWith(expression = "sslSession.handshake()"),
+        level = DeprecationLevel.WARNING)
+    fun get(sslSession: SSLSession) = sslSession.handshake()
 
     @JvmStatic
     fun get(

--- a/okhttp/src/test/java/okhttp3/ConscryptTest.kt
+++ b/okhttp/src/test/java/okhttp3/ConscryptTest.kt
@@ -65,7 +65,7 @@ class ConscryptTest {
     val response = client.newCall(request).execute()
 
     assertThat(response.protocol()).isEqualTo(Protocol.HTTP_2)
-    assertThat(response.handshake()!!.tlsVersion()).isEqualTo(TlsVersion.TLS_1_3)
+    assertThat(response.handshake()!!.tlsVersion).isEqualTo(TlsVersion.TLS_1_3)
   }
 
   @Test
@@ -77,9 +77,9 @@ class ConscryptTest {
     val response = client.newCall(request).execute()
 
     assertThat(response.protocol()).isEqualTo(Protocol.HTTP_2)
-    if (response.handshake()!!.tlsVersion() != TlsVersion.TLS_1_3) {
+    if (response.handshake()!!.tlsVersion != TlsVersion.TLS_1_3) {
       System.err.println("Flaky TLSv1.3 with google")
-//    assertThat(response.handshake()!!.tlsVersion()).isEqualTo(TlsVersion.TLS_1_3)
+//    assertThat(response.handshake()!!.tlsVersion).isEqualTo(TlsVersion.TLS_1_3)
     }
   }
 


### PR DESCRIPTION
I'm using DeprecationLevel.WARNING because I can't make the test
work otherwise:

https://stackoverflow.com/questions/56102107/suppress-deprecationlevel-error-in-kotlin