### PR TITLE
Allow for users who have disabled certificate checks in dev.

### DIFF
--- a/okhttp/src/main/java/okhttp3/Handshake.kt
+++ b/okhttp/src/main/java/okhttp3/Handshake.kt
@@ -22,7 +22,6 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSession
 import okhttp3.internal.immutableListOf
-import okhttp3.internal.platform.Platform
 import okhttp3.internal.toImmutableList
 
 /**
@@ -53,7 +52,6 @@ class Handshake internal constructor(
     try {
       peerCertificatesFn()
     } catch (spue: SSLPeerUnverifiedException) {
-      Platform.get().log("Unable to verify connection certificates", Platform.INFO, spue)
       listOf<Certificate>()
     }
   }
@@ -128,11 +126,7 @@ class Handshake internal constructor(
   }
 
   override fun toString(): String {
-    val peerCertificatesString = try {
-      peerCertificates.map { it.name }.toString()
-    } catch (_: SSLPeerUnverifiedException) {
-      "Failed: SSLPeerUnverifiedException"
-    }
+    val peerCertificatesString = peerCertificates.map { it.name }.toString()
     return "Handshake{" +
         "tlsVersion=$tlsVersion " +
         "cipherSuite=$cipherSuite " +

--- a/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
@@ -142,10 +142,10 @@ class ExchangeFinder(
     synchronized(connectionPool) {
       if (call.isCanceled()) throw IOException("Canceled")
 
-      val existingCallConnection = call.connection
-      releasedConnection = existingCallConnection
-      toClose = if (existingCallConnection != null &&
-          (existingCallConnection.noNewExchanges || !existingCallConnection.safeSupportsUrl(address.url))) {
+      val callConnection = call.connection // changes within this overall method
+      releasedConnection = callConnection
+      toClose = if (callConnection != null && (callConnection.noNewExchanges ||
+              !callConnection.supportsUrl(address.url))) {
         call.releaseConnectionNoEvents()
       } else {
         null

--- a/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
@@ -17,6 +17,7 @@ package okhttp3.internal.connection
 
 import java.io.IOException
 import java.net.Socket
+import javax.net.ssl.SSLPeerUnverifiedException
 import okhttp3.Address
 import okhttp3.EventListener
 import okhttp3.OkHttpClient
@@ -30,7 +31,6 @@ import okhttp3.internal.http.RealInterceptorChain
 import okhttp3.internal.http2.ConnectionShutdownException
 import okhttp3.internal.http2.ErrorCode
 import okhttp3.internal.http2.StreamResetException
-import javax.net.ssl.SSLPeerUnverifiedException
 
 /**
  * Attempts to find the connections for an exchange and any retries that follow. This uses the

--- a/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/ExchangeFinder.kt
@@ -154,18 +154,18 @@ class ExchangeFinder(
     synchronized(connectionPool) {
       if (call.isCanceled()) throw IOException("Canceled")
 
-      val callConnection = call.connection
-      releasedConnection = callConnection
-      toClose = if (callConnection != null &&
-          (callConnection.noNewExchanges || !callConnection.isSupported())) {
+      val existingCallConnection = call.connection
+      releasedConnection = existingCallConnection
+      toClose = if (existingCallConnection != null &&
+          (existingCallConnection.noNewExchanges || !existingCallConnection.isSupported())) {
         call.releaseConnectionNoEvents()
       } else {
         null
       }
 
-      if (callConnection != null) {
+      if (call.connection != null) {
         // We had an already-allocated connection and it's good.
-        result = callConnection
+        result = call.connection
         releasedConnection = null
       }
 
@@ -178,7 +178,7 @@ class ExchangeFinder(
         // Attempt to get a connection from the pool.
         if (connectionPool.callAcquirePooledConnection(address, call, null, false)) {
           foundPooledConnection = true
-          result = callConnection
+          result = call.connection
         } else if (nextRouteToTry != null) {
           selectedRoute = nextRouteToTry
           nextRouteToTry = null

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -46,6 +46,7 @@ import okhttp3.Response
 import okhttp3.Route
 import okhttp3.internal.EMPTY_RESPONSE
 import okhttp3.internal.assertThreadDoesntHoldLock
+import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.http.ExchangeCodec
@@ -583,6 +584,8 @@ class RealConnection(
     } catch (_: SSLPeerUnverifiedException) {
       // OkHostnameVerifier isn't guaranteed to work is user has disabled security via
       // TrustManager and hostnameVerifier
+      connectionPool.assertThreadHoldsLock()
+      noCoalescedConnections = true
       return false
     }
   }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -575,10 +575,16 @@ class RealConnection(
       return true // Host match. The URL is supported.
     }
 
-    // We have a host mismatch. But if the certificate matches, we're still good.
-    return !noCoalescedConnections &&
-        handshake != null &&
-        OkHostnameVerifier.verify(url.host, handshake!!.peerCertificates[0] as X509Certificate)
+    try {
+      // We have a host mismatch. But if the certificate matches, we're still good.
+      return !noCoalescedConnections &&
+          handshake != null &&
+          OkHostnameVerifier.verify(url.host, handshake!!.peerCertificates[0] as X509Certificate)
+    } catch (_: SSLPeerUnverifiedException) {
+      // OkHostnameVerifier isn't guaranteed to work is user has disabled security via
+      // TrustManager and hostnameVerifier
+      return false
+    }
   }
 
   @Throws(SocketException::class)

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -584,7 +584,6 @@ class RealConnection(
     } catch (_: SSLPeerUnverifiedException) {
       // OkHostnameVerifier isn't guaranteed to work if user has disabled security via
       // TrustManager and hostnameVerifier
-      connectionPool.assertThreadHoldsLock()
       noCoalescedConnections = true
       return false
     }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -566,6 +566,8 @@ class RealConnection(
   }
 
   fun supportsUrl(url: HttpUrl): Boolean {
+    connectionPool.assertThreadHoldsLock()
+
     val routeUrl = route.address.url
 
     if (url.port != routeUrl.port) {
@@ -583,7 +585,7 @@ class RealConnection(
           OkHostnameVerifier.verify(url.host, handshake!!.peerCertificates[0] as X509Certificate)
     } catch (_: SSLPeerUnverifiedException) {
       // OkHostnameVerifier isn't guaranteed to work if user has disabled security via
-      // TrustManager and hostnameVerifier
+      // TrustManager and hostnameVerifier.
       noCoalescedConnections = true
       return false
     }

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -46,6 +46,7 @@ import okhttp3.Response
 import okhttp3.Route
 import okhttp3.internal.EMPTY_RESPONSE
 import okhttp3.internal.assertThreadDoesntHoldLock
+import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.http.ExchangeCodec
@@ -538,7 +539,7 @@ class RealConnection(
 
     // 3. This connection's server certificate's must cover the new host.
     if (address.hostnameVerifier !== OkHostnameVerifier) return false
-    if (!supportsUrl(address.url)) return false
+    if (!safeSupportsUrl(address.url)) return false
 
     // 4. Certificate pinning must match the host.
     try {
@@ -562,6 +563,22 @@ class RealConnection(
           route.proxy.type() == Proxy.Type.DIRECT &&
           route.socketAddress == it.socketAddress
     }
+  }
+
+  /**
+   * The same as [supportsUrl] but catching any issues that would disqualify this live Connection
+   * for use across others urls. In that case noCoalescedConnections is updated, but the method
+   * must be called within the connectionPool lock.
+   */
+  fun safeSupportsUrl(url: HttpUrl) = try {
+    connectionPool.assertThreadHoldsLock()
+
+    supportsUrl(url)
+  } catch (_: SSLPeerUnverifiedException) {
+    // OkHostnameVerifier isn't guaranteed to work if user has disabled security via
+    // TrustManager and hostnameVerifier.
+    noCoalescedConnections = true
+    false
   }
 
   fun supportsUrl(url: HttpUrl): Boolean {

--- a/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/RealConnection.kt
@@ -582,7 +582,7 @@ class RealConnection(
           handshake != null &&
           OkHostnameVerifier.verify(url.host, handshake!!.peerCertificates[0] as X509Certificate)
     } catch (_: SSLPeerUnverifiedException) {
-      // OkHostnameVerifier isn't guaranteed to work is user has disabled security via
+      // OkHostnameVerifier isn't guaranteed to work if user has disabled security via
       // TrustManager and hostnameVerifier
       connectionPool.assertThreadHoldsLock()
       noCoalescedConnections = true

--- a/okhttp/src/test/java/okhttp3/ConnectionCoalescingTest.java
+++ b/okhttp/src/test/java/okhttp3/ConnectionCoalescingTest.java
@@ -435,8 +435,7 @@ public final class ConnectionCoalescingTest {
   }
 
   /**
-   * Test connecting to the main host then an alternative, although only subject alternative names
-   * are used if present no special consideration of common name.
+   * Won't coalesce if we can't clean certs e.g. a dev setup.
    */
   @Test public void redirectWithDevSetup() throws Exception {
     X509TrustManager TRUST_MANAGER = new X509TrustManager() {

--- a/okhttp/src/test/java/okhttp3/ConnectionCoalescingTest.java
+++ b/okhttp/src/test/java/okhttp3/ConnectionCoalescingTest.java
@@ -19,12 +19,14 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.X509TrustManager;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.testing.PlatformRule;
@@ -428,6 +430,39 @@ public final class ConnectionCoalescingTest {
     assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(0);
     assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(1);
     assertThat(server.takeRequest().getSequenceNumber()).isEqualTo(0); // Fresh connection.
+
+    assertThat(client.connectionPool().connectionCount()).isEqualTo(2);
+  }
+
+  /**
+   * Test connecting to the main host then an alternative, although only subject alternative names
+   * are used if present no special consideration of common name.
+   */
+  @Test public void redirectWithDevSetup() throws Exception {
+    X509TrustManager TRUST_MANAGER = new X509TrustManager() {
+      @Override
+      public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
+      }
+
+      @Override
+      public X509Certificate[] getAcceptedIssuers() {
+        return new X509Certificate[0];
+      }
+    };
+
+    client = client.newBuilder().sslSocketFactory(client.sslSocketFactory(), TRUST_MANAGER).build();
+
+    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse());
+
+    assert200Http2Response(execute(url), server.getHostName());
+
+    HttpUrl sanUrl = url.newBuilder().host("san.com").build();
+    assert200Http2Response(execute(sanUrl), "san.com");
 
     assertThat(client.connectionPool().connectionCount()).isEqualTo(2);
   }


### PR DESCRIPTION
In dev with disabled TrustManager and hostName verifier, just checking whether we can reuse a connection across hosts can cause a failure