### PR TITLE
change the order of two parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ public static final MediaType JSON
 OkHttpClient client = new OkHttpClient();
 
 String post(String url, String json) throws IOException {
-  RequestBody body = RequestBody.create(JSON, json);
+  RequestBody body = RequestBody.create(json, JSON);
   Request request = new Request.Builder()
       .url(url)
       .post(body)


### PR DESCRIPTION
The order of the two parameters seems to be *inconsistent* with the code on [another page](https://raw.githubusercontent.com/square/okhttp/master/samples/guide/src/main/java/okhttp3/guide/PostExample.java).

In [https://github.com/square/okhttp/blob/master/README.md#post-to-a-server](https://github.com/square/okhttp/blob/master/README.md#post-to-a-server) we can see
> RequestBody.create(JSON, json);

(the following pic shows the details)
![image](https://user-images.githubusercontent.com/3983683/69476871-4b17a200-0e1a-11ea-8327-41b259d50c73.png)

But if you click the `Full source`(the link is https://raw.githubusercontent.com/square/okhttp/master/samples/guide/src/main/java/okhttp3/guide/PostExample.java)
![image](https://user-images.githubusercontent.com/3983683/69476883-6387bc80-0e1a-11ea-87ac-f375f44cd01a.png)
you will see
> RequestBody.create(json, JSON);

(the following pic shows the details)
![image](https://user-images.githubusercontent.com/3983683/69476892-7ac6aa00-0e1a-11ea-982b-a1a5c8123ad5.png)

I tried both of them on my Mac with the following dependency
```xml
<dependency>
    <groupId>com.squareup.okhttp3</groupId>
    <artifactId>okhttp</artifactId>
    <version>4.1.0</version>
</dependency>
```
![image](https://user-images.githubusercontent.com/3983683/69476931-fcb6d300-0e1a-11ea-81b7-be1e6bbee8c3.png)
It seems that
> RequestBody.create(JSON, json);

is deprecated while 
> RequestBody.create(json, JSON);

seems to be the recommended way.