### PR TITLE
Clean up unused variables/methods in Test

### DIFF
--- a/okhttp/src/test/java/okhttp3/CallTest.java
+++ b/okhttp/src/test/java/okhttp3/CallTest.java
@@ -3309,7 +3309,7 @@ public final class CallTest {
         .build();
 
     try {
-      Response response = client.newCall(request).execute();
+      client.newCall(request).execute();
       fail();
     } catch (IOException expected) {
     }

--- a/okhttp/src/test/java/okhttp3/ConnectionSpecTest.java
+++ b/okhttp/src/test/java/okhttp3/ConnectionSpecTest.java
@@ -176,7 +176,7 @@ public final class ConnectionSpecTest {
   @Test public void tls_stringCiphersAndVersions() throws Exception {
     // Supporting arbitrary input strings allows users to enable suites and versions that are not
     // yet known to the library, but are supported by the platform.
-    ConnectionSpec tlsSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+    new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
         .cipherSuites("MAGIC-CIPHER")
         .tlsVersions("TLS9k")
         .build();

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -309,18 +309,6 @@ public final class EventListenerTest {
     };
   }
 
-  private Matcher<Long> lessThan(final long value) {
-    return new BaseMatcher<Long>() {
-      @Override public void describeTo(Description description) {
-        description.appendText("< " + value);
-      }
-
-      @Override public boolean matches(Object o) {
-        return ((Long) o) < value;
-      }
-    };
-  }
-
   private Matcher<Response> matchesProtocol(final Protocol protocol) {
     return new BaseMatcher<Response>() {
       @Override public void describeTo(Description description) {

--- a/okhttp/src/test/java/okhttp3/HeadersTest.java
+++ b/okhttp/src/test/java/okhttp3/HeadersTest.java
@@ -133,7 +133,7 @@ public final class HeadersTest {
 
   @Test public void addUnsafeNonAsciiRejectsUnicodeName() {
     try {
-      Headers headers = new Headers.Builder()
+      new Headers.Builder()
           .addUnsafeNonAscii("héader1", "value1")
           .build();
       fail("Should have complained about invalid value");

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
@@ -187,7 +187,7 @@ public final class ConnectionPoolTest {
     TaskRunner realTaskRunner = TaskRunner.INSTANCE;
     RealConnectionPool pool = new RealConnectionPool(
         realTaskRunner, 2, 100L, TimeUnit.NANOSECONDS);
-    RealConnection c1 = newConnection(pool, routeA1, Long.MAX_VALUE);
+    newConnection(pool, routeA1, Long.MAX_VALUE);
 
     assertThat(realTaskRunner.activeQueues()).isNotEmpty();
 

--- a/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
@@ -1817,11 +1817,6 @@ public final class Http2ConnectionTest {
     assertThat(actual).isEqualTo(expected);
   }
 
-  /** Reads {@code prefix} from {@code source}. */
-  private void assertStreamPrefix(String prefix, BufferedSource source) throws IOException {
-    assertThat(source.readUtf8(Utf8.size(prefix))).isEqualTo(prefix);
-  }
-
   /**
    * Returns true when all work currently in progress by the watchdog have completed. This method
    * creates more work for the watchdog and waits for that work to be executed. When it is, we know


### PR DESCRIPTION
Let's clean up warnings caught by errorprone.

- headers
```
okhttp/src/test/java/okhttp3/HeadersTest.java:136: warning: [UnusedVariable] The local variable 'headers' is never read.
      Headers headers = new Headers.Builder()
              ^
    (see https://errorprone.info/bugpattern/UnusedVariable)
  Did you mean to remove this line or 'new Headers.Builder()'?
```

- lessThan
```
okhttp/src/test/java/okhttp3/EventListenerTest.java:312: warning: [UnusedMethod] Private method 'lessThan' is never used.
  private Matcher<Long> lessThan(final long value) {
                        ^
    (see https://errorprone.info/bugpattern/UnusedMethod)
  Did you mean to remove this line?
```

- response
```
okhttp/src/test/java/okhttp3/CallTest.java:3312: warning: [UnusedVariable] The local variable 'response' is never read.
      Response response = client.newCall(request).execute();
```

- assertStreamPrefix
```
okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java:1821: warning: [UnusedMethod] Private method 'assertStreamPrefix' is never used.
  private void assertStreamPrefix(String prefix, BufferedSource source) throws IOException {
```

- c1
```
okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java:190: warning: [UnusedVariable] The local variable 'c1' is never read.
    RealConnection c1 = newConnection(pool, routeA1, Long.MAX_VALUE);
                   ^
    (see https://errorprone.info/bugpattern/UnusedVariable)
  Did you mean to remove this line or 'newConnection(pool, routeA1, Long.MAX_VALUE);'?
```

- tlsSpec
```
okhttp/src/test/java/okhttp3/ConnectionSpecTest.java:179: warning: [UnusedVariable] The local variable 'tlsSpec' is never read.
    ConnectionSpec tlsSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
                   ^
    (see https://errorprone.info/bugpattern/UnusedVariable)
```