### PR TITLE
Avoid gradle assemble in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ dist: trusty
 jdk:
   - oraclejdk8
 
+# avoid ./gradlew assemble default which builds docs
+install:
+ - ./gradlew jar --parallel
+
 script:
- - ./gradlew check --parallel
+ - ./gradlew test --parallel
 
 after_success:
   - .buildscript/deploy_snapshot.sh


### PR DESCRIPTION
Two changes

1) Externally - disabled here https://travis-ci.org/square/okhttp/settings
2) Travis config avoids assemble task