### PR TITLE
Make all TaskRunner tasks cancelable

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
@@ -389,7 +389,7 @@ class MockWebServer : ExternalResource(), Closeable {
 
     portField = serverSocket!!.localPort
 
-    taskRunner.newQueue().execute("MockWebServer $portField") {
+    taskRunner.newQueue().execute("MockWebServer $portField", cancelable = false) {
       try {
         logger.info("${this@MockWebServer} starting to accept connections")
         acceptConnections()
@@ -464,7 +464,7 @@ class MockWebServer : ExternalResource(), Closeable {
   }
 
   private fun serveConnection(raw: Socket) {
-    taskRunner.newQueue().execute("MockWebServer ${raw.remoteSocketAddress}") {
+    taskRunner.newQueue().execute("MockWebServer ${raw.remoteSocketAddress}", cancelable = false) {
       try {
         SocketHandler(raw).handle()
       } catch (e: IOException) {

--- a/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.kt
+++ b/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.kt
@@ -168,7 +168,7 @@ class DiskLruCache internal constructor(
   private var nextSequenceNumber: Long = 0
 
   private val cleanupQueue = taskRunner.newQueue()
-  private val cleanupTask = object : Task("OkHttp Cache", cancelable = false) {
+  private val cleanupTask = object : Task("OkHttp Cache") {
     override fun runOnce(): Long {
       synchronized(this@DiskLruCache) {
         if (!initialized || closed) {

--- a/okhttp/src/main/java/okhttp3/internal/concurrent/Task.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/Task.kt
@@ -48,7 +48,7 @@ package okhttp3.internal.concurrent
  */
 abstract class Task(
   val name: String,
-  val cancelable: Boolean
+  val cancelable: Boolean = true
 ) {
   // Guarded by the TaskRunner.
   internal var queue: TaskQueue? = null

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
@@ -40,7 +40,7 @@ class RealConnectionPool(
   private val keepAliveDurationNs: Long = timeUnit.toNanos(keepAliveDuration)
 
   private val cleanupQueue: TaskQueue = taskRunner.newQueue()
-  private val cleanupTask = object : Task("OkHttp ConnectionPool", cancelable = true) {
+  private val cleanupTask = object : Task("OkHttp ConnectionPool") {
     override fun runOnce() = cleanup(System.nanoTime())
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
@@ -393,7 +393,7 @@ class RealWebSocket(
 
   private fun runWriter() {
     assert(Thread.holdsLock(this))
-    taskQueue.trySchedule(writerTask!!)
+    taskQueue.schedule(writerTask!!)
   }
 
   /**
@@ -535,7 +535,7 @@ class RealWebSocket(
     val sink: BufferedSink
   ) : Closeable
 
-  private inner class WriterTask : Task("$name writer", cancelable = true) {
+  private inner class WriterTask : Task("$name writer") {
     override fun runOnce(): Long {
       try {
         if (writeOneFrame()) return 0L


### PR DESCRIPTION
This probably should have been the case all along. Unfortunately,
ExecutorService Runnables are not cancelable by default, and that's
where we started.

After implementing all of TaskRunner it looks like where we're
cancelable and where we aren't is totally arbitrary. Making everything
cancelable simplifies the implementation and model.

The last remaining non-cancelable tasks:
 * awaitIdle() which we use in our tests only.
 * MockWebServer, where canceling would leak sockets