### PR TITLE
Run Jdk8 on CI and fix test expectations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,8 @@ workflows:
       - testjdk8:
           filters:
             branches:
-              only: master
+              ignore:
+                - gh-pages
       - testjdk8alpn:
           filters:
             branches:


### PR DESCRIPTION
Test doesn't need to care about which response, timing related issues are secondary.  Just that it succeeds and we don't somehow disconnect and reconnect.