### PR TITLE
Switch to Gradle's Maven Publishing Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,6 @@ buildscript {
   ]
 
   dependencies {
-    // TODO(jwilson): configure maven-publish-plugin to limit which artifacts are published.
-    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.8.0'
     classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.1.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.0"
@@ -69,8 +67,9 @@ plugins {
 }
 
 allprojects {
-  group = GROUP
-  version = VERSION_NAME
+  group = 'com.squareup.okhttp3'
+  project.ext.artifactId = artifactId(project)
+  version = '4.4.0-SNAPSHOT'
 
   repositories {
     mavenCentral()
@@ -89,8 +88,7 @@ allprojects {
 }
 
 subprojects { project ->
-  if (project.name == 'android-test')
-    return
+  if (project.name == 'android-test') return
 
   apply plugin: 'java'
   apply plugin: 'java-library'
@@ -100,6 +98,8 @@ subprojects { project ->
   apply plugin: 'net.ltgt.errorprone'
   apply plugin: 'org.jetbrains.dokka'
   apply plugin: 'com.diffplug.gradle.spotless'
+  apply plugin: 'maven-publish'
+  apply plugin: 'signing'
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 
@@ -197,26 +197,57 @@ subprojects { project ->
     }
   }
 
-  // We have to set the dokka configuration after evaluation since the com.vanniktech.maven.publish
-  // plugin overwrites our dokka configuration on projects where it's applied.
-  afterEvaluate { p ->
-    p.tasks.dokka {
-      configuration {
-        reportUndocumented = false
-        skipDeprecated = true
-        jdkVersion = 8
-        perPackageOption {
-          prefix = "okhttp3.internal"
-          suppress = true
-        }
-        if (project.file('Module.md').exists()) {
-          includes = ['Module.md']
-        }
-        externalDocumentationLink {
-          url = new URL("https://square.github.io/okio/2.x/okio/")
-          packageListUrl = new URL("https://square.github.io/okio/2.x/okio/package-list")
+  dokka {
+    configuration {
+      reportUndocumented = false
+      skipDeprecated = true
+      jdkVersion = 8
+      perPackageOption {
+        prefix = "okhttp3.internal"
+        suppress = true
+      }
+      if (project.file('Module.md').exists()) {
+        includes = ['Module.md']
+      }
+      externalDocumentationLink {
+        url = new URL("https://square.github.io/okio/2.x/okio/")
+        packageListUrl = new URL("https://square.github.io/okio/2.x/okio/package-list")
+      }
+    }
+  }
+
+  if (project.ext.artifactId != null) {
+    publishing {
+      java {
+        withJavadocJar()
+        withSourcesJar()
+      }
+      publications {
+        maven(MavenPublication) {
+          groupId = project.group
+          artifactId = project.ext.artifactId
+          version = project.version
+          from components.java
+          pom {
+            url = 'https://square.github.io/okhttp/'
+            licenses {
+              license {
+                name = 'The Apache Software License, Version 2.0'
+                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+              }
+            }
+            scm {
+              connection = 'scm:git:https://github.com/square/okhttp.git'
+              developerConnection = 'scm:git:ssh://git@github.com/square/okhttp.git'
+              url = 'https://github.com/square/okhttp'
+            }
+          }
         }
       }
+    }
+
+    signing {
+      sign publishing.publications.maven
     }
   }
 }
@@ -241,6 +272,23 @@ def alpnBootVersion() {
   if (!patchVersionMatcher.find()) return null
   def patchVersion = Integer.parseInt(patchVersionMatcher.group(1))
   return alpnBootVersionForPatchVersion(javaVersion, patchVersion)
+}
+
+def artifactId(Project project) {
+  if (project.name == 'okhttp-logging-interceptor') {
+    return 'logging-interceptor'
+  } else if (project.name == 'mockwebserver'
+      || project.name == 'okcurl'
+      || project.name == 'okhttp'
+      || project.name == 'okhttp-brotli'
+      || project.name == 'okhttp-dnsoverhttps'
+      || project.name == 'okhttp-sse'
+      || project.name == 'okhttp-tls'
+      || project.name == 'okhttp-urlconnection') {
+    return project.name
+  } else {
+    return null
+  }
 }
 
 def alpnBootVersionForPatchVersion(String javaVersion, int patchVersion) {
@@ -282,8 +330,8 @@ def alpnBootVersionForPatchVersion(String javaVersion, int patchVersion) {
  * https://github.com/Visistema/Groovy1/blob/ba5eb9b2f19ca0cc8927359ce414c4e1974b7016/gradle/binarycompatibility.gradle#L48
  */
 ext.baselineJar = { project, version ->
-  def group = project.property("GROUP")
-  def artifactId = project.property("POM_ARTIFACT_ID")
+  def group = project.group
+  def artifactId = project.ext.artifactId
   try {
     String jarFile = "$artifactId-${version}.jar"
     project.group = 'virtual_group_for_japicmp' // Prevent it from resolving the current version.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -78,8 +78,8 @@ Cutting a Release
 
     ```
     sed -i "" \
-      "s/VERSION_NAME=.*/VERSION_NAME=$RELEASE_VERSION/g" \
-      gradle.properties
+      "s/version = '.*'/version = '$RELEASE_VERSION'/g" \
+      build.gradle
     sed -i "" \
       "s/\"com.squareup.okhttp3:\([^\:]*\):[^\"]*\"/\"com.squareup.okhttp3:\1:$RELEASE_VERSION\"/g" \
       `find . -name "README.md"`
@@ -98,8 +98,8 @@ Cutting a Release
     git commit -am "Prepare for release $RELEASE_VERSION."
     git tag -a parent-$RELEASE_VERSION -m "Version $RELEASE_VERSION"
     sed -i "" \
-      "s/VERSION_NAME=.*/VERSION_NAME=$NEXT_VERSION/g" \
-      gradle.properties
+      "s/version = '.*'/version = '$NEXT_VERSION'/g" \
+      build.gradle
     git commit -am "Prepare next development version."
     git push && git push --tags
     ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,1 @@
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
-
-GROUP=com.squareup.okhttp3
-VERSION_NAME=4.4.0-SNAPSHOT
-
-POM_URL=https://github.com/square/okhttp
-POM_SCM_URL=https://github.com/square/okhttp
-POM_SCM_CONNECTION=scm:git:https://github.com/square/okhttp.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/square/okhttp.git
-
-POM_LICENCE_NAME=The Apache Software License, Version 2.0
-POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
-POM_LICENCE_DIST=repo
-
-POM_DEVELOPER_ID=square
-POM_DEVELOPER_NAME=Square, Inc.

--- a/mockwebserver/build.gradle
+++ b/mockwebserver/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'me.champeau.gradle.japicmp'
 
 jar {

--- a/mockwebserver/gradle.properties
+++ b/mockwebserver/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=mockwebserver
-POM_NAME=mockwebserver
-POM_PACKAGING=jar

--- a/okcurl/build.gradle
+++ b/okcurl/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 jar {
@@ -18,7 +17,7 @@ compileJava {
 task copyResourcesTemplates(type: Copy) {
   from 'src/main/resources-templates'
   into "$buildDir/generated/resources-templates"
-  expand('projectVersion': "$VERSION_NAME")
+  expand('projectVersion': "${project.version}")
   filteringCharset = 'UTF-8'
 }
 

--- a/okcurl/gradle.properties
+++ b/okcurl/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=okcurl
-POM_NAME=okcurl
-POM_PACKAGING=jar

--- a/okhttp-brotli/build.gradle
+++ b/okhttp-brotli/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.vanniktech.maven.publish'
-
 jar {
   manifest {
     attributes('Automatic-Module-Name': 'okhttp3.brotli')

--- a/okhttp-brotli/gradle.properties
+++ b/okhttp-brotli/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=okhttp-brotli
-POM_NAME=okhttp-brotli
-POM_PACKAGING=jar

--- a/okhttp-dnsoverhttps/build.gradle
+++ b/okhttp-dnsoverhttps/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.vanniktech.maven.publish'
-
 jar {
   manifest {
     attributes('Automatic-Module-Name': 'okhttp3.dnsoverhttps')

--- a/okhttp-dnsoverhttps/gradle.properties
+++ b/okhttp-dnsoverhttps/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=okhttp-dnsoverhttps
-POM_NAME=okhttp-dnsoverhttps
-POM_PACKAGING=jar

--- a/okhttp-logging-interceptor/build.gradle
+++ b/okhttp-logging-interceptor/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'me.champeau.gradle.japicmp'
 
 jar {

--- a/okhttp-logging-interceptor/gradle.properties
+++ b/okhttp-logging-interceptor/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=logging-interceptor
-POM_NAME=logging-interceptor
-POM_PACKAGING=jar

--- a/okhttp-sse/build.gradle
+++ b/okhttp-sse/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'me.champeau.gradle.japicmp'
 
 jar {

--- a/okhttp-sse/gradle.properties
+++ b/okhttp-sse/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=okhttp-sse
-POM_NAME=okhttp-sse
-POM_PACKAGING=jar

--- a/okhttp-tls/build.gradle
+++ b/okhttp-tls/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'me.champeau.gradle.japicmp'
 
 jar {

--- a/okhttp-tls/gradle.properties
+++ b/okhttp-tls/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=okhttp-tls
-POM_NAME=okhttp-tls
-POM_PACKAGING=jar

--- a/okhttp-urlconnection/build.gradle
+++ b/okhttp-urlconnection/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'me.champeau.gradle.japicmp'
 
 jar {

--- a/okhttp-urlconnection/gradle.properties
+++ b/okhttp-urlconnection/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=okhttp-urlconnection
-POM_NAME=okhttp-urlconnection
-POM_PACKAGING=jar

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'me.champeau.gradle.japicmp'
 
 jar {
@@ -18,7 +17,7 @@ compileKotlin {
 task copyJavaTemplates(type: Copy) {
   from 'src/main/java-templates'
   into "$buildDir/generated/sources/java-templates/java/main"
-  expand('projectVersion': "$VERSION_NAME")
+  expand('projectVersion': "${project.version}")
   filteringCharset = 'UTF-8'
 }
 

--- a/okhttp/gradle.properties
+++ b/okhttp/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=okhttp
-POM_NAME=okhttp
-POM_PACKAGING=jar


### PR DESCRIPTION
This removes a bunch of low-value stuff from the pom.xml files:

 - name
 - description
 - licence distribution ('repo')
 - developers clause
 - test dependencies

I don't think any of this will be missed, and it shrinks the pom.xml
file to the minimal set of useful stuff.

This also causes us to publish a gradle .module file. This is the
motivation for this change. It'll allow us to ship a Gradle platform,
which is a more capable than a Maven BOM.