### PR TITLE
Allow interrupt of singleton cleanup thread

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
@@ -49,8 +49,7 @@ class RealConnectionPool(
           this@RealConnectionPool.lockAndWaitNanos(waitNanos)
         } catch (ie: InterruptedException) {
           cleanupRunning = false
-          val count = connectionCount()
-          if (count > 0) {
+          if (connectionCount() > 0) {
             Platform.get().log(
                 Platform.WARN,
                 "${Thread.currentThread().name} interrupted without cleanly closing connections",

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
@@ -21,10 +21,10 @@ import okhttp3.ConnectionPool
 import okhttp3.Route
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.connection.Transmitter.TransmitterReference
+import okhttp3.internal.lockAndWaitNanos
 import okhttp3.internal.notifyAll
 import okhttp3.internal.platform.Platform
 import okhttp3.internal.threadFactory
-import okhttp3.internal.lockAndWaitNanos
 import java.io.IOException
 import java.net.Proxy
 import java.util.ArrayDeque
@@ -47,7 +47,16 @@ class RealConnectionPool(
         if (waitNanos == -1L) return
         try {
           this@RealConnectionPool.lockAndWaitNanos(waitNanos)
-        } catch (_: InterruptedException) {
+        } catch (ie: InterruptedException) {
+          cleanupRunning = false
+          val count = connectionCount()
+          if (count > 0) {
+            Platform.get().log(
+                Platform.WARN,
+                "${Thread.currentThread().name} interrupted without cleanly closing connections",
+                ie)
+          }
+          break
         }
       }
     }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
@@ -48,14 +48,8 @@ class RealConnectionPool(
         try {
           this@RealConnectionPool.lockAndWaitNanos(waitNanos)
         } catch (ie: InterruptedException) {
-          cleanupRunning = false
-          if (connectionCount() > 0) {
-            Platform.get().log(
-                Platform.WARN,
-                "${Thread.currentThread().name} interrupted without cleanly closing connections",
-                ie)
-          }
-          break
+          // Will cause the thread to exit unless other connections are created!
+          evictAll()
         }
       }
     }

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
@@ -185,6 +185,8 @@ public final class ConnectionPoolTest {
 
     assertThat(pool.getCleanupRunning()).isTrue();
 
+    Thread.sleep(100);
+
     Thread[] threads = new Thread[Thread.activeCount() * 2];
     Thread.enumerate(threads);
     for (Thread t: threads) {

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
@@ -191,7 +191,6 @@ public final class ConnectionPoolTest {
     Thread.enumerate(threads);
     for (Thread t: threads) {
       if (t != null && t.getName().equals("OkHttp ConnectionPool")) {
-        System.out.println("Interrupting " + t.getId());
         t.interrupt();
       }
     }

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
@@ -179,6 +179,25 @@ public final class ConnectionPoolTest {
     assertThat(c1.getNoNewExchanges()).isTrue();
   }
 
+  @Test public void interruptStopsThread() throws Exception {
+    RealConnectionPool pool = new RealConnectionPool(2, 100L, TimeUnit.NANOSECONDS);
+    RealConnection c1 = newConnection(pool, routeA1, Long.MAX_VALUE);
+
+    assertThat(pool.getCleanupRunning()).isTrue();
+
+    Thread[] threads = new Thread[Thread.activeCount() * 2];
+    Thread.enumerate(threads);
+    for (Thread t: threads) {
+      if (t != null && t.getName().equals("OkHttp ConnectionPool")) {
+        t.interrupt();
+      }
+    }
+
+    Thread.sleep(100);
+
+    assertThat(pool.getCleanupRunning()).isFalse();
+  }
+
   /** Use a helper method so there's no hidden reference remaining on the stack. */
   private void allocateAndLeakAllocation(ConnectionPool pool, RealConnection connection) {
     synchronized (RealConnectionPool.Companion.get(pool)) {

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
@@ -189,6 +189,7 @@ public final class ConnectionPoolTest {
     Thread.enumerate(threads);
     for (Thread t: threads) {
       if (t != null && t.getName().equals("OkHttp ConnectionPool")) {
+        System.out.println("Interrupting " + t.getId());
         t.interrupt();
       }
     }


### PR DESCRIPTION
If container aggressively interrupts the RealConnectionPool cleanup thread, then take notice to avoid waiting 60 seconds for daemon thread to cleanup normally.  However leave things in a sane state, so next connection established will restart it, and OkHttp will noisily log if this is done improperly without closing connections.

Related to https://github.com/square/okhttp/issues/3957 and Maven which violently interrupts daemon threads and noisily complains if they swallow interrupt exceptions.

TODO add tests if there is loose agreement this is correct logic. 