### PR TITLE
Remove JDK 12 (non-LTS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,21 +174,6 @@ jobs:
       - runtests:
           platform: jdk9
 
-  testjdk12:
-    docker:
-      # best source of JDK 12 for now
-      - image: circleci/dynamodb:12.0.2-jdk
-
-    environment:
-      JVM_OPTS: -Xmx1g
-      TERM: dumb
-
-    steps:
-      - checkout
-
-      - runtests:
-          platform: jdk9
-
   testjdk13:
     docker:
       - image: circleci/openjdk:13.0.1-jdk-buster
@@ -263,10 +248,6 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      - testjdk12:
-          filters:
-            branches:
-              only: master
       - testjdk13:
           filters:
             branches:
@@ -299,9 +280,6 @@ workflows:
           requires:
             - compile
       - testjdk11:
-          requires:
-            - compile
-      - testjdk12:
           requires:
             - compile
       - testjdk13:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,10 +239,6 @@ workflows:
           filters:
             branches:
               only: master
-      - testopenjsse:
-          filters:
-            branches:
-              only: master
       - testjdk11:
           filters:
             branches:
@@ -253,10 +249,8 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      - testconscrypt:
-          filters:
-            branches:
-              only: master
+      #- testopenjsse
+      #- testconscrypt
       #- testcorretto
   nightly:
     triggers:


### PR DESCRIPTION
Suggested policy

JDK 8 - minimum with/out ALPN
JDK11 - Current LTS
JDK13 - Current JDK
JDK14ea - Next EA (when supported by toolchain)

As we have flaky integration tests, this is already ambitious.  So set this as the rough size of our integration tests.
