### PR TITLE
Bump Travis to JDK 11

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -6,7 +6,7 @@
 # https://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
 SLUG="square/okhttp"
-JDK="oraclejdk8"
+JDK="oraclejdk11"
 BRANCH="master"
 
 set -e

--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -6,7 +6,7 @@
 # https://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
 SLUG="square/okhttp"
-JDK="oraclejdk11"
+JDK="openjdk11"
 BRANCH="master"
 
 set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 dist: trusty
 
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 # avoid ./gradlew assemble default which builds docs
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,8 @@ env:
     - secure: "WMkcWrsvzJNf48w7DJwipUNbhAoggCkC+NM31esq9/GDceGtVWj4hssQETynG4+ckxr0wGqUxsTRTz0uGhX6Fi58haG8yKp+g/HVClqI5EYjI44ptPcwlqlbYjuGbk65k1OGGZLctA6fQA3uT0zee05/yBjJx/jOqrN+PD1tW38="
 
 branches:
-  except:
-    - gh-pages
-#  only:
-#    - master
+  only:
+    - master
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ env:
     - secure: "WMkcWrsvzJNf48w7DJwipUNbhAoggCkC+NM31esq9/GDceGtVWj4hssQETynG4+ckxr0wGqUxsTRTz0uGhX6Fi58haG8yKp+g/HVClqI5EYjI44ptPcwlqlbYjuGbk65k1OGGZLctA6fQA3uT0zee05/yBjJx/jOqrN+PD1tW38="
 
 branches:
-  only:
-    - master
+  except:
+    - gh-pages
+#  only:
+#    - master
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 dist: trusty
 
 jdk:
-  - openjdk11
+  - openjdk10
 
 # avoid ./gradlew assemble default which builds docs
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,10 @@ language: java
 dist: trusty
 
 jdk:
-  - openjdk10
-
-# avoid ./gradlew assemble default which builds docs
-install:
- - ./gradlew jar --parallel
+  - openjdk11
 
 script:
- - ./gradlew test --parallel
+  - ./gradlew jar --parallel
 
 after_success:
   - .buildscript/deploy_snapshot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 dist: trusty
 
 jdk:
-  - oraclejdk11
+  - oraclejdk9
 
 # avoid ./gradlew assemble default which builds docs
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 dist: trusty
 
 jdk:
-  - oraclejdk9
+  - openjdk11
 
 # avoid ./gradlew assemble default which builds docs
 install:


### PR DESCRIPTION
- Build using the minimum suitable LTS (JDK11)
- Avoid running tests because Travis has old versions of JDK11 that have SSL bugs