### PR TITLE
DiskLruCache snapshot() method removing entries that are being cached (3.14.x branch)

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.java
+++ b/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.java
@@ -747,6 +747,7 @@ public final class DiskLruCache implements Closeable, Flushable {
 
           while (delegate.hasNext()) {
             Entry entry = delegate.next();
+            if (!entry.readable) continue; // Entry during edit.
             Snapshot snapshot = entry.snapshot();
             if (snapshot == null) continue; // Evicted since we copied the entries.
             nextSnapshot = snapshot;


### PR DESCRIPTION
Fixed a bug I found.
When using DiskLruCache, hasNext() method of Iterator<Snapshot> returned by snapshot() method iterates through lruEntries, however if entry is not completed yet, it is removed (together with dirtyFiles) as cleanFiles don't exist yet - during saving response to disk. This caused sometimes file not being cached at all.