### PR TITLE
Use asX() instead of toX() when a view is returned

### DIFF
--- a/UPGRADING_TO_OKHTTP_4.md
+++ b/UPGRADING_TO_OKHTTP_4.md
@@ -175,9 +175,9 @@ _Code Cleanup_ will fix these too:
 | MediaType.parse(String)             | String.toMediaTypeOrNull()      |
 | RequestBody.create(ByteArray)       | ByteArray.toRequestBody()       |
 | RequestBody.create(ByteString)      | ByteString.toRequestBody()      |
-| RequestBody.create(File)            | File.toRequestBody()            |
+| RequestBody.create(File)            | File.asRequestBody()            |
 | RequestBody.create(String)          | String.toRequestBody()          |
-| ResponseBody.create(BufferedSource) | BufferedSource.toResponseBody() |
+| ResponseBody.create(BufferedSource) | BufferedSource.asResponseBody() |
 | ResponseBody.create(ByteArray)      | ByteArray.toResponseBody()      |
 | ResponseBody.create(ByteString)     | ByteString.toResponseBody()     |
 | ResponseBody.create(String)         | String.toResponseBody()         |

--- a/okhttp/src/main/java/okhttp3/RequestBody.kt
+++ b/okhttp/src/main/java/okhttp3/RequestBody.kt
@@ -152,7 +152,7 @@ abstract class RequestBody {
     /** Returns a new request body that transmits the content of this. */
     @JvmStatic
     @JvmName("create")
-    fun File.toRequestBody(contentType: MediaType? = null): RequestBody {
+    fun File.asRequestBody(contentType: MediaType? = null): RequestBody {
       return object : RequestBody() {
         override fun contentType() = contentType
 
@@ -207,10 +207,10 @@ abstract class RequestBody {
     @Deprecated(
         message = "Moved to extension function. Put the 'file' argument first to fix Java",
         replaceWith = ReplaceWith(
-            expression = "file.toRequestBody(contentType)",
-            imports = ["okhttp3.RequestBody.Companion.toRequestBody"]
+            expression = "file.asRequestBody(contentType)",
+            imports = ["okhttp3.RequestBody.Companion.asRequestBody"]
         ),
         level = DeprecationLevel.WARNING)
-    fun create(contentType: MediaType?, file: File) = file.toRequestBody(contentType)
+    fun create(contentType: MediaType?, file: File) = file.asRequestBody(contentType)
   }
 }

--- a/okhttp/src/main/java/okhttp3/Response.kt
+++ b/okhttp/src/main/java/okhttp3/Response.kt
@@ -15,7 +15,7 @@
  */
 package okhttp3
 
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import okhttp3.internal.connection.Exchange
 import okhttp3.internal.http.StatusLine.Companion.HTTP_PERM_REDIRECT
 import okhttp3.internal.http.StatusLine.Companion.HTTP_TEMP_REDIRECT
@@ -196,7 +196,7 @@ class Response internal constructor(
     val buffer = Buffer()
     peeked.request(byteCount)
     buffer.write(peeked, minOf(byteCount, peeked.buffer.size))
-    return buffer.toResponseBody(body.contentType(), buffer.size)
+    return buffer.asResponseBody(body.contentType(), buffer.size)
   }
 
   @JvmName("-deprecated_body")

--- a/okhttp/src/main/java/okhttp3/ResponseBody.kt
+++ b/okhttp/src/main/java/okhttp3/ResponseBody.kt
@@ -223,7 +223,7 @@ abstract class ResponseBody : Closeable {
         }
       }
       val buffer = Buffer().writeString(this, charset)
-      return buffer.toResponseBody(finalContentType, buffer.size)
+      return buffer.asResponseBody(finalContentType, buffer.size)
     }
 
     /** Returns a new response body that transmits this byte array. */
@@ -232,7 +232,7 @@ abstract class ResponseBody : Closeable {
     fun ByteArray.toResponseBody(contentType: MediaType? = null): ResponseBody {
       return Buffer()
           .write(this)
-          .toResponseBody(contentType, size.toLong())
+          .asResponseBody(contentType, size.toLong())
     }
 
     /** Returns a new response body that transmits this byte string. */
@@ -241,13 +241,13 @@ abstract class ResponseBody : Closeable {
     fun ByteString.toResponseBody(contentType: MediaType? = null): ResponseBody {
       return Buffer()
           .write(this)
-          .toResponseBody(contentType, size.toLong())
+          .asResponseBody(contentType, size.toLong())
     }
 
     /** Returns a new response body that transmits this source. */
     @JvmStatic
     @JvmName("create")
-    fun BufferedSource.toResponseBody(
+    fun BufferedSource.asResponseBody(
       contentType: MediaType? = null,
       contentLength: Long = -1L
     ): ResponseBody = object : ResponseBody() {
@@ -255,7 +255,7 @@ abstract class ResponseBody : Closeable {
 
       override fun contentLength() = contentLength
 
-      override fun source() = this@toResponseBody
+      override fun source() = this@asResponseBody
     }
 
     @JvmStatic
@@ -292,14 +292,14 @@ abstract class ResponseBody : Closeable {
     @Deprecated(
         message = "Moved to extension function. Put the 'content' argument first to fix Java",
         replaceWith = ReplaceWith(
-            expression = "content.toResponseBody(contentType, contentLength)",
-            imports = ["okhttp3.ResponseBody.Companion.toResponseBody"]
+            expression = "content.asResponseBody(contentType, contentLength)",
+            imports = ["okhttp3.ResponseBody.Companion.asResponseBody"]
         ),
         level = DeprecationLevel.WARNING)
     fun create(
       contentType: MediaType?,
       contentLength: Long,
       content: BufferedSource
-    ) = content.toResponseBody(contentType, contentLength)
+    ) = content.asResponseBody(contentType, contentLength)
   }
 }

--- a/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
+++ b/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
@@ -23,7 +23,9 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
 import okhttp3.internal.http2.Settings
 import okhttp3.internal.proxy.NullProxySelector
 import okhttp3.internal.tls.OkHostnameVerifier
@@ -1006,8 +1008,8 @@ class KotlinSourceModernTest {
     requestBody = byteArrayOf(0, 1).toRequestBody("".toMediaTypeOrNull(), 0, 2)
     requestBody = byteArrayOf(0, 1).toRequestBody(null, 0, 2)
     requestBody = byteArrayOf(0, 1).toRequestBody("".toMediaTypeOrNull(), 0, 2)
-    requestBody = File("").toRequestBody(null)
-    requestBody = File("").toRequestBody("".toMediaTypeOrNull())
+    requestBody = File("").asRequestBody(null)
+    requestBody = File("").asRequestBody("".toMediaTypeOrNull())
   }
 
   @Test @Ignore
@@ -1087,8 +1089,8 @@ class KotlinSourceModernTest {
     responseBody = ByteString.EMPTY.toResponseBody(null)
     responseBody = byteArrayOf(0, 1).toResponseBody("".toMediaType())
     responseBody = byteArrayOf(0, 1).toResponseBody(null)
-    responseBody = Buffer().toResponseBody("".toMediaType(), 0L)
-    responseBody = Buffer().toResponseBody(null, 0L)
+    responseBody = Buffer().asResponseBody("".toMediaType(), 0L)
+    responseBody = Buffer().asResponseBody(null, 0L)
   }
 
   @Test @Ignore


### PR DESCRIPTION
When the returned value remembers what it was created with, we use as()

Closes: https://github.com/square/okhttp/issues/5177