### PR TITLE
Don't do infinite retries on server-canceled calls

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
@@ -164,7 +164,7 @@ class Exchange(
 
   private fun trackFailure(e: IOException) {
     finder.trackFailure(e)
-    codec.connection.trackFailure(call.client, e)
+    codec.connection.trackFailure(call, e)
   }
 
   fun <E : IOException?> bodyComplete(

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -881,9 +881,17 @@ public final class HttpOverHttp2Test {
   }
 
   @Test public void recoverFromOneInternalErrorRequiresNewConnection() throws Exception {
+    recoverFromOneHttp2ErrorRequiresNewConnection(ErrorCode.INTERNAL_ERROR);
+  }
+
+  @Test public void recoverFromOneCancelRequiresNewConnection() throws Exception {
+    recoverFromOneHttp2ErrorRequiresNewConnection(ErrorCode.CANCEL);
+  }
+
+  private void recoverFromOneHttp2ErrorRequiresNewConnection(ErrorCode errorCode) throws Exception {
     server.enqueue(new MockResponse()
         .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
-        .setHttp2ErrorCode(ErrorCode.INTERNAL_ERROR.getHttpCode()));
+        .setHttp2ErrorCode(errorCode.getHttpCode()));
     server.enqueue(new MockResponse()
         .setBody("abc"));
 
@@ -1062,6 +1070,10 @@ public final class HttpOverHttp2Test {
 
   @Test public void noRecoveryFromInternalErrorWithRetryDisabled() throws Exception {
     noRecoveryFromErrorWithRetryDisabled(ErrorCode.INTERNAL_ERROR);
+  }
+
+  @Test public void noRecoveryFromCancelWithRetryDisabled() throws Exception {
+    noRecoveryFromErrorWithRetryDisabled(ErrorCode.CANCEL);
   }
 
   private void noRecoveryFromErrorWithRetryDisabled(ErrorCode errorCode) throws Exception {


### PR DESCRIPTION
We originally had a bug where Call.cancel() would incorrectly
cause HTTP/2 connections to be closed.

The fix was to not consider HTTP/2 connections to be degraded
when a CANCEL error is received:
https://github.com/square/okhttp/pull/4052

This closes the loop to make sure that we only treat CANCEL as
expected when the call was actually canceled.

Closes: https://github.com/square/okhttp/issues/5726