### PR TITLE
Add githubs security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 4.x     | :white_check_mark: |
+| 3.14.x  | :white_check_mark: |
+| 3.12.x  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Square recognizes the important contributions the security research community
+can make. We therefore encourage reporting security issues with the code
+contained in this repository.
+
+If you believe you have discovered a security vulnerability, please follow the
+guidelines at https://hackerone.com/square-open-source


### PR DESCRIPTION
Copied from  okhttp/BUG-BOUNTY.md

Seems to be a standard location e.g.

https://github.com/electron/electron/blob/master/SECURITY.md
https://github.com/standard/standard/blob/master/SECURITY.md