### PR TITLE
Add TrustManager accessor to OkHttpClient.

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.kt
@@ -177,6 +177,8 @@ open class OkHttpClient internal constructor(
   @get:JvmName("sslSocketFactory") val sslSocketFactory: SSLSocketFactory
     get() = sslSocketFactoryOrNull ?: throw IllegalStateException("CLEARTEXT-only client")
 
+  @get:JvmName("x509TrustManager") val x509TrustManager: X509TrustManager?
+
   @get:JvmName("connectionSpecs") val connectionSpecs: List<ConnectionSpec> =
       builder.connectionSpecs
 
@@ -212,11 +214,12 @@ open class OkHttpClient internal constructor(
     if (builder.sslSocketFactoryOrNull != null || connectionSpecs.none { it.isTls }) {
       this.sslSocketFactoryOrNull = builder.sslSocketFactoryOrNull
       this.certificateChainCleaner = builder.certificateChainCleaner
+      this.x509TrustManager = builder.x509TrustManagerOrNull
     } else {
-      val trustManager = Platform.get().platformTrustManager()
-      Platform.get().configureTrustManager(trustManager)
-      this.sslSocketFactoryOrNull = newSslSocketFactory(trustManager)
-      this.certificateChainCleaner = CertificateChainCleaner.get(trustManager)
+      this.x509TrustManager = Platform.get().platformTrustManager()
+      Platform.get().configureTrustManager(x509TrustManager)
+      this.sslSocketFactoryOrNull = newSslSocketFactory(x509TrustManager!!)
+      this.certificateChainCleaner = CertificateChainCleaner.get(x509TrustManager!!)
     }
 
     if (sslSocketFactoryOrNull != null) {
@@ -448,6 +451,7 @@ open class OkHttpClient internal constructor(
     internal var proxyAuthenticator: Authenticator = Authenticator.NONE
     internal var socketFactory: SocketFactory = SocketFactory.getDefault()
     internal var sslSocketFactoryOrNull: SSLSocketFactory? = null
+    internal var x509TrustManagerOrNull: X509TrustManager? = null
     internal var connectionSpecs: List<ConnectionSpec> = DEFAULT_CONNECTION_SPECS
     internal var protocols: List<Protocol> = DEFAULT_PROTOCOLS
     internal var hostnameVerifier: HostnameVerifier = OkHostnameVerifier
@@ -477,6 +481,7 @@ open class OkHttpClient internal constructor(
       this.proxyAuthenticator = okHttpClient.proxyAuthenticator
       this.socketFactory = okHttpClient.socketFactory
       this.sslSocketFactoryOrNull = okHttpClient.sslSocketFactoryOrNull
+      this.x509TrustManagerOrNull = okHttpClient.x509TrustManager
       this.connectionSpecs = okHttpClient.connectionSpecs
       this.protocols = okHttpClient.protocols
       this.hostnameVerifier = okHttpClient.hostnameVerifier
@@ -721,6 +726,7 @@ open class OkHttpClient internal constructor(
     ) = apply {
       this.sslSocketFactoryOrNull = sslSocketFactory
       this.certificateChainCleaner = CertificateChainCleaner.get(trustManager)
+      this.x509TrustManagerOrNull = trustManager
     }
 
     fun connectionSpecs(connectionSpecs: List<ConnectionSpec>) = apply {

--- a/okhttp/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp/src/test/java/okhttp3/OkHttpClientTest.java
@@ -119,12 +119,14 @@ public final class OkHttpClientTest {
     assertThat(a.dispatcher()).isNotNull();
     assertThat(a.connectionPool()).isNotNull();
     assertThat(a.sslSocketFactory()).isNotNull();
+    assertThat(a.x509TrustManager()).isNotNull();
 
     // Multiple clients share the instances.
     OkHttpClient b = client.newBuilder().build();
     assertThat(b.dispatcher()).isSameAs(a.dispatcher());
     assertThat(b.connectionPool()).isSameAs(a.connectionPool());
     assertThat(b.sslSocketFactory()).isSameAs(a.sslSocketFactory());
+    assertThat(b.x509TrustManager()).isSameAs(a.x509TrustManager());
   }
 
   @Test public void setProtocolsRejectsHttp10() throws Exception {


### PR DESCRIPTION
We are able to access the SSLSocketFactory from the OkHttpClient but not the TrustManager used. Since there is no way to recover the used trust manager from the socket factory, we are adding explicit accessors.