### PR TITLE
Add SuppressedExceptions for multiple Routes

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/java/okhttp3/internal/Util.kt
@@ -581,3 +581,11 @@ internal inline fun Any.assertThreadDoesntHoldLock() {
     throw AssertionError("Thread ${Thread.currentThread().name} MUST NOT hold lock on $this")
   }
 }
+
+fun Exception.withSuppressed(suppressed: List<Exception>): Throwable = apply {
+  if (suppressed.size > 1) {
+    println(suppressed)
+  }
+
+  for (e in suppressed) addSuppressed(e)
+}

--- a/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
@@ -357,7 +357,7 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
 
 private fun Exception.withSuppressed(suppressed: MutableList<IOException>?): Throwable {
   if (suppressed != null) {
-    for (it in suppressed) this.addSuppressed(it)
+    for (e in suppressed) addSuppressed(e)
   }
   return this
 }

--- a/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
@@ -223,7 +223,6 @@ class CallKotlinTest {
 
     server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
 
-    // Pin publicobject.com's cert.
     client = client.newBuilder()
         .proxySelector(proxySelector)
         .readTimeout(Duration.ofMillis(100))

--- a/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
@@ -228,21 +228,17 @@ class CallKotlinTest {
         .proxySelector(proxySelector)
         .readTimeout(Duration.ofMillis(100))
         .connectTimeout(Duration.ofMillis(100))
-        .certificatePinner(CertificatePinner.Builder()
-            .add(server.hostName, "sha1/DmxUShsZuNiqPQsX2Oi9uv2sCnw=")
-            .build())
         .build()
 
     val request = Request.Builder().url(server.url("/")).build()
     try {
       client.newCall(request).execute()
       fail()
-    } catch (expected: SocketException) {
-      expected.printStackTrace()
-
-      assertThat(expected.message).startsWith("Connection reset")
+    } catch (expected: IOException) {
       assertThat(expected.suppressed).hasSize(1)
-      assertThat(expected.suppressed[0]).isInstanceOf(SocketTimeoutException::class.java)
+      val suppressed = expected.suppressed[0]
+      assertThat(suppressed).isInstanceOf(IOException::class.java)
+      assertThat(suppressed).isNotSameAs(expected)
     }
   }
 }

--- a/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
@@ -16,12 +16,17 @@
 package okhttp3
 
 import java.io.IOException
+import java.net.Proxy
+import java.net.SocketException
+import java.net.SocketTimeoutException
 import java.security.cert.X509Certificate
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.internal.connection.RealConnection
 import okhttp3.internal.connection.RealConnection.Companion.IDLE_CONNECTION_HEALTHY_NS
+import okhttp3.internal.http.RecordingProxySelector
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
@@ -209,5 +214,35 @@ class CallKotlinTest {
     val responseB = client.newCall(requestB).execute()
     assertThat(responseB.body!!.string()).isEqualTo("b")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
+  }
+
+  @Test fun exceptionsAreReturnedAsSuppressed() {
+    val proxySelector = RecordingProxySelector()
+    proxySelector.proxies.add(Proxy(Proxy.Type.HTTP, TestUtil.UNREACHABLE_ADDRESS))
+    proxySelector.proxies.add(Proxy.NO_PROXY)
+
+    server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+
+    // Pin publicobject.com's cert.
+    client = client.newBuilder()
+        .proxySelector(proxySelector)
+        .readTimeout(Duration.ofMillis(100))
+        .connectTimeout(Duration.ofMillis(100))
+        .certificatePinner(CertificatePinner.Builder()
+            .add(server.hostName, "sha1/DmxUShsZuNiqPQsX2Oi9uv2sCnw=")
+            .build())
+        .build()
+
+    val request = Request.Builder().url(server.url("/")).build()
+    try {
+      client.newCall(request).execute()
+      fail()
+    } catch (expected: SocketException) {
+      expected.printStackTrace()
+
+      assertThat(expected.message).startsWith("Connection reset")
+      assertThat(expected.suppressed).hasSize(1)
+      assertThat(expected.suppressed[0]).isInstanceOf(SocketTimeoutException::class.java)
+    }
   }
 }

--- a/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
@@ -17,8 +17,6 @@ package okhttp3
 
 import java.io.IOException
 import java.net.Proxy
-import java.net.SocketException
-import java.net.SocketTimeoutException
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.concurrent.TimeUnit


### PR DESCRIPTION
Before we have Happy Eyeballs, we currently throw the exception for the final Route.  Often a failure for an earlier Route may be more actionable, so add to suppressed.

n.b. RouteException already has a suppressed chain so this is a two level tree effectively.