### PR TITLE
Turn on web socket compression

### DIFF
--- a/okhttp/src/main/java/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/java/okhttp3/OkHttpClient.kt
@@ -248,8 +248,6 @@ open class OkHttpClient internal constructor(
 
   /** Uses [request] to connect a new web socket. */
   override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {
-    // Compress messages 1 KiB or larger.
-    val minimumDeflateSize = 1024L
     val webSocket = RealWebSocket(
         taskRunner = TaskRunner.INSTANCE,
         originalRequest = request,
@@ -257,7 +255,7 @@ open class OkHttpClient internal constructor(
         random = Random(),
         pingIntervalMillis = pingIntervalMillis.toLong(),
         extensions = null, // Always null for clients.
-        minimumDeflateSize = minimumDeflateSize
+        minimumDeflateSize = RealWebSocket.DEFAULT_MINIMUM_DEFLATE_SIZE
     )
     webSocket.connect(this)
     return webSocket

--- a/okhttp/src/main/java/okhttp3/internal/ws/MessageInflater.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/MessageInflater.kt
@@ -35,6 +35,14 @@ class MessageInflater(
   fun inflate(buffer: Buffer) {
     require(deflatedBytes.size == 0L)
 
+    // Handle the empty message special case. The compressed empty message is one byte, '0x00'. We
+    // can't use the normal flow here because inflaterSource.read() throws EOFException if the
+    // deflated stream isn't complete but there's no bytes to return.
+    if (buffer.size == 1L && buffer[0L] == 0.toByte()) {
+      buffer.skip(1L)
+      return
+    }
+
     if (noContextTakeover) {
       inflater.reset()
     }

--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
@@ -144,6 +144,12 @@ class RealWebSocket(
   }
 
   fun connect(client: OkHttpClient) {
+    if (originalRequest.header("Sec-WebSocket-Extensions") != null) {
+      failWebSocket(ProtocolException(
+          "Request header not permitted: 'Sec-WebSocket-Extensions'"), null)
+      return
+    }
+
     val webSocketClient = client.newBuilder()
         .eventListener(EventListener.NONE)
         .protocols(ONLY_HTTP1)
@@ -153,6 +159,7 @@ class RealWebSocket(
         .header("Connection", "Upgrade")
         .header("Sec-WebSocket-Key", key)
         .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Extensions", "permessage-deflate")
         .build()
     call = RealCall(webSocketClient, request, forWebSocket = true)
     call!!.enqueue(object : Callback {
@@ -162,13 +169,22 @@ class RealWebSocket(
         try {
           checkUpgradeSuccess(response, exchange)
           streams = exchange!!.newWebSocketStreams()
-          // TODO(jwilson): use request & response headers to negotiate extensions.
-          extensions = WebSocketExtensions()
         } catch (e: IOException) {
           exchange?.webSocketUpgradeFailed()
           failWebSocket(e, response)
           response.closeQuietly()
           return
+        }
+
+        // Apply the extensions. If they're unacceptable initiate a graceful shut down.
+        // TODO(jwilson): Listeners should get onFailure() instead of onClosing() + onClosed(1010).
+        val extensions = WebSocketExtensions.parse(response.headers)
+        this@RealWebSocket.extensions = extensions
+        if (!extensions.isValid()) {
+          synchronized(this@RealWebSocket) {
+            messageAndCloseQueue.clear() // Don't transmit any messages.
+            close(1010, "unexpected Sec-WebSocket-Extensions in response header")
+          }
         }
 
         // Process all web socket messages.
@@ -186,6 +202,20 @@ class RealWebSocket(
         failWebSocket(e, null)
       }
     })
+  }
+
+  private fun WebSocketExtensions.isValid(): Boolean {
+    // If the server returned parameters we don't understand, fail the web socket.
+    if (unknownValues) return false
+
+    // If the server returned a value for client_max_window_bits, fail the web socket.
+    if (clientMaxWindowBits != null) return false
+
+    // If the server returned an illegal server_max_window_bits, fail the web socket.
+    if (serverMaxWindowBits != null && serverMaxWindowBits !in 8..15) return false
+
+    // Success.
+    return true
   }
 
   @Throws(IOException::class)
@@ -607,5 +637,15 @@ class RealWebSocket(
      * the server doesn't respond the web socket will be canceled.
      */
     private const val CANCEL_AFTER_CLOSE_MILLIS = 60L * 1000
+
+    /**
+     * The smallest message that will be compressed. We use 1024 because smaller messages already
+     * fit comfortably within a single ethernet packet (1500 bytes) even with framing overhead.
+     *
+     * For tests this must be big enough to realize real compression on test messages like
+     * 'aaaaaaaaaa...'. Our tests check if compression was applied just by looking at the size if
+     * the inbound buffer.
+     */
+    const val DEFAULT_MINIMUM_DEFLATE_SIZE = 1024L
   }
 }

--- a/okhttp/src/test/java/okhttp3/internal/ws/MessageDeflaterInflaterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/MessageDeflaterInflaterTest.kt
@@ -50,6 +50,19 @@ internal class MessageDeflaterInflaterTest {
     assertThat(inflated).isEqualTo(goldenValue)
   }
 
+  @Test fun `inflate deflate empty message`() {
+    val deflater = MessageDeflater(false)
+    val inflater = MessageInflater(false)
+
+    val goldenValue = "".encodeUtf8()
+
+    val deflated = deflater.deflate(goldenValue)
+    assertThat(deflated).isEqualTo("00".decodeHex())
+    val inflated = inflater.inflate(deflated)
+
+    assertThat(inflated).isEqualTo(goldenValue)
+  }
+
   @Test fun `inflate deflate with context takeover`() {
     val deflater = MessageDeflater(false)
     val inflater = MessageInflater(false)


### PR DESCRIPTION
Theres a few TODOs outstanding around error cases, and I need to
run integration tests against real-world things. But the core
functionality works.

I used coverage to confirm the context takeover cases are exercised
with and without.