### PR TITLE
Beef up Request's toString

### DIFF
--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.java
@@ -73,7 +73,7 @@ public final class LoggingEventListenerTest {
     response.body().bytes();
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + "\\}")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
@@ -104,7 +104,7 @@ public final class LoggingEventListenerTest {
     client.newCall(request().post(RequestBody.create("Hello!", PLAIN)).build()).execute();
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=POST, url=" + url + ", tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=POST, url=" + url + "\\}")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
@@ -144,7 +144,7 @@ public final class LoggingEventListenerTest {
     platform.assumeHttp2Support();
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + "\\}")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")
@@ -187,7 +187,7 @@ public final class LoggingEventListenerTest {
     }
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + "\\}")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("callFailed: java.net.UnknownHostException: reason")
         .assertNoMoreLogs();
@@ -207,7 +207,7 @@ public final class LoggingEventListenerTest {
     }
 
     logRecorder
-        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + ", tags=\\{\\}\\}")
+        .assertLogMatch("callStart: Request\\{method=GET, url=" + url + "\\}")
         .assertLogMatch("dnsStart: " + url.host())
         .assertLogMatch("dnsEnd: \\[.+\\]")
         .assertLogMatch("connectStart: " + url.host() + "/.+ DIRECT")

--- a/okhttp/src/main/java/okhttp3/Request.kt
+++ b/okhttp/src/main/java/okhttp3/Request.kt
@@ -109,7 +109,29 @@ class Request internal constructor(
       level = DeprecationLevel.WARNING)
   fun cacheControl(): CacheControl = cacheControl
 
-  override fun toString(): String = "Request{method=$method, url=$url, tags=$tags}"
+  override fun toString() = buildString {
+    append("Request{method=")
+    append(method)
+    append(", url=")
+    append(url)
+    if (headers.size != 0) {
+      append(", headers=[")
+      headers.forEachIndexed { index, (name, value) ->
+        if (index > 0) {
+          append(", ")
+        }
+        append(name)
+        append(':')
+        append(value)
+      }
+      append(']')
+    }
+    if (tags.isNotEmpty()) {
+      append(", tags=")
+      append(tags)
+    }
+    append('}')
+  }
 
   open class Builder {
     internal var url: HttpUrl? = null


### PR DESCRIPTION
Previously it unconditionally showed tags even if empty and would not show headers.