### PR TITLE
[RFC] Thoughts on ConnectionPool API

### DIFF
--- a/okhttp/src/main/java/okhttp3/Call.kt
+++ b/okhttp/src/main/java/okhttp3/Call.kt
@@ -87,6 +87,8 @@ interface Call : Cloneable {
    */
   fun timeout(): Timeout
 
+  fun eventListener(): EventListener
+
   /**
    * Create a new, identical call to this one which can be enqueued or executed even if this call
    * has already been.

--- a/okhttp/src/main/java/okhttp3/Connection.kt
+++ b/okhttp/src/main/java/okhttp3/Connection.kt
@@ -89,4 +89,12 @@ interface Connection {
    * [Protocol.HTTP_1_0].
    */
   fun protocol(): Protocol
+
+  val allowsNewExchanges: Boolean
+
+  val isMultiplexed: Boolean
+
+  val routeFailureCount: Int
+
+  val successCount: Int
 }

--- a/okhttp/src/main/java/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/java/okhttp3/ConnectionPool.kt
@@ -48,4 +48,11 @@ class ConnectionPool(
   fun evictAll() {
     delegate.evictAll()
   }
+
+  /** Returns a snapshot of current connections */
+  fun listConnections(): List<Connection> {
+    // TODO should it be wrapped connections
+    // TODO what properties hold e.g. identity, equality
+    return delegate.listConnections()
+  }
 }

--- a/okhttp/src/main/java/okhttp3/RealCall.kt
+++ b/okhttp/src/main/java/okhttp3/RealCall.kt
@@ -197,6 +197,8 @@ internal class RealCall private constructor(
     }
   }
 
+  override fun eventListener(): EventListener = transmitter.eventListener
+
   companion object {
     fun newRealCall(
       client: OkHttpClient,

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -100,9 +100,9 @@ class RealConnection(
    * The number of times there was a problem establishing a stream that could be due to route
    * chosen. Guarded by [connectionPool].
    */
-  internal var routeFailureCount = 0
+  override var routeFailureCount = 0
 
-  internal var successCount = 0
+  override var successCount = 0
   private var refusedStreamCount = 0
 
   /**
@@ -121,7 +121,7 @@ class RealConnection(
    * Returns true if this is an HTTP/2 connection. Such connections can be used in multiple HTTP
    * requests simultaneously.
    */
-  val isMultiplexed: Boolean
+  override val isMultiplexed: Boolean
     get() = http2Connection != null
 
   /** Prevent further exchanges from being created on this connection. */
@@ -131,6 +131,9 @@ class RealConnection(
       noNewExchanges = true
     }
   }
+
+  override val allowsNewExchanges: Boolean
+    get() = !noNewExchanges
 
   fun connect(
     connectTimeout: Int,

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
@@ -247,6 +247,8 @@ class RealConnectionPool(
     routeDatabase.failed(failedRoute)
   }
 
+  @Synchronized fun listConnections(): List<RealConnection> = connections.toList()
+
   companion object {
     /**
      * Background threads are used to cleanup expired connections. There will be at most a single

--- a/okhttp/src/main/java/okhttp3/internal/connection/Transmitter.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Transmitter.kt
@@ -51,7 +51,7 @@ class Transmitter(
   private val call: Call
 ) {
   private val connectionPool: RealConnectionPool = client.connectionPool.delegate
-  private val eventListener: EventListener = client.eventListenerFactory.create(call)
+  val eventListener: EventListener = client.eventListenerFactory.create(call)
   private val timeout = object : AsyncTimeout() {
     override fun timedOut() {
       cancel()

--- a/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
+++ b/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
@@ -22,10 +22,10 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
-import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.ResponseBody.Companion.asResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.internal.http2.Settings
 import okhttp3.internal.proxy.NullProxySelector
 import okhttp3.internal.tls.OkHostnameVerifier
@@ -222,6 +222,14 @@ class KotlinSourceModernTest {
       override fun socket(): Socket = TODO()
       override fun handshake(): Handshake? = TODO()
       override fun protocol(): Protocol = TODO()
+      override val allowsNewExchanges: Boolean
+        get() = TODO()
+      override val isMultiplexed: Boolean
+        get() = TODO()
+      override val routeFailureCount: Int
+        get() = TODO()
+      override val successCount: Int
+        get() = TODO()
     }
   }
 
@@ -1165,6 +1173,7 @@ class KotlinSourceModernTest {
       override fun isCanceled(): Boolean = TODO()
       override fun timeout(): Timeout = TODO()
       override fun clone(): Call = TODO()
+      override fun eventListener(): EventListener = TODO()
     }
   }
 


### PR DESCRIPTION
**This is not an indication of a planned public API, just for discussion.**

https://github.com/square/okhttp/issues/5194

- Want to be able to enumerate the connections with some form of identity (id? or reference?), 
- Actively close or soft close a connection
- Understand network (socket? local ip?)

I'd argue for a midsized app, this is behaviour that should be possible e.g. evaluating whether some ConnectionPool tuning change makes a measurable improvement to request latency via higher connection reuse etc.  n.b. This is implicitly available via events on an EventListener. 