### PR TITLE
Get tests passing on OpenJDK 9

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/CallTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/CallTest.java
@@ -1290,7 +1290,8 @@ public final class CallTest {
   @Test public void anonCipherSuiteUnsupported() throws Exception {
     // The _anon_ suites became unsupported in "1.8.0_201" and "11.0.2".
     assumeFalse(System.getProperty("java.version", "unknown").matches("1\\.8\\.0_1\\d\\d"));
-    assumeFalse(System.getProperty("java.version", "unknown").matches("11"));
+    assumeFalse(System.getProperty("java.version", "unknown").matches("9\\..*"));
+    assumeFalse(System.getProperty("java.version", "unknown").matches("11\\..*"));
 
     server.enqueue(new MockResponse());
 


### PR DESCRIPTION
OpenJDK 9 is bad and obsolete and I'd like to avoid it. But we've got
Javadoc issues publishing on OpenJDK 11.