### PR TITLE
Use TaskRunner in web sockets.

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
@@ -781,7 +781,13 @@ class MockWebServer : ExternalResource(), Closeable {
     val streams = object : RealWebSocket.Streams(false, source, sink) {
       override fun close() = connectionClose.countDown()
     }
-    val webSocket = RealWebSocket(fancyRequest, response.webSocketListener!!, SecureRandom(), 0)
+    val webSocket = RealWebSocket(
+        taskRunner = taskRunner,
+        originalRequest = fancyRequest,
+        listener = response.webSocketListener!!,
+        random = SecureRandom(),
+        pingIntervalMillis = 0
+    )
     response.webSocketListener!!.onOpen(webSocket, fancyResponse)
     val name = "MockWebServer WebSocket ${request.path!!}"
     webSocket.initReaderAndWriter(name, streams)

--- a/okhttp/src/main/java/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.kt
@@ -19,6 +19,7 @@ import okhttp3.Protocol.HTTP_1_1
 import okhttp3.Protocol.HTTP_2
 import okhttp3.internal.asFactory
 import okhttp3.internal.checkDuration
+import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.immutableListOf
 import okhttp3.internal.platform.Platform
 import okhttp3.internal.proxy.NullProxySelector
@@ -244,7 +245,13 @@ open class OkHttpClient internal constructor(
 
   /** Uses [request] to connect a new web socket. */
   override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {
-    val webSocket = RealWebSocket(request, listener, Random(), pingIntervalMillis.toLong())
+    val webSocket = RealWebSocket(
+        TaskRunner.INSTANCE,
+        request,
+        listener,
+        Random(),
+        pingIntervalMillis.toLong()
+    )
     webSocket.connect(this)
     return webSocket
   }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.kt
@@ -433,7 +433,7 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
 
   /**
    * Closes this connection. This cancels all open streams and unanswered pings. It closes the
-   * underlying input and output streams and shuts down internal executor services.
+   * underlying input and output streams and shuts down internal executor services and task queues.
    */
   override fun close() {
     close(ErrorCode.NO_ERROR, ErrorCode.CANCEL, null)
@@ -687,7 +687,7 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
      *
      * Since we can't ACK settings on the current reader thread (the reader thread can't write) we
      * execute all peer settings logic on the writer thread. This relies on the fact that the
-     * writer executor won't reorder tasks; otherwise settings could be applied in the opposite
+     * writer task queue won't reorder tasks; otherwise settings could be applied in the opposite
      * order than received.
      */
     fun applyAndAckSettings(clearPrevious: Boolean, settings: Settings) {

--- a/okhttp/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.internal.concurrent.TaskRunner;
 import okio.ByteString;
 import okio.Okio;
 import okio.Pipe;
@@ -372,7 +373,8 @@ public final class RealWebSocketTest {
           .request(new Request.Builder().url(url).build())
           .protocol(Protocol.HTTP_1_1)
           .build();
-      webSocket = new RealWebSocket(response.request(), listener, random, pingIntervalMillis);
+      webSocket = new RealWebSocket(
+          TaskRunner.INSTANCE, response.request(), listener, random, pingIntervalMillis);
       webSocket.initReaderAndWriter(name, this);
     }
 

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -36,6 +36,7 @@ import okhttp3.Response;
 import okhttp3.TestLogHandler;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
+import okhttp3.internal.concurrent.TaskRunner;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -798,7 +799,7 @@ public final class WebSocketHttpTest {
 
   private RealWebSocket newWebSocket(Request request) {
     RealWebSocket webSocket = new RealWebSocket(
-        request, clientListener, random, client.pingIntervalMillis());
+        TaskRunner.INSTANCE, request, clientListener, random, client.pingIntervalMillis());
     webSocket.connect(client);
     return webSocket;
   }


### PR DESCRIPTION
The most consequential change here is that the background thread is
now a daemon thread. A program consisting of exactly one web socket
will exit when the reader reads an inbound close message. Previously
such a program would continue running until the writer acknowledged
this close.