### PR TITLE
Allow Handshake.toString() for debugging, even when CertificateCleaner will fail

### DIFF
--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -449,8 +449,6 @@ class OkHttpTest {
     val hostnameVerifier = HostnameVerifier { _, _ -> true }
 
     client = client.newBuilder()
-        // avoid cleaning bug for now
-        .eventListener(EventListener.NONE)
         .sslSocketFactory(sslSocketFactory, trustManager)
         .hostnameVerifier(hostnameVerifier)
         .build()
@@ -482,8 +480,6 @@ class OkHttpTest {
     val hostnameVerifier = HostnameVerifier { _, _ -> true }
 
     client = client.newBuilder()
-        // avoid cleaning bug for now
-        .eventListener(EventListener.NONE)
         .sslSocketFactory(sslSocketFactory, trustManager)
         .hostnameVerifier(hostnameVerifier)
         .build()

--- a/okhttp/src/main/java/okhttp3/Handshake.kt
+++ b/okhttp/src/main/java/okhttp3/Handshake.kt
@@ -121,10 +121,15 @@ class Handshake internal constructor(
   }
 
   override fun toString(): String {
+    val peerCertificatesString = try {
+      peerCertificates.map { it.name }.toString()
+    } catch (_: SSLPeerUnverifiedException) {
+      "Failed: SSLPeerUnverifiedException"
+    }
     return "Handshake{" +
         "tlsVersion=$tlsVersion " +
         "cipherSuite=$cipherSuite " +
-        "peerCertificates=${peerCertificates.map { it.name }} " +
+        "peerCertificates=$peerCertificatesString " +
         "localCertificates=${localCertificates.map { it.name }}}"
   }
 


### PR DESCRIPTION
For discussion.  CertificateCleaner will fail for these tests, but we have overridden the TrustManager to allow it to pass.  Accessing the peerCertificates (which are lazily cleaned) directly, or via toString, equals, hashCode will therefore fail.

This seems like the minimal fix for debugging sanity.