### PR TITLE
Build in Travis CI only on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
     - secure: "WMkcWrsvzJNf48w7DJwipUNbhAoggCkC+NM31esq9/GDceGtVWj4hssQETynG4+ckxr0wGqUxsTRTz0uGhX6Fi58haG8yKp+g/HVClqI5EYjI44ptPcwlqlbYjuGbk65k1OGGZLctA6fQA3uT0zee05/yBjJx/jOqrN+PD1tW38="
 
 branches:
-  except:
-    - gh-pages
+  only:
+    - master
 
 notifications:
   email: false


### PR DESCRIPTION
Build only when we actually want a snapshot built as part of .buildscript/deploy_snapshot.sh