### PR TITLE
Use JUnit 4.13-beta-3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,8 @@ buildscript {
       'java': '1.8',
       'jnrUnixsocket': '0.22',
       'jsoup': '1.11.3',
-      'junit': '4.12',
+      'junit': '4.13-beta-3',
+      'junitStable': '4.12',
       'kotlin': '1.3.31',
       'moshi': '1.8.0',
       'okio': '2.2.2',
@@ -33,6 +34,7 @@ buildscript {
       'jsoup': "org.jsoup:jsoup:${versions.jsoup}",
       'jsr305': "com.google.code.findbugs:jsr305:${versions.findbugs}",
       'junit': "junit:junit:${versions.junit}",
+      'junitStable': "junit:junit:${versions.junitStable}",
       'kotlinStdlib': "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
       'moshi': "com.squareup.moshi:moshi:${versions.moshi}",
       'okio': "com.squareup.okio:okio:${versions.okio}"

--- a/mockwebserver/build.gradle
+++ b/mockwebserver/build.gradle
@@ -9,7 +9,7 @@ jar {
 
 dependencies {
   api project(':okhttp')
-  api deps.junit
+  api deps.junitStable
 
   testImplementation project(':okhttp-testing-support')
   testImplementation project(':okhttp-tls')


### PR DESCRIPTION
To be prepared for 4.13 upgrade, use the latest beta version for all modules except `MockWebSerer`.