### PR TITLE
Bouncy Castle Provider working with HTTP/2 on JDK 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ buildscript {
       'animalSniffer': "org.codehaus.mojo:animal-sniffer-annotations:${versions.animalSniffer}",
       'assertj': "org.assertj:assertj-core:${versions.assertj}",
       'bouncycastle': "org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}",
+      'bouncycastledebug': "org.bouncycastle:bcprov-debug-jdk15on:${versions.bouncycastle}",
+      'bouncycastlepkix': "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}",
       'bouncycastletls': "org.bouncycastle:bctls-jdk15on:${versions.bouncycastle}",
       'brotli': "org.brotli:dec:${versions.brotli}",
       'conscrypt': "org.conscrypt:conscrypt-openjdk-uber:${versions.conscrypt}",

--- a/okhttp-testing-support/build.gradle
+++ b/okhttp-testing-support/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   api deps.assertj
   api deps.bouncycastledebug
   implementation deps.bouncycastlepkix, {
+    // prefer debug build for our own testing
     exclude module:"bcprov-jdk15on"
   }
   implementation deps.bouncycastletls, {

--- a/okhttp-testing-support/build.gradle
+++ b/okhttp-testing-support/build.gradle
@@ -2,8 +2,13 @@ dependencies {
   api project(':okhttp')
   api deps.junit
   api deps.assertj
-  api deps.bouncycastle
-  api deps.bouncycastletls
+  api deps.bouncycastledebug
+  implementation deps.bouncycastlepkix, {
+    exclude module:"bcprov-jdk15on"
+  }
+  implementation deps.bouncycastletls, {
+    exclude module:"bcprov-jdk15on"
+  }
   api deps.conscrypt
   api deps.corretto
   api deps.openjsse

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpDebugLogging.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpDebugLogging.kt
@@ -47,17 +47,5 @@ object OkHttpDebugLogging {
     }
   }
 
-  fun enable(loggerClass: KClass<*>) {
-    val logger = Logger.getLogger(loggerClass.java.name)
-    if (configuredLoggers.add(logger)) {
-      logger.addHandler(ConsoleHandler().apply {
-        level = Level.FINE
-        formatter = object : SimpleFormatter() {
-          override fun format(record: LogRecord) =
-              String.format("[%1\$tF %1\$tT] %2\$s %n", record.millis, record.message)
-        }
-      })
-      logger.level = Level.FINEST
-    }
-  }
+  fun enable(loggerClass: KClass<*>) = enable(loggerClass.java.name)
 }

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpDebugLogging.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpDebugLogging.kt
@@ -33,7 +33,21 @@ object OkHttpDebugLogging {
 
   fun enableTaskRunner() = enable(TaskRunner::class)
 
-  private fun enable(loggerClass: KClass<*>) {
+  fun enable(loggerClass: String) {
+    val logger = Logger.getLogger(loggerClass)
+    if (configuredLoggers.add(logger)) {
+      logger.addHandler(ConsoleHandler().apply {
+        level = Level.FINE
+        formatter = object : SimpleFormatter() {
+          override fun format(record: LogRecord) =
+            String.format("[%1\$tF %1\$tT] %2\$s %n", record.millis, record.message)
+        }
+      })
+      logger.level = Level.FINEST
+    }
+  }
+
+  fun enable(loggerClass: KClass<*>) {
     val logger = Logger.getLogger(loggerClass.java.name)
     if (configuredLoggers.add(logger)) {
       logger.addHandler(ConsoleHandler().apply {
@@ -43,7 +57,7 @@ object OkHttpDebugLogging {
               String.format("[%1\$tF %1\$tT] %2\$s %n", record.millis, record.message)
         }
       })
-      logger.level = Level.FINE
+      logger.level = Level.FINEST
     }
   }
 }

--- a/okhttp-tls/build.gradle
+++ b/okhttp-tls/build.gradle
@@ -9,7 +9,13 @@ jar {
 dependencies {
   api deps.okio
   implementation project(':okhttp')
-  implementation deps.bouncycastle
+  implementation deps.bouncycastledebug
+  implementation deps.bouncycastlepkix, {
+    exclude module:"bcprov-jdk15on"
+  }
+  implementation deps.bouncycastletls, {
+    exclude module:"bcprov-jdk15on"
+  }
   compileOnly deps.jsr305
 
   testImplementation project(':okhttp-testing-support')

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -25,6 +25,8 @@ dependencies {
   api deps.okio
   api deps.kotlinStdlib
   compileOnly deps.android
+  compileOnly deps.bouncycastledebug
+  compileOnly deps.bouncycastletls
   compileOnly deps.conscrypt
   compileOnly deps.openjsse
   compileOnly deps.jsr305

--- a/okhttp/src/main/java/okhttp3/internal/platform/BouncyCastlePlatform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/BouncyCastlePlatform.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.platform
+
+import java.security.KeyStore
+import java.security.Provider
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+import okhttp3.Protocol
+import org.bouncycastle.jsse.BCSSLSocket
+import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+
+/**
+ * Platform using BouncyCastle if installed as the first Security Provider.
+ *
+ * Requires org.bouncycastle:bctls-jdk15on on the classpath.
+ */
+class BouncyCastlePlatform private constructor() : Platform() {
+  private val provider: Provider = BouncyCastleJsseProvider()
+
+  override fun newSSLContext(): SSLContext =
+      SSLContext.getInstance("TLS", provider)
+
+  override fun platformTrustManager(): X509TrustManager {
+    val factory = TrustManagerFactory.getInstance(
+        "PKIX", BouncyCastleJsseProvider.PROVIDER_NAME)
+    factory.init(null as KeyStore?)
+    val trustManagers = factory.trustManagers!!
+    check(trustManagers.size == 1 && trustManagers[0] is X509TrustManager) {
+      "Unexpected default trust managers: ${trustManagers.contentToString()}"
+    }
+    return trustManagers[0] as X509TrustManager
+  }
+
+  public override fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? =
+      throw UnsupportedOperationException(
+          "clientBuilder.sslSocketFactory(SSLSocketFactory) not supported with BouncyCastle")
+
+  override fun configureTlsExtensions(
+    sslSocket: SSLSocket,
+    hostname: String?,
+    protocols: List<@JvmSuppressWildcards Protocol>
+  ) {
+    if (sslSocket is BCSSLSocket) {
+      val sslParameters = sslSocket.parameters
+
+      // Enable ALPN.
+      val names = alpnProtocolNames(protocols)
+      sslParameters.applicationProtocols = names.toTypedArray()
+
+      sslSocket.parameters = sslParameters
+    } else {
+      super.configureTlsExtensions(sslSocket, hostname, protocols)
+    }
+  }
+
+  override fun getSelectedProtocol(sslSocket: SSLSocket): String? =
+      if (sslSocket is BCSSLSocket) {
+        when (val protocol = (sslSocket as BCSSLSocket).applicationProtocol) {
+          // Handles both un-configured and none selected.
+          null, "" -> null
+          else -> protocol
+        }
+      } else {
+        super.getSelectedProtocol(sslSocket)
+      }
+
+  companion object {
+    val isSupported: Boolean = try {
+      // Trigger an early exception over a fatal error, prefer a RuntimeException over Error.
+      Class.forName("org.bouncycastle.jsse.provider.BouncyCastleJsseProvider")
+
+      true
+    } catch (_: ClassNotFoundException) {
+      false
+    }
+
+    fun buildIfSupported(): BouncyCastlePlatform? = if (isSupported) BouncyCastlePlatform() else null
+  }
+}

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.kt
@@ -198,8 +198,7 @@ open class Platform {
 
     private val isBouncyCastlePreferred: Boolean
       get() {
-        val preferredProvider = Security.getProviders()[0].name
-        return preferredProvider.startsWith("BC")
+        return System.getProperty("okhttp.platform") == "bouncycastle"
       }
 
     /** Attempt to match the host runtime to a capable Platform implementation. */

--- a/okhttp/src/main/java/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Platform.kt
@@ -196,6 +196,12 @@ open class Platform {
         return "OpenJSSE" == preferredProvider
       }
 
+    private val isBouncyCastlePreferred: Boolean
+      get() {
+        val preferredProvider = Security.getProviders()[0].name
+        return preferredProvider.startsWith("BC")
+      }
+
     /** Attempt to match the host runtime to a capable Platform implementation. */
     private fun findPlatform(): Platform {
       val android10 = Android10Platform.buildIfSupported()
@@ -215,6 +221,14 @@ open class Platform {
 
         if (conscrypt != null) {
           return conscrypt
+        }
+      }
+
+      if (isBouncyCastlePreferred) {
+        val bc = BouncyCastlePlatform.buildIfSupported()
+
+        if (bc != null) {
+          return bc
         }
       }
 


### PR DESCRIPTION
Improves client side for BouncyCastle use.  n.b. highlights issues when properly using BouncyCastle in a server.  Fixes for that to come separately.