### PR TITLE
Remove the application plugin from okcurl

### DIFF
--- a/okcurl/build.gradle
+++ b/okcurl/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-  id "application"
-}
-
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 
@@ -10,10 +6,6 @@ jar {
     attributes 'Automatic-Module-Name': 'okhttp3.curl'
     attributes 'Main-Class': 'okhttp3.curl.Main'
   }
-}
-
-application {
-  mainClassName = "okhttp3.curl.Main"
 }
 
 // resources-templates.


### PR DESCRIPTION
I can't have both this and shadow concurrently because they both attempt
to use the same classifier when publishing.