### PR TITLE
Remove always-false check of retryCurrentRoute() and unreachable code.

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
@@ -174,8 +174,6 @@ class ExchangeFinder(
         } else if (nextRouteToTry != null) {
           selectedRoute = nextRouteToTry
           nextRouteToTry = null
-        } else if (retryCurrentRoute()) {
-          selectedRoute = call.connection!!.route()
         }
       }
     }


### PR DESCRIPTION
**This `retryCurrentRoute()` check will always return false, because `transmitter.connection` is `null` here.**

**Reason**: 
Just a few lines above, `result` is set to `transmitter.connection`, with the condition `transmitter.connection != null`. And as `result == null` is the entry condition of this lower block, `transmitter.connection` should definitely be `null`, which makes `retryCurrentRoute()` always return `false`.

```kotlin
// findConnection()
// wrapped in a synchronized block

if (transmitter.connection != null) {
    // We had an already-allocated connection and it's good.
    result = transmitter.connection
    releasedConnection = null
}

if (result == null) {
  // Attempt to get a connection from the pool.
  if (connectionPool.transmitterAcquirePooledConnection(address, transmitter, null, false)) {
    foundPooledConnection = true
    result = transmitter.connection
  } else if (nextRouteToTry != null) {
    selectedRoute = nextRouteToTry
    nextRouteToTry = null
  } else if (retryCurrentRoute()) {
    selectedRoute = transmitter.connection!!.route()
  }
}


...


private fun retryCurrentRoute(): Boolean {
  return transmitter.connection != null &&
      transmitter.connection!!.routeFailureCount == 0 &&
      transmitter.connection!!.route().address.url.canReuseConnectionFor(address.url)
}
``` 