### PR TITLE
Force cancel all events on client

### DIFF
--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -167,6 +167,7 @@ class OkHttpTest {
       }
     } finally {
       Security.removeProvider("Conscrypt")
+      client.close()
     }
   }
 
@@ -202,6 +203,7 @@ class OkHttpTest {
       }
     } finally {
       Security.removeProvider("GmsCore_OpenSSL")
+      client.close()
     }
   }
 
@@ -549,6 +551,11 @@ class OkHttpTest {
     } catch (uhe: UnknownHostException) {
       assumeNoException(uhe)
     }
+  }
+
+  fun OkHttpClient.close() {
+    dispatcher.executorService.shutdown()
+    connectionPool.evictAll()
   }
 
   companion object {

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -20,7 +20,8 @@ import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.testing.Flaky
-import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -88,19 +89,15 @@ class OkHttpClientTestRule : TestRule {
     testClient?.let {
       val connectionPool = it.connectionPool
       connectionPool.evictAll()
-      assertThat(connectionPool.connectionCount()).isEqualTo(0)
+      assertEquals(0, connectionPool.connectionCount())
     }
   }
 
   private fun ensureAllTaskQueuesIdle() {
     try {
       for (queue in TaskRunner.INSTANCE.activeQueues()) {
-        assertThat(
-            queue.idleLatch()
-                .await(1_000L, TimeUnit.MILLISECONDS)
-        )
-            .withFailMessage("Queue still active after 1000 ms")
-            .isTrue()
+        assertTrue("Queue still active after 1000 ms",
+            queue.idleLatch().await(1_000L, TimeUnit.MILLISECONDS))
       }
     } finally {
       TaskRunner.INSTANCE.cancelAll()

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -15,17 +15,16 @@
  */
 package okhttp3
 
-import java.net.InetAddress
-import java.util.concurrent.TimeUnit
-import java.util.logging.Logger
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.testing.Flaky
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import java.net.InetAddress
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
 
 /**
  * Apply this rule to all tests. It adds additional checks for leaked resources and uncaught

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -93,10 +93,17 @@ class OkHttpClientTestRule : TestRule {
   }
 
   private fun ensureAllTaskQueuesIdle() {
-    for (queue in TaskRunner.INSTANCE.activeQueues()) {
-      assertThat(queue.idleLatch().await(1_000L, TimeUnit.MILLISECONDS))
-          .withFailMessage("Queue still active after 1000 ms")
-          .isTrue()
+    try {
+      for (queue in TaskRunner.INSTANCE.activeQueues()) {
+        assertThat(
+            queue.idleLatch()
+                .await(1_000L, TimeUnit.MILLISECONDS)
+        )
+            .withFailMessage("Queue still active after 1000 ms")
+            .isTrue()
+      }
+    } finally {
+      TaskRunner.INSTANCE.cancelAll()
     }
   }
 

--- a/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/OkHttpClientTestRule.kt
@@ -15,6 +15,9 @@
  */
 package okhttp3
 
+import java.net.InetAddress
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.testing.Flaky
 import org.junit.Assert.assertEquals
@@ -22,9 +25,6 @@ import org.junit.Assert.fail
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.net.InetAddress
-import java.util.concurrent.TimeUnit
-import java.util.logging.Logger
 
 /**
  * Apply this rule to all tests. It adds additional checks for leaked resources and uncaught

--- a/okhttp/src/main/java/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/TaskRunner.kt
@@ -242,9 +242,9 @@ class TaskRunner(
     }
   }
 
-  public fun cancelAll() {
+  fun cancelAll() {
     for (i in busyQueues.size - 1 downTo 0) {
-      readyQueues[i].cancelAllAndDecide()
+      busyQueues[i].cancelAllAndDecide()
     }
     for (i in readyQueues.size - 1 downTo 0) {
       val queue = readyQueues[i]

--- a/okhttp/src/main/java/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/main/java/okhttp3/internal/concurrent/TaskRunner.kt
@@ -242,7 +242,7 @@ class TaskRunner(
     }
   }
 
-  private fun cancelAll() {
+  public fun cancelAll() {
     for (i in busyQueues.size - 1 downTo 0) {
       readyQueues[i].cancelAllAndDecide()
     }


### PR DESCRIPTION
Once a test leaves a client running, all other tests will fail.  But leaving things running can impact other tests, so make another attempt to cleanup.