### PR TITLE
Limit recovery attempts for REFUSED_STREAM errors

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
@@ -163,7 +163,7 @@ class Exchange(
   }
 
   private fun trackFailure(e: IOException) {
-    finder.trackFailure()
+    finder.trackFailure(e)
     codec.connection.trackFailure(call.client, e)
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.java
@@ -89,7 +89,7 @@ public final class ConnectionPoolTest {
           .connectionPool(poolApi)
           .build();
       RealCall call = (RealCall) client.newCall(newRequest(addressA));
-      call.enterNetworkInterceptorExchange(call.request());
+      call.enterNetworkInterceptorExchange(call.request(), true);
       call.acquireConnectionNoEvents(c1);
     }
 
@@ -211,7 +211,7 @@ public final class ConnectionPoolTest {
           .connectionPool(pool)
           .build();
       RealCall call = (RealCall) client.newCall(newRequest(connection.route().address()));
-      call.enterNetworkInterceptorExchange(call.request());
+      call.enterNetworkInterceptorExchange(call.request(), true);
       call.acquireConnectionNoEvents(connection);
     }
   }


### PR DESCRIPTION
We limit per-connection retries but not per-call retries, so this was
creating large numbers of connections each of which called the server
and accepted yet another REFUSED_STREAM.

Instead we fail sooner with a StreamResetException.

This shows that the ExchangeFinder interface is still somewhat inadequate
to support all of the use cases we have.