### PR TITLE
Reorganize RealCall and RealInterceptorChain

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
@@ -156,7 +156,7 @@ class Exchange(
    */
   fun detachWithViolence() {
     codec.cancel()
-    call.exchangeMessageDone(this, requestDone = true, responseDone = true, e = null)
+    call.messageDone(this, requestDone = true, responseDone = true, e = null)
   }
 
   private fun trackFailure(e: IOException) {
@@ -187,11 +187,11 @@ class Exchange(
         eventListener.responseBodyEnd(call, bytesRead)
       }
     }
-    return call.exchangeMessageDone(this, requestDone, responseDone, e)
+    return call.messageDone(this, requestDone, responseDone, e)
   }
 
   fun noRequestBody() {
-    call.exchangeMessageDone(this, requestDone = true, responseDone = false, e = null)
+    call.messageDone(this, requestDone = true, responseDone = false, e = null)
   }
 
   /** A request body that fires events when it completes. */

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -40,7 +40,6 @@ import okhttp3.EventListener
 import okhttp3.Handshake
 import okhttp3.Handshake.Companion.handshake
 import okhttp3.HttpUrl
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
@@ -51,6 +50,7 @@ import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.http.ExchangeCodec
+import okhttp3.internal.http.RealInterceptorChain
 import okhttp3.internal.http1.Http1ExchangeCodec
 import okhttp3.internal.http2.ConnectionShutdownException
 import okhttp3.internal.http2.ErrorCode
@@ -564,7 +564,7 @@ class RealConnection(
   }
 
   @Throws(SocketException::class)
-  internal fun newCodec(client: OkHttpClient, chain: Interceptor.Chain): ExchangeCodec {
+  internal fun newCodec(client: OkHttpClient, chain: RealInterceptorChain): ExchangeCodec {
     val socket = this.socket!!
     val source = this.source!!
     val sink = this.sink!!
@@ -574,8 +574,8 @@ class RealConnection(
       Http2ExchangeCodec(client, this, chain, http2Connection)
     } else {
       socket.soTimeout = chain.readTimeoutMillis()
-      source.timeout().timeout(chain.readTimeoutMillis().toLong(), MILLISECONDS)
-      sink.timeout().timeout(chain.writeTimeoutMillis().toLong(), MILLISECONDS)
+      source.timeout().timeout(chain.readTimeoutMillis.toLong(), MILLISECONDS)
+      sink.timeout().timeout(chain.writeTimeoutMillis.toLong(), MILLISECONDS)
       Http1ExchangeCodec(client, this, source, sink)
     }
   }

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.kt
@@ -28,8 +28,8 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
     val realChain = chain as RealInterceptorChain
-    val exchange = realChain.exchange()
-    val request = realChain.request()
+    val exchange = realChain.exchange!!
+    val request = realChain.request
     val requestBody = request.body
     val sentRequestMillis = System.currentTimeMillis()
 

--- a/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
@@ -17,6 +17,7 @@ package okhttp3.internal.http
 
 import java.io.IOException
 import java.util.concurrent.TimeUnit
+import okhttp3.Call
 import okhttp3.Connection
 import okhttp3.Interceptor
 import okhttp3.Request
@@ -33,82 +34,76 @@ import okhttp3.internal.connection.RealCall
  * a network interceptor and [exchange] must be non-null.
  */
 class RealInterceptorChain(
+  internal val call: RealCall,
   private val interceptors: List<Interceptor>,
-  private val call: RealCall,
-  private val exchange: Exchange?,
   private val index: Int,
-  private val request: Request,
-  private val connectTimeout: Int,
-  private val readTimeout: Int,
-  private val writeTimeout: Int
+  internal val exchange: Exchange?,
+  internal val request: Request,
+  internal val connectTimeoutMillis: Int,
+  internal val readTimeoutMillis: Int,
+  internal val writeTimeoutMillis: Int
 ) : Interceptor.Chain {
 
   private var calls: Int = 0
 
+  internal fun copy(
+    index: Int = this.index,
+    exchange: Exchange? = this.exchange,
+    request: Request = this.request,
+    connectTimeoutMillis: Int = this.connectTimeoutMillis,
+    readTimeoutMillis: Int = this.readTimeoutMillis,
+    writeTimeoutMillis: Int = this.writeTimeoutMillis
+  ) = RealInterceptorChain(call, interceptors, index, exchange, request, connectTimeoutMillis,
+      readTimeoutMillis, writeTimeoutMillis)
+
   override fun connection(): Connection? = exchange?.connection()
 
-  override fun connectTimeoutMillis(): Int = connectTimeout
+  override fun connectTimeoutMillis(): Int = connectTimeoutMillis
 
-  override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
-    val millis = checkDuration("timeout", timeout.toLong(), unit)
-    return RealInterceptorChain(interceptors, call, exchange, index, request, millis,
-        readTimeout, writeTimeout)
-  }
+  override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain =
+      copy(connectTimeoutMillis = checkDuration("connectTimeout", timeout.toLong(), unit))
 
-  override fun readTimeoutMillis(): Int = readTimeout
+  override fun readTimeoutMillis(): Int = readTimeoutMillis
 
-  override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
-    val millis = checkDuration("timeout", timeout.toLong(), unit)
-    return RealInterceptorChain(interceptors, call, exchange, index, request, connectTimeout,
-        millis, writeTimeout)
-  }
+  override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain =
+      copy(readTimeoutMillis = checkDuration("readTimeout", timeout.toLong(), unit))
 
-  override fun writeTimeoutMillis(): Int = writeTimeout
+  override fun writeTimeoutMillis(): Int = writeTimeoutMillis
 
-  override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
-    val millis = checkDuration("timeout", timeout.toLong(), unit)
-    return RealInterceptorChain(interceptors, call, exchange, index, request, connectTimeout,
-        readTimeout, millis)
-  }
+  override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain =
+      copy(writeTimeoutMillis = checkDuration("writeTimeout", timeout.toLong(), unit))
 
-  fun exchange(): Exchange = exchange!!
-
-  override fun call(): RealCall = call
+  override fun call(): Call = call
 
   override fun request(): Request = request
 
-  override fun proceed(request: Request): Response {
-    return proceed(request, exchange)
-  }
-
   @Throws(IOException::class)
-  fun proceed(request: Request, exchange: Exchange?): Response {
-    if (index >= interceptors.size) throw AssertionError()
+  override fun proceed(request: Request): Response {
+    check(index < interceptors.size)
 
     calls++
 
-    // If we already have an exchange, confirm that the incoming request will use it.
-    check(this.exchange == null || this.exchange.connection()!!.supportsUrl(request.url)) {
-      "network interceptor ${interceptors[index - 1]} must retain the same host and port"
-    }
-
-    // If we already have an exchange, confirm that this is the only call to chain.proceed().
-    check(this.exchange == null || calls <= 1) {
-      "network interceptor ${interceptors[index - 1]} must call proceed() exactly once"
+    if (exchange != null) {
+      check(exchange.connection()!!.supportsUrl(request.url)) {
+        "network interceptor ${interceptors[index - 1]} must retain the same host and port"
+      }
+      check(calls == 1) {
+        "network interceptor ${interceptors[index - 1]} must call proceed() exactly once"
+      }
     }
 
     // Call the next interceptor in the chain.
-    val next = RealInterceptorChain(interceptors, call, exchange,
-        index + 1, request, connectTimeout, readTimeout, writeTimeout)
+    val next = copy(index = index + 1, request = request)
     val interceptor = interceptors[index]
 
     @Suppress("USELESS_ELVIS")
     val response = interceptor.intercept(next) ?: throw NullPointerException(
         "interceptor $interceptor returned null")
 
-    // Confirm that the next interceptor made its required call to chain.proceed().
-    check(exchange == null || index + 1 >= interceptors.size || next.calls == 1) {
-      "network interceptor $interceptor must call proceed() exactly once"
+    if (exchange != null) {
+      check(index + 1 >= interceptors.size || next.calls == 1) {
+        "network interceptor $interceptor must call proceed() exactly once"
+      }
     }
 
     check(response.body != null) { "interceptor $interceptor returned a response with no body" }

--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
@@ -53,9 +53,9 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
 
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
-    var request = chain.request()
     val realChain = chain as RealInterceptorChain
-    val call = realChain.call()
+    var request = chain.request
+    val call = realChain.call
     var followUpCount = 0
     var priorResponse: Response? = null
     while (true) {
@@ -68,7 +68,7 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
       var response: Response
       var success = false
       try {
-        response = realChain.proceed(request, null)
+        response = realChain.proceed(request)
         success = true
       } catch (e: RouteException) {
         // The attempt to connect via a route failed. The request will not have been sent.

--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2ExchangeCodec.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2ExchangeCodec.kt
@@ -21,7 +21,6 @@ import java.util.ArrayList
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import okhttp3.Headers
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
@@ -29,6 +28,7 @@ import okhttp3.Response
 import okhttp3.internal.connection.RealConnection
 import okhttp3.internal.headersContentLength
 import okhttp3.internal.http.ExchangeCodec
+import okhttp3.internal.http.RealInterceptorChain
 import okhttp3.internal.http.RequestLine
 import okhttp3.internal.http.StatusLine
 import okhttp3.internal.http.StatusLine.Companion.HTTP_CONTINUE
@@ -50,7 +50,7 @@ import okio.Source
 class Http2ExchangeCodec(
   client: OkHttpClient,
   private val realConnection: RealConnection,
-  private val chain: Interceptor.Chain,
+  private val chain: RealInterceptorChain,
   private val connection: Http2Connection
 ) : ExchangeCodec {
   @Volatile private var stream: Http2Stream? = null
@@ -84,8 +84,8 @@ class Http2ExchangeCodec(
       stream!!.closeLater(ErrorCode.CANCEL)
       throw IOException("Canceled")
     }
-    stream!!.readTimeout().timeout(chain.readTimeoutMillis().toLong(), TimeUnit.MILLISECONDS)
-    stream!!.writeTimeout().timeout(chain.writeTimeoutMillis().toLong(), TimeUnit.MILLISECONDS)
+    stream!!.readTimeout().timeout(chain.readTimeoutMillis.toLong(), TimeUnit.MILLISECONDS)
+    stream!!.writeTimeout().timeout(chain.writeTimeoutMillis.toLong(), TimeUnit.MILLISECONDS)
   }
 
   override fun flushRequest() {


### PR DESCRIPTION
I've attempted to put RealCall's methods into a logical order; it's approximately
the order the methods get called in for a successful call.

For RealInterceptorChain I've created a copy() method inspired-by data classes.
This has the added benefit of shrinking the call stack everywhere.