### PR TITLE
Unnecessary call removed from the code.

### DIFF
--- a/samples/guide/src/main/java/okhttp3/recipes/CustomTrust.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/CustomTrust.java
@@ -192,7 +192,7 @@ public final class CustomTrust {
     // Use it to build an X509 trust manager.
     KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(
         KeyManagerFactory.getDefaultAlgorithm());
-    keyManagerFactory.init(keyStore, password);
+    
     TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
         TrustManagerFactory.getDefaultAlgorithm());
     trustManagerFactory.init(keyStore);

--- a/samples/guide/src/main/java/okhttp3/recipes/CustomTrust.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/CustomTrust.java
@@ -190,8 +190,6 @@ public final class CustomTrust {
     }
 
     // Use it to build an X509 trust manager.
-    KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(
-        KeyManagerFactory.getDefaultAlgorithm());
     
     TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
         TrustManagerFactory.getDefaultAlgorithm());


### PR DESCRIPTION
 Fixes #4370

Unnecessary call to KeyManagerFactory.init in CustomTrust recipe removed.
