### PR TITLE
Fix a regression in combining cache headers

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/cache/CacheInterceptor.kt
@@ -213,7 +213,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
     private fun combine(cachedHeaders: Headers, networkHeaders: Headers): Headers {
       val result = Headers.Builder()
 
-      for (index in cachedHeaders.names().indices) {
+      for (index in 0 until cachedHeaders.size) {
         val fieldName = cachedHeaders.name(index)
         val value = cachedHeaders.value(index)
         if ("Warning".equals(fieldName, ignoreCase = true) && value.startsWith("1")) {
@@ -227,7 +227,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
         }
       }
 
-      for (index in networkHeaders.names().indices) {
+      for (index in 0 until networkHeaders.size) {
         val fieldName = networkHeaders.name(index)
         if (!isContentSpecificHeader(fieldName) && isEndToEnd(fieldName)) {
           result.addLenient(fieldName, networkHeaders.value(index))

--- a/okhttp/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp/src/test/java/okhttp3/CacheTest.java
@@ -2456,6 +2456,34 @@ public final class CacheTest {
     assertThat(server.takeRequest().getHeader("If-None-Match")).isEqualTo("α");
   }
 
+  @Test public void conditionalHitHeadersCombined() throws Exception {
+    server.enqueue(new MockResponse()
+        .addHeader("Etag", "a")
+        .addHeader("Cache-Control: max-age=0")
+        .addHeader("A: a1")
+        .addHeader("B: b2")
+        .addHeader("B: b3")
+        .setBody("abcd"));
+    server.enqueue(new MockResponse()
+        .setResponseCode(HttpURLConnection.HTTP_NOT_MODIFIED)
+        .addHeader("B: b4")
+        .addHeader("B: b5")
+        .addHeader("C: c6"));
+
+    Response response1 = get(server.url("/"));
+    assertThat(response1.body().string()).isEqualTo("abcd");
+    assertThat(response1.headers()).isEqualTo(Headers.of("Etag", "a", "Cache-Control", "max-age=0",
+        "A", "a1", "B", "b2", "B", "b3", "Content-Length", "4"));
+
+    // The original 'A' header is retained because the network response doesn't have one.
+    // The original 'B' headers are replaced by the network response.
+    // The network's 'C' header is added.
+    Response response2 = get(server.url("/"));
+    assertThat(response2.body().string()).isEqualTo("abcd");
+    assertThat(response2.headers()).isEqualTo(Headers.of("Etag", "a", "Cache-Control", "max-age=0",
+        "A", "a1", "Content-Length", "4", "B", "b4", "B", "b5", "C", "c6"));
+  }
+
   private Response get(HttpUrl url) throws IOException {
     Request request = new Request.Builder()
         .url(url)


### PR DESCRIPTION
This was introduced with our migration to Kotlin. Iterating over the indices
of the header names doesn't work because header names are not distinct.

Closes: https://github.com/square/okhttp/issues/5413