### PR TITLE
Remove unnecessary use of grouping parentheses

### DIFF
--- a/okhttp/src/test/java/okhttp3/CallTest.java
+++ b/okhttp/src/test/java/okhttp3/CallTest.java
@@ -2022,7 +2022,7 @@ public final class CallTest {
           }
 
           @Override public void writeTo(BufferedSink sink) throws IOException {
-            sink.writeUtf8("attempt " + (attempt++));
+            sink.writeUtf8("attempt " + attempt++);
           }
         })
         .build();
@@ -2053,7 +2053,7 @@ public final class CallTest {
           }
 
           @Override public void writeTo(BufferedSink sink) throws IOException {
-            sink.writeUtf8("attempt " + (attempt++));
+            sink.writeUtf8("attempt " + attempt++);
           }
 
           @Override public boolean isOneShot() {

--- a/okhttp/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp/src/test/java/okhttp3/OkHttpClientTest.java
@@ -284,7 +284,7 @@ public final class OkHttpClientTest {
       new OkHttpClient.Builder().protocols(protocols);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected.getMessage()).isEqualTo(("protocols must not contain null"));
+      assertThat(expected.getMessage()).isEqualTo("protocols must not contain null");
     }
   }
 


### PR DESCRIPTION
Let's remove warnings found by errorprone.

- attempt
```
okhttp/okhttp/src/test/java/okhttp3/CallTest.java:2056: warning: [UnnecessaryParentheses] Unnecessary use of grouping parentheses
            sink.writeUtf8("attempt " + (attempt++));
                                        ^
    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
  Did you mean 'sink.writeUtf8("attempt " + attempt++);'?
```

- isEaualTo
```
okhttp/src/test/java/okhttp3/OkHttpClientTest.java:287: warning: [UnnecessaryParentheses] Unnecessary use of grouping parentheses
      assertThat(expected.getMessage()).isEqualTo(("protocols must not contain null"));
                                                  ^
    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
```