### PR TITLE
Expose SSLContext in public API

### DIFF
--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -22,6 +22,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.net.InetAddress
 import java.util.concurrent.ConcurrentLinkedDeque
+import javax.net.ssl.SSLSessionContext
 
 /** Apply this rule to tests that need an OkHttpClient instance. */
 class OkHttpClientTestRule : TestRule {
@@ -81,6 +82,11 @@ class OkHttpClientTestRule : TestRule {
 
       private fun releaseClient() {
         prototype?.let {
+          it.sslSessionContext?.let { sslSessionContext: SSLSessionContext ->
+            for (session in sslSessionContext.ids) {
+              sslSessionContext.getSession(session).invalidate()
+            }
+          }
           prototypes.push(it)
           prototype = null
         }

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -82,14 +82,20 @@ class OkHttpClientTestRule : TestRule {
 
       private fun releaseClient() {
         prototype?.let {
-          it.sslSessionContext?.let { sslSessionContext: SSLSessionContext ->
-            for (session in sslSessionContext.ids) {
-              sslSessionContext.getSession(session).invalidate()
-            }
-          }
+          it.sslSessionContext.releaseSslSessions()
           prototypes.push(it)
           prototype = null
         }
+      }
+    }
+  }
+
+  private fun SSLSessionContext.releaseSslSessions() {
+    for (session in ids) {
+      try {
+        getSession(session).invalidate()
+      } catch (_: UnsupportedOperationException) {
+        // unavoidable https://github.com/google/conscrypt/issues/708
       }
     }
   }

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -82,7 +82,7 @@ class OkHttpClientTestRule : TestRule {
 
       private fun releaseClient() {
         prototype?.let {
-          it.sslSessionContext.releaseSslSessions()
+          it.sslContext.clientSessionContext.releaseSslSessions()
           prototypes.push(it)
           prototype = null
         }

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.kt
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit
 import javax.net.SocketFactory
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLContext
-import javax.net.ssl.SSLSessionContext
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.kt
@@ -180,7 +180,10 @@ open class OkHttpClient internal constructor(
 
   @get:JvmName("x509TrustManager") val x509TrustManager: X509TrustManager?
 
-  @get:JvmName("sslSessionContext") val sslSessionContext: SSLSessionContext?
+  private val sslSessionContextOrNull: SSLSessionContext?
+
+  @get:JvmName("sslSessionContext") val sslSessionContext: SSLSessionContext
+    get() = sslSessionContextOrNull ?: throw IllegalStateException("CLEARTEXT-only client")
 
   @get:JvmName("connectionSpecs") val connectionSpecs: List<ConnectionSpec> =
       builder.connectionSpecs
@@ -218,13 +221,13 @@ open class OkHttpClient internal constructor(
       this.sslSocketFactoryOrNull = builder.sslSocketFactoryOrNull
       this.certificateChainCleaner = builder.certificateChainCleaner
       this.x509TrustManager = builder.x509TrustManagerOrNull
-      this.sslSessionContext = builder.sslSessionContextOrNull
+      this.sslSessionContextOrNull = builder.sslSessionContextOrNull
     } else {
       this.x509TrustManager = Platform.get().platformTrustManager()
       Platform.get().configureTrustManager(x509TrustManager)
       val (newSSLSessionContext, newSslSocketFactory) = newSslSocketFactory(x509TrustManager!!)
       this.sslSocketFactoryOrNull = newSslSocketFactory
-      this.sslSessionContext = newSSLSessionContext
+      this.sslSessionContextOrNull = newSSLSessionContext
       this.certificateChainCleaner = CertificateChainCleaner.get(x509TrustManager!!)
     }
 

--- a/okhttp/src/test/java/okhttp3/ConscryptTest.kt
+++ b/okhttp/src/test/java/okhttp3/ConscryptTest.kt
@@ -19,6 +19,7 @@ import okhttp3.TestUtil.assumeNetwork
 import okhttp3.internal.platform.ConscryptPlatform
 import okhttp3.internal.platform.Platform
 import okhttp3.testing.PlatformRule
+import okio.ByteString.Companion.toByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.conscrypt.Conscrypt
 import org.junit.Assert.assertFalse
@@ -61,11 +62,11 @@ class ConscryptTest {
   }
 
   @Test
-  @Ignore
+//  @Ignore
   fun testGoogle() {
     assumeNetwork()
 
-    val request = Request.Builder().url("https://google.com/robots.txt").build()
+    val request = Request.Builder().url("https://www.google.com/robots.txt").build()
 
     client.newCall(request).execute().use {
       assertThat(it.protocol).isEqualTo(Protocol.HTTP_2)
@@ -73,6 +74,13 @@ class ConscryptTest {
         System.err.println("Flaky TLSv1.3 with google")
 //    assertThat(it.handshake()!!.tlsVersion).isEqualTo(TlsVersion.TLS_1_3)
       }
+    }
+
+    val sslSessionContext = client.sslSessionContext
+    for (id in sslSessionContext.ids) {
+      val session = sslSessionContext.getSession(id)
+      println(
+          "${session.javaClass.simpleName} ${session.peerHost} ${session.creationTime} ${session.isValid} ${session.id.toByteString().hex()}")
     }
   }
 
@@ -90,7 +98,8 @@ class ConscryptTest {
     assertTrue(ConscryptPlatform.atLeastVersion(version.major()))
     assertTrue(ConscryptPlatform.atLeastVersion(version.major(), version.minor()))
     assertTrue(ConscryptPlatform.atLeastVersion(version.major(), version.minor(), version.patch()))
-    assertFalse(ConscryptPlatform.atLeastVersion(version.major(), version.minor(), version.patch() + 1))
+    assertFalse(
+        ConscryptPlatform.atLeastVersion(version.major(), version.minor(), version.patch() + 1))
     assertFalse(ConscryptPlatform.atLeastVersion(version.major(), version.minor() + 1))
     assertFalse(ConscryptPlatform.atLeastVersion(version.major() + 1))
   }

--- a/okhttp/src/test/java/okhttp3/ConscryptTest.kt
+++ b/okhttp/src/test/java/okhttp3/ConscryptTest.kt
@@ -62,7 +62,7 @@ class ConscryptTest {
   }
 
   @Test
-//  @Ignore
+  @Ignore
   fun testGoogle() {
     assumeNetwork()
 
@@ -76,7 +76,8 @@ class ConscryptTest {
       }
     }
 
-    val sslSessionContext = client.sslSessionContext
+    // Print out useful debugging of SSL session tickets
+    val sslSessionContext = client.sslContext.clientSessionContext
     for (id in sslSessionContext.ids) {
       val session = sslSessionContext.getSession(id)
       println(


### PR DESCRIPTION
Expose the SSLContext since it is created internally by Platform with non-trivial rules e.g. Conscrypt installed and available.

Open Question: 

1. Should it be internal, or exposed as public API?
2. Should we focus on a common API instead for performance aware users e.g. session resumption rates, connection pool stats etc.

n.b. I'd like to allow okhttp users to understand whether features like session resumption is working and tuned correctly with their servers.