### PR TITLE
Default to jdk9 platform for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ subprojects { project ->
     }
   }
 
-  def platform = System.getProperty("okhttp.platform", "jdk8")
+  def platform = System.getProperty("okhttp.platform", "jdk9")
   def platformJavaHome = System.getProperty('test.java.home')
 
   test {


### PR DESCRIPTION
Since we build with jdk11 etc, default to jdk9 platform for tests unless overridden.