### PR TITLE
Allow users to set status code 0 in Response to maintain backward compatibility in OkHttp4.0

### DIFF
--- a/okhttp/src/main/java/okhttp3/Response.kt
+++ b/okhttp/src/main/java/okhttp3/Response.kt
@@ -433,7 +433,7 @@ class Response internal constructor(
     }
 
     open fun build(): Response {
-      check(code > 0) { "code < 0: $code" }
+      check(code >= 0) { "code < 0: $code" }
       return Response(
           checkNotNull(request) { "request == null" },
           checkNotNull(protocol) { "protocol == null" },

--- a/okhttp/src/test/java/okhttp3/ResponseTest.java
+++ b/okhttp/src/test/java/okhttp3/ResponseTest.java
@@ -24,6 +24,7 @@ import okio.Timeout;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 
 public final class ResponseTest {
@@ -61,6 +62,16 @@ public final class ResponseTest {
     assertThat(p2.string()).isEqualTo("ab");
   }
 
+  @Test public void negativeStatusCodeThrowsIllegalStateException() {
+    assertThatThrownBy(() -> newResponse(responseBody("set status code -1"), -1))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test public void zeroStatusCodeIsValid() {
+    Response response = newResponse(responseBody("set status code 0"), 0);
+    assertThat(response.code()).isEqualTo(0);
+  }
+
   /**
    * Returns a new response body that refuses to be read once it has been closed. This is true of
    * most {@link BufferedSource} instances, but not of {@link Buffer}.
@@ -89,12 +100,16 @@ public final class ResponseTest {
   }
 
   private Response newResponse(ResponseBody responseBody) {
+    return newResponse(responseBody, 200);
+  }
+
+  private Response newResponse(ResponseBody responseBody, int code) {
     return new Response.Builder()
         .request(new Request.Builder()
             .url("https://example.com/")
             .build())
         .protocol(Protocol.HTTP_1_1)
-        .code(200)
+        .code(code)
         .message("OK")
         .body(responseBody)
         .build();


### PR DESCRIPTION
Fixes https://github.com/square/okhttp/issues/5209

Previously in OkHttp3, status code == 0 was acceptable.
ref. [status code validity check in 3.14.2](https://github.com/square/okhttp/blob/parent-3.14.2/okhttp/src/main/java/okhttp3/Response.java#L453)