### PR TITLE
Defer EventListener events until bytes are returned

### DIFF
--- a/okhttp-testing-support/src/main/java/okhttp3/CallEvent.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/CallEvent.kt
@@ -22,150 +22,178 @@ import java.net.Proxy
 
 /** Data classes that correspond to each of the methods of [EventListener]. */
 sealed class CallEvent {
+  abstract val timestampNs: Long
   abstract val call: Call
 
   val name: String
     get() = javaClass.simpleName
 
-  open fun closes(): CallEvent? = null
+  /** Returns the open event that this close event closes, or null if this is not a close event. */
+  open fun closes(timestampNs: Long): CallEvent? = null
 
   data class ProxySelectStart(
+    override val timestampNs: Long,
     override val call: Call,
     val url: HttpUrl
   ) : CallEvent()
 
   data class ProxySelectEnd(
+    override val timestampNs: Long,
     override val call: Call,
     val url: HttpUrl,
     val proxies: List<Proxy>?
   ) : CallEvent()
 
   data class DnsStart(
+    override val timestampNs: Long,
     override val call: Call,
     val domainName: String
   ) : CallEvent()
 
   data class DnsEnd(
+    override val timestampNs: Long,
     override val call: Call,
     val domainName: String,
     val inetAddressList: List<InetAddress>
   ) : CallEvent() {
-    override fun closes() = DnsStart(call, domainName)
+    override fun closes(timestampNs: Long) = DnsStart(timestampNs, call, domainName)
   }
 
   data class ConnectStart(
+    override val timestampNs: Long,
     override val call: Call,
     val inetSocketAddress: InetSocketAddress,
     val proxy: Proxy?
   ) : CallEvent()
 
   data class ConnectEnd(
+    override val timestampNs: Long,
     override val call: Call,
     val inetSocketAddress: InetSocketAddress,
     val proxy: Proxy?,
     val protocol: Protocol?
   ) : CallEvent() {
-    override fun closes() = ConnectStart(call, inetSocketAddress, proxy)
+    override fun closes(timestampNs: Long) =
+        ConnectStart(timestampNs, call, inetSocketAddress, proxy)
   }
 
   data class ConnectFailed(
+    override val timestampNs: Long,
     override val call: Call,
     val inetSocketAddress: InetSocketAddress,
     val proxy: Proxy,
     val protocol: Protocol?,
     val ioe: IOException
   ) : CallEvent() {
-    override fun closes() = ConnectStart(call, inetSocketAddress, proxy)
+    override fun closes(timestampNs: Long) =
+        ConnectStart(timestampNs, call, inetSocketAddress, proxy)
   }
 
   data class SecureConnectStart(
+    override val timestampNs: Long,
     override val call: Call
   ) : CallEvent()
 
   data class SecureConnectEnd(
+    override val timestampNs: Long,
     override val call: Call,
     val handshake: Handshake?
   ) : CallEvent() {
-    override fun closes() = SecureConnectStart(call)
+    override fun closes(timestampNs: Long) = SecureConnectStart(timestampNs, call)
   }
 
   data class ConnectionAcquired(
+    override val timestampNs: Long,
     override val call: Call,
     val connection: Connection
   ) : CallEvent()
 
   data class ConnectionReleased(
+    override val timestampNs: Long,
     override val call: Call,
     val connection: Connection
   ) : CallEvent() {
-    override fun closes() = ConnectionAcquired(call, connection)
+    override fun closes(timestampNs: Long) = ConnectionAcquired(timestampNs, call, connection)
   }
 
   data class CallStart(
+    override val timestampNs: Long,
     override val call: Call
   ) : CallEvent()
 
   data class CallEnd(
+    override val timestampNs: Long,
     override val call: Call
   ) : CallEvent() {
-    override fun closes() = CallStart(call)
+    override fun closes(timestampNs: Long) = CallStart(timestampNs, call)
   }
 
   data class CallFailed(
+    override val timestampNs: Long,
     override val call: Call,
     val ioe: IOException
   ) : CallEvent()
 
   data class RequestHeadersStart(
+    override val timestampNs: Long,
     override val call: Call
   ) : CallEvent()
 
   data class RequestHeadersEnd(
+    override val timestampNs: Long,
     override val call: Call,
     val headerLength: Long
   ) : CallEvent() {
-    override fun closes() = RequestHeadersStart(call)
+    override fun closes(timestampNs: Long) = RequestHeadersStart(timestampNs, call)
   }
 
   data class RequestBodyStart(
+    override val timestampNs: Long,
     override val call: Call
   ) : CallEvent()
 
   data class RequestBodyEnd(
+    override val timestampNs: Long,
     override val call: Call,
     val bytesWritten: Long
   ) : CallEvent() {
-    override fun closes() = RequestBodyStart(call)
+    override fun closes(timestampNs: Long) = RequestBodyStart(timestampNs, call)
   }
 
   data class RequestFailed(
+    override val timestampNs: Long,
     override val call: Call,
     val ioe: IOException
   ) : CallEvent()
 
   data class ResponseHeadersStart(
+    override val timestampNs: Long,
     override val call: Call
   ) : CallEvent()
 
   data class ResponseHeadersEnd(
+    override val timestampNs: Long,
     override val call: Call,
     val headerLength: Long
   ) : CallEvent() {
-    override fun closes() = RequestHeadersStart(call)
+    override fun closes(timestampNs: Long) = RequestHeadersStart(timestampNs, call)
   }
 
   data class ResponseBodyStart(
+    override val timestampNs: Long,
     override val call: Call
   ) : CallEvent()
 
   data class ResponseBodyEnd(
+    override val timestampNs: Long,
     override val call: Call,
     val bytesRead: Long
   ) : CallEvent() {
-    override fun closes() = ResponseBodyStart(call)
+    override fun closes(timestampNs: Long) = ResponseBodyStart(timestampNs, call)
   }
 
   data class ResponseFailed(
+    override val timestampNs: Long,
     override val call: Call,
     val ioe: IOException
   ) : CallEvent()

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -590,7 +590,7 @@ class RealConnection(
     noNewExchanges()
     return object : RealWebSocket.Streams(true, source, sink) {
       override fun close() {
-        exchange.bodyComplete<IOException?>(-1L, true, true, null)
+        exchange.bodyComplete<IOException?>(-1L, responseDone = true, requestDone = true, e = null)
       }
     }
   }

--- a/okhttp/src/test/java/okhttp3/CallTest.java
+++ b/okhttp/src/test/java/okhttp3/CallTest.java
@@ -1168,7 +1168,7 @@ public final class CallTest {
     server.setDispatcher(dispatcher);
 
     listener = new RecordingEventListener() {
-      @Override public void responseHeadersStart(Call call) {
+      @Override public void requestHeadersEnd(Call call, Request request) {
         requestFinished.countDown();
         super.responseHeadersStart(call);
       }

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -16,6 +16,7 @@
 package okhttp3;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -28,17 +29,25 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import okhttp3.CallEvent.CallEnd;
 import okhttp3.CallEvent.CallFailed;
+import okhttp3.CallEvent.CallStart;
 import okhttp3.CallEvent.ConnectEnd;
 import okhttp3.CallEvent.ConnectFailed;
 import okhttp3.CallEvent.ConnectStart;
 import okhttp3.CallEvent.ConnectionAcquired;
+import okhttp3.CallEvent.ConnectionReleased;
 import okhttp3.CallEvent.DnsEnd;
 import okhttp3.CallEvent.DnsStart;
+import okhttp3.CallEvent.ProxySelectEnd;
+import okhttp3.CallEvent.ProxySelectStart;
 import okhttp3.CallEvent.RequestBodyEnd;
+import okhttp3.CallEvent.RequestBodyStart;
 import okhttp3.CallEvent.RequestHeadersEnd;
+import okhttp3.CallEvent.RequestHeadersStart;
 import okhttp3.CallEvent.ResponseBodyEnd;
+import okhttp3.CallEvent.ResponseBodyStart;
 import okhttp3.CallEvent.ResponseFailed;
 import okhttp3.CallEvent.ResponseHeadersEnd;
+import okhttp3.CallEvent.ResponseHeadersStart;
 import okhttp3.CallEvent.SecureConnectEnd;
 import okhttp3.CallEvent.SecureConnectStart;
 import okhttp3.internal.DoubleInetAddressDns;
@@ -153,9 +162,12 @@ public final class EventListenerTest {
   }
 
   @Test public void failedCallEventSequence() {
-    server.enqueue(new MockResponse().setHeadersDelay(2, TimeUnit.SECONDS));
+    server.enqueue(new MockResponse()
+        .setHeadersDelay(2, TimeUnit.SECONDS));
 
-    client = client.newBuilder().readTimeout(250, TimeUnit.MILLISECONDS).build();
+    client = client.newBuilder()
+        .readTimeout(250, TimeUnit.MILLISECONDS)
+        .build();
 
     Call call = client.newCall(new Request.Builder()
         .url(server.url("/"))
@@ -170,8 +182,7 @@ public final class EventListenerTest {
     assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
         "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
-        "RequestHeadersEnd", "ResponseHeadersStart", "ResponseFailed", "ConnectionReleased",
-        "CallFailed");
+        "RequestHeadersEnd", "ResponseFailed", "ConnectionReleased", "CallFailed");
   }
 
   @Test public void failedDribbledCallEventSequence() throws IOException {
@@ -1138,7 +1149,9 @@ public final class EventListenerTest {
 
   private void requestBodySuccess(RequestBody body, Matcher<Long> requestBodyBytes,
       Matcher<Long> responseHeaderLength) throws IOException {
-    server.enqueue(new MockResponse().setResponseCode(200).setBody("World!"));
+    server.enqueue(new MockResponse()
+        .setResponseCode(200)
+        .setBody("World!"));
 
     Call call = client.newCall(new Request.Builder()
         .url(server.url("/"))
@@ -1149,6 +1162,115 @@ public final class EventListenerTest {
 
     assertBytesReadWritten(listener, any(Long.class), requestBodyBytes, responseHeaderLength,
         equalTo(6L));
+  }
+
+  @Test public void timeToFirstByteHttp1OverHttps() throws IOException {
+    enableTlsWithTunnel(false);
+    server.setProtocols(asList(Protocol.HTTP_1_1));
+
+    timeToFirstByte();
+  }
+
+  @Test public void timeToFirstByteHttp2OverHttps() throws IOException {
+    platform.assumeHttp2Support();
+    enableTlsWithTunnel(false);
+    server.setProtocols(asList(Protocol.HTTP_2, Protocol.HTTP_1_1));
+
+    timeToFirstByte();
+  }
+
+  /**
+   * Test to confirm that events are reported at the time they occur and no earlier and no later.
+   * This inserts a bunch of synthetic 250 ms delays into both client and server and confirms that
+   * the same delays make it back into the events.
+   *
+   * We've had bugs where we report an event when we request data rather than when the data actually
+   * arrives. https://github.com/square/okhttp/issues/5578
+   */
+  private void timeToFirstByte() throws IOException {
+    long applicationInterceptorDelay = 250L;
+    long networkInterceptorDelay = 250L;
+    long requestBodyDelay = 250L;
+    long responseHeadersStartDelay = 250L;
+    long responseBodyStartDelay = 250L;
+    long responseBodyEndDelay = 250L;
+
+    // Warm up the client so the timing part of the test gets a pooled connection.
+    server.enqueue(new MockResponse());
+    Call warmUpCall = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    try (Response warmUpResponse = warmUpCall.execute()) {
+      warmUpResponse.body().string();
+    }
+    listener.clearAllEvents();
+
+    // Create a client with artificial delays.
+    client = client.newBuilder()
+        .addInterceptor(chain -> {
+          try {
+            Thread.sleep(applicationInterceptorDelay);
+            return chain.proceed(chain.request());
+          } catch (InterruptedException e) {
+            throw new InterruptedIOException();
+          }
+        })
+        .addNetworkInterceptor(chain -> {
+          try {
+            Thread.sleep(networkInterceptorDelay);
+            return chain.proceed(chain.request());
+          } catch (InterruptedException e) {
+            throw new InterruptedIOException();
+          }
+        })
+        .build();
+
+    // Create a request body with artificial delays.
+    Call call = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .post(new RequestBody() {
+          @Override public @Nullable MediaType contentType() {
+            return null;
+          }
+
+          @Override public void writeTo(BufferedSink sink) throws IOException {
+            try {
+              Thread.sleep(requestBodyDelay);
+              sink.writeUtf8("abc");
+            } catch (InterruptedException e) {
+              throw new InterruptedIOException();
+            }
+          }
+        })
+        .build());
+
+    // Create a response with artificial delays.
+    server.enqueue(new MockResponse()
+        .setHeadersDelay(responseHeadersStartDelay, TimeUnit.MILLISECONDS)
+        .setBodyDelay(responseBodyStartDelay, TimeUnit.MILLISECONDS)
+        .throttleBody(5, responseBodyEndDelay, TimeUnit.MILLISECONDS)
+        .setBody("fghijk"));
+
+    // Make the call.
+    try (Response response = call.execute()) {
+      assertThat(response.body().string()).isEqualTo("fghijk");
+    }
+
+    // Confirm the events occur when expected.
+    listener.takeEvent(CallStart.class, 0L);
+    listener.takeEvent(ProxySelectStart.class, applicationInterceptorDelay);
+    listener.takeEvent(ProxySelectEnd.class, 0L);
+    listener.takeEvent(ConnectionAcquired.class, 0L);
+    listener.takeEvent(RequestHeadersStart.class, networkInterceptorDelay);
+    listener.takeEvent(RequestHeadersEnd.class, 0L);
+    listener.takeEvent(RequestBodyStart.class, 0L);
+    listener.takeEvent(RequestBodyEnd.class, requestBodyDelay);
+    listener.takeEvent(ResponseHeadersStart.class, responseHeadersStartDelay);
+    listener.takeEvent(ResponseHeadersEnd.class, 0L);
+    listener.takeEvent(ResponseBodyStart.class, responseBodyStartDelay);
+    listener.takeEvent(ResponseBodyEnd.class, responseBodyEndDelay);
+    listener.takeEvent(ConnectionReleased.class, 0L);
+    listener.takeEvent(CallEnd.class, 0L);
   }
 
   private void enableTlsWithTunnel(boolean tunnelProxy) {
@@ -1268,5 +1390,28 @@ public final class EventListenerTest {
         "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd",
         "ResponseHeadersStart", "RequestBodyStart", "RequestBodyEnd", "ResponseHeadersEnd",
         "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
+  }
+
+  @Test public void timeToFirstByteGapBetweenResponseHeaderStartAndEnd() throws IOException {
+    long responseHeadersStartDelay = 250L;
+    server.enqueue(new MockResponse()
+        .setSocketPolicy(SocketPolicy.EXPECT_CONTINUE)
+        .setHeadersDelay(responseHeadersStartDelay, TimeUnit.MILLISECONDS));
+
+    Request request = new Request.Builder()
+        .url(server.url("/"))
+        .header("Expect", "100-continue")
+        .post(RequestBody.create("abc", MediaType.get("text/plain")))
+        .build();
+
+    Call call = client.newCall(request);
+    try (Response response = call.execute()) {
+      assertThat(response.body().string()).isEqualTo("");
+    }
+
+    listener.removeUpToEvent(ResponseHeadersStart.class);
+    listener.takeEvent(RequestBodyStart.class, 0L);
+    listener.takeEvent(RequestBodyEnd.class, 0L);
+    listener.takeEvent(ResponseHeadersEnd.class, responseHeadersStartDelay);
   }
 }


### PR DESCRIPTION
This changes the timing of responseHeaderStart and responseBodyStart events to
fire when bytes are received from the server. This is a non-trivial behavior
change and should be documented as such in the release notes. In particular,
the responseFailed event may be fired without a preceding responseHeadersStart
event.

To test this I've added a timestamp to our CallEvent test facet.

Closes: https://github.com/square/okhttp/issues/5578