### PR TITLE
Conscrypt 2.2.1 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
       'bouncycastle': '1.62',
       'brotli': '0.1.2',
       'checkstyle': '8.15',
-      'conscrypt': '2.1.0',
+      'conscrypt': '2.2.1',
       'findbugs': '3.0.2',
       'guava': '27.0.1-jre',
       'java': '1.8',


### PR DESCRIPTION
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/conscrypt/05b7227B9to/QxWewCTMCgAJ

> We're pleased to announce that we've released Conscrypt 2.2.1.  This release includes the following notable changes:
> 
> == AES-GCM-SIV ==
> 
> We've added support for the AES-GCM-SIV AEAD construction, a nonce-misuse resistant AEAD, under the identifier AES/GCM-SIV/NoPadding.  For more information on what it is and when you might want to use it, we recommend you read Adam Langley's discussion at https://www.imperialviolet.org/2017/05/14/aesgcmsiv.html.
> 
> == Other Changes ==
> 
> * Added an implementation of available() for SSLSocket's InputStream and fixed the existing implementation in the engine-based socket
> * Improved compatibility with Android Keystore keys
> * Fixed some issues in the SSLEngine implementation where API methods weren't implemented as documented