### PR TITLE
Implement TaskRunner.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -516,10 +516,8 @@ fun Int.toHexString(): String = Integer.toHexString(this)
  */
 @Throws(InterruptedException::class)
 fun Any.lockAndWaitNanos(nanos: Long) {
-  val ms = nanos / 1_000_000L
-  val ns = nanos - (ms * 1_000_000L)
   synchronized(this) {
-    waitMillis(ms, ns.toInt())
+    objectWaitNanos(nanos)
   }
 }
 
@@ -527,13 +525,16 @@ fun Any.lockAndWaitNanos(nanos: Long) {
 inline fun Any.wait() = (this as Object).wait()
 
 /**
- * Lock and wait a duration in milliseconds and nanos.
- * Unlike [java.lang.Object.wait] this interprets 0 as "don't wait" instead of "wait forever".
+ * Wait a duration in nanoseconds. Unlike [java.lang.Object.wait] this interprets 0 as "don't wait"
+ * instead of "wait forever".
  */
+@Throws(InterruptedException::class)
 @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-fun Any.waitMillis(timeout: Long, nanos: Int = 0) {
-  if (timeout > 0L || nanos > 0) {
-    (this as Object).wait(timeout, nanos)
+fun Any.objectWaitNanos(nanos: Long) {
+  val ms = nanos / 1_000_000L
+  val ns = nanos - (ms * 1_000_000L)
+  if (ms > 0L || nanos > 0) {
+    (this as Object).wait(ms, ns.toInt())
   }
 }
 
@@ -565,4 +566,8 @@ fun <T> readFieldOrNull(instance: Any, fieldType: Class<T>, fieldName: String): 
   }
 
   return null
+}
+
+internal fun <E> MutableList<E>.addIfAbsent(element: E) {
+  if (!contains(element)) add(element)
 }

--- a/okhttp/src/main/java/okhttp3/internal/concurrent/TaskQueue.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/TaskQueue.kt
@@ -15,21 +15,44 @@
  */
 package okhttp3.internal.concurrent
 
+import okhttp3.internal.addIfAbsent
+
 /**
  * A set of tasks that are executed in sequential order.
  *
  * Work within queues is not concurrent. This is equivalent to each queue having a dedicated thread
  * for its work; in practice a set of queues may share a set of threads to save resources.
  */
-interface TaskQueue {
+class TaskQueue internal constructor(
+  private val taskRunner: TaskRunner,
+
   /**
    * An application-level object like a connection pool or HTTP call that this queue works on behalf
    * of. This is intended to be useful for testing and debugging only.
    */
   val owner: Any
+) {
+  /** This queue's currently-executing task, or null if none is currently executing. */
+  private var activeTask: Task? = null
 
-  /** Returns a snapshot of tasks currently scheduled for execution. */
+  /** Scheduled tasks ordered by [Task.nextExecuteNanoTime]. */
+  private val futureTasks = mutableListOf<Task>()
+
+  /** Tasks to cancel. Always either [activeTask] or a member of [futureTasks]. */
+  private val cancelTasks = mutableListOf<Task>()
+
+  internal fun isActive(): Boolean {
+    check(Thread.holdsLock(taskRunner))
+
+    return activeTask != null || futureTasks.isNotEmpty()
+  }
+
+  /**
+   * Returns a snapshot of tasks currently scheduled for execution. Does not include the
+   * currently-executing task unless it is also scheduled for future execution.
+   */
   val scheduledTasks: List<Task>
+    get() = synchronized(taskRunner) { futureTasks.toList() }
 
   /**
    * Schedules [task] for execution in [delayNanos]. A task may only have one future execution
@@ -39,12 +62,126 @@ interface TaskQueue {
    * is running when that time is reached, that task is allowed to complete before this task is
    * started. Similarly the task will be delayed if the host lacks compute resources.
    */
-  fun schedule(task: Task, delayNanos: Long = 0L)
+  fun schedule(task: Task, delayNanos: Long) {
+    task.initQueue(this)
+
+    synchronized(taskRunner) {
+      if (scheduleAndDecide(task, delayNanos)) {
+        taskRunner.kickCoordinator(this)
+      }
+    }
+  }
+
+  /** Adds [task] to run in [delayNanos]. Returns true if the coordinator should run. */
+  private fun scheduleAndDecide(task: Task, delayNanos: Long): Boolean {
+    val now = taskRunner.backend.nanoTime()
+    val executeNanoTime = now + delayNanos
+
+    // If the task is already scheduled, take the earlier of the two times.
+    val existingIndex = futureTasks.indexOf(task)
+    if (existingIndex != -1) {
+      if (task.nextExecuteNanoTime <= executeNanoTime) return false // Already scheduled earlier.
+      futureTasks.removeAt(existingIndex) // Already scheduled later: reschedule below!
+    }
+    task.nextExecuteNanoTime = executeNanoTime
+
+    // Insert in chronological order. Always compare deltas because nanoTime() is permitted to wrap.
+    var insertAt = futureTasks.indexOfFirst { it.nextExecuteNanoTime - now > delayNanos }
+    if (insertAt == -1) insertAt = futureTasks.size
+    futureTasks.add(insertAt, task)
+
+    // Run the coordinator if we inserted at the front.
+    return insertAt == 0
+  }
 
   /**
    * Schedules immediate execution of [Task.tryCancel] on all currently-enqueued tasks. These calls
    * will not be made until any currently-executing task has completed. Tasks that return true will
    * be removed from the execution schedule.
    */
-  fun cancelAll()
+  fun cancelAll() {
+    synchronized(taskRunner) {
+      if (cancelAllAndDecide()) {
+        taskRunner.kickCoordinator(this)
+      }
+    }
+  }
+
+  /** Returns true if the coordinator should run. */
+  private fun cancelAllAndDecide(): Boolean {
+    val runningTask = activeTask
+    if (runningTask != null) {
+      cancelTasks.addIfAbsent(runningTask)
+    }
+
+    for (task in futureTasks) {
+      cancelTasks.addIfAbsent(task)
+    }
+
+    // Run the coordinator if tasks were canceled.
+    return cancelTasks.isNotEmpty()
+  }
+
+  /**
+   * Posts the next available task to an executor for immediate execution.
+   *
+   * Returns the delay until the next call to this method, -1L for no further calls, or
+   * [Long.MAX_VALUE] to wait indefinitely.
+   */
+  internal fun executeReadyTask(now: Long): Long {
+    check(Thread.holdsLock(taskRunner))
+
+    if (activeTask != null) return Long.MAX_VALUE // This queue is busy.
+
+    // Find a task to cancel.
+    val cancelTask = cancelTasks.firstOrNull()
+    if (cancelTask != null) {
+      activeTask = cancelTask
+      cancelTasks.removeAt(0)
+      taskRunner.backend.executeTask(cancelTask.cancelRunnable!!)
+      return Long.MAX_VALUE // This queue is busy until the cancel completes.
+    }
+
+    // Check if a task is immediately ready.
+    val runTask = futureTasks.firstOrNull() ?: return -1L
+    val delayNanos = runTask.nextExecuteNanoTime - now
+    if (delayNanos <= 0) {
+      activeTask = runTask
+      futureTasks.removeAt(0)
+      taskRunner.backend.executeTask(runTask.runRunnable!!)
+      return Long.MAX_VALUE // This queue is busy until the run completes.
+    }
+
+    // Wait until the next task is ready.
+    return delayNanos
+  }
+
+  internal fun runCompleted(task: Task, delayNanos: Long) {
+    synchronized(taskRunner) {
+      check(activeTask === task)
+
+      if (delayNanos != -1L) {
+        scheduleAndDecide(task, delayNanos)
+      } else if (!futureTasks.contains(task)) {
+        cancelTasks.remove(task) // We don't need to cancel it because it isn't scheduled.
+      }
+
+      activeTask = null
+      taskRunner.kickCoordinator(this)
+    }
+  }
+
+  internal fun tryCancelCompleted(task: Task, skipExecution: Boolean) {
+    synchronized(taskRunner) {
+      check(activeTask === task)
+
+      if (skipExecution) {
+        futureTasks.remove(task)
+        cancelTasks.remove(task)
+      }
+
+      activeTask = null
+      taskRunner.kickCoordinator(this)
+    }
+  }
 }

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
@@ -1,0 +1,509 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.concurrent
+
+import okhttp3.internal.concurrent.TaskRunnerTest.FakeBackend
+import okhttp3.internal.notify
+import okhttp3.internal.threadFactory
+import okhttp3.internal.wait
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.concurrent.Executor
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+/**
+ * This test uses [FakeBackend] so that everything is sequential and deterministic.
+ *
+ * All tasks are executed synchronously on the test thread. The coordinator does run in a background
+ * thread. Its [FakeBackend.coordinatorNotify] and [FakeBackend.coordinatorWait] calls don't use
+ * wall-clock time to avoid delays.
+ */
+class TaskRunnerTest {
+  private val backend = FakeBackend()
+  private val taskRunner = TaskRunner(backend)
+  private val log = mutableListOf<String>()
+  private val redQueue = taskRunner.newQueue("red")
+  private val blueQueue = taskRunner.newQueue("blue")
+  private val greenQueue = taskRunner.newQueue("green")
+
+  init {
+    backend.taskRunner = taskRunner
+  }
+
+  @Test fun executeDelayed() {
+    redQueue.schedule(object : Task("task", false) {
+      override fun runOnce(): Long {
+        log += "run@${backend.nanoTime()}"
+        return -1L
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).containsExactly()
+
+    backend.advanceUntil(99L)
+    assertThat(log).containsExactly()
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly("run@100")
+
+    backend.assertNoMoreTasks()
+  }
+
+  @Test fun executeRepeated() {
+    redQueue.schedule(object : Task("task", false) {
+      val delays = mutableListOf(50L, 150L, -1L)
+      override fun runOnce(): Long {
+        log += "run@${backend.nanoTime()}"
+        return delays.removeAt(0)
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).containsExactly()
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly("run@100")
+
+    backend.advanceUntil(150L)
+    assertThat(log).containsExactly("run@100", "run@150")
+
+    backend.advanceUntil(299L)
+    assertThat(log).containsExactly("run@100", "run@150")
+
+    backend.advanceUntil(300L)
+    assertThat(log).containsExactly("run@100", "run@150", "run@300")
+
+    backend.assertNoMoreTasks()
+  }
+
+  /** Repeat with a delay of 200 but schedule with a delay of 50. The schedule wins. */
+  @Test fun executeScheduledEarlierReplacesRepeatedLater() {
+    redQueue.schedule(object : Task("task", false) {
+      val schedules = mutableListOf(50L)
+      val delays = mutableListOf(200L, -1L)
+      override fun runOnce(): Long {
+        log += "run@${backend.nanoTime()}"
+        if (schedules.isNotEmpty()) {
+          redQueue.schedule(this, schedules.removeAt(0))
+        }
+        return delays.removeAt(0)
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).isEmpty()
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly("run@100")
+
+    backend.advanceUntil(150L)
+    assertThat(log).containsExactly("run@100", "run@150")
+
+    backend.assertNoMoreTasks()
+  }
+
+  /** Schedule with a delay of 200 but repeat with a delay of 50. The repeat wins. */
+  @Test fun executeRepeatedEarlierReplacesScheduledLater() {
+    redQueue.schedule(object : Task("task", false) {
+      val schedules = mutableListOf(200L)
+      val delays = mutableListOf(50L, -1L)
+      override fun runOnce(): Long {
+        log += "run@${backend.nanoTime()}"
+        if (schedules.isNotEmpty()) {
+          redQueue.schedule(this, schedules.removeAt(0))
+        }
+        return delays.removeAt(0)
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).isEmpty()
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly("run@100")
+
+    backend.advanceUntil(150L)
+    assertThat(log).containsExactly("run@100", "run@150")
+
+    backend.assertNoMoreTasks()
+  }
+
+  @Test fun cancelReturnsTruePreventsNextExecution() {
+    redQueue.schedule(object : Task("task", false) {
+      override fun runOnce(): Long {
+        log += "run@${backend.nanoTime()}"
+        return -1L
+      }
+
+      override fun tryCancel(): Boolean {
+        log += "cancel@${backend.nanoTime()}"
+        return true
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).isEmpty()
+
+    redQueue.cancelAll()
+
+    backend.advanceUntil(99L)
+    assertThat(log).containsExactly("cancel@99")
+
+    backend.assertNoMoreTasks()
+  }
+
+  @Test fun cancelReturnsFalseDoesNotCancel() {
+    redQueue.schedule(object : Task("task", false) {
+      override fun runOnce(): Long {
+        log += "run@${backend.nanoTime()}"
+        return -1L
+      }
+
+      override fun tryCancel(): Boolean {
+        log += "cancel@${backend.nanoTime()}"
+        return false
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).isEmpty()
+
+    redQueue.cancelAll()
+
+    backend.advanceUntil(99L)
+    assertThat(log).containsExactly("cancel@99")
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly("cancel@99", "run@100")
+
+    backend.assertNoMoreTasks()
+  }
+
+  @Test fun cancelWhileExecutingPreventsRepeat() {
+    redQueue.schedule(object : Task("task", false) {
+      override fun runOnce(): Long {
+        log += "run@${backend.nanoTime()}"
+        redQueue.cancelAll()
+        return 100L
+      }
+
+      override fun tryCancel(): Boolean {
+        log += "cancel@${backend.nanoTime()}"
+        return true
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).isEmpty()
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly("run@100", "cancel@100")
+
+    backend.assertNoMoreTasks()
+  }
+
+  @Test fun cancelWhileExecutingDoesNothingIfTaskDoesNotRepeat() {
+    redQueue.schedule(object : Task("task", false) {
+      override fun runOnce(): Long {
+        log += "run@${backend.nanoTime()}"
+        redQueue.cancelAll()
+        return -1L
+      }
+
+      override fun tryCancel(): Boolean {
+        log += "cancel@${backend.nanoTime()}"
+        return true
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).isEmpty()
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly("run@100")
+
+    backend.assertNoMoreTasks()
+  }
+
+  /** Inspect how many runnables have been enqueued. If none then we're truly sequential. */
+  @Test fun singleQueueIsSerial() {
+    redQueue.schedule(object : Task("task one", false) {
+      override fun runOnce(): Long {
+        log += "one:run@${backend.nanoTime()} tasksSize=${backend.tasksSize}"
+        return -1L
+      }
+    }, 100L)
+
+    redQueue.schedule(object : Task("task two", false) {
+      override fun runOnce(): Long {
+        log += "two:run@${backend.nanoTime()} tasksSize=${backend.tasksSize}"
+        return -1L
+      }
+    }, 100L)
+
+    redQueue.schedule(object : Task("task three", false) {
+      override fun runOnce(): Long {
+        log += "three:run@${backend.nanoTime()} tasksSize=${backend.tasksSize}"
+        return -1L
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).isEmpty()
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly(
+        "one:run@100 tasksSize=0",
+        "two:run@100 tasksSize=0",
+        "three:run@100 tasksSize=0"
+    )
+
+    backend.assertNoMoreTasks()
+  }
+
+  /** Inspect how many runnables have been enqueued. If non-zero then we're truly parallel. */
+  @Test fun differentQueuesAreParallel() {
+    redQueue.schedule(object : Task("task one", false) {
+      override fun runOnce(): Long {
+        log += "one:run@${backend.nanoTime()} tasksSize=${backend.tasksSize}"
+        return -1L
+      }
+    }, 100L)
+
+    blueQueue.schedule(object : Task("task two", false) {
+      override fun runOnce(): Long {
+        log += "two:run@${backend.nanoTime()} tasksSize=${backend.tasksSize}"
+        return -1L
+      }
+    }, 100L)
+
+    greenQueue.schedule(object : Task("task three", false) {
+      override fun runOnce(): Long {
+        log += "three:run@${backend.nanoTime()} tasksSize=${backend.tasksSize}"
+        return -1L
+      }
+    }, 100L)
+
+    backend.advanceUntil(0L)
+    assertThat(log).isEmpty()
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly(
+        "one:run@100 tasksSize=2",
+        "two:run@100 tasksSize=1",
+        "three:run@100 tasksSize=0"
+    )
+
+    backend.assertNoMoreTasks()
+  }
+
+  /** Test the introspection method [TaskQueue.scheduledTasks]. */
+  @Test fun scheduledTasks() {
+    redQueue.schedule(object : Task("task one", false) {
+      override fun runOnce(): Long = -1L
+
+      override fun toString() = "one"
+    }, 100L)
+
+    redQueue.schedule(object : Task("task two", false) {
+      override fun runOnce(): Long = -1L
+
+      override fun toString() = "two"
+    }, 200L)
+
+    assertThat(redQueue.scheduledTasks.toString()).isEqualTo("[one, two]")
+  }
+
+  /**
+   * We don't track the active task in scheduled tasks. This behavior might be a mistake, but it's
+   * cumbersome to implement properly because the active task might be a cancel.
+   */
+  @Test fun scheduledTasksDoesNotIncludeRunningTask() {
+    redQueue.schedule(object : Task("task one", false) {
+      val schedules = mutableListOf(200L)
+      override fun runOnce(): Long {
+        if (schedules.isNotEmpty()) {
+          redQueue.schedule(this, schedules.removeAt(0)) // Add it at the end also.
+        }
+        log += "scheduledTasks=${redQueue.scheduledTasks}"
+        return -1L
+      }
+
+      override fun toString() = "one"
+    }, 100L)
+
+    redQueue.schedule(object : Task("task two", false) {
+      override fun runOnce(): Long {
+        log += "scheduledTasks=${redQueue.scheduledTasks}"
+        return -1L
+      }
+
+      override fun toString() = "two"
+    }, 200L)
+
+    backend.advanceUntil(100L)
+    assertThat(log).containsExactly(
+        "scheduledTasks=[two, one]"
+    )
+
+    backend.advanceUntil(200L)
+    assertThat(log).containsExactly(
+        "scheduledTasks=[two, one]",
+        "scheduledTasks=[one]"
+    )
+
+    backend.advanceUntil(300L)
+    assertThat(log).containsExactly(
+        "scheduledTasks=[two, one]",
+        "scheduledTasks=[one]",
+        "scheduledTasks=[]"
+    )
+
+    backend.assertNoMoreTasks()
+  }
+
+  /**
+   * The runner doesn't hold references to its queues! Otherwise we'd need a mechanism to clean them
+   * up when they're no longer needed and that's annoying. Instead the task runner only tracks which
+   * queues have work scheduled.
+   */
+  @Test fun activeQueuesContainsOnlyQueuesWithScheduledTasks() {
+    redQueue.schedule(object : Task("task one", false) {
+      override fun runOnce() = -1L
+    }, 100L)
+
+    blueQueue.schedule(object : Task("task two", false) {
+      override fun runOnce() = -1L
+    }, 200L)
+
+    backend.advanceUntil(0L)
+    assertThat(taskRunner.activeQueues()).containsExactly(redQueue, blueQueue)
+
+    backend.advanceUntil(100L)
+    assertThat(taskRunner.activeQueues()).containsExactly(blueQueue)
+
+    backend.advanceUntil(200L)
+    assertThat(taskRunner.activeQueues()).isEmpty()
+
+    backend.assertNoMoreTasks()
+  }
+
+  class FakeBackend : TaskRunner.Backend {
+    private val coordinatorExecutor: Executor = ThreadPoolExecutor(
+        0, // corePoolSize.
+        1, // maximumPoolSize.
+        100, TimeUnit.MILLISECONDS, // keepAliveTime.
+        SynchronousQueue(),
+        threadFactory("TaskRunner.FakeBackend", true)
+    )
+    private var coordinatorToExecute: Runnable? = null
+    private val tasks = mutableListOf<Runnable>()
+
+    /** How many tasks can be executed immediately. */
+    val tasksSize: Int get() = tasks.size
+
+    /** The task runner to lock on. */
+    lateinit var taskRunner: TaskRunner
+
+    /** Guarded by taskRunner. */
+    private var nanoTime = 0L
+
+    /** Guarded by taskRunner. Time at which we should yield execution to the coordinator. */
+    private var coordinatorWaitingUntilTime = Long.MAX_VALUE
+
+    override fun executeCoordinator(runnable: Runnable) {
+      check(coordinatorToExecute == null)
+      coordinatorToExecute = Runnable {
+        runnable.run()
+        synchronized(taskRunner) {
+          coordinatorWaitingUntilTime = Long.MAX_VALUE
+          taskRunner.notify() // Release the waiting advanceUntil() or runRunnables() call.
+        }
+      }
+    }
+
+    override fun executeTask(runnable: Runnable) {
+      check(Thread.holdsLock(taskRunner))
+      tasks += runnable
+    }
+
+    override fun nanoTime(): Long {
+      check(Thread.holdsLock(taskRunner))
+      return nanoTime
+    }
+
+    override fun coordinatorNotify(taskRunner: TaskRunner) {
+      check(Thread.holdsLock(taskRunner))
+      coordinatorWaitingUntilTime = nanoTime
+    }
+
+    override fun coordinatorWait(taskRunner: TaskRunner, nanos: Long) {
+      check(Thread.holdsLock(taskRunner))
+
+      coordinatorWaitingUntilTime = if (nanos < Long.MAX_VALUE) nanoTime + nanos else Long.MAX_VALUE
+      if (nanoTime < coordinatorWaitingUntilTime) {
+        // Stall because there's no work to do.
+        taskRunner.notify()
+        taskRunner.wait()
+      }
+      coordinatorWaitingUntilTime = Long.MAX_VALUE
+    }
+
+    /** Advance the simulated clock and run anything ready at the new time. */
+    fun advanceUntil(newTime: Long) {
+      check(!Thread.holdsLock(taskRunner))
+
+      synchronized(taskRunner) {
+        nanoTime = newTime
+
+        while (true) {
+          runRunnables()
+
+          if (coordinatorWaitingUntilTime <= nanoTime) {
+            // Let the coordinator do its business at the new time.
+            taskRunner.notify()
+            taskRunner.wait()
+          } else {
+            return
+          }
+        }
+      }
+    }
+
+    /** Returns true if anything was executed. */
+    private fun runRunnables() {
+      if (coordinatorToExecute != null) {
+        coordinatorExecutor.execute(coordinatorToExecute!!)
+        coordinatorToExecute = null
+        taskRunner.wait() // Wait for the coordinator to stall.
+      }
+
+      while (tasks.isNotEmpty()) {
+        val task = tasks.removeAt(0)
+        task.run()
+      }
+    }
+
+    fun assertNoMoreTasks() {
+      assertThat(coordinatorToExecute).isNull()
+      assertThat(tasks).isEmpty()
+      assertThat(coordinatorWaitingUntilTime).isEqualTo(Long.MAX_VALUE)
+    }
+  }
+}


### PR DESCRIPTION
This is attempting to balance simplicity, efficiency, and testability.
It doesn't use ScheduledExecutorService because that class wants a
permanent scheduler thread. Instead this uses a coordinator thread
that does its own wait and notify, similar to the mechanism in the
ConnectionPool that this is intended to replace.