### PR TITLE
Encode ampersand that is part of a string in the query parameter.

### DIFF
--- a/okhttp/src/test/java/okhttp3/HttpUrlTest.java
+++ b/okhttp/src/test/java/okhttp3/HttpUrlTest.java
@@ -1712,6 +1712,12 @@ public final class HttpUrlTest {
     assertThat(parse("https://127.0.0.1").topPrivateDomain()).isNull();
   }
 
+  @Test public void encodeAmpersandInQueryParameter() throws Exception {
+    HttpUrl url = parse("http://host/?foo=Foo&bar=Bar&Co&baz=Baz");
+    assertThat(url.querySize()).isEqualTo(3);
+    assertThat(url.toString()).isEqualTo("http://host/?foo=Foo&bar=Bar%26Co&baz=Baz");
+  }
+
   private void assertInvalid(String string, String exceptionMessage) {
     if (useGet) {
       try {


### PR DESCRIPTION
Fixes [#5468](https://github.com/square/okhttp/issues/5468)

Encodes the ampersand that has been passed as part of a string in the query parameter to ```%26```. for example ```http://host/?foo=Foo&bar=Bar&Co&baz=Baz``` to ```http://host/?foo=Foo&bar=Bar%26Co&baz=Baz```.

Thanks.