### PR TITLE
Avoid using non-null assertion in ConnectionSpec

### DIFF
--- a/okhttp/src/main/java/okhttp3/ConnectionSpec.kt
+++ b/okhttp/src/main/java/okhttp3/ConnectionSpec.kt
@@ -168,13 +168,12 @@ class ConnectionSpec internal constructor(
     if (other !is ConnectionSpec) return false
     if (other === this) return true
 
-    val that = other as ConnectionSpec?
-    if (this.isTls != that!!.isTls) return false
+    if (this.isTls != other.isTls) return false
 
     if (isTls) {
-      if (!Arrays.equals(this.cipherSuitesAsString, that.cipherSuitesAsString)) return false
-      if (!Arrays.equals(this.tlsVersionsAsString, that.tlsVersionsAsString)) return false
-      if (this.supportsTlsExtensions != that.supportsTlsExtensions) return false
+      if (!Arrays.equals(this.cipherSuitesAsString, other.cipherSuitesAsString)) return false
+      if (!Arrays.equals(this.tlsVersionsAsString, other.tlsVersionsAsString)) return false
+      if (this.supportsTlsExtensions != other.supportsTlsExtensions) return false
     }
 
     return true
@@ -183,8 +182,8 @@ class ConnectionSpec internal constructor(
   override fun hashCode(): Int {
     var result = 17
     if (isTls) {
-      result = 31 * result + cipherSuitesAsString!!.contentHashCode()
-      result = 31 * result + tlsVersionsAsString!!.contentHashCode()
+      result = 31 * result + (cipherSuitesAsString?.contentHashCode() ?: 0)
+      result = 31 * result + (tlsVersionsAsString?.contentHashCode() ?: 0)
       result = 31 * result + if (supportsTlsExtensions) 0 else 1
     }
     return result

--- a/okhttp/src/test/java/okhttp3/ConnectionSpecTest.java
+++ b/okhttp/src/test/java/okhttp3/ConnectionSpecTest.java
@@ -284,6 +284,8 @@ public final class ConnectionSpecTest {
     assertThat(set.add(ConnectionSpec.CLEARTEXT)).isTrue();
     assertThat(set.add(allTlsVersions)).isTrue();
     assertThat(set.add(allCipherSuites)).isTrue();
+    allCipherSuites.hashCode();
+    assertThat(allCipherSuites.equals(null)).isFalse();
 
     assertThat(set.remove(ConnectionSpec.MODERN_TLS)).isTrue();
     assertThat(set.remove(ConnectionSpec.COMPATIBLE_TLS)).isTrue();
@@ -291,6 +293,8 @@ public final class ConnectionSpecTest {
     assertThat(set.remove(allTlsVersions)).isTrue();
     assertThat(set.remove(allCipherSuites)).isTrue();
     assertThat(set).isEmpty();
+    allTlsVersions.hashCode();
+    assertThat(allTlsVersions.equals(null)).isFalse();
   }
 
   @Test public void allEnabledToString() throws Exception {


### PR DESCRIPTION
Fix #5280 

To be compatible with OkHttp3, OkHttp4.0 doesn't use non-null assertion.