### PR TITLE
Limit the route database to 128 elements

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -172,6 +172,17 @@ fun Array<String>.concat(value: String): Array<String> {
 }
 
 /**
+ * Removes the first element of this non-empty set and returns it. If this set was created with
+ * [mutableSetOf] this returns the oldest element in the set.
+ */
+fun <T : Any?> MutableSet<T>.removeFirst(): T {
+  val i = iterator()
+  val result = i.next()
+  i.remove()
+  return result
+}
+
+/**
  * Increments [startIndex] until this string is not ASCII whitespace. Stops at [endIndex].
  */
 fun String.indexOfFirstNonAsciiWhitespace(startIndex: Int = 0, endIndex: Int = length): Int {

--- a/okhttp/src/test/java/okhttp3/internal/UtilTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/UtilTest.kt
@@ -34,4 +34,26 @@ class UtilTest {
     } catch (_: UnsupportedOperationException) {
     }
   }
+
+  @Test fun removeFirst() {
+    val set = mutableSetOf<String>()
+    set += "s"
+    set += "q"
+    set += "u"
+    set += "a"
+    set += "r"
+    set += "e"
+    assertThat(set.removeFirst()).isEqualTo("s")
+    assertThat(set).containsExactly("q", "u", "a", "r", "e")
+    assertThat(set.removeFirst()).isEqualTo("q")
+    assertThat(set).containsExactly("u", "a", "r", "e")
+    assertThat(set.removeFirst()).isEqualTo("u")
+    assertThat(set).containsExactly("a", "r", "e")
+    assertThat(set.removeFirst()).isEqualTo("a")
+    assertThat(set).containsExactly("r", "e")
+    assertThat(set.removeFirst()).isEqualTo("r")
+    assertThat(set).containsExactly("e")
+    assertThat(set.removeFirst()).isEqualTo("e")
+    assertThat(set).isEmpty()
+  }
 }


### PR DESCRIPTION
We don't have an API to clear this, and in some degenerate situations it
can grow to hundreds of megabytes in size because the SSLSocketFactory
instances held by Route are large.

Closes: https://github.com/square/okhttp/issues/4689