### PR TITLE
Explicitly specify site-url for mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: OkHttp
+site_url: https://square.github.com/okhttp/
 repo_name: OkHttp
 repo_url: https://github.com/square/okhttp
 site_description: "An HTTP & HTTP/2 client for Android and Java applications"


### PR DESCRIPTION
| Before | After |
| --- | --- |
| https://square.github.com/okhttp/nicolas-cage | https://saket.github.io/okhttp/nicolas-cage |
| ![image](https://user-images.githubusercontent.com/2387680/71314734-c0779200-241b-11ea-8589-e4c619cecf0b.png) | ![image](https://user-images.githubusercontent.com/2387680/71314730-b81f5700-241b-11ea-846f-8b0482ddfc91.png) |

MkDocs' 404 page uses relative links to the organization's github page by default resulting in broken resources (stylesheets, images et al). What's worse is that the links in the navigation sidebar also get affected so manually changing the url in the address bar is the only way to exit. 

The fix is to specify the site URL explicitly ([source](https://github.com/mkdocs/mkdocs/issues/77)). 