### PR TITLE
Be more consistent with task names

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
@@ -100,7 +100,9 @@ import javax.net.ssl.X509TrustManager
  * in sequence.
  */
 class MockWebServer : ExternalResource(), Closeable {
-  private val taskRunner = TaskRunner()
+  private val taskRunnerBackend = TaskRunner.RealBackend(
+      threadFactory("MockWebServer TaskRunner", true))
+  private val taskRunner = TaskRunner(taskRunnerBackend)
   private val requestQueue = LinkedBlockingQueue<RecordedRequest>()
   private val openClientSockets =
       Collections.newSetFromMap(ConcurrentHashMap<Socket, Boolean>())
@@ -463,6 +465,7 @@ class MockWebServer : ExternalResource(), Closeable {
         throw IOException("Gave up waiting for queue to shut down")
       }
     }
+    taskRunnerBackend.shutdown()
   }
 
   @Synchronized override fun after() {

--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -359,7 +359,7 @@ fun Source.discard(timeout: Int, timeUnit: TimeUnit): Boolean = try {
   false
 }
 
-fun Socket.connectionName(): String {
+fun Socket.peerName(): String {
   val address = remoteSocketAddress
   return if (address is InetSocketAddress) address.hostName else address.toString()
 }

--- a/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.kt
+++ b/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.kt
@@ -168,7 +168,7 @@ class DiskLruCache internal constructor(
   private var nextSequenceNumber: Long = 0
 
   private val cleanupQueue = taskRunner.newQueue()
-  private val cleanupTask = object : Task("OkHttp DiskLruCache", cancelable = false) {
+  private val cleanupTask = object : Task("OkHttp Cache", cancelable = false) {
     override fun runOnce(): Long {
       synchronized(this@DiskLruCache) {
         if (!initialized || closed) {

--- a/okhttp/src/main/java/okhttp3/internal/concurrent/Task.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/Task.kt
@@ -48,7 +48,7 @@ package okhttp3.internal.concurrent
  */
 abstract class Task(
   val name: String,
-  val cancelable: Boolean = true
+  val cancelable: Boolean
 ) {
   // Guarded by the TaskRunner.
   internal var queue: TaskQueue? = null
@@ -65,4 +65,6 @@ abstract class Task(
     check(this.queue === null) { "task is in multiple queues" }
     this.queue = queue
   }
+
+  override fun toString() = name
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
@@ -40,7 +40,7 @@ class RealConnectionPool(
   private val keepAliveDurationNs: Long = timeUnit.toNanos(keepAliveDuration)
 
   private val cleanupQueue: TaskQueue = taskRunner.newQueue()
-  private val cleanupTask = object : Task("OkHttp ConnectionPool") {
+  private val cleanupTask = object : Task("OkHttp ConnectionPool", cancelable = true) {
     override fun runOnce() = cleanup(System.nanoTime())
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
@@ -196,7 +196,7 @@ public final class ConnectionPoolTest {
     Thread[] threads = new Thread[Thread.activeCount() * 2];
     Thread.enumerate(threads);
     for (Thread t: threads) {
-      if (t != null && t.getName().equals("OkHttp Task")) {
+      if (t != null && t.getName().equals("OkHttp TaskRunner")) {
         t.interrupt();
       }
     }


### PR DESCRIPTION
Examples:
  - OkHttp TaskRunner
  - MockWebServer TaskRunner
  - OkHttp ConnectionPool
  - MockWebServer localhost applyAndAckSettings
  - OkHttp android.com applyAndAckSettings
  - OkHttp android.com onSettings
  - OkHttp awaitIdle
  - OkHttp localhost

I'm trying to use type names where appropriate, or method names otherwise.
Names include hostname and stream name if the task is working on behalf
of a specific stream or connection.