### PR TITLE
Document maximum close reason length

### DIFF
--- a/okhttp/src/main/java/okhttp3/WebSocket.kt
+++ b/okhttp/src/main/java/okhttp3/WebSocket.kt
@@ -98,8 +98,8 @@ interface WebSocket {
    *
    * @param code Status code as defined by
    *     [Section 7.4 of RFC 6455](http://tools.ietf.org/html/rfc6455#section-7.4).
-   * @param reason Reason for shutting down or null.
-   * @throws IllegalArgumentException if code is invalid.
+   * @param reason Reason for shutting down, no longer than 123 bytes of UTF-8 encoded data (**not** characters) or null.
+   * @throws IllegalArgumentException if [code] is invalid or [reason] is too long.
    */
   fun close(code: Int, reason: String?): Boolean
 


### PR DESCRIPTION
This PR adds documentation to the exception which is thrown when the close reason is longer than 123 UTF-8 encoded bytes, addressing concerns from #5594. There are [preexisting tests](https://github.com/square/okhttp/blob/4c1f65d1388ae8d5720530ca9b0094f7343eb1c8/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java#L476) for this behavior yet it is currently undocumented.