### PR TITLE
Make okhttp native-image compatible

### DIFF
--- a/okhttp/src/main/java/okhttp3/Authenticator.kt
+++ b/okhttp/src/main/java/okhttp3/Authenticator.kt
@@ -110,7 +110,8 @@ interface Authenticator {
   companion object {
     /** An authenticator that knows no credentials and makes no attempt to authenticate. */
     @JvmField
-    val NONE = object : Authenticator {
+    val NONE: Authenticator = AuthenticatorNone()
+    private class AuthenticatorNone : Authenticator {
       override fun authenticate(route: Route?, response: Response): Request? = null
     }
   }

--- a/okhttp/src/main/java/okhttp3/CookieJar.kt
+++ b/okhttp/src/main/java/okhttp3/CookieJar.kt
@@ -51,7 +51,8 @@ interface CookieJar {
   companion object {
     /** A cookie jar that never accepts any cookies. */
     @JvmField
-    val NO_COOKIES: CookieJar = object : CookieJar {
+    val NO_COOKIES: CookieJar = NoCookies()
+    private class NoCookies : CookieJar {
       override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
       }
 

--- a/okhttp/src/main/java/okhttp3/Dns.kt
+++ b/okhttp/src/main/java/okhttp3/Dns.kt
@@ -42,7 +42,8 @@ interface Dns {
      * lookup IP addresses. Most custom [Dns] implementations should delegate to this instance.
      */
     @JvmField
-    val SYSTEM = object : Dns {
+    val SYSTEM: Dns = DnsSystem()
+    private class DnsSystem : Dns {
       override fun lookup(hostname: String): List<InetAddress> {
         try {
           return InetAddress.getAllByName(hostname).toList()

--- a/okhttp/src/main/java/okhttp3/internal/http2/PushObserver.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/PushObserver.kt
@@ -72,7 +72,8 @@ interface PushObserver {
   fun onReset(streamId: Int, errorCode: ErrorCode)
 
   companion object {
-    @JvmField val CANCEL: PushObserver = object : PushObserver {
+    @JvmField val CANCEL: PushObserver = PushObserverCancel()
+    private class PushObserverCancel : PushObserver {
 
       override fun onRequest(streamId: Int, requestHeaders: List<Header>): Boolean {
         return true


### PR DESCRIPTION
There is a [known issue][2] on Kotlin which make it impossible to compile kotlin softwares to binary using native-image when using [object expressions][3] inside interfaces. By this reason okhttp4+ can't be compiled to binary using [native-image][4]. Unfortunately there is no a road map for kotlin team to fix the issue. 

To make okhttp native-image friendly I'm proposing this pull request, this way it will compiles and run on native-image binaries successfully.

[here a working sample][5] after the fix

[1]: https://github.com/oracle/graal/issues/1521
[2]: https://youtrack.jetbrains.com/issue/KT-33097
[3]: https://kotlinlang.org/docs/reference/object-declarations.html#object-expressions
[4]: https://github.com/oracle/graal/tree/master/substratevm#introduction
[5]: https://github.com/mageddo/graalvm-examples/tree/okhttp-4-graalvm-19.2.1-working