### PR TITLE
Add link to okio proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,6 @@ implementation("com.squareup.okhttp3:okhttp:4.2.1")
 Snapshot builds are [available][snap].
 
 
-R8 / ProGuard
--------------
-
-If you are using R8 or ProGuard add the options from [`okhttp3.pro`][okhttp3_pro].
-
-You might also need [rules for Okio][okio proguard] which is a dependency of this library.
-
-
 MockWebServer
 -------------
 
@@ -155,4 +147,3 @@ limitations under the License.
  [recipes]: http://square.github.io/okhttp/recipes/
  [snap]: https://oss.sonatype.org/content/repositories/snapshots/
  [tls_history]: https://square.github.io/okhttp/tls_configuration_history/
- [okio proguard]: https://square.github.io/okio/#r8-proguard

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ R8 / ProGuard
 
 If you are using R8 or ProGuard add the options from [`okhttp3.pro`][okhttp3_pro].
 
-You might also need rules for Okio which is a dependency of this library.
+You might also need [rules for Okio][okio proguard] which is a dependency of this library.
 
 
 MockWebServer
@@ -155,3 +155,4 @@ limitations under the License.
  [recipes]: http://square.github.io/okhttp/recipes/
  [snap]: https://oss.sonatype.org/content/repositories/snapshots/
  [tls_history]: https://square.github.io/okhttp/tls_configuration_history/
+ [okio proguard]: https://square.github.io/okio/#r8-proguard

--- a/docs/r8_proguard.md
+++ b/docs/r8_proguard.md
@@ -1,0 +1,9 @@
+R8 / ProGuard
+=====
+
+If you use OkHttp as a dependency in an Android project which uses R8 as
+a default compiler you don't have to do anything.
+The specific rules are [already bundled](https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro) into the JAR which can be interpreted by R8 automatically.
+
+If you, however, don't use R8 you have to apply the rules from [this file](https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro).
+You might also need rules from [Okio](https://github.com/square/okio/) which is a dependency of this library.


### PR DESCRIPTION
Always when I search for the proguard rules of my app I jump from dependency to dependency.
okhttp makes it a little bit easier by saying "You also need the Okio rules".
But just saying it means I have to open a new tab, go to github.com/square/okio (or google it), and copy the stuff to my proguard files.

With that link we simplify the process 😇 