### PR TITLE
Fix the visibility of Call.clone() called from Kotlin

### DIFF
--- a/okhttp/src/main/java/okhttp3/Call.kt
+++ b/okhttp/src/main/java/okhttp3/Call.kt
@@ -91,7 +91,7 @@ interface Call : Cloneable {
    * Create a new, identical call to this one which can be enqueued or executed even if this call
    * has already been.
    */
-  override fun clone(): Call
+  public override fun clone(): Call
 
   interface Factory {
     fun newCall(request: Request): Call

--- a/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.rules.Timeout
+import java.util.concurrent.TimeUnit
+
+class CallKotlinTest {
+  @JvmField @Rule val platform = PlatformRule()
+  @JvmField @Rule val timeout: TestRule = Timeout(30_000, TimeUnit.MILLISECONDS)
+  @JvmField @Rule val server = MockWebServer()
+  @JvmField @Rule val clientTestRule = OkHttpClientTestRule()
+
+  private val client = clientTestRule.client
+
+  @Test
+  fun legalToExecuteTwiceCloning() {
+    server.enqueue(MockResponse().setBody("abc"))
+    server.enqueue(MockResponse().setBody("def"))
+
+    val request = Request.Builder()
+        .url(server.url("/"))
+        .build()
+
+    val call = client.newCall(request)
+    val response1 = call.execute()
+
+    val cloned = call.clone()
+    val response2 = cloned.execute()
+
+    assertThat("abc").isEqualTo(response1.body!!.string())
+    assertThat("def").isEqualTo(response2.body!!.string())
+  }
+}


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/5161