### PR TITLE
Don't create inflaters or deflaters until they're needed

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/RealWebSocket.kt
@@ -259,7 +259,8 @@ class RealWebSocket(
           isClient = streams.client,
           sink = streams.sink,
           random = random,
-          messageDeflater = extensions.newMessageDeflater(streams.client),
+          perMessageDeflate = extensions.perMessageDeflate,
+          noContextTakeover = extensions.noContextTakeover(streams.client),
           minimumDeflateSize = minimumDeflateSize
       )
       this.writerTask = WriterTask()
@@ -279,7 +280,8 @@ class RealWebSocket(
         isClient = streams.client,
         source = streams.source,
         frameCallback = this,
-        messageInflater = extensions.newMessageInflater(streams.client)
+        perMessageDeflate = extensions.perMessageDeflate,
+        noContextTakeover = extensions.noContextTakeover(!streams.client)
     )
   }
 

--- a/okhttp/src/main/java/okhttp3/internal/ws/WebSocketExtensions.kt
+++ b/okhttp/src/main/java/okhttp3/internal/ws/WebSocketExtensions.kt
@@ -79,28 +79,12 @@ data class WebSocketExtensions(
   @JvmField val unknownValues: Boolean = false
 ) {
 
-  /** Returns a message deflater as specified by this, or null if compression is not enabled. */
-  fun newMessageDeflater(client: Boolean): MessageDeflater? {
-    if (!perMessageDeflate) return null
-
-    val noContextTakeover = when {
-      client -> clientNoContextTakeover // Compressing client.
-      else -> serverNoContextTakeover // Compressing server.
+  fun noContextTakeover(clientOriginated: Boolean): Boolean {
+    if (clientOriginated) {
+      return clientNoContextTakeover // Client is deflating.
+    } else {
+      return serverNoContextTakeover // Server is deflating.
     }
-
-    return MessageDeflater(noContextTakeover)
-  }
-
-  /** Returns a message inflater as specified by this, or null if compression is not enabled. */
-  fun newMessageInflater(client: Boolean): MessageInflater? {
-    if (!perMessageDeflate) return null
-
-    val noContextTakeover = when {
-      client -> serverNoContextTakeover // Decompressing client.
-      else -> clientNoContextTakeover // Decompressing server.
-    }
-
-    return MessageInflater(noContextTakeover)
   }
 
   companion object {

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketReaderTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketReaderTest.java
@@ -35,13 +35,13 @@ public final class WebSocketReaderTest {
 
   // Mutually exclusive. Use the one corresponding to the peer whose behavior you wish to test.
   final WebSocketReader serverReader =
-      new WebSocketReader(false, data, callback.asFrameCallback(), null);
+      new WebSocketReader(false, data, callback.asFrameCallback(), false, false);
   final WebSocketReader serverReaderWithCompression =
-      new WebSocketReader(false, data, callback.asFrameCallback(), new MessageInflater(false));
+      new WebSocketReader(false, data, callback.asFrameCallback(), true, false);
   final WebSocketReader clientReader =
-      new WebSocketReader(true, data, callback.asFrameCallback(), null);
+      new WebSocketReader(true, data, callback.asFrameCallback(), false, false);
   final WebSocketReader clientReaderWithCompression =
-      new WebSocketReader(true, data, callback.asFrameCallback(), new MessageInflater(false));
+      new WebSocketReader(true, data, callback.asFrameCallback(), true, false);
 
   @After public void tearDown() {
     callback.assertExhausted();
@@ -423,6 +423,10 @@ public final class WebSocketReaderTest {
   }
 
   @Test public void clientWithCompressionCannotBeUsedAfterClose() throws IOException {
+    data.write(ByteString.decodeHex("c107f248cdc9c90700")); // Hello
+    clientReaderWithCompression.processNextFrame();
+    callback.assertTextMessage("Hello");
+
     data.write(ByteString.decodeHex("c107f248cdc9c90700")); // Hello
     clientReaderWithCompression.close();
     try {

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketWriterTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketWriterTest.java
@@ -52,8 +52,10 @@ public final class WebSocketWriterTest {
   };
 
   // Mutually exclusive. Use the one corresponding to the peer whose behavior you wish to test.
-  private final WebSocketWriter serverWriter = new WebSocketWriter(false, data, random, null, 0L);
-  private final WebSocketWriter clientWriter = new WebSocketWriter(true, data, random, null, 0L);
+  private final WebSocketWriter serverWriter = new WebSocketWriter(
+      false, data, random, false, false, 0L);
+  private final WebSocketWriter clientWriter = new WebSocketWriter(
+      true, data, random, false, false, 0L);
 
   @Test public void serverTextMessage() throws IOException {
     serverWriter.writeMessageFrame(OPCODE_TEXT, ByteString.encodeUtf8("Hello"));
@@ -62,7 +64,7 @@ public final class WebSocketWriterTest {
 
   @Test public void serverCompressedTextMessage() throws IOException {
     WebSocketWriter serverWriter = new WebSocketWriter(
-        false, data, random, new MessageDeflater(false), 0L);
+        false, data, random, true, false, 0L);
     serverWriter.writeMessageFrame(OPCODE_TEXT, ByteString.encodeUtf8("Hello"));
     assertData("c107f248cdc9c90700");
   }
@@ -94,7 +96,7 @@ public final class WebSocketWriterTest {
 
   @Test public void clientCompressedTextMessage() throws IOException {
     WebSocketWriter clientWriter = new WebSocketWriter(
-        false, data, random, new MessageDeflater(false), 0L);
+        false, data, random, true, false, 0L);
     clientWriter.writeMessageFrame(OPCODE_TEXT, ByteString.encodeUtf8("Hello"));
     assertData("c107f248cdc9c90700");
   }


### PR DESCRIPTION
They consume a decent amount of memory and it's possible that
they won't even be used, even if compression is negotiated.

Closes: https://github.com/square/okhttp/issues/5876