### PR TITLE
Run error-prone on JDK 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ subprojects { project ->
     options.errorprone {
       check("MissingFail", CheckSeverity.ERROR)
       check("MissingOverride", CheckSeverity.ERROR)
-      enabled = JavaVersion.current() < JavaVersion.VERSION_11
+      enabled = JavaVersion.current() < JavaVersion.VERSION_12
     }
   }
 


### PR DESCRIPTION
JDK 12+ is where it currently is unsupported.