### PR TITLE
TaskRunner support for shutting down queues

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
@@ -25,6 +25,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.internal.addHeaderLenient
 import okhttp3.internal.closeQuietly
+import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.duplex.MwsDuplexAccess
 import okhttp3.internal.execute
 import okhttp3.internal.http.HttpMethod
@@ -99,6 +100,7 @@ import javax.net.ssl.X509TrustManager
  * in sequence.
  */
 class MockWebServer : ExternalResource(), Closeable {
+  private val taskRunner = TaskRunner()
   private val requestQueue = LinkedBlockingQueue<RecordedRequest>()
   private val openClientSockets =
       Collections.newSetFromMap(ConcurrentHashMap<Socket, Boolean>())
@@ -454,6 +456,12 @@ class MockWebServer : ExternalResource(), Closeable {
     } catch (e: InterruptedException) {
       throw AssertionError()
     }
+
+    for (queue in taskRunner.activeQueues()) {
+      if (!queue.awaitIdle(TimeUnit.MILLISECONDS.toNanos(500L))) {
+        throw IOException("Gave up waiting for ${queue.owner} to shut down")
+      }
+    }
   }
 
   @Synchronized override fun after() {
@@ -533,7 +541,7 @@ class MockWebServer : ExternalResource(), Closeable {
 
       if (protocol === Protocol.HTTP_2 || protocol === Protocol.H2_PRIOR_KNOWLEDGE) {
         val http2SocketHandler = Http2SocketHandler(socket, protocol)
-        val connection = Http2Connection.Builder(false)
+        val connection = Http2Connection.Builder(false, taskRunner)
             .socket(socket)
             .listener(http2SocketHandler)
             .build()

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/internal/http2/Http2Server.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/internal/http2/Http2Server.java
@@ -29,6 +29,7 @@ import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import okhttp3.Headers;
 import okhttp3.Protocol;
+import okhttp3.internal.concurrent.TaskRunner;
 import okhttp3.internal.http2.Header;
 import okhttp3.internal.http2.Http2Connection;
 import okhttp3.internal.http2.Http2Stream;
@@ -69,7 +70,7 @@ public final class Http2Server extends Http2Connection.Listener {
         if (protocol != Protocol.HTTP_2) {
           throw new ProtocolException("Protocol " + protocol + " unsupported");
         }
-        Http2Connection connection = new Http2Connection.Builder(false)
+        Http2Connection connection = new Http2Connection.Builder(false, TaskRunner.INSTANCE)
             .socket(sslSocket)
             .listener(this)
             .build();

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -15,8 +15,6 @@
  */
 package okhttp3
 
-import okhttp3.internal.concurrent.Task
-import okhttp3.internal.concurrent.TaskQueue
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.testing.Flaky
 import org.assertj.core.api.Assertions.assertThat
@@ -25,7 +23,6 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.net.InetAddress
 import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 /** Apply this rule to tests that need an OkHttpClient instance. */
@@ -66,7 +63,7 @@ class OkHttpClientTestRule : TestRule {
 
   private fun ensureAllTaskQueuesIdle() {
     for (queue in TaskRunner.INSTANCE.activeQueues()) {
-      assertThat(queue.awaitIdle(500L, TimeUnit.MILLISECONDS))
+      assertThat(queue.awaitIdle(TimeUnit.MILLISECONDS.toNanos(500L)))
           .withFailMessage("Queue ${queue.owner} still active after 500ms")
           .isTrue()
     }
@@ -131,19 +128,6 @@ class OkHttpClientTestRule : TestRule {
       it.dispatcher.executorService.shutdownNow()
       it.connectionPool.evictAll()
     }
-  }
-
-  /** Returns true if this queue became idle before the timeout elapsed. */
-  private fun TaskQueue.awaitIdle(timeout: Long, timeUnit: TimeUnit): Boolean {
-    val latch = CountDownLatch(1)
-    schedule(object : Task("awaitIdle") {
-      override fun runOnce(): Long {
-        latch.countDown()
-        return -1L
-      }
-    })
-
-    return latch.await(timeout, timeUnit)
   }
 
   companion object {

--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -49,7 +49,6 @@ import java.util.LinkedHashMap
 import java.util.Locale
 import java.util.TimeZone
 import java.util.concurrent.Executor
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import kotlin.text.Charsets.UTF_32BE
@@ -393,14 +392,6 @@ inline fun Executor.execute(name: String, crossinline block: () -> Unit) {
   }
 }
 
-/** Executes [block] unless this executor has been shutdown, in which case this does nothing. */
-inline fun Executor.tryExecute(name: String, crossinline block: () -> Unit) {
-  try {
-    execute(name, block)
-  } catch (_: RejectedExecutionException) {
-  }
-}
-
 fun Buffer.skipAll(b: Byte): Int {
   var count = 0
   while (!exhausted() && this[0] == b) {
@@ -510,33 +501,8 @@ fun Long.toHexString(): String = java.lang.Long.toHexString(this)
 
 fun Int.toHexString(): String = Integer.toHexString(this)
 
-/**
- * Lock and wait a duration in nanoseconds. Unlike [java.lang.Object.wait] this interprets 0 as
- * "don't wait" instead of "wait forever".
- */
-@Throws(InterruptedException::class)
-fun Any.lockAndWaitNanos(nanos: Long) {
-  synchronized(this) {
-    objectWaitNanos(nanos)
-  }
-}
-
 @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
 inline fun Any.wait() = (this as Object).wait()
-
-/**
- * Wait a duration in nanoseconds. Unlike [java.lang.Object.wait] this interprets 0 as "don't wait"
- * instead of "wait forever".
- */
-@Throws(InterruptedException::class)
-@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-fun Any.objectWaitNanos(nanos: Long) {
-  val ms = nanos / 1_000_000L
-  val ns = nanos - (ms * 1_000_000L)
-  if (ms > 0L || nanos > 0) {
-    (this as Object).wait(ms, ns.toInt())
-  }
-}
 
 @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
 inline fun Any.notify() = (this as Object).notify()

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -33,6 +33,7 @@ import okhttp3.Response
 import okhttp3.Route
 import okhttp3.internal.EMPTY_RESPONSE
 import okhttp3.internal.closeQuietly
+import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.http.ExchangeCodec
 import okhttp3.internal.http1.Http1ExchangeCodec
 import okhttp3.internal.http2.ConnectionShutdownException
@@ -321,7 +322,7 @@ class RealConnection(
     val source = this.source!!
     val sink = this.sink!!
     socket.soTimeout = 0 // HTTP/2 connection timeouts are set per-stream.
-    val http2Connection = Http2Connection.Builder(true)
+    val http2Connection = Http2Connection.Builder(client = true, taskRunner = TaskRunner.INSTANCE)
         .socket(socket, route.address.url.host, source, sink)
         .listener(this)
         .pingIntervalMillis(pingIntervalMillis)

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskFaker.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskFaker.kt
@@ -40,7 +40,7 @@ class TaskFaker {
   /** How many tasks can be executed immediately. */
   val tasksSize: Int get() = tasks.size
 
-  /** Guarded by taskRunner. */
+  /** Guarded by [taskRunner]. */
   var nanoTime = 0L
     private set
 
@@ -143,7 +143,9 @@ class TaskFaker {
   fun assertNoMoreTasks() {
     assertThat(coordinatorToRun).isNull()
     assertThat(tasks).isEmpty()
-    assertThat(coordinatorWaitingUntilTime).isEqualTo(Long.MAX_VALUE)
+    assertThat(coordinatorWaitingUntilTime)
+        .withFailMessage("tasks are scheduled to run at $coordinatorWaitingUntilTime")
+        .isEqualTo(Long.MAX_VALUE)
   }
 
   fun interruptCoordinatorThread() {

--- a/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import okhttp3.Headers;
 import okhttp3.internal.Util;
+import okhttp3.internal.concurrent.TaskRunner;
 import okhttp3.internal.http2.MockHttp2Peer.InFrame;
 import okio.AsyncTimeout;
 import okio.Buffer;
@@ -498,7 +499,7 @@ public final class Http2ConnectionTest {
 
     String longString = repeat('a', Http2.INITIAL_MAX_FRAME_SIZE + 1);
     Socket socket = peer.openSocket();
-    Http2Connection connection = new Http2Connection.Builder(true)
+    Http2Connection connection = new Http2Connection.Builder(true, TaskRunner.INSTANCE)
         .socket(socket)
         .pushObserver(IGNORE)
         .build();
@@ -1786,7 +1787,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // GOAWAY
     peer.play();
 
-    Http2Connection connection = new Http2Connection.Builder(true)
+    Http2Connection connection = new Http2Connection.Builder(true, TaskRunner.INSTANCE)
         .socket(peer.openSocket())
         .build();
     connection.start(false);
@@ -1857,7 +1858,7 @@ public final class Http2ConnectionTest {
   /** Builds a new connection to {@code peer} with settings acked. */
   private Http2Connection connect(MockHttp2Peer peer, PushObserver pushObserver,
       Http2Connection.Listener listener) throws Exception {
-    Http2Connection connection = new Http2Connection.Builder(true)
+    Http2Connection connection = new Http2Connection.Builder(true, TaskRunner.INSTANCE)
         .socket(peer.openSocket())
         .pushObserver(pushObserver)
         .listener(listener)


### PR DESCRIPTION
Shutting down queues makes it easier to implement HTTP/2
shutdown because we can enqueue everywhere and centralize
the logic that decides whether we're shutdown or not.

Use this new functionality to implement HTTP/2 on task queues.
It's mostly a drop-in replacement, though opting-into cancel
looks like a mistake when it's what we do most of the time.

When testing this the OkHttpClientTestRule was failing because
tasks were incomplete. I was puzzled by this until I realized
that the OkHttpClientTestRule performs that validation before
we stop the MockWebServer. I changed MockWebServer to have its
own TaskRunner and that made the problem go away.