### PR TITLE
Flaky test improvements

### DIFF
--- a/okhttp-testing-support/src/main/java/okhttp3/ClientRuleEventListener.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/ClientRuleEventListener.kt
@@ -21,7 +21,7 @@ import java.net.InetSocketAddress
 import java.net.Proxy
 import java.util.concurrent.TimeUnit
 
-class ClientRuleEventListener(var logger: (String) -> Unit) : EventListener(),
+class ClientRuleEventListener(val delegate: EventListener = NONE, var logger: (String) -> Unit) : EventListener(),
     EventListener.Factory {
   private var startNs: Long = 0
 
@@ -31,34 +31,50 @@ class ClientRuleEventListener(var logger: (String) -> Unit) : EventListener(),
     startNs = System.nanoTime()
 
     logWithTime("callStart: ${call.request()}")
+
+    delegate.callStart(call)
   }
 
   override fun proxySelectStart(call: Call, url: HttpUrl) {
     logWithTime("proxySelectStart: $url")
+
+    delegate.proxySelectStart(call, url)
   }
 
   override fun proxySelectEnd(call: Call, url: HttpUrl, proxies: List<Proxy>) {
     logWithTime("proxySelectEnd: $proxies")
+
+    delegate.proxySelectEnd(call, url, proxies)
   }
 
   override fun dnsStart(call: Call, domainName: String) {
     logWithTime("dnsStart: $domainName")
+
+    delegate.dnsStart(call, domainName)
   }
 
   override fun dnsEnd(call: Call, domainName: String, inetAddressList: List<InetAddress>) {
     logWithTime("dnsEnd: $inetAddressList")
+
+    delegate.dnsEnd(call, domainName, inetAddressList)
   }
 
   override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
     logWithTime("connectStart: $inetSocketAddress $proxy")
+
+    delegate.connectStart(call, inetSocketAddress, proxy)
   }
 
   override fun secureConnectStart(call: Call) {
     logWithTime("secureConnectStart")
+
+    delegate.secureConnectStart(call)
   }
 
   override fun secureConnectEnd(call: Call, handshake: Handshake?) {
     logWithTime("secureConnectEnd: $handshake")
+
+    delegate.secureConnectEnd(call, handshake)
   }
 
   override fun connectEnd(
@@ -68,6 +84,8 @@ class ClientRuleEventListener(var logger: (String) -> Unit) : EventListener(),
     protocol: Protocol?
   ) {
     logWithTime("connectEnd: $protocol")
+
+    delegate.connectEnd(call, inetSocketAddress, proxy, protocol)
   }
 
   override fun connectFailed(
@@ -78,62 +96,92 @@ class ClientRuleEventListener(var logger: (String) -> Unit) : EventListener(),
     ioe: IOException
   ) {
     logWithTime("connectFailed: $protocol $ioe")
+
+    delegate.connectFailed(call, inetSocketAddress, proxy, protocol, ioe)
   }
 
   override fun connectionAcquired(call: Call, connection: Connection) {
     logWithTime("connectionAcquired: $connection")
+
+    delegate.connectionAcquired(call, connection)
   }
 
   override fun connectionReleased(call: Call, connection: Connection) {
     logWithTime("connectionReleased")
+
+    delegate.connectionReleased(call, connection)
   }
 
   override fun requestHeadersStart(call: Call) {
     logWithTime("requestHeadersStart")
+
+    delegate.requestHeadersStart(call)
   }
 
   override fun requestHeadersEnd(call: Call, request: Request) {
     logWithTime("requestHeadersEnd")
+
+    delegate.requestHeadersEnd(call, request)
   }
 
   override fun requestBodyStart(call: Call) {
     logWithTime("requestBodyStart")
+
+    delegate.requestBodyStart(call)
   }
 
   override fun requestBodyEnd(call: Call, byteCount: Long) {
     logWithTime("requestBodyEnd: byteCount=$byteCount")
+
+    delegate.requestBodyEnd(call, byteCount)
   }
 
   override fun requestFailed(call: Call, ioe: IOException) {
     logWithTime("requestFailed: $ioe")
+
+    delegate.requestFailed(call, ioe)
   }
 
   override fun responseHeadersStart(call: Call) {
     logWithTime("responseHeadersStart")
+
+    delegate.responseHeadersStart(call)
   }
 
   override fun responseHeadersEnd(call: Call, response: Response) {
     logWithTime("responseHeadersEnd: $response")
+
+    delegate.responseHeadersEnd(call, response)
   }
 
   override fun responseBodyStart(call: Call) {
     logWithTime("responseBodyStart")
+
+    delegate.responseBodyStart(call)
   }
 
   override fun responseBodyEnd(call: Call, byteCount: Long) {
     logWithTime("responseBodyEnd: byteCount=$byteCount")
+
+    delegate.requestBodyEnd(call, byteCount)
   }
 
   override fun responseFailed(call: Call, ioe: IOException) {
     logWithTime("responseFailed: $ioe")
+
+    delegate.responseFailed(call, ioe)
   }
 
   override fun callEnd(call: Call) {
     logWithTime("callEnd")
+
+    delegate.callEnd(call)
   }
 
   override fun callFailed(call: Call, ioe: IOException) {
     logWithTime("callFailed: $ioe")
+
+    delegate.callFailed(call, ioe)
   }
 
   private fun logWithTime(message: String) {

--- a/okhttp-testing-support/src/main/java/okhttp3/ClientRuleEventListener.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/ClientRuleEventListener.kt
@@ -163,7 +163,7 @@ class ClientRuleEventListener(val delegate: EventListener = NONE, var logger: (S
   override fun responseBodyEnd(call: Call, byteCount: Long) {
     logWithTime("responseBodyEnd: byteCount=$byteCount")
 
-    delegate.requestBodyEnd(call, byteCount)
+    delegate.responseBodyEnd(call, byteCount)
   }
 
   override fun responseFailed(call: Call, ioe: IOException) {

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -29,6 +29,10 @@ class OkHttpClientTestRule : TestRule {
   private val clientEventsList = mutableListOf<String>()
   private var testClient: OkHttpClient? = null
 
+  fun wrap(eventListener: EventListener) = object : EventListener.Factory {
+    override fun create(call: Call): EventListener = ClientRuleEventListener(eventListener) { addEvent(it) }
+  }
+
   /**
    * Returns an OkHttpClient for tests to use as a starting point.
    *
@@ -43,7 +47,9 @@ class OkHttpClientTestRule : TestRule {
     if (client == null) {
       client = OkHttpClient.Builder()
           .dns(SINGLE_INET_ADDRESS_DNS) // Prevent unexpected fallback addresses.
-          .eventListener(ClientRuleEventListener { addEvent(it) })
+          .eventListenerFactory(object : EventListener.Factory {
+            override fun create(call: Call): EventListener = ClientRuleEventListener { addEvent(it) }
+          })
           .build()
       testClient = client
     }

--- a/okhttp-testing-support/src/main/java/okhttp3/RecordingEventListener.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/RecordingEventListener.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
 import static org.junit.Assert.assertTrue;
 
 public class RecordingEventListener extends EventListener {
@@ -86,8 +87,7 @@ public class RecordingEventListener extends EventListener {
     logEvent(new ProxySelectStart(call, url));
   }
 
-  @Override public void proxySelectEnd(Call call, HttpUrl url,
-      List<Proxy> proxies) {
+  @Override public void proxySelectEnd(Call call, HttpUrl url, List<Proxy> proxies) {
     logEvent(new ProxySelectEnd(call, url, proxies));
   }
 
@@ -99,8 +99,7 @@ public class RecordingEventListener extends EventListener {
     logEvent(new DnsEnd(call, domainName, inetAddressList));
   }
 
-  @Override public void connectStart(Call call, InetSocketAddress inetSocketAddress,
-      Proxy proxy) {
+  @Override public void connectStart(Call call, InetSocketAddress inetSocketAddress, Proxy proxy) {
     logEvent(new ConnectStart(call, inetSocketAddress, proxy));
   }
 

--- a/okhttp-testing-support/src/main/java/okhttp3/RecordingEventListener.java
+++ b/okhttp-testing-support/src/main/java/okhttp3/RecordingEventListener.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.in;
 import static org.junit.Assert.assertTrue;
 
 public class RecordingEventListener extends EventListener {
@@ -87,7 +86,8 @@ public class RecordingEventListener extends EventListener {
     logEvent(new ProxySelectStart(call, url));
   }
 
-  @Override public void proxySelectEnd(Call call, HttpUrl url, List<Proxy> proxies) {
+  @Override public void proxySelectEnd(Call call, HttpUrl url,
+      List<Proxy> proxies) {
     logEvent(new ProxySelectEnd(call, url, proxies));
   }
 
@@ -99,7 +99,8 @@ public class RecordingEventListener extends EventListener {
     logEvent(new DnsEnd(call, domainName, inetAddressList));
   }
 
-  @Override public void connectStart(Call call, InetSocketAddress inetSocketAddress, Proxy proxy) {
+  @Override public void connectStart(Call call, InetSocketAddress inetSocketAddress,
+      Proxy proxy) {
     logEvent(new ConnectStart(call, inetSocketAddress, proxy));
   }
 

--- a/okhttp/src/test/java/okhttp3/CallTest.java
+++ b/okhttp/src/test/java/okhttp3/CallTest.java
@@ -72,6 +72,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.QueueDispatcher;
 import okhttp3.mockwebserver.RecordedRequest;
 import okhttp3.mockwebserver.SocketPolicy;
+import okhttp3.testing.Flaky;
 import okhttp3.testing.PlatformRule;
 import okhttp3.tls.HandshakeCertificates;
 import okhttp3.tls.HeldCertificate;
@@ -112,7 +113,7 @@ public final class CallTest {
   private RecordingEventListener listener = new RecordingEventListener();
   private HandshakeCertificates handshakeCertificates = localhost();
   private OkHttpClient client = clientTestRule.newClientBuilder()
-      .eventListener(listener)
+      .eventListenerFactory(clientTestRule.wrap(listener))
       .build();
   private RecordingCallback callback = new RecordingCallback();
   private TestLogHandler logHandler = new TestLogHandler();
@@ -1181,7 +1182,7 @@ public final class CallTest {
 
     client = client.newBuilder()
         .dns(new DoubleInetAddressDns())
-        .eventListener(listener)
+        .eventListenerFactory(clientTestRule.wrap(listener))
         .build();
     assertThat(client.retryOnConnectionFailure()).isTrue();
 
@@ -2963,6 +2964,7 @@ public final class CallTest {
   }
 
   /** We had a bug where failed HTTP/2 calls could break the entire connection. */
+  @Flaky
   @Test public void failingCallsDoNotInterfereWithConnection() throws Exception {
     enableProtocol(Protocol.HTTP_2);
 

--- a/okhttp/src/test/java/okhttp3/ConnectionCoalescingTest.java
+++ b/okhttp/src/test/java/okhttp3/ConnectionCoalescingTest.java
@@ -221,7 +221,7 @@ public final class ConnectionCoalescingTest {
           connection.set(chain.connection());
           return chain.proceed(chain.request());
         })
-        .eventListener(listener1)
+        .eventListenerFactory(clientTestRule.wrap(listener1))
         .build();
 
     Request request = new Request.Builder().url(sanUrl).build();
@@ -245,7 +245,7 @@ public final class ConnectionCoalescingTest {
     });
 
     OkHttpClient client2 = client.newBuilder()
-        .eventListener(request2Listener)
+        .eventListenerFactory(clientTestRule.wrap(request2Listener))
         .build();
     Call call2 = client2.newCall(request);
     Response response = call2.execute();
@@ -357,7 +357,7 @@ public final class ConnectionCoalescingTest {
       }
     };
     client = client.newBuilder()
-        .eventListener(listener)
+        .eventListenerFactory(clientTestRule.wrap(listener))
         .build();
 
     assert200Http2Response(execute(url), server.getHostName());

--- a/okhttp/src/test/java/okhttp3/DispatcherTest.java
+++ b/okhttp/src/test/java/okhttp3/DispatcherTest.java
@@ -22,7 +22,7 @@ public final class DispatcherTest {
   RecordingEventListener listener = new RecordingEventListener();
   OkHttpClient client = clientTestRule.newClientBuilder()
       .dispatcher(dispatcher)
-      .eventListener(listener)
+      .eventListenerFactory(clientTestRule.wrap(listener))
       .build();
 
   @Before public void setUp() throws Exception {

--- a/okhttp/src/test/java/okhttp3/DuplexTest.java
+++ b/okhttp/src/test/java/okhttp3/DuplexTest.java
@@ -52,7 +52,7 @@ public final class DuplexTest {
   private RecordingEventListener listener = new RecordingEventListener();
   private HandshakeCertificates handshakeCertificates = localhost();
   private OkHttpClient client = clientTestRule.newClientBuilder()
-      .eventListener(listener)
+      .eventListenerFactory(clientTestRule.wrap(listener))
       .build();
 
   @Before public void setUp() {

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -48,6 +48,7 @@ import okhttp3.logging.HttpLoggingInterceptor;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.SocketPolicy;
+import okhttp3.testing.Flaky;
 import okhttp3.testing.PlatformRule;
 import okhttp3.tls.HandshakeCertificates;
 import okio.Buffer;
@@ -71,6 +72,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
+@Flaky // STDOUT logging enabled for test
 public final class EventListenerTest {
   public static final Matcher<Response> anyResponse = CoreMatchers.any(Response.class);
 
@@ -83,7 +85,7 @@ public final class EventListenerTest {
   private final HandshakeCertificates handshakeCertificates = localhost();
 
   private OkHttpClient client = clientTestRule.newClientBuilder()
-      .eventListener(listener)
+      .eventListenerFactory(clientTestRule.wrap(listener))
       .build();
   private SocksProxy socksProxy;
 

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -1603,7 +1603,7 @@ public final class HttpOverHttp2Test {
       }
     };
 
-    client = client.newBuilder().eventListener(new EventListener() {
+    client = client.newBuilder().eventListenerFactory(clientTestRule.wrap(new EventListener() {
       int callCount;
 
       @Override public void connectionAcquired(Call call, Connection connection) {
@@ -1615,7 +1615,7 @@ public final class HttpOverHttp2Test {
           fail();
         }
       }
-    }).build();
+    })).build();
 
     client.newCall(new Request.Builder().url(server.url("")).build()).enqueue(callback);
     client.newCall(new Request.Builder().url(server.url("")).build()).enqueue(callback);

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -681,7 +681,7 @@ public final class WebSocketHttpTest {
     RecordingEventListener listener = new RecordingEventListener();
 
     client = client.newBuilder()
-        .eventListener(listener)
+        .eventListenerFactory(clientTestRule.wrap(listener))
         .build();
 
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));


### PR DESCRIPTION
Keep the client event logging for flaky tests even when another listener is applied.

Used to generate a baseline for https://github.com/square/okhttp/issues/5576