### PR TITLE
Support 3.12.x through December 31, 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Security.insertProviderAt(Conscrypt.newProvider(), 1);
 
 The OkHttp 3.12.x branch supports Android 2.3+ (API level 9+) and Java 7+. These platforms lack
 support for TLS 1.2 and should not be used. But because upgrading is difficult we will backport
-critical fixes to the [3.12.x branch][okhttp_312x] through December 31, 2020.
+critical fixes to the [3.12.x branch][okhttp_312x] through December 31, 2021.
 
 
 Releases

--- a/docs/changelog_3x.md
+++ b/docs/changelog_3x.md
@@ -166,7 +166,8 @@ _2019-02-04_
 
     The OkHttp 3.12.x branch will be our long-term branch for Android 2.3+ (API level 9+) and Java
     7+. These platforms lack support for TLS 1.2 and should not be used. But because upgrading is
-    difficult we will backport critical fixes to the 3.12.x branch through December 31, 2020.
+    difficult we will backport critical fixes to the 3.12.x branch through December 31, 2021. (This
+    commitment was originally through December 31, 2020; we have since extended it.)
 
  *  **TLSv1 and TLSv1.1 are no longer enabled by default.** Major web browsers are working towards
     removing these versions altogether in early 2020. If your servers aren't ready yet you can

--- a/docs/security.md
+++ b/docs/security.md
@@ -3,11 +3,11 @@ Security Policy
 
 ## Supported Versions
 
-| Version | Supported  | Notes          |
-| ------- | ---------- | -------------- |
-| 4.x     | ✅         |                |
-| 3.14.x  | ✅         |                |
-| 3.12.x  | ✅         | Android 2.3+ (API level 9+) and Java 7+. Platforms may not support TLSv1.2. Until December 31, 2020  |
+| Version | Supported        | Notes          |
+| ------- | ---------------- | -------------- |
+| 4.x     | ✅              |                |
+| 3.14.x  | Until 2020-06-30 |                |
+| 3.12.x  | Until 2021-12-31 | Android 2.3+ (API level 9+) and Java 7+. Platforms may not support TLSv1.2. |
 
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
Our original expectations were that KitKat devices would age out in
2020. It's been a garbage year and this expectations no longer hold.
We're extending support an extra year.

We continue to support OkHttp 3.12.x because later releases are not
usable on older devices and JVMs.

OkHttp 3.14.x has no such reason to receive support, and we'll stop
updating it on June 30, 2020. Users of OkHttp 3.14.x should upgrade
to the 4.x series. Android apps should accept Kotlin libraries; it's
the platform's future. And JVM apps are less constrained by binary
size. Here's the size of OkHttp + transitive dependencies, and those
of alternatives:

 * OkHttp 4.4: 2.47 MiB including Kotlin stdlib (1.51 MiB)
 * Apache HTTP Client 5.0: 1.78 MiB including slf4j-api (0.04 MiB)
 * Jetty HTTP Client 9.4: 1.19 MiB