### PR TITLE
Test for OpenJSSE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,8 +200,7 @@ workflows:
       - testjdk8:
           filters:
             branches:
-              ignore:
-                - gh-pages
+              only: master
       - testjdk8alpn:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,8 @@ workflows:
       - testjdk8:
           filters:
             branches:
-              only: master
+              ignore:
+                - gh-pages
       - testjdk8alpn:
           filters:
             branches:

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,8 @@ buildscript {
       'moshi': '1.8.0',
       'okio': '2.2.2',
       'ktlint': '0.31.0',
-      'picocli': '4.0.1'
+      'picocli': '4.0.1',
+      'openjsse': '1.1.0'
   ]
 
   ext.deps = [
@@ -37,7 +38,8 @@ buildscript {
       'junit': "junit:junit:${versions.junit}",
       'kotlinStdlib': "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
       'moshi': "com.squareup.moshi:moshi:${versions.moshi}",
-      'okio': "com.squareup.okio:okio:${versions.okio}"
+      'okio': "com.squareup.okio:okio:${versions.okio}",
+      'openjsse': "org.openjsse:openjsse:${versions.openjsse}"
   ]
 
   dependencies {

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   testImplementation deps.conscrypt
   testImplementation deps.junit
   testImplementation deps.assertj
+  testImplementation deps.openjsse
   testCompileOnly deps.jsr305
 }
 

--- a/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
@@ -32,7 +32,7 @@ class OpenJSSETest {
   }
 
   @Test
-  fun testX() {
+  fun testTlsv13Works() {
     enableTls()
 
     server.enqueue(MockResponse().setBody("abc"))
@@ -49,6 +49,7 @@ class OpenJSSETest {
 
   private fun enableTls() {
     // Generate a self-signed cert for the server to serve and the client to trust.
+    // can't use localhost with a non OpenJSSE trust manager
     val heldCertificate = HeldCertificate.Builder()
         .commonName("localhost")
         .addSubjectAlternativeName(InetAddress.getByName("localhost").canonicalHostName)

--- a/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
@@ -21,6 +21,7 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -65,6 +66,8 @@ class OpenJSSETest {
       assertEquals(200, response.code)
       assertEquals(TlsVersion.TLS_1_3, response.handshake?.tlsVersion)
       assertEquals(Protocol.HTTP_1_1, response.protocol)
+
+      assertThat(response.exchange?.connection()?.socket()).isInstanceOf(SSLSocketImpl::class.java)
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
@@ -7,6 +7,7 @@ import okhttp3.tls.HeldCertificate
 import okhttp3.tls.internal.TlsUtil.localhost
 import org.junit.After
 import org.junit.Assert
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,7 +42,8 @@ class OpenJSSETest {
     val response = client.newCall(request).execute()
 
     response.use {
-      Assert.assertEquals(200, response.code)
+      assertEquals(200, response.code)
+      assertEquals(TlsVersion.TLS_1_3, response.handshake?.tlsVersion)
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
@@ -4,10 +4,8 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
-import okhttp3.tls.internal.TlsUtil.localhost
 import org.junit.After
-import org.junit.Assert
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okhttp3
 
 import okhttp3.mockwebserver.MockResponse

--- a/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
@@ -18,6 +18,7 @@ package okhttp3
 import okhttp3.Protocol.HTTP_2
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.testing.PlatformRule
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
 import org.junit.After
@@ -32,12 +33,15 @@ import java.net.InetAddress
 import java.security.Security
 
 class OpenJSSETest {
+  @JvmField @Rule var platform = PlatformRule()
   @JvmField @Rule val clientTestRule = OkHttpClientTestRule()
   @JvmField @Rule val server = MockWebServer()
   lateinit var client: OkHttpClient
 
   @Before
   fun setUp() {
+    platform.assumeJdk8()
+
     Security.insertProviderAt(OpenJSSE(), 1)
     client = clientTestRule.newClient()
   }

--- a/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
@@ -1,0 +1,65 @@
+package okhttp3
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import okhttp3.tls.internal.TlsUtil.localhost
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.openjsse.net.ssl.OpenJSSE
+import java.net.InetAddress
+import java.security.Security
+
+class OpenJSSETest {
+  @JvmField @Rule val clientTestRule = OkHttpClientTestRule()
+  @JvmField @Rule val server = MockWebServer()
+  lateinit var client: OkHttpClient
+
+  @Before
+  fun setUp() {
+    Security.insertProviderAt(OpenJSSE(), 1)
+    client = clientTestRule.newClient()
+  }
+
+  @After
+  fun cleanup() {
+    Security.removeProvider("OpenJSSE")
+  }
+
+  @Test
+  fun testX() {
+    enableTls()
+
+    server.enqueue(MockResponse().setBody("abc"))
+
+    val request = Request.Builder().url(server.url("/")).build()
+
+    val response = client.newCall(request).execute()
+
+    response.use {
+      Assert.assertEquals(200, response.code)
+    }
+  }
+
+  private fun enableTls() {
+    // Generate a self-signed cert for the server to serve and the client to trust.
+    val heldCertificate = HeldCertificate.Builder()
+        .commonName("localhost")
+        .addSubjectAlternativeName(InetAddress.getByName("localhost").canonicalHostName)
+        .build()
+    val handshakeCertificates = HandshakeCertificates.Builder()
+        .heldCertificate(heldCertificate)
+        .addTrustedCertificate(heldCertificate.certificate)
+        .build()
+
+    client = client.newBuilder()
+        .sslSocketFactory(
+            handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager)
+        .build()
+    server.useHttps(handshakeCertificates.sslSocketFactory(), false)
+  }
+}


### PR DESCRIPTION
https://github.com/openjsse/openjsse from Azul

TLSv1.3 on JDK 8

At the moment, no code changes or custom support enabling HTTP/2, only a test that it works in JDK8.