### PR TITLE
Don't crash looking up an absent class on Android 4.x

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.java
@@ -167,6 +167,11 @@ class AndroidPlatform extends Platform {
   }
 
   @Override public boolean isCleartextTrafficPermitted(String hostname) {
+    // Don't look for NetworkSecurityPolicy on older devices; that might crash them.
+    // https://github.com/square/okhttp/issues/3772#issuecomment-527711999
+    if (Build.VERSION.SDK_INT < 23) {
+      return super.isCleartextTrafficPermitted(hostname);
+    }
     try {
       Class<?> networkPolicyClass = Class.forName("android.security.NetworkSecurityPolicy");
       Method getInstanceMethod = networkPolicyClass.getMethod("getInstance");


### PR DESCRIPTION
Some Android 4.2.2 devices don't like the try/catch block
so avoid it.

https://github.com/square/okhttp/issues/3772