### PR TITLE
Degrade connections after a timeout

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
@@ -526,6 +526,7 @@ class MockWebServer : ExternalResource(), Closeable {
       }
 
       if (socketPolicy === STALL_SOCKET_AT_START) {
+        dispatchBookkeepingRequest(sequenceNumber, socket)
         return // Ignore the socket until the server is shut down!
       }
 

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -614,7 +614,7 @@ class RealConnection(
 
     val http2Connection = this.http2Connection
     if (http2Connection != null) {
-      return !http2Connection.isShutdown
+      return http2Connection.isHealthy(System.nanoTime())
     }
 
     if (doExtensiveChecks) {

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2Stream.kt
@@ -670,6 +670,7 @@ class Http2Stream internal constructor(
   internal inner class StreamTimeout : AsyncTimeout() {
     override fun timedOut() {
       closeLater(ErrorCode.CANCEL)
+      connection.sendDegradedPingLater()
     }
 
     override fun newTimeoutException(cause: IOException?): IOException {

--- a/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.java
@@ -36,7 +36,6 @@ import okio.BufferedSource;
 import okio.Okio;
 import okio.Sink;
 import okio.Source;
-import okio.Utf8;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,6 +48,9 @@ import static okhttp3.TestUtil.headerEntries;
 import static okhttp3.TestUtil.repeat;
 import static okhttp3.internal.Util.EMPTY_BYTE_ARRAY;
 import static okhttp3.internal.Util.EMPTY_HEADERS;
+import static okhttp3.internal.http2.Http2Connection.AWAIT_PING;
+import static okhttp3.internal.http2.Http2Connection.DEGRADED_PING;
+import static okhttp3.internal.http2.Http2Connection.DEGRADED_PONG_TIMEOUT_NS;
 import static okhttp3.internal.http2.Http2Connection.Listener.REFUSE_INCOMING_STREAMS;
 import static okhttp3.internal.http2.Settings.DEFAULT_INITIAL_WINDOW_SIZE;
 import static okhttp3.internal.http2.Settings.ENABLE_PUSH;
@@ -170,7 +172,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // ACK
     peer.sendFrame().windowUpdate(0, 10); // Increase the connection window size.
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.acceptFrame(); // HEADERS STREAM 3
     peer.sendFrame().windowUpdate(3, 5);
     peer.acceptFrame(); // DATA STREAM 3 "abcde"
@@ -242,7 +244,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // SYN_STREAM 5
     peer.sendFrame().goAway(3, ErrorCode.PROTOCOL_ERROR, EMPTY_BYTE_ARRAY);
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.acceptFrame(); // DATA STREAM 3
     peer.play();
 
@@ -526,7 +528,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().headers(false, 3, headerEntries("a", "android"));
     peer.sendFrame().data(true, 3, new Buffer().writeUtf8("robot"), 5);
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0); // PING
+    peer.sendFrame().ping(true, AWAIT_PING, 0); // PING
     peer.play();
 
     // play it back
@@ -558,7 +560,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // SYN_STREAM
     peer.acceptFrame(); // PING
     peer.sendFrame().headers(true, 3, headerEntries("headers", "bam"));
-    peer.sendFrame().ping(true, 1, 0); // PONG
+    peer.sendFrame().ping(true, AWAIT_PING, 0); // PONG
     peer.play();
 
     // play it back
@@ -586,7 +588,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().headers(false, 3, headerEntries("headers", "bam"));
     peer.acceptFrame(); // PING
     peer.sendFrame().headers(true, 3, headerEntries("trailers", "boom"));
-    peer.sendFrame().ping(true, 1, 0); // PONG
+    peer.sendFrame().ping(true, AWAIT_PING, 0); // PONG
     peer.play();
 
     // play it back
@@ -651,7 +653,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().data(false, 3, new Buffer().writeUtf8("robot"), 5);
     peer.sendFrame().headers(true, 3, headerEntries("trailers", "boom"));
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0); // PONG
+    peer.sendFrame().ping(true, AWAIT_PING, 0); // PONG
     peer.play();
 
     // play it back
@@ -672,7 +674,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().rstStream(3, ErrorCode.PROTOCOL_ERROR);
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0); // PONG
+    peer.sendFrame().ping(true, AWAIT_PING, 0); // PONG
     peer.play();
 
     // play it back
@@ -691,7 +693,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().settings(new Settings());
     peer.acceptFrame(); // ACK
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.play();
 
     // Play it back.
@@ -715,7 +717,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().headers(false, 3, headerEntries("headers", "bam"));
     peer.sendFrame().data(true, 3, new Buffer().writeUtf8("robot"), 5);
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0); // PONG
+    peer.sendFrame().ping(true, AWAIT_PING, 0); // PONG
     peer.play();
 
     // play it back
@@ -746,7 +748,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // HEADERS
     peer.sendFrame().headers(true, 3, headerEntries("a", "android"));
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0); // PING
+    peer.sendFrame().ping(true, AWAIT_PING, 0); // PING
     peer.play();
 
     // play it back
@@ -780,7 +782,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // SYN_STREAM
     peer.acceptFrame(); // PING
     peer.sendFrame().headers(true, 3, headerEntries("a", "android"));
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.play();
 
     // play it back
@@ -821,7 +823,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().settings(new Settings());
     peer.acceptFrame(); // ACK
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 5);
+    peer.sendFrame().ping(true, AWAIT_PING, 5);
     peer.play();
 
     // play it back
@@ -836,20 +838,18 @@ public final class Http2ConnectionTest {
     InFrame pingFrame = peer.takeFrame();
     assertThat(pingFrame.type).isEqualTo(Http2.TYPE_PING);
     assertThat(pingFrame.streamId).isEqualTo(0);
-    // OkOk
-    assertThat(pingFrame.payload1).isEqualTo(0x4f4b6f6b);
-    // donut
-    assertThat(pingFrame.payload2).isEqualTo(0xf09f8da9);
+    assertThat(pingFrame.payload1).isEqualTo(AWAIT_PING);
+    assertThat(pingFrame.payload2).isEqualTo(0x4f4b6f6b); // OKok.
     assertThat(pingFrame.ack).isFalse();
   }
 
-  @Test public void unexpectedPingIsNotReturned() throws Exception {
+  @Test public void unexpectedPongIsNotReturned() throws Exception {
     // write the mocking script
     peer.sendFrame().settings(new Settings());
     peer.acceptFrame(); // ACK
     peer.sendFrame().ping(false, 2, 0);
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 3, 0); // This ping will not be returned.
+    peer.sendFrame().ping(true, 99, 0); // This pong is silently ignored.
     peer.sendFrame().ping(false, 4, 0);
     peer.acceptFrame(); // PING
     peer.play();
@@ -1002,7 +1002,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().rstStream(3, ErrorCode.CANCEL);
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.play();
 
     // play it back
@@ -1131,7 +1131,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().headers(false, 3, headerEntries("b", "banana"));
     peer.sendFrame().data(true, 3, new Buffer().writeUtf8("square"), 6);
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.play();
 
     // play it back
@@ -1157,7 +1157,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().headers(false, 3, headerEntries("a", "android"));
     peer.acceptFrame(); // PING
     peer.sendFrame().headers(false, 3, headerEntries("b", "banana"));
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.play();
 
     // play it back
@@ -1269,7 +1269,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // SYN_STREAM 3
     peer.acceptFrame(); // PING.
     peer.sendFrame().goAway(3, ErrorCode.PROTOCOL_ERROR, Util.EMPTY_BYTE_ARRAY);
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.acceptFrame(); // DATA STREAM 1
     peer.play();
 
@@ -1320,18 +1320,18 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // GOAWAY
     peer.acceptFrame(); // PING
     peer.sendFrame().headers(false, 2, headerEntries("b", "b")); // Should be ignored!
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.play();
 
     // play it back
     Http2Connection connection = connect(peer);
     connection.newStream(headerEntries("a", "android"), false);
     synchronized (connection) {
-      if (connection.isShutdown()) {
+      if (!connection.isHealthy(System.nanoTime())) {
         throw new ConnectionShutdownException();
       }
     }
-    connection.writePing(false, 0x01, 0x02);
+    connection.writePing();
     connection.shutdown(ErrorCode.PROTOCOL_ERROR);
     assertThat(connection.openStreamCount()).isEqualTo(1);
     connection.awaitPong(); // Prevent the peer from exiting prematurely.
@@ -1421,23 +1421,34 @@ public final class Http2ConnectionTest {
     assertThat(peer.takeFrame().type).isEqualTo(Http2.TYPE_RST_STREAM);
   }
 
+  /**
+   * Confirm that the client times out if the server stalls after 3 bytes. After the timeout the
+   * connection is still considered healthy while we await the degraded pong. When that doesn't
+   * arrive the connection goes unhealthy.
+   */
   @Test public void readTimesOut() throws Exception {
     // write the mocking script
     peer.sendFrame().settings(new Settings());
     peer.acceptFrame(); // ACK
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().headers(false, 3, headerEntries("a", "android"));
+    peer.sendFrame().data(false, 3, new Buffer().writeUtf8("abc"), 3);
     peer.acceptFrame(); // RST_STREAM
+    peer.acceptFrame(); // DEGRADED PING
+    peer.acceptFrame(); // AWAIT PING
+    peer.sendFrame().ping(true, DEGRADED_PING, 1); // DEGRADED PONG
+    peer.sendFrame().ping(true, AWAIT_PING, 0); // AWAIT PONG
     peer.play();
 
     // play it back
     Http2Connection connection = connect(peer);
     Http2Stream stream = connection.newStream(headerEntries("b", "banana"), false);
     stream.readTimeout().timeout(500, TimeUnit.MILLISECONDS);
-    Source source = stream.getSource();
+    BufferedSource source = Okio.buffer(stream.getSource());
+    source.require(3);
     long startNanos = System.nanoTime();
     try {
-      source.read(new Buffer(), 1);
+      source.require(4);
       fail();
     } catch (InterruptedIOException expected) {
     }
@@ -1447,9 +1458,22 @@ public final class Http2ConnectionTest {
     assertThat((double) TimeUnit.NANOSECONDS.toMillis(elapsedNanos)).isCloseTo(500d, offset(200d));
     assertThat(connection.openStreamCount()).isEqualTo(0);
 
+    // When the timeout is sent the connection doesn't immediately go unhealthy.
+    assertThat(connection.isHealthy(System.nanoTime())).isTrue();
+
+    // But if the ping doesn't arrive, the connection goes unhealthy.
+    Thread.sleep(TimeUnit.NANOSECONDS.toMillis(DEGRADED_PONG_TIMEOUT_NS));
+    assertThat(connection.isHealthy(System.nanoTime())).isFalse();
+
+    // When a pong does arrive, the connection becomes healthy again.
+    connection.writePingAndAwaitPong();
+    assertThat(connection.isHealthy(System.nanoTime())).isTrue();
+
     // verify the peer received what was expected
     assertThat(peer.takeFrame().type).isEqualTo(Http2.TYPE_HEADERS);
     assertThat(peer.takeFrame().type).isEqualTo(Http2.TYPE_RST_STREAM);
+    assertThat(peer.takeFrame().type).isEqualTo(Http2.TYPE_PING);
+    assertThat(peer.takeFrame().type).isEqualTo(Http2.TYPE_PING);
   }
 
   @Test public void writeTimesOutAwaitingStreamWindow() throws Exception {
@@ -1460,7 +1484,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().settings(peerSettings);
     peer.acceptFrame(); // ACK SETTINGS
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().headers(false, 3, headerEntries("a", "android"));
     peer.acceptFrame(); // DATA
@@ -1503,11 +1527,11 @@ public final class Http2ConnectionTest {
     peer.sendFrame().settings(peerSettings);
     peer.acceptFrame(); // ACK SETTINGS
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.acceptFrame(); // SYN_STREAM
     peer.sendFrame().headers(false, 3, headerEntries("a", "android"));
     peer.acceptFrame(); // PING
-    peer.sendFrame().ping(true, 3, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.acceptFrame(); // DATA
     peer.acceptFrame(); // RST_STREAM
     peer.play();
@@ -1575,7 +1599,7 @@ public final class Http2ConnectionTest {
     peer.acceptFrame(); // PING
     peer.sendFrame().headers(false, 3, headerEntries("a", "android"));
     peer.sendFrame().headers(false, 3, headerEntries("c", "c3po"));
-    peer.sendFrame().ping(true, 1, 0);
+    peer.sendFrame().ping(true, AWAIT_PING, 0);
     peer.play();
 
     // play it back
@@ -1600,7 +1624,7 @@ public final class Http2ConnectionTest {
     peer.sendFrame().headers(false, 3, headerEntries("a", "android"));
     peer.acceptFrame(); // PING
     peer.sendFrame().headers(true, 3, headerEntries("c", "cola"));
-    peer.sendFrame().ping(true, 1, 0); // PONG
+    peer.sendFrame().ping(true, AWAIT_PING, 0); // PONG
     peer.play();
 
     // play it back

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -1277,6 +1277,95 @@ public final class HttpOverHttp2Test {
         (long) 0);
   }
 
+  @Test public void streamTimeoutDegradesConnectionAfterNoPong() throws Exception {
+    client = client.newBuilder()
+        .readTimeout(500, MILLISECONDS)
+        .build();
+
+    // Stalling the socket will cause TWO requests to time out!
+    server.enqueue(new MockResponse()
+        .setSocketPolicy(SocketPolicy.STALL_SOCKET_AT_START));
+
+    // The 3rd request should be sent to a fresh connection.
+    server.enqueue(new MockResponse()
+        .setBody("fresh connection"));
+
+    // The first call times out.
+    Call call1 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    try {
+      call1.execute();
+      fail();
+    } catch (SocketTimeoutException expected) {
+    }
+
+    // The second call times out because it uses the same bad connection.
+    Call call2 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    try {
+      call2.execute();
+      fail();
+    } catch (SocketTimeoutException expected) {
+    }
+
+    // But after the degraded pong timeout, that connection is abandoned.
+    Thread.sleep(TimeUnit.NANOSECONDS.toMillis(Http2Connection.DEGRADED_PONG_TIMEOUT_NS));
+    Call call3 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    try (Response response = call3.execute()) {
+      assertThat(response.body().string()).isEqualTo("fresh connection");
+    }
+  }
+
+  @Test public void oneStreamTimeoutDoesNotBreakConnection() throws Exception {
+    client = client.newBuilder()
+        .readTimeout(500, MILLISECONDS)
+        .build();
+
+    server.enqueue(new MockResponse()
+        .setBodyDelay(1_000, MILLISECONDS)
+        .setBody("a"));
+    server.enqueue(new MockResponse()
+        .setBody("b"));
+    server.enqueue(new MockResponse()
+        .setBody("c"));
+
+    // The first call times out.
+    Call call1 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    try (Response response = call1.execute()) {
+      response.body().string();
+      fail();
+    } catch (SocketTimeoutException expected) {
+    }
+
+    // The second call succeeds.
+    Call call2 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    try (Response response = call2.execute()) {
+      assertThat(response.body().string()).isEqualTo("b");
+    }
+
+    // Calls succeed after the degraded pong timeout because the degraded pong was received.
+    Thread.sleep(TimeUnit.NANOSECONDS.toMillis(Http2Connection.DEGRADED_PONG_TIMEOUT_NS));
+    Call call3 = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    try (Response response = call3.execute()) {
+      assertThat(response.body().string()).isEqualTo("c");
+    }
+
+    // All calls share a connection.
+    assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(0);
+    assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(1);
+    assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(2);
+  }
+
   private String firstFrame(List<String> logs, String type) {
     for (String log : logs) {
       if (log.contains(type)) {


### PR DESCRIPTION
This is based roughly on the 'Degraded Connections' proposal here
https://github.com/square/okhttp/issues/3146#issuecomment-471196032

I'm using 1000 ms instead of 500 ms. That's about the cost of a (slow)
TLS handshake, which is what callers would need to do if we degrade
unnecessarily.