### PR TITLE
Acknowledge and apply inbound settings atomically (3.14.x branch)

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
@@ -946,7 +946,7 @@ public final class Http2ConnectionTest {
     // fake a settings frame with clear flag set.
     Settings settings2 = new Settings();
     settings2.set(MAX_CONCURRENT_STREAMS, 60000);
-    connection.readerRunnable.settings(true, settings2);
+    connection.readerRunnable.applyAndAckSettings(true, settings2);
 
     synchronized (connection) {
       assertThat(connection.peerSettings.getHeaderTableSize()).isEqualTo(-1);


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/5422

Unfortunately testing this is awkward because it's racy. I did
run a stress test that used to reproduce the problem, and now it
doesn't, so I am satisfied.