### PR TITLE
Refactor OkHttpClient#xxxTimeout(...) to fix errorprone PreferJavaTimeOverload in tests

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.kt
@@ -24,6 +24,7 @@ import java.util.Collections
 import java.util.Random
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.net.SocketFactory
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSocketFactory
@@ -905,7 +906,7 @@ open class OkHttpClient internal constructor(
      */
     @IgnoreJRERequirement
     fun callTimeout(duration: Duration) = apply {
-      callTimeout = checkDuration("timeout", duration.toMillis(), TimeUnit.MILLISECONDS)
+      callTimeout(duration.toMillis(), MILLISECONDS)
     }
 
     /**
@@ -928,7 +929,7 @@ open class OkHttpClient internal constructor(
      */
     @IgnoreJRERequirement
     fun connectTimeout(duration: Duration) = apply {
-      connectTimeout = checkDuration("timeout", duration.toMillis(), TimeUnit.MILLISECONDS)
+      connectTimeout(duration.toMillis(), MILLISECONDS)
     }
 
     /**
@@ -957,7 +958,7 @@ open class OkHttpClient internal constructor(
      */
     @IgnoreJRERequirement
     fun readTimeout(duration: Duration) = apply {
-      readTimeout = checkDuration("timeout", duration.toMillis(), TimeUnit.MILLISECONDS)
+      readTimeout(duration.toMillis(), MILLISECONDS)
     }
 
     /**
@@ -984,7 +985,7 @@ open class OkHttpClient internal constructor(
      */
     @IgnoreJRERequirement
     fun writeTimeout(duration: Duration) = apply {
-      writeTimeout = checkDuration("timeout", duration.toMillis(), TimeUnit.MILLISECONDS)
+      writeTimeout(duration.toMillis(), MILLISECONDS)
     }
 
     /**
@@ -1019,7 +1020,7 @@ open class OkHttpClient internal constructor(
      */
     @IgnoreJRERequirement
     fun pingInterval(duration: Duration) = apply {
-      pingInterval = checkDuration("timeout", duration.toMillis(), TimeUnit.MILLISECONDS)
+      pingInterval(duration.toMillis(), MILLISECONDS)
     }
 
     fun build(): OkHttpClient = OkHttpClient(this)

--- a/okhttp/src/test/java/okhttp3/CallTest.java
+++ b/okhttp/src/test/java/okhttp3/CallTest.java
@@ -30,6 +30,7 @@ import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.net.UnknownServiceException;
 import java.security.cert.Certificate;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -889,15 +890,15 @@ public final class CallTest {
     server.enqueue(new MockResponse().setBody("abc"));
     server.enqueue(new MockResponse().setBody("def").throttleBody(1, 750, TimeUnit.MILLISECONDS));
 
-    // First request: time out after 1000ms.
+    // First request: time out after 1s.
     client = client.newBuilder()
-        .readTimeout(1000, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ofSeconds(1))
         .build();
     executeSynchronously("/a").assertBody("abc");
 
     // Second request: time out after 250ms.
     client = client.newBuilder()
-        .readTimeout(250, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ofMillis(250))
         .build();
     Request request = new Request.Builder().url(server.url("/b")).build();
     Response response = client.newCall(request).execute();
@@ -928,7 +929,7 @@ public final class CallTest {
         .setBody("unreachable!"));
 
     client = client.newBuilder()
-        .readTimeout(100, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ofMillis(100))
         .build();
 
     Request request = new Request.Builder().url(server.url("/")).build();
@@ -953,8 +954,8 @@ public final class CallTest {
         .setBody("success!"));
     client = client.newBuilder()
         .proxySelector(proxySelector)
-        .readTimeout(100, TimeUnit.MILLISECONDS)
-        .connectTimeout(100, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ofMillis(100))
+        .connectTimeout(Duration.ofMillis(100))
         .build();
 
     Request request = new Request.Builder().url("http://android.com/").build();
@@ -1032,7 +1033,7 @@ public final class CallTest {
 
     client = client.newBuilder()
         .proxySelector(proxySelector)
-        .readTimeout(100, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ofMillis(100))
         .build();
 
     Request request = new Request.Builder().url("http://android.com/").build();
@@ -2766,7 +2767,7 @@ public final class CallTest {
         .setSocketPolicy(SocketPolicy.NO_RESPONSE));
 
     client = client.newBuilder()
-        .readTimeout(500, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ofMillis(500))
         .build();
 
     Request request = new Request.Builder()
@@ -2815,7 +2816,7 @@ public final class CallTest {
 
   @Test public void serverRespondsWith100ContinueOnly() throws Exception {
     client = client.newBuilder()
-        .readTimeout(1, TimeUnit.SECONDS)
+        .readTimeout(Duration.ofSeconds(1))
         .build();
 
     server.enqueue(new MockResponse()

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -164,7 +165,7 @@ public final class EventListenerTest {
         .setHeadersDelay(2, TimeUnit.SECONDS));
 
     client = client.newBuilder()
-        .readTimeout(250, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ofMillis(250))
         .build();
 
     Call call = client.newCall(new Request.Builder()
@@ -190,7 +191,7 @@ public final class EventListenerTest {
 
     client = client.newBuilder()
         .protocols(Collections.singletonList(Protocol.HTTP_1_1))
-        .readTimeout(250, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ofMillis(250))
         .build();
 
     Call call = client.newCall(new Request.Builder()

--- a/okhttp/src/test/java/okhttp3/InterceptorTest.java
+++ b/okhttp/src/test/java/okhttp3/InterceptorTest.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -693,7 +694,7 @@ public final class InterceptorTest {
     new Socket().connect(serverSocket.getLocalSocketAddress());
 
     client = client.newBuilder()
-        .connectTimeout(5, TimeUnit.SECONDS)
+        .connectTimeout(Duration.ofSeconds(5))
         .addInterceptor(interceptor1)
         .addInterceptor(interceptor2)
         .build();
@@ -733,7 +734,7 @@ public final class InterceptorTest {
     };
 
     client = client.newBuilder()
-        .readTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(Duration.ofSeconds(5))
         .addInterceptor(interceptor1)
         .addInterceptor(interceptor2)
         .build();
@@ -771,7 +772,7 @@ public final class InterceptorTest {
     };
 
     client = client.newBuilder()
-        .writeTimeout(5, TimeUnit.SECONDS)
+        .writeTimeout(Duration.ofSeconds(5))
         .addInterceptor(interceptor1)
         .addInterceptor(interceptor2)
         .build();

--- a/okhttp/src/test/java/okhttp3/OkHttpClientTest.java
+++ b/okhttp/src/test/java/okhttp3/OkHttpClientTest.java
@@ -24,11 +24,11 @@ import java.net.ResponseCache;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.security.KeyManagementException;
+import java.time.Duration;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
@@ -75,35 +75,35 @@ public final class OkHttpClientTest {
   @Test public void timeoutValidRange() {
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
     try {
-      builder.callTimeout(1, TimeUnit.NANOSECONDS);
+      builder.callTimeout(Duration.ofNanos(1));
     } catch (IllegalArgumentException ignored) {
     }
     try {
-      builder.connectTimeout(1, TimeUnit.NANOSECONDS);
+      builder.connectTimeout(Duration.ofNanos(1));
     } catch (IllegalArgumentException ignored) {
     }
     try {
-      builder.writeTimeout(1, TimeUnit.NANOSECONDS);
+      builder.writeTimeout(Duration.ofNanos(1));
     } catch (IllegalArgumentException ignored) {
     }
     try {
-      builder.readTimeout(1, TimeUnit.NANOSECONDS);
+      builder.readTimeout(Duration.ofNanos(1));
     } catch (IllegalArgumentException ignored) {
     }
     try {
-      builder.callTimeout(365, TimeUnit.DAYS);
+      builder.callTimeout(Duration.ofDays(365));
     } catch (IllegalArgumentException ignored) {
     }
     try {
-      builder.connectTimeout(365, TimeUnit.DAYS);
+      builder.connectTimeout(Duration.ofDays(365));
     } catch (IllegalArgumentException ignored) {
     }
     try {
-      builder.writeTimeout(365, TimeUnit.DAYS);
+      builder.writeTimeout(Duration.ofDays(365));
     } catch (IllegalArgumentException ignored) {
     }
     try {
-      builder.readTimeout(365, TimeUnit.DAYS);
+      builder.readTimeout(Duration.ofDays(365));
     } catch (IllegalArgumentException ignored) {
     }
   }
@@ -347,7 +347,7 @@ public final class OkHttpClientTest {
     // same client with no change affecting route db
     assertSame(client.getRouteDatabase(), client.newBuilder().build().getRouteDatabase());
     assertSame(client.getRouteDatabase(),
-        client.newBuilder().callTimeout(5, TimeUnit.SECONDS).build().getRouteDatabase());
+        client.newBuilder().callTimeout(Duration.ofSeconds(5)).build().getRouteDatabase());
 
     // logically different scope of client for route db
     assertNotSame(client.getRouteDatabase(),

--- a/okhttp/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp/src/test/java/okhttp3/URLConnectionTest.java
@@ -38,6 +38,7 @@ import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -2572,7 +2573,7 @@ public final class URLConnectionTest {
             return socket;
           }
         })
-        .writeTimeout(500, TimeUnit.MILLISECONDS)
+        .writeTimeout(Duration.ofMillis(500))
         .build();
 
     server.start();

--- a/okhttp/src/test/java/okhttp3/WholeOperationTimeoutTest.java
+++ b/okhttp/src/test/java/okhttp3/WholeOperationTimeoutTest.java
@@ -18,6 +18,7 @@ package okhttp3;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.HttpURLConnection;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -54,7 +55,7 @@ public final class WholeOperationTimeoutTest {
         .build();
 
     OkHttpClient timeoutClient = client.newBuilder()
-        .callTimeout(456, TimeUnit.MILLISECONDS)
+        .callTimeout(Duration.ofMillis(456))
         .build();
 
     Call call = timeoutClient.newCall(request);

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.net.Authenticator;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -546,7 +547,7 @@ public final class HttpOverHttp2Test {
     server.enqueue(new MockResponse().setBody("A"));
 
     client = client.newBuilder()
-        .readTimeout(1000, MILLISECONDS)
+        .readTimeout(Duration.ofSeconds(1))
         .build();
 
     // Make a call expecting a timeout reading the response headers.
@@ -584,7 +585,7 @@ public final class HttpOverHttp2Test {
         .throttleBody(1024, 1, SECONDS)); // Slow connection 1KiB/second.
 
     client = client.newBuilder()
-        .readTimeout(2, SECONDS)
+        .readTimeout(Duration.ofSeconds(2))
         .build();
 
     Call call = client.newCall(new Request.Builder()
@@ -610,7 +611,7 @@ public final class HttpOverHttp2Test {
         .setBody(body));
 
     client = client.newBuilder()
-        .readTimeout(500, MILLISECONDS) // Half a second to read something.
+        .readTimeout(Duration.ofMillis(500)) // Half a second to read something.
         .build();
 
     // Make a call expecting a timeout reading the response body.
@@ -643,7 +644,7 @@ public final class HttpOverHttp2Test {
         .setBodyDelay(1, SECONDS));
 
     OkHttpClient client1 = client.newBuilder()
-        .readTimeout(2000, MILLISECONDS)
+        .readTimeout(Duration.ofSeconds(2))
         .build();
     Call call1 = client1
         .newCall(new Request.Builder()
@@ -651,7 +652,7 @@ public final class HttpOverHttp2Test {
             .build());
 
     OkHttpClient client2 = client.newBuilder()
-        .readTimeout(200, MILLISECONDS)
+        .readTimeout(Duration.ofMillis(200))
         .build();
     Call call2 = client2
         .newCall(new Request.Builder()
@@ -1286,7 +1287,7 @@ public final class HttpOverHttp2Test {
   @Test public void pingsTransmitted() throws Exception {
     // Ping every 500 ms, starting at 500 ms.
     client = client.newBuilder()
-        .pingInterval(500, TimeUnit.MILLISECONDS)
+        .pingInterval(Duration.ofMillis(500))
         .build();
 
     // Delay the response to give 1 ping enough time to be sent and replied to.
@@ -1323,8 +1324,8 @@ public final class HttpOverHttp2Test {
 
     // Ping every 500 ms, starting at 500 ms.
     client = client.newBuilder()
-        .readTimeout(10, TimeUnit.SECONDS) // Confirm we fail before the read timeout.
-        .pingInterval(500, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ofSeconds(10)) // Confirm we fail before the read timeout.
+        .pingInterval(Duration.ofMillis(500))
         .build();
 
     // Set up the server to ignore the socket. It won't respond to pings!
@@ -1360,7 +1361,7 @@ public final class HttpOverHttp2Test {
     TestUtil.assumeNotWindows();
 
     client = client.newBuilder()
-        .readTimeout(500, MILLISECONDS)
+        .readTimeout(Duration.ofMillis(500))
         .build();
 
     // Stalling the socket will cause TWO requests to time out!
@@ -1403,7 +1404,7 @@ public final class HttpOverHttp2Test {
 
   @Test public void oneStreamTimeoutDoesNotBreakConnection() throws Exception {
     client = client.newBuilder()
-        .readTimeout(500, MILLISECONDS)
+        .readTimeout(Duration.ofMillis(500))
         .build();
 
     server.enqueue(new MockResponse()

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -21,6 +21,7 @@ import java.io.InterruptedIOException;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -75,8 +76,8 @@ public final class WebSocketHttpTest {
   private final WebSocketRecorder serverListener = new WebSocketRecorder("server");
   private final Random random = new Random(0);
   private OkHttpClient client = clientTestRule.newClientBuilder()
-      .writeTimeout(500, TimeUnit.MILLISECONDS)
-      .readTimeout(500, TimeUnit.MILLISECONDS)
+      .writeTimeout(Duration.ofMillis(500))
+      .readTimeout(Duration.ofMillis(500))
       .addInterceptor(chain -> {
         Response response = chain.proceed(chain.request());
         // Ensure application interceptors never see a null body.
@@ -569,7 +570,7 @@ public final class WebSocketHttpTest {
 
   @Test public void clientPingsServerOnInterval() throws Exception {
     client = client.newBuilder()
-        .pingInterval(500, TimeUnit.MILLISECONDS)
+        .pingInterval(Duration.ofMillis(500))
         .build();
 
     webServer.enqueue(new MockResponse().withWebSocketUpgrade(serverListener));
@@ -628,7 +629,7 @@ public final class WebSocketHttpTest {
     TestUtil.assumeNotWindows();
 
     client = client.newBuilder()
-        .pingInterval(500, TimeUnit.MILLISECONDS)
+        .pingInterval(Duration.ofMillis(500))
         .build();
 
     // Stall in onOpen to prevent pongs from being sent.
@@ -711,9 +712,9 @@ public final class WebSocketHttpTest {
         .setHeadersDelay(500, TimeUnit.MILLISECONDS));
 
     client = client.newBuilder()
-        .readTimeout(0, TimeUnit.MILLISECONDS)
-        .writeTimeout(0, TimeUnit.MILLISECONDS)
-        .callTimeout(100, TimeUnit.MILLISECONDS)
+        .readTimeout(Duration.ZERO)
+        .writeTimeout(Duration.ZERO)
+        .callTimeout(Duration.ofMillis(100))
         .build();
 
     newWebSocket();
@@ -722,7 +723,7 @@ public final class WebSocketHttpTest {
 
   @Test public void callTimeoutDoesNotApplyOnceConnected() throws Exception {
     client = client.newBuilder()
-        .callTimeout(100, TimeUnit.MILLISECONDS)
+        .callTimeout(Duration.ofMillis(100))
         .build();
 
     webServer.enqueue(new MockResponse()


### PR DESCRIPTION
When compiling OkHttp, we have warnings regarding PreferJavaTimeOverload.

For example:
```
okhttp/okhttp/src/test/java/okhttp3/EventListenerTest.java:193: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(250, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
```
<details>
<summary>Click to see all the related logs!</summary>

```
okhttp/okhttp/src/test/java/okhttp3/OkHttpClientTest.java:78: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      builder.callTimeout(1, TimeUnit.NANOSECONDS);
                         ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean 'builder.callTimeout(Duration.ofNanos(1));'?
okhttp/okhttp/src/test/java/okhttp3/OkHttpClientTest.java:82: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      builder.connectTimeout(1, TimeUnit.NANOSECONDS);
                            ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean 'builder.connectTimeout(Duration.ofNanos(1));'?
okhttp/okhttp/src/test/java/okhttp3/OkHttpClientTest.java:86: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      builder.writeTimeout(1, TimeUnit.NANOSECONDS);
                          ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean 'builder.writeTimeout(Duration.ofNanos(1));'?
okhttp/okhttp/src/test/java/okhttp3/OkHttpClientTest.java:90: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      builder.readTimeout(1, TimeUnit.NANOSECONDS);
                         ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean 'builder.readTimeout(Duration.ofNanos(1));'?
okhttp/okhttp/src/test/java/okhttp3/OkHttpClientTest.java:94: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      builder.callTimeout(365, TimeUnit.DAYS);
                         ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean 'builder.callTimeout(Duration.ofDays(365));'?
okhttp/okhttp/src/test/java/okhttp3/OkHttpClientTest.java:98: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      builder.connectTimeout(365, TimeUnit.DAYS);
                            ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean 'builder.connectTimeout(Duration.ofDays(365));'?
okhttp/okhttp/src/test/java/okhttp3/OkHttpClientTest.java:102: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      builder.writeTimeout(365, TimeUnit.DAYS);
                          ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean 'builder.writeTimeout(Duration.ofDays(365));'?
okhttp/okhttp/src/test/java/okhttp3/OkHttpClientTest.java:106: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      builder.readTimeout(365, TimeUnit.DAYS);
                         ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean 'builder.readTimeout(Duration.ofDays(365));'?
okhttp/okhttp/src/test/java/okhttp3/OkHttpClientTest.java:350: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        client.newBuilder().callTimeout(5, TimeUnit.SECONDS).build().getRouteDatabase());
                                       ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean 'client.newBuilder().callTimeout(Duration.ofSeconds(5)).build().getRouteDatabase());'?
okhttp/okhttp/src/test/java/okhttp3/InterceptorTest.java:696: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .connectTimeout(5, TimeUnit.SECONDS)
                       ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.connectTimeout(Duration.ofSeconds(5))'?
okhttp/okhttp/src/test/java/okhttp3/InterceptorTest.java:736: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(5, TimeUnit.SECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofSeconds(5))'?
okhttp/okhttp/src/test/java/okhttp3/InterceptorTest.java:774: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .writeTimeout(5, TimeUnit.SECONDS)
                     ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.writeTimeout(Duration.ofSeconds(5))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:549: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(1000, MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(1000))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:587: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(2, SECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofSeconds(2))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:613: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(500, MILLISECONDS) // Half a second to read something.
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:646: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(2000, MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(2000))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:654: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(200, MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(200))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:1250: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .pingInterval(500, TimeUnit.MILLISECONDS)
                     ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.pingInterval(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:1288: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .pingInterval(500, TimeUnit.MILLISECONDS)
                     ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.pingInterval(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:1287: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(10, TimeUnit.SECONDS) // Confirm we fail before the read timeout.
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofSeconds(10))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:1324: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(500, MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java:1367: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(500, MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java:79: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      .readTimeout(500, TimeUnit.MILLISECONDS)
                  ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java:78: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
      .writeTimeout(500, TimeUnit.MILLISECONDS)
                   ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.writeTimeout(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java:572: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .pingInterval(500, TimeUnit.MILLISECONDS)
                     ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.pingInterval(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java:631: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .pingInterval(500, TimeUnit.MILLISECONDS)
                     ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.pingInterval(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java:716: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .callTimeout(100, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.callTimeout(Duration.ofMillis(100))'?
okhttp/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java:715: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .writeTimeout(0, TimeUnit.MILLISECONDS)
                     ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.writeTimeout(Duration.ofMillis(0))'?
okhttp/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java:714: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(0, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(0))'?
okhttp/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java:725: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .callTimeout(100, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.callTimeout(Duration.ofMillis(100))'?
okhttp/okhttp/src/test/java/okhttp3/CallTest.java:894: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(1000, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(1000))'?
okhttp/okhttp/src/test/java/okhttp3/CallTest.java:900: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(250, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(250))'?
okhttp/okhttp/src/test/java/okhttp3/CallTest.java:931: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(100, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(100))'?
okhttp/okhttp/src/test/java/okhttp3/CallTest.java:957: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .connectTimeout(100, TimeUnit.MILLISECONDS)
                       ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.connectTimeout(Duration.ofMillis(100))'?
okhttp/okhttp/src/test/java/okhttp3/CallTest.java:956: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(100, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(100))'?
okhttp/okhttp/src/test/java/okhttp3/CallTest.java:1035: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(100, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(100))'?
okhttp/okhttp/src/test/java/okhttp3/CallTest.java:2769: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(500, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/CallTest.java:2818: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(1, TimeUnit.SECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofSeconds(1))'?
okhttp/okhttp/src/test/java/okhttp3/URLConnectionTest.java:2575: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .writeTimeout(500, TimeUnit.MILLISECONDS)
                     ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.writeTimeout(Duration.ofMillis(500))'?
okhttp/okhttp/src/test/java/okhttp3/EventListenerTest.java:167: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(250, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(250))'?
okhttp/okhttp/src/test/java/okhttp3/EventListenerTest.java:193: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .readTimeout(250, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.readTimeout(Duration.ofMillis(250))'?
okhttp/okhttp/src/test/java/okhttp3/WholeOperationTimeoutTest.java:57: warning: [PreferJavaTimeOverload] Prefer using java.time-based APIs when available. Note that this checker does not and cannot guarantee that the overloads have equivalent semantics, but that is generally the case with overloaded methods.
        .callTimeout(456, TimeUnit.MILLISECONDS)
                    ^
    (see https://errorprone.info/bugpattern/PreferJavaTimeOverload)
  Did you mean '.callTimeout(Duration.ofMillis(456))'?
```
</details>

To fix this, `java.time.Duration` API is used instead of `java.util.concurrent.TimeUnit`

Also, OkHttp examples in `recipies.md` is fixed.