### PR TITLE
OkHttpClientTestRule check connectionCount instead of idle

### DIFF
--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -44,9 +44,11 @@ class OkHttpClientTestRule : TestRule {
   }
 
   fun ensureAllConnectionsReleased() {
-    val connectionPool = prototype!!.connectionPool
-    connectionPool.evictAll()
-    assertThat(connectionPool.connectionCount()).isEqualTo(0)
+    prototype?.let {
+      val connectionPool = it.connectionPool
+      connectionPool.evictAll()
+      assertThat(connectionPool.connectionCount()).isEqualTo(0)
+    }
   }
 
   override fun apply(base: Statement, description: Description): Statement {
@@ -68,9 +70,22 @@ class OkHttpClientTestRule : TestRule {
       }
 
       private fun releaseClient() {
-        prototypes.push(prototype)
-        prototype = null
+        prototype?.let {
+          prototypes.push(it)
+          prototype = null
+        }
       }
+    }
+  }
+
+  /**
+   * Called if a test is known to be leaky.
+   */
+  fun abandonClient(client: OkHttpClient) {
+    if (prototype == client) {
+      prototype = null
+      client.dispatcher.executorService.shutdownNow()
+      client.connectionPool.evictAll()
     }
   }
 

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -46,7 +46,7 @@ class OkHttpClientTestRule : TestRule {
   fun ensureAllConnectionsReleased() {
     val connectionPool = prototype!!.connectionPool
     connectionPool.evictAll()
-    assertThat(connectionPool.idleConnectionCount()).isEqualTo(0)
+    assertThat(connectionPool.connectionCount()).isEqualTo(0)
   }
 
   override fun apply(base: Statement, description: Description): Statement {

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -81,11 +81,11 @@ class OkHttpClientTestRule : TestRule {
   /**
    * Called if a test is known to be leaky.
    */
-  fun abandonClient(client: OkHttpClient) {
-    if (prototype == client) {
+  fun abandonClient() {
+    prototype?.let {
       prototype = null
-      client.dispatcher.executorService.shutdownNow()
-      client.connectionPool.evictAll()
+      it.dispatcher.executorService.shutdownNow()
+      it.connectionPool.evictAll()
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -84,7 +84,7 @@ public final class WebSocketHttpTest {
     clientListener.assertExhausted();
 
     // TODO: assert all connections are released once leaks are fixed
-    clientTestRule.abandonClient(client);
+    clientTestRule.abandonClient();
   }
 
   @Test public void textMessage() {

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -84,6 +84,7 @@ public final class WebSocketHttpTest {
     clientListener.assertExhausted();
 
     // TODO: assert all connections are released once leaks are fixed
+    clientTestRule.abandonClient(client);
   }
 
   @Test public void textMessage() {


### PR DESCRIPTION
Clients should be clean after use, not just from idle connections.