### PR TITLE
Expire old routes in the failed routes database

### DIFF
--- a/okhttp-dnsoverhttps/build.gradle
+++ b/okhttp-dnsoverhttps/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   testImplementation deps.conscrypt
   testImplementation deps.junit
   testImplementation deps.assertj
+  testImplementation deps.guava
 }
 
 afterEvaluate { project ->

--- a/okhttp-logging-interceptor/build.gradle
+++ b/okhttp-logging-interceptor/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   testImplementation project(':okhttp-testing-support')
   testImplementation project(':okhttp-tls')
   testImplementation deps.assertj
+  testImplementation deps.guava
 }
 
 afterEvaluate { project ->

--- a/okhttp-sse/build.gradle
+++ b/okhttp-sse/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   testImplementation project(':mockwebserver')
   testImplementation deps.junit
   testImplementation deps.assertj
+  testImplementation deps.guava
   testCompileOnly deps.jsr305
 }
 

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -40,6 +40,7 @@ dependencies {
   testImplementation deps.junit
   testImplementation deps.assertj
   testImplementation deps.openjsse
+  testImplementation deps.guava
   testCompileOnly deps.jsr305
 }
 

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   compileOnly deps.openjsse
   compileOnly deps.jsr305
   compileOnly deps.animalSniffer
+  compileOnly deps.guava
 
   testImplementation project(':okhttp-testing-support')
   testImplementation project(':okhttp-tls')

--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteDatabase.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteDatabase.kt
@@ -33,7 +33,7 @@ class RouteDatabase {
 
   /** Records a failure connecting to [failedRoute]. */
   @Synchronized fun failed(failedRoute: Route) {
-    failedRoutes.put(failedRoute, Object())
+    failedRoutes.put(failedRoute, Any())
   }
 
   /** Records success connecting to [route]. */

--- a/okhttp/src/main/java/okhttp3/internal/connection/RouteDatabase.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RouteDatabase.kt
@@ -16,8 +16,8 @@
 package okhttp3.internal.connection
 
 import com.google.common.cache.CacheBuilder
+import java.util.concurrent.TimeUnit
 import okhttp3.Route
-import java.time.Duration
 
 /**
  * A blacklist of failed routes to avoid when creating a new connection to a target address. This is
@@ -28,8 +28,8 @@ import java.time.Duration
 class RouteDatabase {
   private val failedRoutes = CacheBuilder.newBuilder()
           .maximumSize(1000)
-          .expireAfterAccess(Duration.ofMinutes(10))
-          .build<Route, Object>()
+          .expireAfterAccess(10, TimeUnit.MINUTES)
+          .build<Route, Any>()
 
   /** Records a failure connecting to [failedRoute]. */
   @Synchronized fun failed(failedRoute: Route) {


### PR DESCRIPTION
Currently the RouteDatabase uses a set to track failed routes. If a route is never attempted again, it can accumulate in this set indefinitely since there is no mechanism to purge old routes. 

Each route requires about 270KB, so even 1000 routes will use 270MB of heap. 

This PR uses a cache with an expiration time of 10 minutes and a max size of 1,000 routes.


For context, we have clients that talk to applications in a cluster. The cluster has many nodes and each node hosts many applications, which are on randomized ports. Since each host/port can be random, the list of failed routes can grow indefinitely. 

This PR addresses this issue https://github.com/square/okhttp/issues/4689