### PR TITLE
Adds Maven coordinates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,7 @@ Releases
 
 Our [change log][changelog] has release history.
 
-```kotlin
-implementation("com.squareup.okhttp3:okhttp:4.2.1")
-```
-
-```xml
-<dependency>
-  <groupId>com.squareup.okhttp3</groupId>
-  <artifactId>okhttp</artifactId>
-  <version>4.2.1</version>
-</dependency>
-```
+The latest release Maven coordinates are `com.squareup.okhttp3:okhttp:4.2.1`.
 
 Snapshot builds are [available][snap].
 
@@ -127,9 +117,7 @@ MockWebServer
 
 OkHttp includes a library for testing HTTP, HTTPS, and HTTP/2 clients.
 
-```kotlin
-testImplementation("com.squareup.okhttp3:mockwebserver:4.2.1")
-```
+Use the Maven coordinates `com.squareup.okhttp3:mockwebserver:4.2.1`.
 
 
 License

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ MockWebServer
 
 OkHttp includes a library for testing HTTP, HTTPS, and HTTP/2 clients.
 
-The latest release is available on [Maven Central](https://search.maven.org/artifact/com.squareup.okhttp3/mockwebserver/4.2.2/jar)
+The latest release is available on [Maven Central](https://search.maven.org/artifact/com.squareup.okhttp3/mockwebserver/4.2.2/jar).
 
 ```kotlin
 testImplementation("com.squareup.okhttp3:mockwebserver:4.2.2")

--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ Releases
 
 Our [change log][changelog] has release history.
 
-The latest release Maven coordinates are `com.squareup.okhttp3:okhttp:4.2.1`.
+The latest release is available on [Maven Central](https://search.maven.org/artifact/com.squareup.okhttp3/okhttp/4.2.2/jar).
+
+```kotlin
+implementation("com.squareup.okhttp3:okhttp:4.2.2")
+```
 
 Snapshot builds are [available][snap].
 
@@ -117,8 +121,11 @@ MockWebServer
 
 OkHttp includes a library for testing HTTP, HTTPS, and HTTP/2 clients.
 
-Use the Maven coordinates `com.squareup.okhttp3:mockwebserver:4.2.1`.
+The latest release is available on [Maven Central](https://search.maven.org/artifact/com.squareup.okhttp3/mockwebserver/4.2.2/jar)
 
+```kotlin
+testImplementation("com.squareup.okhttp3:mockwebserver:4.2.2")
+```
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Our [change log][changelog] has release history.
 implementation("com.squareup.okhttp3:okhttp:4.2.1")
 ```
 
+```xml
+<dependency>
+  <groupId>com.squareup.okhttp3</groupId>
+  <artifactId>okhttp</artifactId>
+  <version>4.2.1</version>
+</dependency>
+```
+
 Snapshot builds are [available][snap].
 
 


### PR DESCRIPTION
The README still contains Java examples, but is missing what most Java projects would use: Maven coordinates. This PR adds that.

Note that something about the README (or the lack of an actual pom.xml file perhaps) confuses GitHub's Dependency graph page. Here https://github.com/nielsgron/quicksilver/network/dependencies it detects for com.squareup.okhttp3:okhttp the repository https://github.com/lizhangqu/PriorityOkHttp . It would be good to see with GitHub how to make this the canonical repository for OkHttp on Maven. 