### PR TITLE
Move the code that clears out the next route to try

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
@@ -162,7 +162,6 @@ class ExchangeFinder(
         // We had an already-allocated connection and it's good.
         result = call.connection
         releasedConnection = null
-        nextRouteToTry = null
       }
 
       if (result == null) {
@@ -284,6 +283,7 @@ class ExchangeFinder(
     connectionPool.assertThreadDoesntHoldLock()
 
     synchronized(connectionPool) {
+      nextRouteToTry = null
       if (e is StreamResetException && e.errorCode == ErrorCode.REFUSED_STREAM) {
         refusedStreamCount++
       } else if (e is ConnectionShutdownException) {


### PR DESCRIPTION
I prefer the old code esthetically, but this has the behavior I want. The
core problem is we're deciding about nextRouteToTry too early, before a
failure makes that route ineligible.

Closes: https://github.com/square/okhttp/issues/5791