### PR TITLE
Emulate Windows file system restrictions in a wrapper

### DIFF
--- a/okhttp-testing-support/src/main/java/okhttp3/TestUtil.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/TestUtil.kt
@@ -20,7 +20,8 @@ import java.net.InetSocketAddress
 import java.net.UnknownHostException
 import java.util.Arrays
 import okhttp3.internal.http2.Header
-import org.junit.Assume
+import org.junit.Assume.assumeFalse
+import org.junit.Assume.assumeNoException
 
 object TestUtil {
   @JvmField
@@ -59,20 +60,16 @@ object TestUtil {
     try {
       InetAddress.getByName("www.google.com")
     } catch (uhe: UnknownHostException) {
-      Assume.assumeNoException(uhe)
+      assumeNoException(uhe)
     }
   }
 
   @JvmStatic
   fun assumeNotWindows() {
-    var isWindows = false
-    try {
-      val osName = System.getProperty("os.name")
-      isWindows = osName.startsWith("Windows")
-    } catch (ex: Exception) {
-      // Any exception means this is not a Windows system
-      // or we do not have permissions to check
-    }
-    Assume.assumeFalse("This test fails on Windows.", isWindows)
+    assumeFalse("This test fails on Windows.", windows)
   }
+
+  @JvmStatic
+  val windows: Boolean
+    get() = System.getProperty("os.name", "?").startsWith("Windows")
 }

--- a/okhttp-testing-support/src/main/java/okhttp3/internal/io/InMemoryFileSystem.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/internal/io/InMemoryFileSystem.kt
@@ -146,4 +146,6 @@ class InMemoryFileSystem : FileSystem, TestRule {
       ) i.remove()
     }
   }
+
+  override fun toString() = "InMemoryFileSystem"
 }

--- a/okhttp-testing-support/src/main/java/okhttp3/internal/io/WindowsFileSystem.kt
+++ b/okhttp-testing-support/src/main/java/okhttp3/internal/io/WindowsFileSystem.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.io
+
+import java.io.File
+import java.util.Collections
+import okio.ForwardingSink
+import okio.ForwardingSource
+import okio.IOException
+import okio.Sink
+import okio.Source
+
+/**
+ * Emulate Windows file system limitations on any file system. In particular, Windows will throw an
+ * [IOException] when asked to delete or rename an open file.
+ */
+class WindowsFileSystem(val delegate: FileSystem) : FileSystem {
+  /** Guarded by itself. */
+  private val openFiles = Collections.synchronizedList(mutableListOf<File>())
+
+  override fun source(file: File): Source = FileSource(file, delegate.source(file))
+
+  override fun sink(file: File): Sink = FileSink(file, delegate.sink(file))
+
+  override fun appendingSink(file: File): Sink = FileSink(file, delegate.appendingSink(file))
+
+  override fun delete(file: File) {
+    val fileOpen = file in openFiles
+    if (fileOpen) throw IOException("file is open $file")
+    delegate.delete(file)
+  }
+
+  override fun exists(file: File) = delegate.exists(file)
+
+  override fun size(file: File) = delegate.size(file)
+
+  override fun rename(from: File, to: File) {
+    val fromOpen = from in openFiles
+    if (fromOpen) throw IOException("file is open $from")
+
+    val toOpen = to in openFiles
+    if (toOpen) throw IOException("file is open $to")
+
+    delegate.rename(from, to)
+  }
+
+  override fun deleteContents(directory: File) {
+    val openChild = synchronized(openFiles) {
+      openFiles.firstOrNull { it.isDescendentOf(directory) }
+    }
+    if (openChild != null) throw IOException("file is open $openChild")
+    delegate.deleteContents(directory)
+  }
+
+  private tailrec fun File.isDescendentOf(directory: File): Boolean {
+    val parentFile = parentFile ?: return false
+    if (parentFile == directory) return true
+    return parentFile.isDescendentOf(directory)
+  }
+
+  private inner class FileSink(val file: File, delegate: Sink) : ForwardingSink(delegate) {
+    var closed = false
+
+    init {
+      openFiles += file
+    }
+
+    override fun close() {
+      if (!closed) {
+        closed = true
+        val removed = openFiles.remove(file)
+        check(removed)
+      }
+      delegate.close()
+    }
+  }
+
+  private inner class FileSource(val file: File, delegate: Source) : ForwardingSource(delegate) {
+    var closed = false
+
+    init {
+      openFiles += file
+    }
+
+    override fun close() {
+      if (!closed) {
+        closed = true
+        val removed = openFiles.remove(file)
+        check(removed)
+      }
+      delegate.close()
+    }
+  }
+
+  override fun toString() = "$delegate for Windows™"
+}

--- a/okhttp/src/main/java/okhttp3/internal/io/FileSystem.kt
+++ b/okhttp/src/main/java/okhttp3/internal/io/FileSystem.kt
@@ -102,6 +102,8 @@ interface FileSystem {
           }
         }
       }
+
+      override fun toString() = "FileSystem.SYSTEM"
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/io/FileSystemTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/io/FileSystemTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.io
+
+import java.io.File
+import java.io.IOException
+import okhttp3.TestUtil
+import okio.buffer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+/**
+ * Test that our file system abstraction is consistent and sufficient for OkHttp's needs. We're
+ * particularly interested in what happens when open files are moved or deleted on Windows.
+ */
+@RunWith(Parameterized::class)
+class FileSystemTest(
+  private var fileSystem: FileSystem,
+  private val windows: Boolean
+) {
+  @Rule @JvmField val temporaryFolder = TemporaryFolder()
+
+  companion object {
+    @Parameters(name = "{0}") @JvmStatic
+    fun parameters(): Collection<Array<Any>> = listOf(
+        arrayOf(FileSystem.SYSTEM, TestUtil.windows),
+        arrayOf(InMemoryFileSystem(), false),
+        arrayOf(WindowsFileSystem(FileSystem.SYSTEM), true),
+        arrayOf(WindowsFileSystem(InMemoryFileSystem()), true)
+    )
+  }
+
+  @Test fun `delete open for writing fails on Windows`() {
+    val file = temporaryFolder.newFile("file.txt")
+    expectIOExceptionOnWindows {
+      fileSystem.sink(file).use {
+        fileSystem.delete(file)
+      }
+    }
+  }
+
+  @Test fun `delete open for appending fails on Windows`() {
+    val file = temporaryFolder.newFile("file.txt")
+    file.write("abc")
+    expectIOExceptionOnWindows {
+      fileSystem.appendingSink(file).use {
+        fileSystem.delete(file)
+      }
+    }
+  }
+
+  @Test fun `delete open for reading fails on Windows`() {
+    val file = temporaryFolder.newFile("file.txt")
+    file.write("abc")
+    expectIOExceptionOnWindows {
+      fileSystem.source(file).use {
+        fileSystem.delete(file)
+      }
+    }
+  }
+
+  @Test fun `rename target exists succeeds on all platforms`() {
+    val from = temporaryFolder.newFile("from.txt")
+    val to = temporaryFolder.newFile("to.txt")
+    from.write("source file")
+    to.write("target file")
+    fileSystem.rename(from, to)
+  }
+
+  @Test fun `rename source is open fails on Windows`() {
+    val from = temporaryFolder.newFile("from.txt")
+    val to = temporaryFolder.newFile("to.txt")
+    from.write("source file")
+    to.write("target file")
+    expectIOExceptionOnWindows {
+      fileSystem.source(from).use {
+        fileSystem.rename(from, to)
+      }
+    }
+  }
+
+  @Test fun `rename target is open fails on Windows`() {
+    val from = temporaryFolder.newFile("from.txt")
+    val to = temporaryFolder.newFile("to.txt")
+    from.write("source file")
+    to.write("target file")
+    expectIOExceptionOnWindows {
+      fileSystem.source(to).use {
+        fileSystem.rename(from, to)
+      }
+    }
+  }
+
+  @Test fun `delete contents of parent of file open for reading fails on Windows`() {
+    val parentA = temporaryFolder.newFolder("a")
+    val parentAB = File(parentA, "b")
+    val parentABC = File(parentAB, "c")
+    val file = File(parentABC, "file.txt")
+    file.write("child file")
+    expectIOExceptionOnWindows {
+      fileSystem.source(file).use {
+        fileSystem.deleteContents(parentA)
+      }
+    }
+  }
+
+  private fun File.write(content: String) {
+    fileSystem.sink(this).buffer().use {
+      it.writeUtf8(content)
+    }
+  }
+
+  private fun expectIOExceptionOnWindows(block: () -> Unit) {
+    try {
+      block()
+      assertThat(windows).isFalse()
+    } catch (_: IOException) {
+      assertThat(windows).isTrue()
+    }
+  }
+}


### PR DESCRIPTION
This should make it possible to get DiskLruCacheTest passing on
Windows even when Windows isn't available.