### PR TITLE
Prefer reporting a JUnit Timeout failure in HttpOverHttp2Test.

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -113,8 +113,8 @@ public final class HttpOverHttp2Test {
   private final PlatformRule platform = new PlatformRule();
   private final OkHttpClientTestRule clientTestRule = new OkHttpClientTestRule();
   @Rule public final TestRule chain = RuleChain.outerRule(platform)
-      .around(clientTestRule)
-      .around(new Timeout(5, SECONDS));
+      .around(new Timeout(60, SECONDS))
+      .around(clientTestRule);
   @Rule public final TemporaryFolder tempDir = new TemporaryFolder();
   @Rule public final MockWebServer server = new MockWebServer();
   @Rule public final TestLogHandler testLogHandler = new TestLogHandler(Http2.class);


### PR DESCRIPTION
I was reviewing a CI test failure reported here: https://circleci.com/gh/square/okhttp/9726

Reviewing the test case everything _seemed_ fine. I noticed that if I breakpoint on the last line of the test and wait 5 seconds it'll timeout. This is expected because we have a timeout rule. But the failure is reporting as `OkHttpClientTestRule.ensureAllConnectionsReleased()`. To me I'd like to see the Timeout failure. It feels like someone might start diving into something that doesn't actually exist. The timeout implies the test didn't complete and we will probably expect leaked connections! 😄 Tricky situation though.

I also made the timeout less aggressive (60 seconds instead of 5.) I think this means we prefer a slightly slower build that likely succeeds rather than a faster build with sporadic timeout failures.

Let me know what you think.