### PR TITLE
Fix crash on repeated MockWebServer shutdown

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
@@ -448,7 +448,7 @@ class MockWebServer : ExternalResource(), Closeable {
 
     // Await shutdown.
     for (queue in taskRunner.activeQueues()) {
-      if (!queue.awaitIdle(TimeUnit.SECONDS.toNanos(5))) {
+      if (!queue.idleLatch().await(5, TimeUnit.SECONDS)) {
         throw IOException("Gave up waiting for queue to shut down")
       }
     }

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -87,7 +87,7 @@ class OkHttpClientTestRule : TestRule {
 
   private fun ensureAllTaskQueuesIdle() {
     for (queue in TaskRunner.INSTANCE.activeQueues()) {
-      assertThat(queue.awaitIdle(TimeUnit.MILLISECONDS.toNanos(1000L)))
+      assertThat(queue.idleLatch().await(1_000L, TimeUnit.MILLISECONDS))
           .withFailMessage("Queue still active after 1000 ms")
           .isTrue()
     }

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
@@ -259,14 +259,14 @@ class RealWebSocket(
   /** For testing: wait until the web socket's executor has terminated. */
   @Throws(InterruptedException::class)
   fun awaitTermination(timeout: Long, timeUnit: TimeUnit) {
-    taskQueue.awaitIdle(timeUnit.toNanos(timeout))
+    taskQueue.idleLatch().await(timeout, timeUnit)
   }
 
   /** For testing: force this web socket to release its threads. */
   @Throws(InterruptedException::class)
   fun tearDown() {
     taskQueue.shutdown()
-    taskQueue.awaitIdle(TimeUnit.SECONDS.toNanos(10L))
+    taskQueue.idleLatch().await(10, TimeUnit.SECONDS)
   }
 
   @Synchronized fun sentPingCount(): Int = sentPingCount

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
@@ -623,6 +623,30 @@ class TaskRunnerTest {
     )
   }
 
+  @Test fun idleLatch() {
+    redQueue.execute("task") {
+      log += "run@${taskFaker.nanoTime}"
+    }
+
+    val idleLatch = redQueue.idleLatch()
+    assertThat(idleLatch.count).isEqualTo(1)
+
+    taskFaker.advanceUntil(0.µs)
+    assertThat(log).containsExactly("run@0")
+
+    assertThat(idleLatch.count).isEqualTo(0)
+  }
+
+  @Test fun multipleCallsToIdleLatchReturnSameInstance() {
+    redQueue.execute("task") {
+      log += "run@${taskFaker.nanoTime}"
+    }
+
+    val idleLatch1 = redQueue.idleLatch()
+    val idleLatch2 = redQueue.idleLatch()
+    assertThat(idleLatch2).isSameAs(idleLatch1)
+  }
+
   private val Int.µs: Long
     get() = this * 1_000L
 }


### PR DESCRIPTION
The problem was the awaitIdle() call was scheduling executor jobs after
the ExecutorService had been shut down. This fixes that and defends
against other races.