### PR TITLE
Fix TaskRunner handling of uncaught exceptions

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/TaskRunner.kt
@@ -56,7 +56,16 @@ class TaskRunner(
           awaitTaskToRun()
         } ?: return
 
-        runTask(task)
+        var completedNormally = false
+        try {
+          runTask(task)
+          completedNormally = true
+        } finally {
+          // If the task is crashing start another thread to service the queues.
+          if (!completedNormally) {
+            backend.execute(this)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Previously an unchecked exception would starve the runner of
threads until another task was scheduled.