### PR TITLE
Rewrite Dokka-generated markdown to include titles.

### DIFF
--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -30,6 +30,26 @@ cd $DIR
   :okhttp-urlconnection:dokka \
   :okhttp:dokka
 
+# Dokka filenames like `-http-url/index.md` don't work well with MkDocs <title> tags.
+# Assign metadata to the file's first Markdown heading.
+# https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data
+title_markdown_file() {
+  TITLE_PATTERN="s/^[#]+ *(.*)/title: \1 - OkHttp/"
+  echo "---"                                                     > "$1.fixed"
+  cat $1 | sed -E "$TITLE_PATTERN" | grep "title: " | head -n 1 >> "$1.fixed"
+  echo "---"                                                    >> "$1.fixed"
+  echo                                                          >> "$1.fixed"
+  cat $1                                                        >> "$1.fixed"
+  mv "$1.fixed" "$1"
+}
+
+set +x
+for MARKDOWN_FILE in $(find docs/4.x/ -name '*.md'); do
+  echo $MARKDOWN_FILE
+  title_markdown_file $MARKDOWN_FILE
+done
+set -x
+
 # Copy in special files that GitHub wants in the project root.
 cat README.md | grep -v 'project website' > docs/index.md
 cp CHANGELOG.md docs/changelog.md


### PR DESCRIPTION
I tried rendering in jekyll mode but that doesn't look as nice with
Mkdocs.