### PR TITLE
Update the libraries that work with OkHttp

### DIFF
--- a/docs/works_with_okhttp.md
+++ b/docs/works_with_okhttp.md
@@ -4,9 +4,10 @@ Works with OkHttp
 Here’s some libraries that work nicely with OkHttp.
 
  * [Chucker](https://github.com/ChuckerTeam/chucker): An in-app HTTP inspector for Android OkHttp clients.
- * [Coil](https://github.com/colinrtwhite/coil): An image loading library for Android backed by Kotlin Coroutines.
+ * [Coil](https://github.com/coil-kt/coil): An image loading library for Android backed by Kotlin Coroutines.
  * [Communicator](https://github.com/Taig/Communicator): An OkHttp wrapper for Scala built with Android in mind.
  * [CWAC-NetSecurity](https://github.com/commonsguy/cwac-netsecurity): Simplifying Secure Internet Access.
+ * [Flipper](https://fbflipper.com/): A desktop debugging platform for mobile developers.
  * [Fresco](https://github.com/facebook/fresco): An Android library for managing images and the memory they use.
  * [Glide](https://github.com/bumptech/glide): An image loading and caching library for Android focused on smooth scrolling.
  * [GoogleAppEngineOkHttp](https://github.com/apkelly/GoogleAppEngineOkHttp): An OkHttp Call that works on Google App Engine.

--- a/docs/works_with_okhttp.md
+++ b/docs/works_with_okhttp.md
@@ -3,14 +3,14 @@ Works with OkHttp
 
 Here’s some libraries that work nicely with OkHttp.
 
- * [Chuck](https://github.com/jgilfelt/chuck): An in-app HTTP inspector for Android OkHttp clients.
+ * [Chucker](https://github.com/ChuckerTeam/chucker): An in-app HTTP inspector for Android OkHttp clients.
+ * [Coil](https://github.com/colinrtwhite/coil): An image loading library for Android backed by Kotlin Coroutines.
  * [Communicator](https://github.com/Taig/Communicator): An OkHttp wrapper for Scala built with Android in mind.
  * [CWAC-NetSecurity](https://github.com/commonsguy/cwac-netsecurity): Simplifying Secure Internet Access.
  * [Fresco](https://github.com/facebook/fresco): An Android library for managing images and the memory they use.
  * [Glide](https://github.com/bumptech/glide): An image loading and caching library for Android focused on smooth scrolling.
  * [GoogleAppEngineOkHttp](https://github.com/apkelly/GoogleAppEngineOkHttp): An OkHttp Call that works on Google App Engine.
  * [Hunter](https://github.com/Leaking/Hunter): Configure all OkHttpClients centrally.
- * [ModernHttpClient](https://github.com/paulcbetts/ModernHttpClient): Xamarin HTTP API that uses native implementations.
  * ⬜️ [Moshi](https://github.com/square/moshi): A modern JSON library for Android and Java.
  * [Ok2Curl](https://github.com/mrmike/Ok2Curl): Convert OkHttp requests into curl logs.
  * [OkHttp AWS Signer](https://github.com/babbel/okhttp-aws-signer): AWS V4 signing algorithm for OkHttp requests
@@ -22,15 +22,12 @@ Here’s some libraries that work nicely with OkHttp.
  * [okhttp-signpost](https://github.com/pakerfeldt/okhttp-signpost): OAuth signing with signpost and OkHttp.
  * [okhttp-staleiferror-interceptor](https://github.com/PeelTechnologies/okhttp-staleiferror-interceptor/): serve stale responses when the server isn’t reachable.
  * [okhttp-stats](https://github.com/flipkart-incubator/okhttp-stats): Get stats like average network speed.
- * [OkHttp-Xamarin](https://github.com/paulcbetts/OkHttp-Xamarin): Xamarin bindings for OkHttp.
  * ⬜️ [Okio](https://github.com/square/okio/): A modern I/O API for Java.
  * [OkLog](https://github.com/simonpercic/OkLog): Response logging interceptor for OkHttp. Logs a URL link with URL-encoded response for every OkHttp call.
  * [Okurl](https://github.com/yschimke/okurl/wiki) A curl-like client for social networks and other APIs.
  * [PersistentCookieJar](https://github.com/franmontiel/PersistentCookieJar): A persistent `CookieJar`.
  * ⬜️ [Picasso](https://github.com/square/picasso): A powerful image downloading and caching library for Android.
  * ⬜️ [Retrofit](https://github.com/square/retrofit): Type-safe HTTP client for Android and Java by Square.
- * [Smash](https://github.com/appformation/smash): A Volley-inspired networking library.
  * [Stetho](https://github.com/facebook/stetho): Stetho is a debug bridge for Android applications.
  * [Thrifty](https://github.com/Microsoft/thrifty): An implementation of Apache Thrift for Android.
- * [Volley-OkHttp-Android](https://github.com/lxdvs/Volley-OkHttp-Android): A fork of Volley with changes to work with OkHttp.
  * ⬜️ [Wire](https://github.com/square/wire): Clean, lightweight protocol buffers for Android and Java.


### PR DESCRIPTION
This prunes a few that haven't been updated and appear obsolete.