### PR TITLE
Add a way for MockWebServer to track truncated requests

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/RecordedRequest.kt
@@ -29,7 +29,7 @@ import java.net.Socket
 import javax.net.ssl.SSLSocket
 
 /** An HTTP request that came into the mock web server. */
-class RecordedRequest(
+class RecordedRequest @JvmOverloads constructor(
   val requestLine: String,
 
   /** All headers. */
@@ -52,7 +52,13 @@ class RecordedRequest(
    * multiple requests, each request is assigned its own sequence number.
    */
   val sequenceNumber: Int,
-  socket: Socket
+  socket: Socket,
+
+  /**
+   * The failure MockWebServer recorded when attempting to decode this request. If, for example,
+   * the inbound request was truncated, this exception will be non-null.
+   */
+  val failure: IOException? = null
 ) {
   val method: String?
   val path: String?

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -68,8 +68,8 @@ class OkHttpClientTestRule : TestRule {
 
   private fun ensureAllTaskQueuesIdle() {
     for (queue in TaskRunner.INSTANCE.activeQueues()) {
-      assertThat(queue.awaitIdle(TimeUnit.MILLISECONDS.toNanos(500L)))
-          .withFailMessage("Queue still active after 500ms")
+      assertThat(queue.awaitIdle(TimeUnit.MILLISECONDS.toNanos(1000L)))
+          .withFailMessage("Queue still active after 1000ms")
           .isTrue()
     }
   }

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
@@ -531,7 +531,6 @@ class RealWebSocket(
     val sink: BufferedSink
   ) : Closeable
 
-
   private inner class PingTask(val delayNanos: Long) : Task("$name Ping") {
     override fun runOnce(): Long {
       writePingFrame()


### PR DESCRIPTION
It now tracks inbound requests that fail with an IOException.

Also add a fix for the bug where we'd send 'END OF STREAM' on a stream
that we'd previously canceled, which raced with the 'RST STREAM' and led
to flakiness.

Before we ship the new API in RecordedRequest we should go over the
other cases where inbound HTTP requests fail and make sure they
get reported through this channel.

Closes: https://github.com/square/okhttp/issues/5388