### PR TITLE
RFC: PlatformRegistry and more predictable running mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,19 +180,10 @@ workflows:
           filters:
             branches:
               ignore: master
-      - testjdk8:
-          filters:
-            branches:
-              only: master
+      - testjdk8
       - testjdk8alpn
-      - testjdk11:
-          filters:
-            branches:
-              only: master
-      - testconscrypt:
-          filters:
-            branches:
-              only: master
+      - testjdk11
+      - testconscrypt
   nightly:
     triggers:
       - schedule:

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ subprojects { project ->
     }
   }
 
-  def platform = System.getProperty("okhttp.platform", "jdk8")
+  def platform = System.getProperty("okhttp.platform", "jdk8alpn")
 
   test {
     jvmArgs += "-Dlistener=okhttp3.testing.InstallUncaughtExceptionHandlerListener"

--- a/okhttp-testing-support/src/main/java/okhttp3/PlatformRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/PlatformRule.kt
@@ -15,9 +15,6 @@
  */
 package okhttp3
 
-import okhttp3.internal.platform.ConscryptPlatform
-import okhttp3.internal.platform.Jdk8WithJettyBootPlatform
-import okhttp3.internal.platform.Jdk9Platform
 import okhttp3.internal.platform.Platform
 import org.conscrypt.Conscrypt
 import org.hamcrest.CoreMatchers.equalTo
@@ -35,25 +32,14 @@ import java.security.Security
  */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 open class PlatformRule @JvmOverloads constructor(
-  val requiredPlatformName: String? = null,
-  val platform: Platform? = null
+  val requiredPlatformName: String? = null
 ) : ExternalResource() {
   override fun before() {
     if (requiredPlatformName != null) {
       assumeThat(getPlatformSystemProperty(), equalTo(requiredPlatformName))
     }
 
-    if (platform != null) {
-      Platform.resetForTests(platform)
-    } else {
-      Platform.resetForTests()
-    }
-  }
-
-  override fun after() {
-    if (platform != null) {
-      Platform.resetForTests()
-    }
+    Platform.resetForTests()
   }
 
   fun isConscrypt() = getPlatformSystemProperty() == CONSCRYPT_PROPERTY
@@ -147,20 +133,7 @@ open class PlatformRule @JvmOverloads constructor(
     }
 
     @JvmStatic
-    fun getPlatformSystemProperty(): String {
-      var property: String? = System.getProperty(PROPERTY_NAME)
-
-      if (property == null) {
-        property = when (Platform.get()) {
-          is ConscryptPlatform -> CONSCRYPT_PROPERTY
-          is Jdk8WithJettyBootPlatform -> CONSCRYPT_PROPERTY
-          is Jdk9Platform -> JDK9_PROPERTY
-          else -> JDK8_PROPERTY
-        }
-      }
-
-      return property
-    }
+    fun getPlatformSystemProperty(): String = System.getProperty(PROPERTY_NAME, CONSCRYPT_PROPERTY)
 
     @JvmStatic
     fun conscrypt() = PlatformRule(CONSCRYPT_PROPERTY)

--- a/okhttp/src/main/java/okhttp3/internal/UtilKt.kt
+++ b/okhttp/src/main/java/okhttp3/internal/UtilKt.kt
@@ -16,6 +16,7 @@
 @file:JvmName("UtilKt")
 package okhttp3.internal
 
+import okhttp3.Protocol
 import okhttp3.Response
 import okio.Buffer
 import okio.BufferedSink
@@ -246,3 +247,6 @@ fun ServerSocket?.closeQuietly() {
 fun isAndroidGetsocknameError(e: AssertionError): Boolean {
   return e.cause != null && e.message?.contains("getsockname failed") == true
 }
+
+fun List<Protocol>.names() =
+    filter { it != Protocol.HTTP_1_0 }.map { it.toString() }

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt
@@ -18,6 +18,8 @@ package okhttp3.internal.platform
 import android.os.Build
 import android.util.Log
 import okhttp3.Protocol
+import okhttp3.internal.Util.concatLengthPrefixed
+import okhttp3.internal.Util.readFieldOrNull
 import okhttp3.internal.isAndroidGetsocknameError
 import okhttp3.internal.tls.BasicTrustRootIndex
 import okhttp3.internal.tls.CertificateChainCleaner

--- a/okhttp/src/main/java/okhttp3/internal/platform/PlatformRegistry.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/PlatformRegistry.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.platform
+
+object PlatformRegistry {
+  @Volatile internal var platform = findPlatform()
+
+  fun get(): Platform = platform
+
+  fun resetForTests(platform: Platform = findPlatform()) {
+    this.platform = platform
+  }
+
+  /** Attempt to match the host runtime to a capable Platform implementation.  */
+  @JvmStatic
+  private fun findPlatform(): Platform {
+    val android = AndroidPlatform.buildIfSupported()
+
+    if (android != null) {
+      return android
+    }
+
+    if (ConscryptPlatform.isConscryptPreferred) {
+      val conscrypt = ConscryptPlatform.buildIfSupported()
+
+      if (conscrypt != null) {
+        return conscrypt
+      }
+    }
+
+    val jdk9 = Jdk9Platform.buildIfSupported()
+
+    if (jdk9 != null) {
+      return jdk9
+    }
+
+    // An Oracle JDK 8 like OpenJDK.
+    val jdkWithJettyBoot = Jdk8WithJettyBootPlatform.buildIfSupported()
+
+    return jdkWithJettyBoot ?: Platform()
+  }
+}


### PR DESCRIPTION
By observation we are generally only running with Platform (no alpn) in IDE mode.  Gradle config doesn't get the right things onto bootclasspath.

Changing the default to Conscrypt will give us better coverage in IDE mode with JDK 8.  With JDK 9 we should be using the Jdk9Platform.

TODO confirm run modes:  

- `./gradlew -Pokhttp.platform=jdk9 test` -> Jdk9Platform
- `./gradlew -Pokhttp.platform=conscrypt test` -> ConscryptPlatform
- `./gradlew -Pokhttp.platform=jdk8 test` -> Platform
- `./gradlew -Pokhttp.platform=jdk8alpn test` -> Jdk8WithJettyBootPlatform
- `./gradlew test`with JDK 9+ -> Jdk9Platform
- `./gradlew test`with JDK 8 -> ConscryptPlatform
- Intellij with JDK 9+ -> Jdk9Platform
- Intellij with JDK 8 -> ConscryptPlatform
 