### PR TITLE
Fix the broken link:

### DIFF
--- a/okhttp-logging-interceptor/README.md
+++ b/okhttp-logging-interceptor/README.md
@@ -42,4 +42,4 @@ implementation("com.squareup.okhttp3:logging-interceptor:4.2.1")
 
 
 
- [1]: ../INTERCEPTORS.md
+ [1]: https://square.github.io/okhttp/interceptors/

--- a/okhttp-logging-interceptor/README.md
+++ b/okhttp-logging-interceptor/README.md
@@ -1,7 +1,7 @@
 Logging Interceptor
 ===================
 
-An [OkHttp interceptor][1] which logs HTTP request and response data.
+An [OkHttp interceptor][interceptors] which logs HTTP request and response data.
 
 ```java
 HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
@@ -41,5 +41,4 @@ implementation("com.squareup.okhttp3:logging-interceptor:4.2.1")
 ```
 
 
-
- [1]: https://square.github.io/okhttp/interceptors/
+[interceptors]: https://square.github.io/okhttp/interceptors/


### PR DESCRIPTION
There is no longer a markdown doc file on interceptors, 
but the article is available on the project website.