### PR TITLE
Kotlin optimized lock asserts

### DIFF
--- a/okhttp/src/main/java/okhttp3/Dispatcher.kt
+++ b/okhttp/src/main/java/okhttp3/Dispatcher.kt
@@ -16,6 +16,7 @@
 package okhttp3
 
 import okhttp3.RealCall.AsyncCall
+import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.threadFactory
 import java.util.ArrayDeque
 import java.util.Collections
@@ -156,7 +157,7 @@ class Dispatcher constructor() {
    * @return true if the dispatcher is currently running calls.
    */
   private fun promoteAndExecute(): Boolean {
-    assert(!Thread.holdsLock(this))
+    this.assertThreadDoesntHoldLock()
 
     val executableCalls = mutableListOf<AsyncCall>()
     val isRunning: Boolean

--- a/okhttp/src/main/java/okhttp3/RealCall.kt
+++ b/okhttp/src/main/java/okhttp3/RealCall.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3
 
+import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.cache.CacheInterceptor
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.connection.ConnectInterceptor
@@ -111,7 +112,8 @@ internal class RealCall private constructor(
      * if the executor has been shut down by reporting the call as failed.
      */
     fun executeOn(executorService: ExecutorService) {
-      assert(!Thread.holdsLock(client.dispatcher))
+      client.dispatcher.assertThreadDoesntHoldLock()
+
       var success = false
       try {
         executorService.execute(this)

--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -530,18 +530,18 @@ internal fun <E> MutableList<E>.addIfAbsent(element: E) {
 }
 
 @JvmField
-internal val AssertionsEnabled = OkHttpClient::class.java.desiredAssertionStatus()
+internal val assertionsEnabled = OkHttpClient::class.java.desiredAssertionStatus()
 
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun Any.assertThreadHoldsLock() {
-  if (AssertionsEnabled && !Thread.holdsLock(this)) {
+  if (assertionsEnabled && !Thread.holdsLock(this)) {
     throw AssertionError("Thread ${Thread.currentThread().name} MUST hold lock on $this")
   }
 }
 
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun Any.assertThreadDoesntHoldLock() {
-  if (AssertionsEnabled && Thread.holdsLock(this)) {
+  if (assertionsEnabled && Thread.holdsLock(this)) {
     throw AssertionError("Thread ${Thread.currentThread().name} MUST NOT hold lock on $this")
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -26,7 +26,6 @@ import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
-import okhttp3.internal.Assertions.AssertionsEnabled
 import okhttp3.internal.http2.Header
 import okio.Buffer
 import okio.BufferedSink
@@ -530,23 +529,19 @@ internal fun <E> MutableList<E>.addIfAbsent(element: E) {
   if (!contains(element)) add(element)
 }
 
-internal object Assertions {
-  @JvmField
-  internal val AssertionsEnabled = OkHttpClient::class.java.desiredAssertionStatus()
-}
+@JvmField
+internal val AssertionsEnabled = OkHttpClient::class.java.desiredAssertionStatus()
 
+@Suppress("NOTHING_TO_INLINE")
 internal inline fun Any.assertThreadHoldsLock() {
-  if (AssertionsEnabled) {
-    if (!Thread.holdsLock(this)) {
-      throw AssertionError("Thread ${Thread.currentThread().name} MUST hold lock on $this")
-    }
+  if (AssertionsEnabled && !Thread.holdsLock(this)) {
+    throw AssertionError("Thread ${Thread.currentThread().name} MUST hold lock on $this")
   }
 }
 
+@Suppress("NOTHING_TO_INLINE")
 internal inline fun Any.assertThreadDoesntHoldLock() {
-  if (AssertionsEnabled) {
-    if (Thread.holdsLock(this)) {
-      throw AssertionError("Thread ${Thread.currentThread().name} MUST NOT hold lock on $this")
-    }
+  if (AssertionsEnabled && Thread.holdsLock(this)) {
+    throw AssertionError("Thread ${Thread.currentThread().name} MUST NOT hold lock on $this")
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -22,9 +22,11 @@ import okhttp3.EventListener
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.internal.Assertions.AssertionsEnabled
 import okhttp3.internal.http2.Header
 import okio.Buffer
 import okio.BufferedSink
@@ -526,4 +528,26 @@ fun <T> readFieldOrNull(instance: Any, fieldType: Class<T>, fieldName: String): 
 
 internal fun <E> MutableList<E>.addIfAbsent(element: E) {
   if (!contains(element)) add(element)
+}
+
+
+internal object Assertions {
+  @JvmField
+  internal val AssertionsEnabled = OkHttpClient::class.java.desiredAssertionStatus()
+}
+
+internal inline fun Any.assertThreadHoldsLock() {
+  if (AssertionsEnabled) {
+    if (!Thread.holdsLock(this)) {
+      throw AssertionError("Thread " + Thread.currentThread().name + " MUST hold lock on " + this)
+    }
+  }
+}
+
+internal inline fun Any.assertThreadDoesntHoldLock() {
+  if (AssertionsEnabled) {
+    if (Thread.holdsLock(this)) {
+      throw AssertionError("Thread " + Thread.currentThread().name + " MUST NOT hold lock on " + this)
+    }
+  }
 }

--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -530,7 +530,6 @@ internal fun <E> MutableList<E>.addIfAbsent(element: E) {
   if (!contains(element)) add(element)
 }
 
-
 internal object Assertions {
   @JvmField
   internal val AssertionsEnabled = OkHttpClient::class.java.desiredAssertionStatus()
@@ -539,7 +538,7 @@ internal object Assertions {
 internal inline fun Any.assertThreadHoldsLock() {
   if (AssertionsEnabled) {
     if (!Thread.holdsLock(this)) {
-      throw AssertionError("Thread " + Thread.currentThread().name + " MUST hold lock on " + this)
+      throw AssertionError("Thread ${Thread.currentThread().name} MUST hold lock on $this")
     }
   }
 }
@@ -547,7 +546,7 @@ internal inline fun Any.assertThreadHoldsLock() {
 internal inline fun Any.assertThreadDoesntHoldLock() {
   if (AssertionsEnabled) {
     if (Thread.holdsLock(this)) {
-      throw AssertionError("Thread " + Thread.currentThread().name + " MUST NOT hold lock on " + this)
+      throw AssertionError("Thread ${Thread.currentThread().name} MUST NOT hold lock on $this")
     }
   }
 }

--- a/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.kt
+++ b/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.kt
@@ -15,6 +15,8 @@
  */
 package okhttp3.internal.cache
 
+import okhttp3.internal.assertThreadDoesntHoldLock
+import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.cache.DiskLruCache.Editor
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.Task
@@ -207,7 +209,7 @@ class DiskLruCache internal constructor(
 
   @Synchronized @Throws(IOException::class)
   fun initialize() {
-    assert(Thread.holdsLock(this))
+    this.assertThreadHoldsLock()
 
     if (initialized) {
       return // Already initialized.
@@ -294,7 +296,7 @@ class DiskLruCache internal constructor(
   private fun newJournalWriter(): BufferedSink {
     val fileSink = fileSystem.appendingSink(journalFile)
     val faultHidingSink = FaultHidingSink(fileSink) {
-      assert(Thread.holdsLock(this@DiskLruCache))
+      this@DiskLruCache.assertThreadHoldsLock()
       hasJournalErrors = true
     }
     return faultHidingSink.buffer()
@@ -948,7 +950,7 @@ class DiskLruCache internal constructor(
      * different edits.
      */
     internal fun snapshot(): Snapshot? {
-      assert(Thread.holdsLock(this@DiskLruCache))
+      this@DiskLruCache.assertThreadHoldsLock()
 
       val sources = mutableListOf<Source>()
       val lengths = this.lengths.clone() // Defensive copy since these can be zeroed out.

--- a/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.kt
+++ b/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.kt
@@ -15,7 +15,6 @@
  */
 package okhttp3.internal.cache
 
-import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.cache.DiskLruCache.Editor
 import okhttp3.internal.closeQuietly

--- a/okhttp/src/main/java/okhttp3/internal/concurrent/TaskQueue.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/TaskQueue.kt
@@ -15,6 +15,8 @@
  */
 package okhttp3.internal.concurrent
 
+import okhttp3.internal.assertThreadDoesntHoldLock
+import okhttp3.internal.assertThreadHoldsLock
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
@@ -146,7 +148,7 @@ class TaskQueue internal constructor(
    * be removed from the execution schedule.
    */
   fun cancelAll() {
-    check(!Thread.holdsLock(this))
+    this.assertThreadDoesntHoldLock()
 
     synchronized(taskRunner) {
       if (cancelAllAndDecide()) {
@@ -156,7 +158,7 @@ class TaskQueue internal constructor(
   }
 
   fun shutdown() {
-    check(!Thread.holdsLock(this))
+    this.assertThreadDoesntHoldLock()
 
     synchronized(taskRunner) {
       shutdown = true

--- a/okhttp/src/main/java/okhttp3/internal/concurrent/TaskQueue.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/TaskQueue.kt
@@ -16,7 +16,6 @@
 package okhttp3.internal.concurrent
 
 import okhttp3.internal.assertThreadDoesntHoldLock
-import okhttp3.internal.assertThreadHoldsLock
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit

--- a/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
@@ -21,6 +21,8 @@ import okhttp3.EventListener
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Route
+import okhttp3.internal.assertThreadDoesntHoldLock
+import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.canReuseConnectionFor
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.http.ExchangeCodec
@@ -270,12 +272,13 @@ class ExchangeFinder(
   }
 
   fun connectingConnection(): RealConnection? {
-    assert(Thread.holdsLock(connectionPool))
+    connectionPool.assertThreadHoldsLock()
     return connectingConnection
   }
 
   fun trackFailure() {
-    assert(!Thread.holdsLock(connectionPool))
+    connectionPool.assertThreadDoesntHoldLock()
+
     synchronized(connectionPool) {
       hasStreamFailure = true // Permit retries.
     }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -32,6 +32,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
 import okhttp3.internal.EMPTY_RESPONSE
+import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.http.ExchangeCodec
@@ -128,7 +129,8 @@ class RealConnection(
 
   /** Prevent further exchanges from being created on this connection. */
   fun noNewExchanges() {
-    assert(!Thread.holdsLock(connectionPool))
+    connectionPool.assertThreadDoesntHoldLock()
+
     synchronized(connectionPool) {
       noNewExchanges = true
     }
@@ -654,7 +656,8 @@ class RealConnection(
    * being used for future exchanges.
    */
   internal fun trackFailure(e: IOException?) {
-    assert(!Thread.holdsLock(connectionPool))
+    connectionPool.assertThreadDoesntHoldLock()
+
     synchronized(connectionPool) {
       if (e is StreamResetException) {
         when (e.errorCode) {

--- a/okhttp/src/main/java/okhttp3/internal/connection/Transmitter.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Transmitter.kt
@@ -24,6 +24,7 @@ import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.canReuseConnectionFor
 import okhttp3.internal.platform.Platform
@@ -171,7 +172,7 @@ class Transmitter(
   }
 
   fun acquireConnectionNoEvents(connection: RealConnection) {
-    assert(Thread.holdsLock(connectionPool))
+    connectionPool.assertThreadHoldsLock()
 
     check(this.connection == null)
     this.connection = connection
@@ -183,7 +184,7 @@ class Transmitter(
    * caller should close.
    */
   fun releaseConnectionNoEvents(): Socket? {
-    assert(Thread.holdsLock(connectionPool))
+    connectionPool.assertThreadHoldsLock()
 
     val index = connection!!.transmitters.indexOfFirst { it.get() == this@Transmitter }
     check(index != -1)

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Connection.kt
@@ -17,6 +17,7 @@ package okhttp3.internal.http2
 
 import okhttp3.internal.EMPTY_BYTE_ARRAY
 import okhttp3.internal.EMPTY_HEADERS
+import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.http2.ErrorCode.REFUSED_STREAM
@@ -424,7 +425,8 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
     streamCode: ErrorCode,
     cause: IOException?
   ) {
-    assert(!Thread.holdsLock(this))
+    this.assertThreadDoesntHoldLock()
+
     ignoreIoExceptions {
       shutdown(connectionCode)
     }

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
@@ -25,6 +25,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
+import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.Task
 import okhttp3.internal.concurrent.TaskRunner
@@ -392,7 +393,8 @@ class RealWebSocket(
   }
 
   private fun runWriter() {
-    assert(Thread.holdsLock(this))
+    this.assertThreadHoldsLock()
+
     taskQueue.schedule(writerTask!!)
   }
 


### PR DESCRIPTION
Use a clear intentional method instead of kotlin assert() function vs JVM assert keyword. Guarded behind a cached assertion status check.

Addressing issue https://github.com/square/okhttp/issues/5586