### PR TITLE
Do not enclose localhost hostname with square brackets #4950

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.kt
@@ -91,7 +91,7 @@ class RecordedRequest(
       val inetAddress = socket.localAddress
 
       var hostname = inetAddress.hostName
-      if (inetAddress is Inet6Address) {
+      if (inetAddress is Inet6Address && hostname != "localhost") {
         hostname = "[$hostname]"
       }
 


### PR DESCRIPTION
Inet6Address is returning localhost as hostname under specific network env (ex. Vpn).
“Localhost” should not be enclosed with square brackets since they will produce IllegalArugmentException in HttpUrl if so.