### PR TITLE
Don't reuse a connection on redirect if certs match but DNS does not (4.4.x)

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt
@@ -40,7 +40,7 @@ import okio.buffer
 class Exchange(
   internal val call: RealCall,
   internal val eventListener: EventListener,
-  private val finder: ExchangeFinder,
+  internal val finder: ExchangeFinder,
   private val codec: ExchangeCodec
 ) {
   /** Returns true if the request body need not complete before the response body starts. */

--- a/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.kt
@@ -84,7 +84,7 @@ class RealInterceptorChain(
     calls++
 
     if (exchange != null) {
-      check(exchange.connection.supportsUrl(request.url)) {
+      check(exchange.finder.sameHostAndPort(request.url)) {
         "network interceptor ${interceptors[index - 1]} must retain the same host and port"
       }
       check(calls == 1) {


### PR DESCRIPTION
We attempt to minimize connection and reconnection work, but in this case we
were overly aggressive about retaining the same connection. In some deployments
services will share certificates but not DNS addresses; when redirecting
between such services we were incorrectly attempting to reuse the connection.

This would have resulted in 404s and other misdirected requests.

Closes: https://github.com/square/okhttp/issues/5859