### PR TITLE
Don't run Windows builds in CircleCI on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,8 +270,7 @@ workflows:
       - testjdk12windows:
           filters:
             branches:
-              ignore:
-                - gh-pages
+              only: master
       - testjdk13:
           filters:
             branches:


### PR DESCRIPTION
Too noisy on PRs, just run on master post commit, and nightly.