### PR TITLE
Limit recovery attempts for REFUSED_STREAM errors

### DIFF
--- a/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/java/okhttp3/mockwebserver/MockWebServer.kt
@@ -559,10 +559,7 @@ class MockWebServer : ExternalResource(), Closeable {
       openClientSockets.remove(socket)
     }
 
-    /**
-     * Respond to CONNECT requests until a SWITCH_TO_SSL_AT_END response is
-     * dispatched.
-     */
+    /** Respond to `CONNECT` requests until a `SWITCH_TO_SSL_AT_END` response is dispatched. */
     @Throws(IOException::class, InterruptedException::class)
     private fun createTunnel() {
       val source = raw.source().buffer()

--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
@@ -163,7 +163,7 @@ class Exchange(
   }
 
   private fun trackFailure(e: IOException) {
-    finder.trackFailure()
+    finder.trackFailure(e)
     codec.connection.trackFailure(call.client, e)
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -690,7 +690,7 @@ class RealConnection(
       if (e is StreamResetException) {
         when (e.errorCode) {
           ErrorCode.REFUSED_STREAM -> {
-            // Retry REFUSED_STREAM errors once on the same connection.
+            // Stop using this connection after one REFUSED_STREAM error.
             refusedStreamCount++
             if (refusedStreamCount > 1) {
               noNewExchanges = true
@@ -699,7 +699,7 @@ class RealConnection(
           }
 
           ErrorCode.CANCEL -> {
-            // Keep the connection for CANCEL errors.
+            // Permit any number of CANCEL errors on each connection.
           }
 
           else -> {

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -31,7 +31,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 import okhttp3.Cache;
@@ -104,7 +103,6 @@ public final class HttpOverHttp2Test {
   // Flaky https://github.com/square/okhttp/issues/4632
   // Flaky https://github.com/square/okhttp/issues/4633
 
-  private static final Logger http2Logger = Logger.getLogger(Http2.class.getName());
   private static final HandshakeCertificates handshakeCertificates = localhost();
 
   @Parameters(name = "{0}")
@@ -114,8 +112,9 @@ public final class HttpOverHttp2Test {
 
   private final PlatformRule platform = new PlatformRule();
   private final OkHttpClientTestRule clientTestRule = new OkHttpClientTestRule();
-  @Rule public final TestRule chain =
-      RuleChain.outerRule(platform).around(clientTestRule).around(new Timeout(5, SECONDS));
+  @Rule public final TestRule chain = RuleChain.outerRule(platform)
+      .around(clientTestRule)
+      .around(new Timeout(5, SECONDS));
   @Rule public final TemporaryFolder tempDir = new TemporaryFolder();
   @Rule public final MockWebServer server = new MockWebServer();
   @Rule public final TestLogHandler testLogHandler = new TestLogHandler(Http2.class);
@@ -854,6 +853,33 @@ public final class HttpOverHttp2Test {
     assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(1);
   }
 
+  /**
+   * We had a bug where we'd perform infinite retries of route that fail with connection shutdown
+   * errors. The problem was that the logic that decided whether to reuse a route didn't track
+   * certain HTTP/2 errors. https://github.com/square/okhttp/issues/5547
+   */
+  @Test
+  public void noRecoveryFromTwoRefusedStreams() throws Exception {
+    server.enqueue(new MockResponse()
+        .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.getHttpCode()));
+    server.enqueue(new MockResponse()
+        .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.getHttpCode()));
+    server.enqueue(new MockResponse()
+        .setBody("abc"));
+
+    Call call = client.newCall(new Request.Builder()
+        .url(server.url("/"))
+        .build());
+    try {
+      call.execute();
+      fail();
+    } catch (StreamResetException expected) {
+      assertThat(expected.errorCode).isEqualTo(ErrorCode.REFUSED_STREAM);
+    }
+  }
+
   @Test public void recoverFromOneInternalErrorRequiresNewConnection() throws Exception {
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
@@ -1529,7 +1555,7 @@ public final class HttpOverHttp2Test {
               assertThat(response.body().string()).isEqualTo("ABC");
               // Wait until the GOAWAY has been processed.
               RealConnection connection = (RealConnection) chain.connection();
-              while (connection.isHealthy(false)) ;
+              while (connection.isHealthy(false));
             }
             return chain.proceed(chain.request());
           }


### PR DESCRIPTION
We limit per-connection retries but not per-call retries, so this was
creating large numbers of connections each of which called the server
and accepted yet another REFUSED_STREAM.

Instead we fail sooner with a StreamResetException.

This shows that the ExchangeFinder interface is still somewhat inadequate
to support all of the use cases we have.