### PR TITLE
Idiomatic Kotlin in HeldCertificate.kt

### DIFF
--- a/okhttp-tls/src/main/java/okhttp3/tls/HeldCertificate.kt
+++ b/okhttp-tls/src/main/java/okhttp3/tls/HeldCertificate.kt
@@ -164,7 +164,7 @@ class HeldCertificate(
    * [rfc_7468]: https://tools.ietf.org/html/rfc7468
    */
   fun privateKeyPkcs1Pem(): String {
-    require(keyPair.private is RSAPrivateKey) { "PKCS1 only supports RSA keys" }
+    check(keyPair.private is RSAPrivateKey) { "PKCS1 only supports RSA keys" }
     return buildString {
       append("-----BEGIN RSA PRIVATE KEY-----\n")
       encodeBase64Lines(pkcs1Bytes())

--- a/okhttp-tls/src/main/java/okhttp3/tls/HeldCertificate.kt
+++ b/okhttp-tls/src/main/java/okhttp3/tls/HeldCertificate.kt
@@ -111,9 +111,23 @@ import javax.security.auth.x500.X500Principal
  * a chain of certificates. The server uses a set of trusted root certificates to authenticate the
  * client. Subject alternative names are not used for client authentication.
  */
-class HeldCertificate(private val keyPair: KeyPair, private val certificate: X509Certificate) {
+class HeldCertificate(
+  @get:JvmName("keyPair") val keyPair: KeyPair,
+  @get:JvmName("certificate") val certificate: X509Certificate
+) {
+
+  @JvmName("-deprecated_certificate")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "certificate"),
+      level = DeprecationLevel.WARNING)
   fun certificate(): X509Certificate = certificate
 
+  @JvmName("-deprecated_keyPair")
+  @Deprecated(
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "keyPair"),
+      level = DeprecationLevel.WARNING)
   fun keyPair(): KeyPair = keyPair
 
   /**

--- a/okhttp-tls/src/main/java/okhttp3/tls/internal/TlsUtil.kt
+++ b/okhttp-tls/src/main/java/okhttp3/tls/internal/TlsUtil.kt
@@ -38,7 +38,7 @@ object TlsUtil {
         .build()
     return@lazy HandshakeCertificates.Builder()
         .heldCertificate(heldCertificate)
-        .addTrustedCertificate(heldCertificate.certificate())
+        .addTrustedCertificate(heldCertificate.certificate)
         .build()
   }
 
@@ -80,9 +80,9 @@ object TlsUtil {
     val keyStore = newEmptyKeyStore(keyStoreType)
     if (heldCertificate != null) {
       val chain = arrayOfNulls<Certificate>(1 + intermediates.size)
-      chain[0] = heldCertificate.certificate()
+      chain[0] = heldCertificate.certificate
       intermediates.copyInto(chain, 1)
-      keyStore.setKeyEntry("private", heldCertificate.keyPair().private, password, chain)
+      keyStore.setKeyEntry("private", heldCertificate.keyPair.private, password, chain)
     }
 
     val factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())

--- a/okhttp/src/test/java/okhttp3/CertificatePinnerKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/CertificatePinnerKotlinTest.kt
@@ -26,10 +26,10 @@ class CertificatePinnerKotlinTest {
   @Test
   fun successfulCheckSha1Pin() {
     val certificatePinner = CertificatePinner.Builder()
-        .add("example.com", "sha1/" + certA1.certificate().toSha1ByteString().base64())
+        .add("example.com", "sha1/" + certA1.certificate.toSha1ByteString().base64())
         .build()
 
-    certificatePinner.check("example.com", certA1.certificate())
+    certificatePinner.check("example.com", certA1.certificate)
   }
 
   @Test fun successfulFindMatchingPins() {
@@ -114,16 +114,16 @@ class CertificatePinnerKotlinTest {
     internal var certA1: HeldCertificate = HeldCertificate.Builder()
         .serialNumber(100L)
         .build()
-    internal var certA1Sha256Pin = CertificatePinner.pin(certA1.certificate())
+    internal var certA1Sha256Pin = CertificatePinner.pin(certA1.certificate)
 
     private var certB1 = HeldCertificate.Builder()
         .serialNumber(200L)
         .build()
-    internal var certB1Sha256Pin = CertificatePinner.pin(certB1.certificate())
+    internal var certB1Sha256Pin = CertificatePinner.pin(certB1.certificate)
 
     private var certC1 = HeldCertificate.Builder()
         .serialNumber(300L)
         .build()
-    internal var certC1Sha256Pin = CertificatePinner.pin(certC1.certificate())
+    internal var certC1Sha256Pin = CertificatePinner.pin(certC1.certificate)
   }
 }


### PR DESCRIPTION
- define `@get:JvmName(...)` for the following vals in constructor.
  - `keyPair: KeyPair`
  - `certificate: X509Certificate`

- add `@Deprecated(...)` to the following functions.
  - `fun certificate(): X509Certificate`
  - `fun keyPair(): KeyPair`

- clean up code where `()`(parentheses) is unnecessarily used.

- use `check(...)` instead of `require(...)` in `HeldCertificate#privateKeyPkcs1Pem()`