### PR TITLE
Avoid Corretto and R8 incompatibility in tests

### DIFF
--- a/android-test/build.gradle
+++ b/android-test/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   androidTestImplementation(project(':okhttp-testing-support')) {
     exclude group: 'org.openjsse', module: 'openjsse'
     exclude group: 'org.conscrypt', module: 'conscrypt-openjdk-uber'
+    exclude group: 'software.amazon.cryptools', module: 'AmazonCorrettoCryptoProvider'
   }
   androidTestImplementation "org.conscrypt:conscrypt-android:2.2.1"
   androidTestImplementation project(':mockwebserver')


### PR DESCRIPTION
Failing with 

```
ANDROID_SDK_ROOT=/Users/yschimke/Library/Android/sdk ./gradlew :android-test:connectedCheck
D8: MethodHandle.invoke and MethodHandle.invokeExact are only supported starting with Android O (--min-api 26)
...
Caused by: com.android.builder.dexing.DexArchiveBuilderException: Failed to process /Users/yschimke/.gradle/caches/modules-2/files-2.1/software.amazon.cryptools/AmazonCorrettoCryptoProvider/1.1.1/a606679a20abcef643ad551bdd6793dba4a11213/AmazonCorrettoCryptoProvider-1.1.1-linux-x86_64.jar
        at com.android.build.gradle.internal.transforms.DexArchiveBuilderTransform.launchProcessing(DexArchiveBuilderTransform.java:909)
        at com.android.build.gradle.internal.transforms.DexArchiveBuilderTransform.lambda$convertToDexArchive$6(DexArchiveBuilderTransform.java:834)
        at java.base/java.util.concurrent.ForkJoinTask$AdaptedCallable.exec(ForkJoinTask.java:1448)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
Caused by: com.android.builder.dexing.DexArchiveBuilderException: Error while dexing.
        at com.android.builder.dexing.D8DexArchiveBuilder.getExceptionToRethrow(D8DexArchiveBuilder.java:124)
        at com.android.builder.dexing.D8DexArchiveBuilder.convert(D8DexArchiveBuilder.java:101)
        at com.android.build.gradle.internal.transforms.DexArchiveBuilderTransform.launchProcessing(DexArchiveBuilderTransform.java:904)
        ... 7 more
Caused by: com.android.tools.r8.CompilationFailedException: Compilation failed to complete
        at com.android.tools.r8.utils.ExceptionUtils.withCompilationHandler(ExceptionUtils.java:81)
        at com.android.tools.r8.utils.ExceptionUtils.withD8CompilationHandler(ExceptionUtils.java:45)
        at com.android.tools.r8.D8.run(D8.java:94)
        at com.android.builder.dexing.D8DexArchiveBuilder.convert(D8DexArchiveBuilder.java:99)
        ... 8 more
Caused by: com.android.tools.r8.utils.AbortException: Error: MethodHandle.invoke and MethodHandle.invokeExact are only supported starting with Android O (--min-api 26)
        at com.android.tools.r8.utils.Reporter.failIfPendingErrors(Reporter.java:101)
        at com.android.tools.r8.utils.Reporter.fatalError(Reporter.java:72)
        at com.android.tools.r8.utils.ExceptionUtils.withCompilationHandler(ExceptionUtils.java:66)
        ... 11 more
```