### PR TITLE
HttpLoggingInterceptor: respect RequestBody.isOneShot()

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -191,6 +191,8 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
         logger.log("--> END ${request.method} (encoded body omitted)")
       } else if (requestBody.isDuplex()) {
         logger.log("--> END ${request.method} (duplex request body omitted)")
+      } else if (requestBody.isOneShot()) {
+        logger.log("--> END ${request.method} (one-shot body omitted)")
       } else {
         val buffer = Buffer()
         requestBody.writeTo(buffer)

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -875,6 +875,53 @@ public final class HttpLoggingInterceptorTest {
         .assertNoMoreLogs();
   }
 
+
+
+  @Test public void oneShotRequestsAreNotLogged() throws Exception {
+    url = server.url("/");
+
+    setLevel(Level.BODY);
+
+    server.enqueue(new MockResponse()
+                           .setBody("Hello response!"));
+
+    RequestBody asyncRequestBody = new RequestBody() {
+      @Override public @Nullable MediaType contentType() {
+        return null;
+      }
+
+      int counter = 0;
+      @Override public void writeTo(BufferedSink sink) throws IOException {
+        counter++;
+        assertThat(counter).isLessThanOrEqualTo(1);
+
+        sink.writeUtf8("Hello request!");
+        sink.close();
+      }
+
+      @Override public boolean isOneShot() {
+        return true;
+      }
+    };
+
+    Request request = request()
+                              .post(asyncRequestBody)
+                              .build();
+    Response response = client.newCall(request).execute();
+
+    assertThat(response.body().string()).isEqualTo("Hello response!");
+
+    applicationLogs
+            .assertLogEqual("--> POST " + url)
+            .assertLogEqual("--> END POST (one-shot body omitted)")
+            .assertLogMatch("<-- 200 OK " + url + " \\(\\d+ms\\)")
+            .assertLogEqual("Content-Length: 15")
+            .assertLogEqual("")
+            .assertLogEqual("Hello response!")
+            .assertLogEqual("<-- END HTTP (15-byte body)")
+            .assertNoMoreLogs();
+  }
+
   private Request.Builder request() {
     return new Request.Builder().url(url);
   }

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.java
@@ -875,8 +875,6 @@ public final class HttpLoggingInterceptorTest {
         .assertNoMoreLogs();
   }
 
-
-
   @Test public void oneShotRequestsAreNotLogged() throws Exception {
     url = server.url("/");
 


### PR DESCRIPTION
Currently, if we have a one-shot request body and try to use the logging interceptor with `Level.BODY`, the `RequestBody.writeTo` method will be called twice. This is broken behaviour.

See #5419 