### PR TITLE
Set hostname on Android 5.0

### DIFF
--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -114,6 +114,19 @@ class OkHttpTest {
   }
 
   @Test
+  fun testRequestWithSniRequirement() {
+    assumeNetwork()
+
+    val request = Request.Builder().url("https://docs.fabric.io/android/changelog.html").build()
+
+    val response = client.newCall(request).execute()
+
+    response.use {
+      assertEquals(200, response.code)
+    }
+  }
+
+  @Test
   fun testConscryptRequest() {
     assumeNetwork()
 

--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
@@ -505,7 +505,7 @@ class MockWebServer : ExternalResource(), Closeable {
           openClientSockets.add(socket)
 
           if (protocolNegotiationEnabled) {
-            Platform.get().configureTlsExtensions(sslSocket, protocols)
+            Platform.get().configureTlsExtensions(sslSocket, null, protocols)
           }
 
           sslSocket.startHandshake()

--- a/mockwebserver/src/test/java/okhttp3/mockwebserver/internal/http2/Http2Server.java
+++ b/mockwebserver/src/test/java/okhttp3/mockwebserver/internal/http2/Http2Server.java
@@ -94,6 +94,7 @@ public final class Http2Server extends Http2Connection.Listener {
         socket, socket.getInetAddress().getHostAddress(), socket.getPort(), true);
     sslSocket.setUseClientMode(false);
     Platform.get().configureTlsExtensions(sslSocket,
+        null,
         Collections.singletonList(Protocol.HTTP_2));
     sslSocket.startHandshake();
     return sslSocket;

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -343,7 +343,7 @@ class RealConnection(
       // Configure the socket's ciphers, TLS versions, and extensions.
       val connectionSpec = connectionSpecSelector.configureSecureSocket(sslSocket)
       if (connectionSpec.supportsTlsExtensions) {
-        Platform.get().configureTlsExtensions(sslSocket, address.protocols)
+        Platform.get().configureTlsExtensions(sslSocket, address.url.host, address.protocols)
       }
 
       // Force handshake. This can throw!

--- a/okhttp/src/main/java/okhttp3/internal/platform/Android10Platform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Android10Platform.kt
@@ -41,10 +41,10 @@ class Android10Platform : Platform() {
       socketAdapters.find { it.matchesSocketFactory(sslSocketFactory) }
           ?.trustManager(sslSocketFactory)
 
-  override fun configureTlsExtensions(sslSocket: SSLSocket, protocols: List<Protocol>) {
+  override fun configureTlsExtensions(sslSocket: SSLSocket, hostname: String?, protocols: List<Protocol>) {
     // No TLS extensions if the socket class is custom.
     socketAdapters.find { it.matchesSocket(sslSocket) }
-        ?.configureTlsExtensions(sslSocket, protocols)
+        ?.configureTlsExtensions(sslSocket, hostname, protocols)
   }
 
   override fun getSelectedProtocol(sslSocket: SSLSocket) =

--- a/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/AndroidPlatform.kt
@@ -72,11 +72,12 @@ class AndroidPlatform : Platform() {
 
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<@JvmSuppressWildcards Protocol>
   ) {
     // No TLS extensions if the socket class is custom.
     socketAdapters.find { it.matchesSocket(sslSocket) }
-        ?.configureTlsExtensions(sslSocket, protocols)
+        ?.configureTlsExtensions(sslSocket, hostname, protocols)
   }
 
   override fun getSelectedProtocol(sslSocket: SSLSocket) =

--- a/okhttp/src/main/java/okhttp3/internal/platform/ConscryptPlatform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/ConscryptPlatform.kt
@@ -64,6 +64,7 @@ class ConscryptPlatform private constructor() : Platform() {
 
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<@JvmSuppressWildcards Protocol>
   ) {
     if (Conscrypt.isConscrypt(sslSocket)) {
@@ -74,7 +75,7 @@ class ConscryptPlatform private constructor() : Platform() {
       val names = alpnProtocolNames(protocols)
       Conscrypt.setApplicationProtocols(sslSocket, names.toTypedArray())
     } else {
-      super.configureTlsExtensions(sslSocket, protocols)
+      super.configureTlsExtensions(sslSocket, hostname, protocols)
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/platform/Jdk8WithJettyBootPlatform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Jdk8WithJettyBootPlatform.kt
@@ -32,6 +32,7 @@ class Jdk8WithJettyBootPlatform(
 ) : Platform() {
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<Protocol>
   ) {
     val names = alpnProtocolNames(protocols)

--- a/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.kt
@@ -24,6 +24,7 @@ import javax.net.ssl.X509TrustManager
 open class Jdk9Platform : Platform() {
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<@JvmSuppressWildcards Protocol>
   ) {
     val sslParameters = sslSocket.sslParameters

--- a/okhttp/src/main/java/okhttp3/internal/platform/OpenJSSEPlatform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/OpenJSSEPlatform.kt
@@ -56,6 +56,7 @@ class OpenJSSEPlatform private constructor() : Platform() {
 
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<@JvmSuppressWildcards Protocol>
   ) {
     if (sslSocket is org.openjsse.javax.net.ssl.SSLSocket) {
@@ -69,7 +70,7 @@ class OpenJSSEPlatform private constructor() : Platform() {
         sslSocket.sslParameters = sslParameters
       }
     } else {
-      super.configureTlsExtensions(sslSocket, protocols)
+      super.configureTlsExtensions(sslSocket, hostname, protocols)
     }
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.kt
@@ -100,6 +100,7 @@ open class Platform {
    */
   open fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<@JvmSuppressWildcards Protocol>
   ) {
   }

--- a/okhttp/src/main/java/okhttp3/internal/platform/android/Android10SocketAdapter.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/android/Android10SocketAdapter.kt
@@ -48,6 +48,7 @@ class Android10SocketAdapter : SocketAdapter {
 
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<Protocol>
   ) {
     socketFactory.setUseSessionTickets(sslSocket, true)

--- a/okhttp/src/main/java/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
@@ -43,6 +43,7 @@ class ConscryptSocketAdapter : SocketAdapter {
 
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<Protocol>
   ) {
     // No TLS extensions if the socket class is custom.

--- a/okhttp/src/main/java/okhttp3/internal/platform/android/DeferredSocketAdapter.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/android/DeferredSocketAdapter.kt
@@ -39,9 +39,10 @@ class DeferredSocketAdapter(private val socketPackage: String) : SocketAdapter {
 
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<Protocol>
   ) {
-    getDelegate(sslSocket)?.configureTlsExtensions(sslSocket, protocols)
+    getDelegate(sslSocket)?.configureTlsExtensions(sslSocket, hostname, protocols)
   }
 
   override fun getSelectedProtocol(sslSocket: SSLSocket): String? {

--- a/okhttp/src/main/java/okhttp3/internal/platform/android/SocketAdapter.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/android/SocketAdapter.kt
@@ -28,6 +28,7 @@ interface SocketAdapter {
 
   fun configureTlsExtensions(
     sslSocket: SSLSocket,
+    hostname: String?,
     protocols: List<Protocol>
   )
 

--- a/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
@@ -30,7 +30,7 @@ public class Jdk9PlatformTest {
   }
 
   @Test
-  public void testToStringIsClassname() throws NoSuchMethodException {
+  public void testToStringIsClassname() {
     assertThat(new Jdk9Platform().toString()).isEqualTo("Jdk9Platform");
   }
 }

--- a/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
@@ -88,7 +88,7 @@ class AndroidSocketAdapterTest(private val adapter: SocketAdapter) {
         object : DelegatingSSLSocket(context.socketFactory.createSocket() as SSLSocket) {}
     assertFalse(adapter.matchesSocket(sslSocket))
 
-    adapter.configureTlsExtensions(sslSocket, listOf(HTTP_2, HTTP_1_1))
+    adapter.configureTlsExtensions(sslSocket, null, listOf(HTTP_2, HTTP_1_1))
     // not connected
     assertNull(adapter.getSelectedProtocol(sslSocket))
   }

--- a/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
@@ -57,7 +57,7 @@ class AndroidSocketAdapterTest(private val adapter: SocketAdapter) {
     val sslSocket = socketFactory.createSocket() as SSLSocket
     assertTrue(adapter.matchesSocket(sslSocket))
 
-    adapter.configureTlsExtensions(sslSocket, listOf(HTTP_2, HTTP_1_1))
+    adapter.configureTlsExtensions(sslSocket, null, listOf(HTTP_2, HTTP_1_1))
     // not connected
     assertNull(adapter.getSelectedProtocol(sslSocket))
   }


### PR DESCRIPTION
Fix for https://github.com/square/okhttp/issues/5700

Android 5.0 requires explicit call to set the hostname.