### PR TITLE
Idiomatic Kotlin in HandshakeCertificates

### DIFF
--- a/okhttp-tls/src/main/java/okhttp3/tls/HandshakeCertificates.kt
+++ b/okhttp-tls/src/main/java/okhttp3/tls/HandshakeCertificates.kt
@@ -67,11 +67,22 @@ import javax.net.ssl.X509TrustManager
  *    roots private to an organization or service.
  */
 class HandshakeCertificates private constructor(
-  private val keyManager: X509KeyManager,
-  private val trustManager: X509TrustManager
+  @get:JvmName("keyManager") val keyManager: X509KeyManager,
+  @get:JvmName("trustManager") val trustManager: X509TrustManager
 ) {
+
+  @JvmName("-deprecated_keyManager")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "keyManager"),
+      level = DeprecationLevel.WARNING)
   fun keyManager(): X509KeyManager = keyManager
 
+  @JvmName("-deprecated_trustManager")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "trustManager"),
+      level = DeprecationLevel.WARNING)
   fun trustManager(): X509TrustManager = trustManager
 
   fun sslSocketFactory(): SSLSocketFactory = sslContext().socketFactory


### PR DESCRIPTION
- define `@get:JvmName(...)` for the following vals in constructor.
  - `keyManager: X509KeyManager`
  - `trustManager: X509TrustManager`

- add `@Deprecated(...)` to the following functions.
  - `fun keyManager(): X509KeyManager`
  - `fun trustManager(): X509TrustManager`
  - `fun sslSocketFactory(): SSLSocketFactory`
  - `fun sslContext(): SSLContext`