### PR TITLE
Acknowledge and apply inbound settings atomically (3.12.x branch)

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
@@ -847,7 +847,7 @@ public final class Http2ConnectionTest {
     // fake a settings frame with clear flag set.
     Settings settings2 = new Settings();
     settings2.set(MAX_CONCURRENT_STREAMS, 60000);
-    connection.readerRunnable.settings(true, settings2);
+    connection.readerRunnable.applyAndAckSettings(true, settings2);
 
     synchronized (connection) {
       assertEquals(-1, connection.peerSettings.getHeaderTableSize());

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.java
@@ -128,7 +128,6 @@ public final class Http2Connection implements Closeable {
   // TODO: MWS will need to guard on this setting before attempting to push.
   final Settings peerSettings = new Settings();
 
-  boolean receivedInitialPeerSettings = false;
   final Socket socket;
   final Http2Writer writer;
 
@@ -701,53 +700,52 @@ public final class Http2Connection implements Closeable {
       }
     }
 
-    @Override public void settings(boolean clearPrevious, Settings newSettings) {
-      long delta = 0;
-      Http2Stream[] streamsToNotify = null;
-      synchronized (Http2Connection.this) {
-        int priorWriteWindowSize = peerSettings.getInitialWindowSize();
-        if (clearPrevious) peerSettings.clear();
-        peerSettings.merge(newSettings);
-        applyAndAckSettings(newSettings);
-        int peerInitialWindowSize = peerSettings.getInitialWindowSize();
-        if (peerInitialWindowSize != -1 && peerInitialWindowSize != priorWriteWindowSize) {
-          delta = peerInitialWindowSize - priorWriteWindowSize;
-          if (!receivedInitialPeerSettings) {
-            receivedInitialPeerSettings = true;
-          }
-          if (!streams.isEmpty()) {
-            streamsToNotify = streams.values().toArray(new Http2Stream[streams.size()]);
-          }
-        }
-        listenerExecutor.execute(new NamedRunnable("OkHttp %s settings", hostname) {
+    @Override public void settings(final boolean clearPrevious, final Settings settings) {
+      try {
+        writerExecutor.execute(new NamedRunnable("OkHttp %s ACK Settings", hostname) {
           @Override public void execute() {
-            listener.onSettings(Http2Connection.this);
+            applyAndAckSettings(clearPrevious, settings);
           }
         });
+      } catch (RejectedExecutionException ignored) {
+        // This connection has been closed.
       }
-      if (streamsToNotify != null && delta != 0) {
+    }
+
+    void applyAndAckSettings(boolean clearPrevious, Settings settings) {
+      long delta = 0;
+      Http2Stream[] streamsToNotify = null;
+      synchronized (writer) {
+        synchronized (Http2Connection.this) {
+          int priorWriteWindowSize = peerSettings.getInitialWindowSize();
+          if (clearPrevious) peerSettings.clear();
+          peerSettings.merge(settings);
+          int peerInitialWindowSize = peerSettings.getInitialWindowSize();
+          if (peerInitialWindowSize != -1 && peerInitialWindowSize != priorWriteWindowSize) {
+            delta = peerInitialWindowSize - priorWriteWindowSize;
+            streamsToNotify = !streams.isEmpty()
+                ? streams.values().toArray(new Http2Stream[streams.size()])
+                : null;
+          }
+        }
+        try {
+          writer.applyAndAckSettings(peerSettings);
+        } catch (IOException e) {
+          failConnection();
+        }
+      }
+      if (streamsToNotify != null) {
         for (Http2Stream stream : streamsToNotify) {
           synchronized (stream) {
             stream.addBytesToWriteWindow(delta);
           }
         }
       }
-    }
-
-    private void applyAndAckSettings(final Settings peerSettings) {
-      try {
-        writerExecutor.execute(new NamedRunnable("OkHttp %s ACK Settings", hostname) {
-          @Override public void execute() {
-            try {
-              writer.applyAndAckSettings(peerSettings);
-            } catch (IOException e) {
-              failConnection();
-            }
-          }
-        });
-      } catch (RejectedExecutionException ignored) {
-        // This connection has been closed.
-      }
+      listenerExecutor.execute(new NamedRunnable("OkHttp %s settings", hostname) {
+        @Override public void execute() {
+          listener.onSettings(Http2Connection.this);
+        }
+      });
     }
 
     @Override public void ackSettings() {


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/5422

Unfortunately testing this is awkward because it's racy. I did
run a stress test that used to reproduce the problem, and now it
doesn't, so I am satisfied.