### PR TITLE
Web Socket message inflater and deflater

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/ws/MessageDeflater.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/MessageDeflater.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.ws
+
+import java.io.Closeable
+import java.io.IOException
+import java.util.zip.Deflater
+import okio.Buffer
+import okio.ByteString
+import okio.ByteString.Companion.decodeHex
+import okio.DeflaterSink
+
+private val EMPTY_DEFLATE_BLOCK = "000000ffff".decodeHex()
+private const val LAST_OCTETS_COUNT_TO_REMOVE_AFTER_DEFLATION = 4
+
+class MessageDeflater(
+  private val noContextTakeover: Boolean
+) : Closeable {
+  private val deflatedBytes = Buffer()
+  private val deflater = Deflater(Deflater.DEFAULT_COMPRESSION, true /* omit zlib header */)
+  private val deflaterSink = DeflaterSink(deflatedBytes, deflater)
+
+  /** Deflates [buffer] in place as described in RFC 7692 section 7.2.1. */
+  @Throws(IOException::class)
+  fun deflate(buffer: Buffer) {
+    require(deflatedBytes.size == 0L)
+
+    if (noContextTakeover) {
+      deflater.reset()
+    }
+
+    deflaterSink.write(buffer, buffer.size)
+    deflaterSink.flush()
+
+    if (deflatedBytes.endsWith(EMPTY_DEFLATE_BLOCK)) {
+      val newSize = deflatedBytes.size - LAST_OCTETS_COUNT_TO_REMOVE_AFTER_DEFLATION
+      deflatedBytes.readAndWriteUnsafe().use { cursor ->
+        cursor.resizeBuffer(newSize)
+      }
+    } else {
+      // Same as adding EMPTY_DEFLATE_BLOCK and then removing 4 bytes.
+      deflatedBytes.writeByte(0x00)
+    }
+
+    buffer.write(deflatedBytes, deflatedBytes.size)
+  }
+
+  @Throws(IOException::class)
+  override fun close() = deflaterSink.close()
+
+  private fun Buffer.endsWith(suffix: ByteString) = rangeEquals(size - suffix.size, suffix)
+}

--- a/okhttp/src/main/java/okhttp3/internal/ws/MessageInflater.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/MessageInflater.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.ws
+
+import java.io.Closeable
+import java.io.IOException
+import java.util.zip.Inflater
+import okio.Buffer
+import okio.InflaterSource
+
+private const val OCTETS_TO_ADD_BEFORE_INFLATION = 0x0000ffff
+
+class MessageInflater(
+  private val noContextTakeover: Boolean
+) : Closeable {
+  private val deflatedBytes = Buffer()
+  private val inflater = Inflater(true /* omit zlib header */)
+  private val inflaterSource = InflaterSource(deflatedBytes, inflater)
+
+  /** Inflates [buffer] in place as described in RFC 7692 section 7.2.2. */
+  @Throws(IOException::class)
+  fun inflate(buffer: Buffer) {
+    require(deflatedBytes.size == 0L)
+
+    if (noContextTakeover) {
+      inflater.reset()
+    }
+
+    deflatedBytes.writeAll(buffer)
+    deflatedBytes.writeInt(OCTETS_TO_ADD_BEFORE_INFLATION)
+
+    val totalBytesToRead = inflater.bytesRead + deflatedBytes.size
+
+    // We cannot read all, as the source does not close.
+    // Instead, we ensure that all bytes from source have been processed by inflater.
+    do {
+      inflaterSource.read(buffer, Long.MAX_VALUE)
+    } while (inflater.bytesRead < totalBytesToRead)
+  }
+
+  @Throws(IOException::class)
+  override fun close() = inflaterSource.close()
+}

--- a/okhttp/src/test/java/okhttp3/internal/ws/MessageDeflaterInflaterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/MessageDeflaterInflaterTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.ws
+
+import java.io.EOFException
+import okio.Buffer
+import okio.ByteString
+import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.encodeUtf8
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
+import org.junit.Test
+
+internal class MessageDeflaterInflaterTest {
+  @Test fun `inflate golden value`() {
+    val inflater = MessageInflater(false)
+    val message = "f248cdc9c957c8cc4bcb492cc9cccf530400".decodeHex()
+    assertThat(inflater.inflate(message)).isEqualTo("Hello inflation!".encodeUtf8())
+  }
+
+  @Test fun `deflate golden value`() {
+    val deflater = MessageDeflater(false)
+    val deflated = deflater.deflate("Hello deflate!".encodeUtf8())
+    assertThat(deflated.hex()).isEqualTo("f248cdc9c95748494dcb492c49550400")
+  }
+
+  @Test fun `inflate deflate`() {
+    val deflater = MessageDeflater(false)
+    val inflater = MessageInflater(false)
+
+    val goldenValue = "Hello deflate!".repeat(100).encodeUtf8()
+
+    val deflated = deflater.deflate(goldenValue)
+    assertThat(deflated.size).isLessThan(goldenValue.size)
+    val inflated = inflater.inflate(deflated)
+
+    assertThat(inflated).isEqualTo(goldenValue)
+  }
+
+  @Test fun `inflate deflate with context takeover`() {
+    val deflater = MessageDeflater(false)
+    val inflater = MessageInflater(false)
+
+    val goldenValue1 = "Hello deflate!".repeat(100).encodeUtf8()
+    val deflatedValue1 = deflater.deflate(goldenValue1)
+    assertThat(inflater.inflate(deflatedValue1)).isEqualTo(goldenValue1)
+
+    val goldenValue2 = "Hello deflate?".repeat(100).encodeUtf8()
+    val deflatedValue2 = deflater.deflate(goldenValue2)
+    assertThat(inflater.inflate(deflatedValue2)).isEqualTo(goldenValue2)
+
+    assertThat(deflatedValue2.size).isLessThan(deflatedValue1.size)
+  }
+
+  @Test fun `inflate deflate with no context takeover`() {
+    val deflater = MessageDeflater(true)
+    val inflater = MessageInflater(true)
+
+    val goldenValue1 = "Hello deflate!".repeat(100).encodeUtf8()
+    val deflatedValue1 = deflater.deflate(goldenValue1)
+    assertThat(inflater.inflate(deflatedValue1)).isEqualTo(goldenValue1)
+
+    val goldenValue2 = "Hello deflate!".repeat(100).encodeUtf8()
+    val deflatedValue2 = deflater.deflate(goldenValue2)
+    assertThat(inflater.inflate(deflatedValue2)).isEqualTo(goldenValue2)
+
+    assertThat(deflatedValue2).isEqualTo(deflatedValue1)
+  }
+
+  @Test fun `deflate after close`() {
+    val deflater = MessageDeflater(true)
+    deflater.close()
+
+    try {
+      deflater.deflate("Hello deflate!".encodeUtf8())
+      fail()
+    } catch (expected: Exception) {
+    }
+  }
+
+  @Test fun `inflate after close`() {
+    val inflater = MessageInflater(false)
+
+    inflater.close()
+
+    try {
+      inflater.inflate("f240e30300".decodeHex())
+      fail()
+    } catch (expected: Exception) {
+    }
+  }
+
+  @Test fun `inflate empty buffer`() {
+    val inflater = MessageInflater(false)
+
+    try {
+      inflater.inflate(Buffer())
+      fail()
+    } catch (e: EOFException) {
+      assertThat(e.message).isEqualTo("source exhausted prematurely")
+    }
+  }
+
+  private fun MessageDeflater.deflate(byteString: ByteString): ByteString {
+    val buffer = Buffer()
+    buffer.write(byteString)
+    deflate(buffer)
+    return buffer.readByteString()
+  }
+
+  private fun MessageInflater.inflate(byteString: ByteString): ByteString {
+    val buffer = Buffer()
+    buffer.write(byteString)
+    inflate(buffer)
+    return buffer.readByteString()
+  }
+}


### PR DESCRIPTION
Originally contributed via PR #4871. This differs from that contribution
in a few ways:

 - Combined inflater and deflater into one test
 - Always operate on a buffer in-place
 - Support no context takeover in both reading and writing