### PR TITLE
Retain binary-compatibility in okhttp3.internal.HttpMethod

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http/HttpMethod.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/HttpMethod.kt
@@ -22,12 +22,14 @@ object HttpMethod {
       method == "DELETE" ||
       method == "MOVE") // WebDAV
 
+  @JvmStatic // Despite being 'internal', this method is called by popular 3rd party SDKs.
   fun requiresRequestBody(method: String): Boolean = (method == "POST" ||
       method == "PUT" ||
       method == "PATCH" ||
       method == "PROPPATCH" || // WebDAV
       method == "REPORT") // CalDAV/CardDAV (defined in WebDAV Versioning)
 
+  @JvmStatic // Despite being 'internal', this method is called by popular 3rd party SDKs.
   fun permitsRequestBody(method: String): Boolean = !(method == "GET" || method == "HEAD")
 
   fun redirectsWithBody(method: String): Boolean =


### PR DESCRIPTION
These methods are used by some popular 3rd party SDKs.