### PR TITLE
Add utility for prior responses as a sequence

### DIFF
--- a/okhttp/src/main/java/okhttp3/Response.kt
+++ b/okhttp/src/main/java/okhttp3/Response.kt
@@ -303,7 +303,7 @@ class Response internal constructor(
   }
 
   /**
-   * Returns the sequence of Responses that
+   * Returns the sequence of Responses that led to this final Response.
    */
   fun responses(): Iterable<Response> = generateSequence(this) {
     it.priorResponse

--- a/okhttp/src/main/java/okhttp3/Response.kt
+++ b/okhttp/src/main/java/okhttp3/Response.kt
@@ -302,10 +302,19 @@ class Response internal constructor(
     checkNotNull(body) { "response is not eligible for a body and must not be closed" }.close()
   }
 
+  /**
+   * Returns the sequence of Responses that
+   */
   fun responses(): Iterable<Response> = generateSequence(this) {
     it.priorResponse
   }.asIterable()
 
+  /**
+   * Returns the number of network Responses that were received to get to this final Response.
+   *
+   * The minimum is 1. A 401 response that is then correctly authenticated will have a response
+   * count of 2.
+   */
   val responseCount = responses().count()
 
   override fun toString() =

--- a/okhttp/src/main/java/okhttp3/Response.kt
+++ b/okhttp/src/main/java/okhttp3/Response.kt
@@ -302,6 +302,12 @@ class Response internal constructor(
     checkNotNull(body) { "response is not eligible for a body and must not be closed" }.close()
   }
 
+  fun responses(): Iterable<Response> = generateSequence(this) {
+    it.priorResponse
+  }.asIterable()
+
+  val responseCount = responses().count()
+
   override fun toString() =
       "Response{protocol=$protocol, code=$code, message=$message, url=${request.url}}"
 


### PR DESCRIPTION
For discussion.  Low value, but something to consider e.g.

- Should these sorts of things be public util API
- extension methods (Response.priorResponses)
- or built in to Response

Second question, should we support an easy way to chain responses when the interceptor is essentially forking? e.g. something like Exception.addSuppressed (but without mutability). Currently it's possible but awkward.