### PR TITLE
Fix connection pooling for different clients with the same pool. (4.2.x branch)

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.kt
@@ -162,9 +162,9 @@ open class OkHttpClient internal constructor(
 
   @get:JvmName("proxySelector") val proxySelector: ProxySelector =
       when {
-        // Avoid possible SecurityException from ProxySelector.getDefault
-        builder.proxy != null -> NullProxySelector()
-        else -> builder.proxySelector ?: ProxySelector.getDefault() ?: NullProxySelector()
+        // Defer calls to ProxySelector.getDefault() because it can throw a SecurityException.
+        builder.proxy != null -> NullProxySelector
+        else -> builder.proxySelector ?: ProxySelector.getDefault() ?: NullProxySelector
       }
 
   @get:JvmName("proxyAuthenticator") val proxyAuthenticator: Authenticator =

--- a/okhttp/src/main/java/okhttp3/internal/proxy/NullProxySelector.kt
+++ b/okhttp/src/main/java/okhttp3/internal/proxy/NullProxySelector.kt
@@ -24,7 +24,7 @@ import java.net.URI
 /**
  * A proxy selector that always returns the [Proxy.NO_PROXY].
  */
-open class NullProxySelector : ProxySelector() {
+object NullProxySelector : ProxySelector() {
   override fun select(uri: URI?): List<Proxy> {
     requireNotNull(uri) { "uri must not be null" }
     return listOf(Proxy.NO_PROXY)

--- a/okhttp/src/test/java/okhttp3/CallTest.java
+++ b/okhttp/src/test/java/okhttp3/CallTest.java
@@ -787,6 +787,63 @@ public final class CallTest {
     assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(2);
   }
 
+  /**
+   * Each OkHttpClient used to get its own instance of NullProxySelector, and because these weren't
+   * equal their connections weren't pooled. That's a nasty performance bug!
+   *
+   * https://github.com/square/okhttp/issues/5519
+   */
+  @Test public void connectionPoolingWithFreshClientSamePool() throws Exception {
+    server.enqueue(new MockResponse().setBody("abc"));
+    server.enqueue(new MockResponse().setBody("def"));
+    server.enqueue(new MockResponse().setBody("ghi"));
+
+    client = new OkHttpClient.Builder()
+        .connectionPool(client.connectionPool())
+        .proxy(server.toProxyAddress())
+        .build();
+    executeSynchronously("/a").assertBody("abc");
+
+    client = new OkHttpClient.Builder()
+        .connectionPool(client.connectionPool())
+        .proxy(server.toProxyAddress())
+        .build();
+    executeSynchronously("/b").assertBody("def");
+
+    client = new OkHttpClient.Builder()
+        .connectionPool(client.connectionPool())
+        .proxy(server.toProxyAddress())
+        .build();
+    executeSynchronously("/c").assertBody("ghi");
+
+    assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(0);
+    assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(1);
+    assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(2);
+  }
+
+  @Test public void connectionPoolingWithClientBuiltOffProxy() throws Exception {
+    client = new OkHttpClient.Builder()
+        .proxy(server.toProxyAddress())
+        .build();
+
+    server.enqueue(new MockResponse().setBody("abc"));
+    server.enqueue(new MockResponse().setBody("def"));
+    server.enqueue(new MockResponse().setBody("ghi"));
+
+    client = client.newBuilder().build();
+    executeSynchronously("/a").assertBody("abc");
+
+    client = client.newBuilder().build();
+    executeSynchronously("/b").assertBody("def");
+
+    client = client.newBuilder().build();
+    executeSynchronously("/c").assertBody("ghi");
+
+    assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(0);
+    assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(1);
+    assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(2);
+  }
+
   @Test public void connectionPooling_Async() throws Exception {
     server.enqueue(new MockResponse().setBody("abc"));
     server.enqueue(new MockResponse().setBody("def"));

--- a/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
+++ b/okhttp/src/test/java/okhttp3/KotlinSourceModernTest.kt
@@ -847,7 +847,7 @@ class KotlinSourceModernTest {
     builder = builder.pingInterval(0L, TimeUnit.SECONDS)
     builder = builder.pingInterval(Duration.ofSeconds(0L))
     builder = builder.proxy(Proxy.NO_PROXY)
-    builder = builder.proxySelector(NullProxySelector())
+    builder = builder.proxySelector(NullProxySelector)
     builder = builder.cookieJar(CookieJar.NO_COOKIES)
     builder = builder.cache(Cache(File("/cache/"), Integer.MAX_VALUE.toLong()))
     builder = builder.dns(Dns.SYSTEM)
@@ -1150,7 +1150,7 @@ class KotlinSourceModernTest {
         Proxy.NO_PROXY,
         listOf(Protocol.HTTP_1_1),
         listOf(ConnectionSpec.MODERN_TLS),
-        NullProxySelector()
+        NullProxySelector
     )
   }
 


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/5519