### PR TITLE
Fix #5057: Remove unnecessary `isAndroidGetsocknameError` function

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/UtilKt.kt
+++ b/okhttp/src/main/java/okhttp3/internal/UtilKt.kt
@@ -222,7 +222,7 @@ fun Socket?.closeQuietly() {
   try {
     this?.close()
   } catch (e: AssertionError) {
-    if (!isAndroidGetsocknameError(e)) throw e
+    throw e
   } catch (rethrown: RuntimeException) {
     throw rethrown
   } catch (_: Exception) {
@@ -237,14 +237,6 @@ fun ServerSocket?.closeQuietly() {
     throw rethrown
   } catch (_: Exception) {
   }
-}
-
-/**
- * Returns true if [e] is due to a firmware bug fixed after Android 4.2.2.
- * https://code.google.com/p/android/issues/detail?id=54072
- */
-fun isAndroidGetsocknameError(e: AssertionError): Boolean {
-  return e.cause != null && e.message?.contains("getsockname failed") == true
 }
 
 fun Long.toHexString() = java.lang.Long.toHexString(this)

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -385,8 +385,6 @@ class RealConnection(
       handshake = unverifiedHandshake
       protocol = if (maybeProtocol != null) Protocol.get(maybeProtocol) else Protocol.HTTP_1_1
       success = true
-    } catch (e: AssertionError) {
-      throw e
     } finally {
       if (sslSocket != null) {
         Platform.get().afterHandshake(sslSocket)

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -41,7 +41,6 @@ import okhttp3.internal.http2.Http2Connection
 import okhttp3.internal.http2.Http2ExchangeCodec
 import okhttp3.internal.http2.Http2Stream
 import okhttp3.internal.http2.StreamResetException
-import okhttp3.internal.isAndroidGetsocknameError
 import okhttp3.internal.platform.Platform
 import okhttp3.internal.tls.OkHostnameVerifier
 import okhttp3.internal.userAgent
@@ -387,7 +386,6 @@ class RealConnection(
       protocol = if (maybeProtocol != null) Protocol.get(maybeProtocol) else Protocol.HTTP_1_1
       success = true
     } catch (e: AssertionError) {
-      if (isAndroidGetsocknameError(e)) throw IOException(e)
       throw e
     } finally {
       if (sslSocket != null) {

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt
@@ -80,8 +80,6 @@ class AndroidPlatform(
   ) {
     try {
       socket.connect(address, connectTimeout)
-    } catch (e: AssertionError) {
-      throw e
     } catch (e: ClassCastException) {
       // On android 8.0, socket.connect throws a ClassCastException due to a bug
       // see https://issuetracker.google.com/issues/63649622

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt
@@ -18,7 +18,6 @@ package okhttp3.internal.platform
 import android.os.Build
 import android.util.Log
 import okhttp3.Protocol
-import okhttp3.internal.isAndroidGetsocknameError
 import okhttp3.internal.tls.BasicTrustRootIndex
 import okhttp3.internal.tls.CertificateChainCleaner
 import okhttp3.internal.tls.TrustRootIndex
@@ -82,7 +81,6 @@ class AndroidPlatform(
     try {
       socket.connect(address, connectTimeout)
     } catch (e: AssertionError) {
-      if (isAndroidGetsocknameError(e)) throw IOException(e)
       throw e
     } catch (e: ClassCastException) {
       // On android 8.0, socket.connect throws a ClassCastException due to a bug


### PR DESCRIPTION
I also had a quick look at `android.os.Build.VERSION.SDK_INT` usages, and I found the following two usages, but I don't know if they could be simplified or if they were left on purpose:

https://github.com/square/okhttp/blob/fbfb5f84612d416c5977f4dd312991f36d3bb0f8/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt#L56-L60

https://github.com/square/okhttp/blob/fbfb5f84612d416c5977f4dd312991f36d3bb0f8/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt#L377-L403