### PR TITLE
Idiomatic Kotlin for Response.kt

### DIFF
--- a/okcurl/src/main/java/okhttp3/curl/Main.kt
+++ b/okcurl/src/main/java/okhttp3/curl/Main.kt
@@ -130,7 +130,7 @@ class Main : Runnable {
       val response = client.newCall(request).execute()
       if (showHeaders) {
         println(StatusLine.get(response))
-        val headers = response.headers()
+        val headers = response.headers
         for ((name, value) in headers) {
           println("$name: $value")
         }
@@ -139,13 +139,13 @@ class Main : Runnable {
 
       // Stream the response to the System.out as it is returned from the server.
       val out = System.out.sink()
-      val source = response.body()!!.source()
+      val source = response.body!!.source()
       while (!source.exhausted()) {
         out.write(source.buffer, source.buffer.size)
         out.flush()
       }
 
-      response.body()!!.close()
+      response.body!!.close()
     } catch (e: IOException) {
       e.printStackTrace()
     } finally {

--- a/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsOverHttps.kt
+++ b/okhttp-dnsoverhttps/src/main/java/okhttp3/dnsoverhttps/DnsOverHttps.kt
@@ -202,7 +202,7 @@ class DnsOverHttps internal constructor(builder: Builder) : Dns {
 
         val cacheResponse = client.newCall(cacheRequest).execute()
 
-        if (cacheResponse.code() != 504) {
+        if (cacheResponse.code != 504) {
           return cacheResponse
         }
       } catch (ioe: IOException) {
@@ -216,16 +216,16 @@ class DnsOverHttps internal constructor(builder: Builder) : Dns {
 
   @Throws(Exception::class)
   private fun readResponse(hostname: String, response: Response): List<InetAddress> {
-    if (response.cacheResponse() == null && response.protocol() !== Protocol.HTTP_2) {
-      Platform.get().log(Platform.WARN, "Incorrect protocol: ${response.protocol()}", null)
+    if (response.cacheResponse == null && response.protocol !== Protocol.HTTP_2) {
+      Platform.get().log(Platform.WARN, "Incorrect protocol: ${response.protocol}", null)
     }
 
     response.use {
       if (!response.isSuccessful) {
-        throw IOException("response: " + response.code() + " " + response.message())
+        throw IOException("response: " + response.code + " " + response.message)
       }
 
-      val body = response.body()
+      val body = response.body
 
       if (body!!.contentLength() > MAX_RESPONSE_SIZE) {
         throw IOException(

--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -223,21 +223,21 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
 
     val tookMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs)
 
-    val responseBody = response.body()!!
+    val responseBody = response.body!!
     val contentLength = responseBody.contentLength()
     val bodySize = if (contentLength != -1L) "$contentLength-byte" else "unknown-length"
     logger.log(
-        "<-- ${response.code()}${if (response.message().isEmpty()) "" else ' ' + response.message()} ${response.request().url} (${tookMs}ms${if (!logHeaders) ", $bodySize body" else ""})")
+        "<-- ${response.code}${if (response.message.isEmpty()) "" else ' ' + response.message} ${response.request.url} (${tookMs}ms${if (!logHeaders) ", $bodySize body" else ""})")
 
     if (logHeaders) {
-      val headers = response.headers()
+      val headers = response.headers
       for (i in 0 until headers.size) {
         logHeader(headers, i)
       }
 
       if (!logBody || !response.promisesBody()) {
         logger.log("<-- END HTTP")
-      } else if (bodyHasUnknownEncoding(response.headers())) {
+      } else if (bodyHasUnknownEncoding(response.headers)) {
         logger.log("<-- END HTTP (encoded body omitted)")
       } else {
         val source = responseBody.source()

--- a/okhttp-sse/src/main/java/okhttp3/internal/sse/RealEventSource.kt
+++ b/okhttp-sse/src/main/java/okhttp3/internal/sse/RealEventSource.kt
@@ -53,7 +53,7 @@ class RealEventSource(
         return
       }
 
-      val body = response.body()!!
+      val body = response.body!!
 
       if (!body.isEventStream()) {
         listener.onFailure(this,

--- a/okhttp-sse/src/main/java/okhttp3/sse/EventSources.kt
+++ b/okhttp-sse/src/main/java/okhttp3/sse/EventSources.kt
@@ -34,7 +34,7 @@ object EventSources {
 
   @JvmStatic
   fun processResponse(response: Response, listener: EventSourceListener) {
-    val eventSource = RealEventSource(response.request(), listener)
+    val eventSource = RealEventSource(response.request, listener)
     eventSource.processResponse(response)
   }
 }

--- a/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.kt
+++ b/okhttp-urlconnection/src/main/java/okhttp3/JavaNetAuthenticator.kt
@@ -29,9 +29,9 @@ class JavaNetAuthenticator : okhttp3.Authenticator {
   @Throws(IOException::class)
   override fun authenticate(route: Route?, response: Response): Request? {
     val challenges = response.challenges()
-    val request = response.request()
+    val request = response.request
     val url = request.url
-    val proxyAuthorization = response.code() == 407
+    val proxyAuthorization = response.code == 407
     val proxy = route?.proxy ?: Proxy.NO_PROXY
 
     for (challenge in challenges) {

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.kt
@@ -54,7 +54,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
 
     if (cacheCandidate != null && cacheResponse == null) {
       // The cache candidate wasn't applicable. Close it.
-      cacheCandidate.body()?.closeQuietly()
+      cacheCandidate.body?.closeQuietly()
     }
 
     // If we're forbidden from using the network and the cache is insufficient, fail.
@@ -83,22 +83,22 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
     } finally {
       // If we're crashing on I/O or otherwise, don't leak the cache body.
       if (networkResponse == null && cacheCandidate != null) {
-        cacheCandidate.body()?.closeQuietly()
+        cacheCandidate.body?.closeQuietly()
       }
     }
 
     // If we have a cache response too, then we're doing a conditional get.
     if (cacheResponse != null) {
-      if (networkResponse?.code() == HTTP_NOT_MODIFIED) {
+      if (networkResponse?.code == HTTP_NOT_MODIFIED) {
         val response = cacheResponse.newBuilder()
-            .headers(combine(cacheResponse.headers(), networkResponse.headers()))
-            .sentRequestAtMillis(networkResponse.sentRequestAtMillis())
-            .receivedResponseAtMillis(networkResponse.receivedResponseAtMillis())
+            .headers(combine(cacheResponse.headers, networkResponse.headers))
+            .sentRequestAtMillis(networkResponse.sentRequestAtMillis)
+            .receivedResponseAtMillis(networkResponse.receivedResponseAtMillis)
             .cacheResponse(stripBody(cacheResponse))
             .networkResponse(stripBody(networkResponse))
             .build()
 
-        networkResponse.body()!!.close()
+        networkResponse.body!!.close()
 
         // Update the cache after combining headers but before stripping the
         // Content-Encoding header (as performed by initContentStream()).
@@ -106,7 +106,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
         cache.update(cacheResponse, response)
         return response
       } else {
-        cacheResponse.body()?.closeQuietly()
+        cacheResponse.body?.closeQuietly()
       }
     }
 
@@ -145,7 +145,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
     if (cacheRequest == null) return response
     val cacheBodyUnbuffered = cacheRequest.body()
 
-    val source = response.body()!!.source()
+    val source = response.body!!.source()
     val cacheBody = cacheBodyUnbuffered.buffer()
 
     val cacheWritingSource = object : Source {
@@ -193,7 +193,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
     }
 
     val contentType = response.header("Content-Type")
-    val contentLength = response.body()!!.contentLength()
+    val contentLength = response.body!!.contentLength()
     return response.newBuilder()
         .body(RealResponseBody(contentType, contentLength, cacheWritingSource.buffer()))
         .build()
@@ -202,7 +202,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
   companion object {
 
     private fun stripBody(response: Response?): Response? {
-      return if (response?.body() != null) {
+      return if (response?.body != null) {
         response.newBuilder().body(null).build()
       } else {
         response

--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheStrategy.kt
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheStrategy.kt
@@ -91,14 +91,14 @@ class CacheStrategy internal constructor(
      * cached response older than 24 hours, we are required to attach a warning.
      */
     private fun isFreshnessLifetimeHeuristic(): Boolean {
-      return cacheResponse!!.cacheControl().maxAgeSeconds == -1 && expires == null
+      return cacheResponse!!.cacheControl.maxAgeSeconds == -1 && expires == null
     }
 
     init {
       if (cacheResponse != null) {
-        this.sentRequestMillis = cacheResponse.sentRequestAtMillis()
-        this.receivedResponseMillis = cacheResponse.receivedResponseAtMillis()
-        val headers = cacheResponse.headers()
+        this.sentRequestMillis = cacheResponse.sentRequestAtMillis
+        this.receivedResponseMillis = cacheResponse.receivedResponseAtMillis
+        val headers = cacheResponse.headers
         for (i in 0 until headers.size) {
           val fieldName = headers.name(i)
           val value = headers.value(i)
@@ -145,7 +145,7 @@ class CacheStrategy internal constructor(
       }
 
       // Drop the cached response if it's missing a required handshake.
-      if (request.isHttps && cacheResponse.handshake() == null) {
+      if (request.isHttps && cacheResponse.handshake == null) {
         return CacheStrategy(request, null)
       }
 
@@ -161,7 +161,7 @@ class CacheStrategy internal constructor(
         return CacheStrategy(request, null)
       }
 
-      val responseCaching = cacheResponse.cacheControl()
+      val responseCaching = cacheResponse.cacheControl
 
       val ageMillis = cacheResponseAge()
       var freshMillis = computeFreshnessLifetime()
@@ -229,7 +229,7 @@ class CacheStrategy internal constructor(
      * date.
      */
     private fun computeFreshnessLifetime(): Long {
-      val responseCaching = cacheResponse!!.cacheControl()
+      val responseCaching = cacheResponse!!.cacheControl
       if (responseCaching.maxAgeSeconds != -1) {
         return SECONDS.toMillis(responseCaching.maxAgeSeconds.toLong())
       }
@@ -241,7 +241,7 @@ class CacheStrategy internal constructor(
         return if (delta > 0L) delta else 0L
       }
 
-      if (lastModified != null && cacheResponse.request().url.query == null) {
+      if (lastModified != null && cacheResponse.request.url.query == null) {
         // As recommended by the HTTP RFC and implemented in Firefox, the max age of a document
         // should be defaulted to 10% of the document's age at the time it was served. Default
         // expiration dates aren't used for URIs containing a query.
@@ -290,7 +290,7 @@ class CacheStrategy internal constructor(
     fun isCacheable(response: Response, request: Request): Boolean {
       // Always go to network for uncacheable response codes (RFC 7231 section 6.1), This
       // implementation doesn't support caching partial content.
-      when (response.code()) {
+      when (response.code) {
         HTTP_OK,
         HTTP_NOT_AUTHORITATIVE,
         HTTP_NO_CONTENT,
@@ -311,9 +311,9 @@ class CacheStrategy internal constructor(
           // http://tools.ietf.org/html/rfc7234#section-3
           // s-maxage is not checked because OkHttp is a private cache that should ignore s-maxage.
           if (response.header("Expires") == null &&
-              response.cacheControl().maxAgeSeconds == -1 &&
-              !response.cacheControl().isPublic &&
-              !response.cacheControl().isPrivate) {
+              response.cacheControl.maxAgeSeconds == -1 &&
+              !response.cacheControl.isPublic &&
+              !response.cacheControl.isPrivate) {
             return false
           }
         }
@@ -325,7 +325,7 @@ class CacheStrategy internal constructor(
       }
 
       // A 'no-store' directive on request or response prevents the response from being cached.
-      return !response.cacheControl().noStore && !request.cacheControl.noStore
+      return !response.cacheControl.noStore && !request.cacheControl.noStore
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -423,7 +423,7 @@ class RealConnection(
           .build()
       tunnelCodec.skipConnectBody(response)
 
-      when (response.code()) {
+      when (response.code) {
         HTTP_OK -> {
           // Assume the server won't send a TLS ServerHello until we send a TLS ClientHello. If
           // that happens, then we will have buffered bytes that are needed by the SSLSocket!
@@ -444,7 +444,7 @@ class RealConnection(
           }
         }
 
-        else -> throw IOException("Unexpected response code for CONNECT: ${response.code()}")
+        else -> throw IOException("Unexpected response code for CONNECT: ${response.code}")
       }
     }
   }

--- a/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.kt
@@ -83,7 +83,7 @@ class BridgeInterceptor(private val cookieJar: CookieJar) : Interceptor {
 
     val networkResponse = chain.proceed(requestBuilder.build())
 
-    cookieJar.receiveHeaders(userRequest.url, networkResponse.headers())
+    cookieJar.receiveHeaders(userRequest.url, networkResponse.headers)
 
     val responseBuilder = networkResponse.newBuilder()
         .request(userRequest)
@@ -91,10 +91,10 @@ class BridgeInterceptor(private val cookieJar: CookieJar) : Interceptor {
     if (transparentGzip &&
         "gzip".equals(networkResponse.header("Content-Encoding"), ignoreCase = true) &&
         networkResponse.promisesBody()) {
-      val responseBody = networkResponse.body()
+      val responseBody = networkResponse.body
       if (responseBody != null) {
         val gzipSource = GzipSource(responseBody.source())
-        val strippedHeaders = networkResponse.headers().newBuilder()
+        val strippedHeaders = networkResponse.headers.newBuilder()
             .removeAll("Content-Encoding")
             .removeAll("Content-Length")
             .build()

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.kt
@@ -87,7 +87,7 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
         .sentRequestAtMillis(sentRequestMillis)
         .receivedResponseAtMillis(System.currentTimeMillis())
         .build()
-    var code = response.code()
+    var code = response.code
     if (code == 100) {
       // server sent a 100-continue even though we did not request one.
       // try again to read the actual response
@@ -97,7 +97,7 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
           .sentRequestAtMillis(sentRequestMillis)
           .receivedResponseAtMillis(System.currentTimeMillis())
           .build()
-      code = response.code()
+      code = response.code
     }
 
     exchange.responseHeadersEnd(response)
@@ -112,13 +112,13 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
           .body(exchange.openResponseBody(response))
           .build()
     }
-    if ("close".equals(response.request().header("Connection"), ignoreCase = true) ||
+    if ("close".equals(response.request.header("Connection"), ignoreCase = true) ||
         "close".equals(response.header("Connection"), ignoreCase = true)) {
       exchange.noNewExchangesOnConnection()
     }
-    if ((code == 204 || code == 205) && response.body()?.contentLength() ?: -1L > 0L) {
+    if ((code == 204 || code == 205) && response.body?.contentLength() ?: -1L > 0L) {
       throw ProtocolException(
-          "HTTP $code had non-zero Content-Length: ${response.body()?.contentLength()}")
+          "HTTP $code had non-zero Content-Length: ${response.body?.contentLength()}")
     }
     return response
   }

--- a/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.kt
@@ -212,11 +212,11 @@ fun CookieJar.receiveHeaders(url: HttpUrl, headers: Headers) {
  */
 fun Response.promisesBody(): Boolean {
   // HEAD requests never yield a body regardless of the response headers.
-  if (request().method == "HEAD") {
+  if (request.method == "HEAD") {
     return false
   }
 
-  val responseCode = code()
+  val responseCode = code
   if ((responseCode < HTTP_CONTINUE || responseCode >= 200) &&
       responseCode != HTTP_NO_CONTENT &&
       responseCode != HTTP_NOT_MODIFIED) {

--- a/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
@@ -117,7 +117,7 @@ class RealInterceptorChain(
       "network interceptor $interceptor must call proceed() exactly once"
     }
 
-    check(response.body() != null) { "interceptor $interceptor returned a response with no body" }
+    check(response.body != null) { "interceptor $interceptor returned a response with no body" }
 
     return response
   }

--- a/okhttp/src/main/java/okhttp3/internal/http/StatusLine.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/StatusLine.kt
@@ -46,7 +46,7 @@ class StatusLine(
     const val HTTP_CONTINUE = 100
 
     fun get(response: Response): StatusLine {
-      return StatusLine(response.protocol(), response.code(), response.message())
+      return StatusLine(response.protocol, response.code, response.message)
     }
 
     @Throws(IOException::class)

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -133,7 +133,7 @@ class Http1ExchangeCodec(
   override fun openResponseBodySource(response: Response): Source {
     return when {
       !response.promisesBody() -> newFixedLengthSource(0)
-      response.isChunked() -> newChunkedSource(response.request().url)
+      response.isChunked() -> newChunkedSource(response.request.url)
       else -> {
         val contentLength = response.headersContentLength()
         if (contentLength != -1L) {

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
@@ -192,9 +192,9 @@ class RealWebSocket(
 
   @Throws(IOException::class)
   internal fun checkUpgradeSuccess(response: Response, exchange: Exchange?) {
-    if (response.code() != 101) {
+    if (response.code != 101) {
       throw ProtocolException(
-          "Expected HTTP 101 response but was '${response.code()} ${response.message()}'")
+          "Expected HTTP 101 response but was '${response.code} ${response.message}'")
     }
 
     val headerConnection = response.header("Connection")

--- a/okhttp/src/test/java/okhttp3/ConscryptTest.kt
+++ b/okhttp/src/test/java/okhttp3/ConscryptTest.kt
@@ -64,8 +64,8 @@ class ConscryptTest {
 
     val response = client.newCall(request).execute()
 
-    assertThat(response.protocol()).isEqualTo(Protocol.HTTP_2)
-    assertThat(response.handshake()!!.tlsVersion).isEqualTo(TlsVersion.TLS_1_3)
+    assertThat(response.protocol).isEqualTo(Protocol.HTTP_2)
+    assertThat(response.handshake!!.tlsVersion).isEqualTo(TlsVersion.TLS_1_3)
   }
 
   @Test
@@ -76,8 +76,8 @@ class ConscryptTest {
 
     val response = client.newCall(request).execute()
 
-    assertThat(response.protocol()).isEqualTo(Protocol.HTTP_2)
-    if (response.handshake()!!.tlsVersion != TlsVersion.TLS_1_3) {
+    assertThat(response.protocol).isEqualTo(Protocol.HTTP_2)
+    if (response.handshake!!.tlsVersion != TlsVersion.TLS_1_3) {
       System.err.println("Flaky TLSv1.3 with google")
 //    assertThat(response.handshake()!!.tlsVersion).isEqualTo(TlsVersion.TLS_1_3)
     }

--- a/okhttp/src/test/java/okhttp3/KotlinSourceCompatibilityTest.kt
+++ b/okhttp/src/test/java/okhttp3/KotlinSourceCompatibilityTest.kt
@@ -1041,27 +1041,27 @@ class KotlinSourceCompatibilityTest {
   @Test @Ignore
   fun response() {
     val response: Response = Response.Builder().build()
-    val request: Request = response.request()
-    val protocol: Protocol = response.protocol()
-    val code: Int = response.code()
+    val request: Request = response.request
+    val protocol: Protocol = response.protocol
+    val code: Int = response.code
     val successful: Boolean = response.isSuccessful
-    val message: String = response.message()
-    val handshake: Handshake? = response.handshake()
+    val message: String = response.message
+    val handshake: Handshake? = response.handshake
     val headersForName: List<String> = response.headers("")
     val header: String? = response.header("")
-    val headers: Headers = response.headers()
+    val headers: Headers = response.headers
     val trailers: Headers = response.trailers()
     val peekBody: ResponseBody = response.peekBody(0L)
-    val body: ResponseBody? = response.body()
+    val body: ResponseBody? = response.body
     val builder: Response.Builder = response.newBuilder()
     val redirect: Boolean = response.isRedirect
-    val networkResponse: Response? = response.networkResponse()
-    val cacheResponse: Response? = response.cacheResponse()
-    val priorResponse: Response? = response.priorResponse()
+    val networkResponse: Response? = response.networkResponse
+    val cacheResponse: Response? = response.cacheResponse
+    val priorResponse: Response? = response.priorResponse
     val challenges: List<Challenge> = response.challenges()
-    val cacheControl: CacheControl = response.cacheControl()
-    val sentRequestAtMillis: Long = response.sentRequestAtMillis()
-    val receivedResponseAtMillis: Long = response.receivedResponseAtMillis()
+    val cacheControl: CacheControl = response.cacheControl
+    val sentRequestAtMillis: Long = response.sentRequestAtMillis
+    val receivedResponseAtMillis: Long = response.receivedResponseAtMillis
   }
 
   @Test @Ignore


### PR DESCRIPTION
- define `@get:JvmName(...)` for the following vals in constructor instead of passing `builder: Builder`.
  - `request: Request`
  - `protocol: Protocol`
  - `message: String`
  - `code: Int`
  - `handshake: Handshake?`
  - `headers: Headers`
  - `body: ResponseBody?`
  - `networkResponse: Response?`
  - `cacheResponse: Response?`
  - `priorResponse: Response?`
  - `sentRequestAtMillis: Long`
  - `receivedResponseAtMillis: Long`
  - `exchange: Exchange?`

- add `@Deprecated(...)` to the following functions.
  - `fun request(): Request`
  - `fun protocol(): Protocol`
  - `fun message(): String`
  - `fun code(): Int`
  - `fun handshake(): Handshake?`
  - `fun headers(): Headers`
  - `fun body(): ResponseBody?`
  - `fun networkResponse(): Response?`
  - `fun cacheResponse(): Response?`
  - `fun priorResponse(): Response?`
  - `fun sentRequestAtMillis(): Long`
  - `fun receivedResponseAtMillis(): Long`
  - `fun cacheControl(): CacheControl`

- clean up code where `()`(parentheses) is unnecessarily used.