### PR TITLE
Rename ErrorCode val from "httpCode" to "code"

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/ErrorCode.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/ErrorCode.kt
@@ -16,7 +16,7 @@
 package okhttp3.internal.http2
 
 /** http://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-7 */
-enum class ErrorCode constructor(val httpCode: Int) {
+enum class ErrorCode constructor(val code: Int) {
   /** Not an error!  */
   NO_ERROR(0),
 
@@ -41,6 +41,6 @@ enum class ErrorCode constructor(val httpCode: Int) {
   HTTP_1_1_REQUIRED(0xd);
 
   companion object {
-    fun fromHttp2(code: Int): ErrorCode? = values().find { it.httpCode == code }
+    fun fromHttp2(code: Int): ErrorCode? = values().find { it.code == code }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Writer.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Writer.kt
@@ -123,7 +123,7 @@ class Http2Writer(
   @Synchronized @Throws(IOException::class)
   fun rstStream(streamId: Int, errorCode: ErrorCode) {
     if (closed) throw IOException("closed")
-    require(errorCode.httpCode != -1)
+    require(errorCode.code != -1)
 
     frameHeader(
         streamId = streamId,
@@ -131,7 +131,7 @@ class Http2Writer(
         type = TYPE_RST_STREAM,
         flags = FLAG_NONE
     )
-    sink.writeInt(errorCode.httpCode)
+    sink.writeInt(errorCode.code)
     sink.flush()
   }
 
@@ -218,7 +218,7 @@ class Http2Writer(
   @Synchronized @Throws(IOException::class)
   fun goAway(lastGoodStreamId: Int, errorCode: ErrorCode, debugData: ByteArray) {
     if (closed) throw IOException("closed")
-    require(errorCode.httpCode != -1) { "errorCode.httpCode == -1" }
+    require(errorCode.code != -1) { "errorCode.code == -1" }
     frameHeader(
         streamId = 0,
         length = 8 + debugData.size,
@@ -226,7 +226,7 @@ class Http2Writer(
         flags = FLAG_NONE
     )
     sink.writeInt(lastGoodStreamId)
-    sink.writeInt(errorCode.httpCode)
+    sink.writeInt(errorCode.code)
     if (debugData.isNotEmpty()) {
       sink.write(debugData)
     }

--- a/okhttp/src/test/java/okhttp3/internal/http2/Http2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/Http2Test.java
@@ -217,7 +217,7 @@ public final class Http2Test {
     frame.writeByte(Http2.TYPE_RST_STREAM);
     frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(expectedStreamId & 0x7fffffff);
-    frame.writeInt(ErrorCode.PROTOCOL_ERROR.getHttpCode());
+    frame.writeInt(ErrorCode.PROTOCOL_ERROR.getCode());
 
     reader.nextFrame(false, new BaseTestHandler() {
       @Override public void rstStream(int streamId, ErrorCode errorCode) {
@@ -604,7 +604,7 @@ public final class Http2Test {
     frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // connection-scope
     frame.writeInt(expectedStreamId); // last good stream.
-    frame.writeInt(expectedError.getHttpCode());
+    frame.writeInt(expectedError.getCode());
 
     // Check writer sends the same bytes.
     assertThat(sendGoAway(expectedStreamId, expectedError, Util.EMPTY_BYTE_ARRAY)).isEqualTo(
@@ -630,7 +630,7 @@ public final class Http2Test {
     frame.writeByte(Http2.FLAG_NONE);
     frame.writeInt(0); // connection-scope
     frame.writeInt(0); // never read any stream!
-    frame.writeInt(expectedError.getHttpCode());
+    frame.writeInt(expectedError.getCode());
     frame.write(expectedData.toByteArray());
 
     // Check writer sends the same bytes.

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -797,7 +797,7 @@ public final class HttpOverHttp2Test {
   @Test public void recoverFromOneRefusedStreamReusesConnection() throws Exception {
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
-        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.getHttpCode()));
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.getCode()));
     server.enqueue(new MockResponse()
         .setBody("abc"));
 
@@ -816,7 +816,7 @@ public final class HttpOverHttp2Test {
   @Test public void recoverFromOneInternalErrorRequiresNewConnection() throws Exception {
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
-        .setHttp2ErrorCode(ErrorCode.INTERNAL_ERROR.getHttpCode()));
+        .setHttp2ErrorCode(ErrorCode.INTERNAL_ERROR.getCode()));
     server.enqueue(new MockResponse()
         .setBody("abc"));
 
@@ -839,10 +839,10 @@ public final class HttpOverHttp2Test {
   @Test public void recoverFromMultipleRefusedStreamsRequiresNewConnection() throws Exception {
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
-        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.getHttpCode()));
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.getCode()));
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
-        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.getHttpCode()));
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.getCode()));
     server.enqueue(new MockResponse()
         .setBody("abc"));
 
@@ -1000,7 +1000,7 @@ public final class HttpOverHttp2Test {
   private void noRecoveryFromErrorWithRetryDisabled(ErrorCode errorCode) throws Exception {
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
-        .setHttp2ErrorCode(errorCode.getHttpCode()));
+        .setHttp2ErrorCode(errorCode.getCode()));
     server.enqueue(new MockResponse()
         .setBody("abc"));
 
@@ -1024,7 +1024,7 @@ public final class HttpOverHttp2Test {
         .setResponseCode(401));
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
-        .setHttp2ErrorCode(ErrorCode.INTERNAL_ERROR.getHttpCode()));
+        .setHttp2ErrorCode(ErrorCode.INTERNAL_ERROR.getCode()));
     server.enqueue(new MockResponse()
         .setBody("DEF"));
     server.enqueue(new MockResponse()


### PR DESCRIPTION
Like [11.4.  Error Code Registry](https://tools.ietf.org/html/rfc7540#section-11.4) mentions, the error code value is `Code`.

```
New registrations are advised to provide the following information:

Name:  A name for the error code.  Specifying an error code name is
      optional.

Code:  The 32-bit error code value.
```