### PR TITLE
Be smarter about connection health checks

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
@@ -112,15 +112,7 @@ class ExchangeFinder(
           connectionRetryEnabled = connectionRetryEnabled
       )
 
-      // If this is a brand new connection, we can skip the extensive health checks.
-      synchronized(connectionPool) {
-        if (candidate.successCount == 0) {
-          return candidate
-        }
-      }
-
-      // Do a (potentially slow) check to confirm that the pooled connection is still good. If it
-      // isn't, take it out of the pool and start again.
+      // Confirm that the connection is good. If it isn't, take it out of the pool and start again.
       if (!candidate.isHealthy(doExtensiveHealthChecks)) {
         candidate.noNewExchanges()
         continue

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealCall.kt
@@ -368,7 +368,7 @@ class RealCall(
     this.connection = null
 
     if (released.calls.isEmpty()) {
-      released.idleAtNanos = System.nanoTime()
+      released.idleAtNs = System.nanoTime()
       if (connectionPool.connectionBecameIdle(released)) {
         return released.socket()
       }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnectionPool.kt
@@ -153,7 +153,7 @@ class RealConnectionPool(
         idleConnectionCount++
 
         // If the connection is ready to be evicted, we're done.
-        val idleDurationNs = now - connection.idleAtNanos
+        val idleDurationNs = now - connection.idleAtNs
         if (idleDurationNs > longestIdleDurationNs) {
           longestIdleDurationNs = idleDurationNs
           longestIdleConnection = connection
@@ -217,7 +217,7 @@ class RealConnectionPool(
 
       // If this was the last allocation, the connection is eligible for immediate eviction.
       if (references.isEmpty()) {
-        connection.idleAtNanos = now - keepAliveDurationNs
+        connection.idleAtNs = now - keepAliveDurationNs
         return 0
       }
     }

--- a/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
@@ -19,8 +19,12 @@ import java.io.IOException
 import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.internal.connection.RealConnection
+import okhttp3.internal.connection.RealConnection.Companion.IDLE_CONNECTION_HEALTHY_NS
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.internal.TlsUtil.localhost
 import okio.BufferedSink
@@ -167,5 +171,43 @@ class CallKotlinTest {
 
     recordedRequest = server.takeRequest()
     assertEquals("HEAD", recordedRequest.method)
+  }
+
+  @Test
+  fun staleConnectionNotReusedForNonIdempotentRequest() {
+    // Capture the connection so that we can later make it stale.
+    var connection: RealConnection? = null
+    client = client.newBuilder()
+        .addNetworkInterceptor(object : Interceptor {
+          override fun intercept(chain: Interceptor.Chain): Response {
+            connection = chain.connection() as RealConnection
+            return chain.proceed(chain.request())
+          }
+        })
+        .build()
+
+    server.enqueue(MockResponse().setBody("a")
+        .setSocketPolicy(SocketPolicy.SHUTDOWN_OUTPUT_AT_END))
+    server.enqueue(MockResponse().setBody("b"))
+
+    val requestA = Request.Builder()
+        .url(server.url("/"))
+        .build()
+    val responseA = client.newCall(requestA).execute()
+
+    assertThat(responseA.body!!.string()).isEqualTo("a")
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
+
+    // Give the socket a chance to become stale.
+    connection!!.idleAtNs -= IDLE_CONNECTION_HEALTHY_NS
+    Thread.sleep(250)
+
+    val requestB = Request.Builder()
+        .url(server.url("/"))
+        .post("b".toRequestBody("text/plain".toMediaType()))
+        .build()
+    val responseB = client.newCall(requestB).execute()
+    assertThat(responseB.body!!.string()).isEqualTo("b")
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
   }
 }

--- a/okhttp/src/test/java/okhttp3/internal/UtilTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/UtilTest.kt
@@ -15,7 +15,12 @@
  */
 package okhttp3.internal
 
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
 import java.util.LinkedHashMap
+import okio.buffer
+import okio.source
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
@@ -33,5 +38,19 @@ class UtilTest {
       fail()
     } catch (_: UnsupportedOperationException) {
     }
+  }
+
+  @Test fun socketIsHealthy() {
+    val localhost = InetAddress.getLoopbackAddress()
+    val serverSocket = ServerSocket(0, 1, localhost)
+
+    val socket = Socket()
+    socket.connect(serverSocket.localSocketAddress)
+    val socketSource = socket.source().buffer()
+
+    assertThat(socket.isHealthy(socketSource)).isTrue()
+
+    serverSocket.close()
+    assertThat(socket.isHealthy(socketSource)).isFalse()
   }
 }


### PR DESCRIPTION
Previously we didn't do any health checks at all until a
connection completed a single exchange. This was awkward
for HTTP/2, which could have multiple exchanges in-flight
before any were health checked.

We were also doing the awkward and expensive read timeout
check on all non-GET requests on pooled connections. Now
we only perform these checks if the connection was idle
for 10 seconds or more.

Closes: https://github.com/square/okhttp/issues/5547