### PR TITLE
TravisCI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
 
+dist: bionic
+
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
  - ./gradlew check --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 dist: trusty
 
 jdk:
-  - openjdk8
+  - oraclejdk8
 
 script:
  - ./gradlew check --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 dist: trusty
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
  - ./gradlew check --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 
-dist: bionic
+dist: trusty
 
 jdk:
   - openjdk8


### PR DESCRIPTION
Addressing PR failures https://travis-ci.org/square/okhttp/builds/563227932?utm_source=github_status&utm_medium=notification

```
Installing oraclejdk8
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2019-07-17
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```