### PR TITLE
Support lambda construction for Logger

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -116,6 +116,21 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
           Platform.get().log(INFO, message, null)
         }
       }
+
+      /**
+       * Constructs an logger for a lambda. This compact syntax is most useful for inline
+       * loggers.
+       *
+       * ```
+       * val logger = Logger { message: String ->
+       *     //custom logging
+       * }
+       * ```
+       */
+      inline operator fun invoke(crossinline block: (message: String) -> Unit): Logger =
+              object : Logger {
+                override fun log(message: String) = block(message)
+              }
     }
   }
 


### PR DESCRIPTION
Support lambda construction for Logger the same way as [Interceptor](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/Interceptor.kt) does, to write
```
val interceptor = HttpLoggingInterceptor(Logger {
    message -> Timber.tag("OkHttp").d(message)
})
```
instead of:
```
val interceptor = HttpLoggingInterceptor(object : Logger {
  override fun log(message: String) {
    Timber.tag("OkHttp").d(message)
  }
})
```