### PR TITLE
Update README.md to match example code for POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ public static final MediaType JSON
 OkHttpClient client = new OkHttpClient();
 
 String post(String url, String json) throws IOException {
-  RequestBody body = RequestBody.create(JSON, json);
+  RequestBody body = RequestBody.create(json, JSON);
   Request request = new Request.Builder()
       .url(url)
       .post(body)


### PR DESCRIPTION
The "Post to a Server" section in the README is using the deprecated
method for creating a new `RequestBody`. This commit uses the
recommended method for the README, but also now matches the example in
`PostExample.java`