### PR TITLE
Formalize the lifecycle of Exchange

### DIFF
--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -70,6 +70,7 @@ task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask, dependsOn: 'jar') {
       'okhttp3.internal.cache2',
       'okhttp3.internal.connection',
       'okhttp3.internal.http',
+      'okhttp3.internal.http1',
       'okhttp3.internal.http2',
       'okhttp3.internal.io',
       'okhttp3.internal.platform',

--- a/okhttp/src/main/java/okhttp3/Dispatcher.kt
+++ b/okhttp/src/main/java/okhttp3/Dispatcher.kt
@@ -117,8 +117,8 @@ class Dispatcher constructor() {
 
       // Mutate the AsyncCall so that it shares the AtomicInteger of an existing running call to
       // the same host.
-      if (!call.get().forWebSocket) {
-        val existingCall = findExistingCallWithHost(call.host())
+      if (!call.call.forWebSocket) {
+        val existingCall = findExistingCallWithHost(call.host)
         if (existingCall != null) call.reuseCallsPerHostFrom(existingCall)
       }
     }
@@ -127,10 +127,10 @@ class Dispatcher constructor() {
 
   private fun findExistingCallWithHost(host: String): AsyncCall? {
     for (existingCall in runningAsyncCalls) {
-      if (existingCall.host() == host) return existingCall
+      if (existingCall.host == host) return existingCall
     }
     for (existingCall in readyAsyncCalls) {
-      if (existingCall.host() == host) return existingCall
+      if (existingCall.host == host) return existingCall
     }
     return null
   }
@@ -141,10 +141,10 @@ class Dispatcher constructor() {
    */
   @Synchronized fun cancelAll() {
     for (call in readyAsyncCalls) {
-      call.get().cancel()
+      call.call.cancel()
     }
     for (call in runningAsyncCalls) {
-      call.get().cancel()
+      call.call.cancel()
     }
     for (call in runningSyncCalls) {
       call.cancel()
@@ -169,10 +169,10 @@ class Dispatcher constructor() {
         val asyncCall = i.next()
 
         if (runningAsyncCalls.size >= this.maxRequests) break // Max capacity.
-        if (asyncCall.callsPerHost().get() >= this.maxRequestsPerHost) continue // Host max capacity.
+        if (asyncCall.callsPerHost.get() >= this.maxRequestsPerHost) continue // Host max capacity.
 
         i.remove()
-        asyncCall.callsPerHost().incrementAndGet()
+        asyncCall.callsPerHost.incrementAndGet()
         executableCalls.add(asyncCall)
         runningAsyncCalls.add(asyncCall)
       }
@@ -194,7 +194,7 @@ class Dispatcher constructor() {
 
   /** Used by `AsyncCall#run` to signal completion. */
   internal fun finished(call: AsyncCall) {
-    call.callsPerHost().decrementAndGet()
+    call.callsPerHost.decrementAndGet()
     finished(runningAsyncCalls, call)
   }
 
@@ -219,12 +219,12 @@ class Dispatcher constructor() {
 
   /** Returns a snapshot of the calls currently awaiting execution. */
   @Synchronized fun queuedCalls(): List<Call> {
-    return Collections.unmodifiableList(readyAsyncCalls.map { it.get() })
+    return Collections.unmodifiableList(readyAsyncCalls.map { it.call })
   }
 
   /** Returns a snapshot of the calls currently being executed. */
   @Synchronized fun runningCalls(): List<Call> {
-    return Collections.unmodifiableList(runningSyncCalls + runningAsyncCalls.map { it.get() })
+    return Collections.unmodifiableList(runningSyncCalls + runningAsyncCalls.map { it.call })
   }
 
   @Synchronized fun queuedCallsCount(): Int = readyAsyncCalls.size

--- a/okhttp/src/main/java/okhttp3/RequestBody.kt
+++ b/okhttp/src/main/java/okhttp3/RequestBody.kt
@@ -83,9 +83,13 @@ abstract class RequestBody {
    * This method returns false unless it is overridden by a subclass.
    *
    * By default OkHttp will attempt to retransmit request bodies when the original request fails
-   * due to a stale connection, a client timeout (HTTP 408), a satisfied authorization challenge
-   * (HTTP 401 and 407), or a retryable server failure (HTTP 503 with a `Retry-After: 0`
-   * header).
+   * due to any of:
+   *
+   *  * A stale connection. The request was made on a reused connection and that reused connection
+   *    has since been closed by the server.
+   *  * A client timeout (HTTP 408).
+   *  * A authorization challenge (HTTP 401 and 407) that is satisfied by the [Authenticator].
+   *  * A retryable server failure (HTTP 503 with a `Retry-After: 0` response header).
    */
   open fun isOneShot(): Boolean = false
 

--- a/okhttp/src/main/java/okhttp3/internal/connection/ConnectInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ConnectInterceptor.kt
@@ -29,7 +29,7 @@ object ConnectInterceptor : Interceptor {
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
     val realChain = chain as RealInterceptorChain
-    val exchange = realChain.call.prepareNewExchange(chain)
+    val exchange = realChain.call.initExchange(chain)
     val connectedChain = realChain.copy(exchange = exchange)
     return connectedChain.proceed(realChain.request)
   }

--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
@@ -44,10 +44,10 @@ class Exchange(
   private val codec: ExchangeCodec
 ) {
   /** Returns true if the request body need not complete before the response body starts. */
-  var isDuplex: Boolean = false
+  internal var isDuplex: Boolean = false
     private set
 
-  fun connection(): RealConnection? = codec.connection()
+  internal val connection: RealConnection = codec.connection
 
   @Throws(IOException::class)
   fun writeRequestHeaders(request: Request) {
@@ -135,7 +135,7 @@ class Exchange(
   @Throws(SocketException::class)
   fun newWebSocketStreams(): RealWebSocket.Streams {
     call.timeoutEarlyExit()
-    return codec.connection()!!.newWebSocketStreams(this)
+    return codec.connection.newWebSocketStreams(this)
   }
 
   fun webSocketUpgradeFailed() {
@@ -143,7 +143,7 @@ class Exchange(
   }
 
   fun noNewExchangesOnConnection() {
-    codec.connection()!!.noNewExchanges()
+    codec.connection.noNewExchanges()
   }
 
   fun cancel() {
@@ -161,7 +161,7 @@ class Exchange(
 
   private fun trackFailure(e: IOException) {
     finder.trackFailure()
-    codec.connection()!!.trackFailure(call.client, e)
+    codec.connection.trackFailure(call.client, e)
   }
 
   fun <E : IOException?> bodyComplete(

--- a/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
@@ -19,6 +19,7 @@ import java.io.IOException
 import java.net.Socket
 import okhttp3.Address
 import okhttp3.EventListener
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Route
 import okhttp3.internal.assertThreadDoesntHoldLock
@@ -49,7 +50,7 @@ import okhttp3.internal.http.RealInterceptorChain
  */
 class ExchangeFinder(
   private val connectionPool: RealConnectionPool,
-  private val address: Address,
+  internal val address: Address,
   private val call: RealCall,
   private val eventListener: EventListener
 ) {
@@ -300,8 +301,11 @@ class ExchangeFinder(
    * coalesced connections.
    */
   private fun retryCurrentRoute(): Boolean {
-    return call.connection != null &&
-        call.connection!!.routeFailureCount == 0 &&
-        call.connection!!.route().address.url.canReuseConnectionFor(address.url)
+    val connection = call.connection
+    return connection != null &&
+        connection.routeFailureCount == 0 &&
+        connection.route().address.url.canReuseConnectionFor(address.url)
   }
+
+  fun canReuseFinderFor(httpUrl: HttpUrl) = httpUrl.canReuseConnectionFor(address.url)
 }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -420,7 +420,7 @@ class RealConnection(
     while (true) {
       val source = this.source!!
       val sink = this.sink!!
-      val tunnelCodec = Http1ExchangeCodec(null, null, source, sink)
+      val tunnelCodec = Http1ExchangeCodec(null, this, source, sink)
       source.timeout().timeout(readTimeout.toLong(), MILLISECONDS)
       sink.timeout().timeout(writeTimeout.toLong(), MILLISECONDS)
       tunnelCodec.writeRequest(nextRequest.headers, requestLine)
@@ -559,8 +559,8 @@ class RealConnection(
     }
 
     // We have a host mismatch. But if the certificate matches, we're still good.
-    return handshake != null && OkHostnameVerifier.verify(
-        url.host, handshake!!.peerCertificates[0] as X509Certificate)
+    return handshake != null &&
+        OkHostnameVerifier.verify(url.host, handshake!!.peerCertificates[0] as X509Certificate)
   }
 
   @Throws(SocketException::class)

--- a/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/CallServerInterceptor.kt
@@ -61,7 +61,7 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
         }
       } else {
         exchange.noRequestBody()
-        if (!exchange.connection()!!.isMultiplexed) {
+        if (!exchange.connection.isMultiplexed) {
           // If the "Expect: 100-continue" expectation wasn't met, prevent the HTTP/1 connection
           // from being reused. Otherwise we're still obligated to transmit the request body to
           // leave the connection in a consistent state.
@@ -84,7 +84,7 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
     }
     var response = responseBuilder
         .request(request)
-        .handshake(exchange.connection()!!.handshake())
+        .handshake(exchange.connection.handshake())
         .sentRequestAtMillis(sentRequestMillis)
         .receivedResponseAtMillis(System.currentTimeMillis())
         .build()
@@ -98,7 +98,7 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
       }
       response = responseBuilder
           .request(request)
-          .handshake(exchange.connection()!!.handshake())
+          .handshake(exchange.connection.handshake())
           .sentRequestAtMillis(sentRequestMillis)
           .receivedResponseAtMillis(System.currentTimeMillis())
           .build()

--- a/okhttp/src/main/java/okhttp3/internal/http/ExchangeCodec.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/ExchangeCodec.kt
@@ -25,9 +25,8 @@ import okio.Source
 
 /** Encodes HTTP requests and decodes HTTP responses. */
 interface ExchangeCodec {
-
   /** Returns the connection that carries this codec. */
-  fun connection(): RealConnection?
+  val connection: RealConnection
 
   /** Returns an output stream where the request body can be streamed. */
   @Throws(IOException::class)

--- a/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
@@ -56,7 +56,7 @@ class RealInterceptorChain(
   ) = RealInterceptorChain(call, interceptors, index, exchange, request, connectTimeoutMillis,
       readTimeoutMillis, writeTimeoutMillis)
 
-  override fun connection(): Connection? = exchange?.connection()
+  override fun connection(): Connection? = exchange?.connection
 
   override fun connectTimeoutMillis(): Int = connectTimeoutMillis
 
@@ -84,7 +84,7 @@ class RealInterceptorChain(
     calls++
 
     if (exchange != null) {
-      check(exchange.connection()!!.supportsUrl(request.url)) {
+      check(exchange.connection.supportsUrl(request.url)) {
         "network interceptor ${interceptors[index - 1]} must retain the same host and port"
       }
       check(calls == 1) {

--- a/okhttp/src/test/java/okhttp3/CallTest.java
+++ b/okhttp/src/test/java/okhttp3/CallTest.java
@@ -26,7 +26,6 @@ import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.ProtocolException;
 import java.net.Proxy;
-import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.net.UnknownServiceException;
@@ -994,10 +993,7 @@ public final class CallTest {
   @Test
   public void interceptorCallsProceedWithoutClosingPriorResponse() throws Exception {
     server.enqueue(new MockResponse()
-        .setBodyDelay(250, TimeUnit.MILLISECONDS)
         .setBody("abc"));
-    server.enqueue(new MockResponse()
-        .setBody("def"));
 
     client = clientTestRule.newClientBuilder()
         .addInterceptor(new Interceptor() {
@@ -1017,8 +1013,7 @@ public final class CallTest {
     Request request = new Request.Builder()
         .url(server.url("/"))
         .build();
-    executeSynchronously(request)
-        .assertFailure(SocketException.class);
+    executeSynchronously(request).assertBody("abc");
   }
 
   /**

--- a/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
@@ -58,7 +58,7 @@ class OpenJSSETest {
       assertEquals(TlsVersion.TLS_1_3, response.handshake?.tlsVersion)
       assertEquals(Protocol.HTTP_2, response.protocol)
 
-      assertThat(response.exchange?.connection()?.socket()).isInstanceOf(SSLSocketImpl::class.java)
+      assertThat(response.exchange?.connection?.socket()).isInstanceOf(SSLSocketImpl::class.java)
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/RecordingExecutor.kt
+++ b/okhttp/src/test/java/okhttp3/RecordingExecutor.kt
@@ -33,7 +33,7 @@ internal class RecordingExecutor(
   }
 
   fun assertJobs(vararg expectedUrls: String) {
-    val actualUrls = calls.map { it.request().url.toString() }
+    val actualUrls = calls.map { it.request.url.toString() }
     assertThat(actualUrls).containsExactly(*expectedUrls)
   }
 
@@ -41,7 +41,7 @@ internal class RecordingExecutor(
     val i = calls.iterator()
     while (i.hasNext()) {
       val call = i.next()
-      if (call.request().url.toString() == url) {
+      if (call.request.url.toString() == url) {
         i.remove()
         dispatcherTest.dispatcher.finished(call)
         return

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
@@ -89,7 +89,7 @@ public final class ConnectionPoolTest {
           .connectionPool(poolApi)
           .build();
       RealCall call = (RealCall) client.newCall(newRequest(addressA));
-      call.prepareExchangeFinder(call.request());
+      call.enterNetworkInterceptorExchange(call.request());
       call.acquireConnectionNoEvents(c1);
     }
 
@@ -211,7 +211,7 @@ public final class ConnectionPoolTest {
           .connectionPool(pool)
           .build();
       RealCall call = (RealCall) client.newCall(newRequest(connection.route().address()));
-      call.prepareExchangeFinder(call.request());
+      call.enterNetworkInterceptorExchange(call.request());
       call.acquireConnectionNoEvents(connection);
     }
   }


### PR DESCRIPTION
There's four useful events:

1. When we're ready to call network interceptors. At this point
   we expect an exchange to exist, as a handle to the connection
   we've chosen for the network call

2. When we hold an exchange that must later be released.

3. When we release the exchange

4. When we're done calling network interceptors. Only at this point
   do we no longer need to remember what the exchange was and what
   connection it used.

In practice 1 and 2 happen mostly at the same time. Right now 1 is
in RetryAndFollowUpInterceptor and 2 is in ConnectInterceptor, but
we should be able to move those around without pain.

But we have a problem with 3 and 4. If the response has no response
body, then 3 will precede 4. We will release the exchange as soon as
we know there's no streams held. This means that network interceptors,
including our own RetryAndFollowUpInterceptor, do not consistently
have an exchange after they've called proceed(). This is problematic
if they want to make decisions based on what connection was used.

I've added a new member, 'interceptorScopedExchange' that holds the
exchange from 1 and 2 through 4, regardless of when 3 happens.

This is all working towards a solution to handling HTTP 421s on
coalesced connections.

https://github.com/square/okhttp/issues/5424