### PR TITLE
Change return type of MockWebServer#takeRequest(...) to nullable to maintain backward compatibility in OkHttp4.0

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
@@ -329,7 +329,7 @@ class MockWebServer : ExternalResource(), Closeable {
    * @return the head of the request queue
    */
   @Throws(InterruptedException::class)
-  fun takeRequest(timeout: Long, unit: TimeUnit): RecordedRequest = requestQueue.poll(timeout, unit)
+  fun takeRequest(timeout: Long, unit: TimeUnit): RecordedRequest? = requestQueue.poll(timeout, unit)
 
   @JvmName("-deprecated_requestCount")
   @Deprecated(

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
@@ -48,6 +48,7 @@ import org.junit.runners.model.Statement;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static okhttp3.tls.internal.TlsUtil.localhost;
@@ -140,6 +141,9 @@ public final class MockWebServerTest {
     RecordedRequest request = server.takeRequest();
     assertThat(request.getRequestLine()).isEqualTo("GET / HTTP/1.1");
     assertThat(request.getHeader("Accept-Language")).isEqualTo("en-US");
+
+    // Server has no more requests.
+    assertThat(server.takeRequest(100, MILLISECONDS)).isNull();
   }
 
   @Test public void redirect() throws Exception {

--- a/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
+++ b/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
@@ -735,8 +735,8 @@ class KotlinSourceModernTest {
     mockWebServer.noClientAuth()
     mockWebServer.requestClientAuth()
     mockWebServer.requireClientAuth()
-    var request: RecordedRequest = mockWebServer.takeRequest()
-    request = mockWebServer.takeRequest(0L, TimeUnit.SECONDS)
+    val request: RecordedRequest = mockWebServer.takeRequest()
+    val nullableRequest: RecordedRequest? = mockWebServer.takeRequest(0L, TimeUnit.SECONDS)
     var requestCount: Int = mockWebServer.requestCount
     mockWebServer.enqueue(MockResponse())
     mockWebServer.start()


### PR DESCRIPTION
Fixes #5208 

Previously in OkHttp3, takeRequest(...) returns RecordedRequest?.
ref. [takeRequest(timeout: Long, unit: TimeUnit) in 3.14.2](https://github.com/square/okhttp/blob/parent-3.14.2/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.java#L308)