### PR TITLE
Upgrade Bouncy Castle to to 1.65

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   ext.versions = [
       'animalSniffer': '1.18',
       'assertj': '3.15.0',
-      'bouncycastle': '1.64',
+      'bouncycastle': '1.65',
       'brotli': '0.1.2',
       'checkstyle': '8.28',
       'conscrypt': '2.4.0',


### PR DESCRIPTION
From the project's release notes:

    Defects Fixed

    DLExternal would encode using DER encoding for tagged SETs. This has been fixed.
    ChaCha20Poly1305 could fail for large (>~2GB) files. This has been fixed.
    ChaCha20Poly1305 could fail for small updates when used via the provider. This has been fixed.
    Properties.getPropertyValue could ignore system property when other local overrides set. This has been fixed.
    The entropy gathering thread was not running in daemon mode, meaning there could be a delay in an application shutting down due to it. This has been fixed.
    A recent change in Java 11 could cause an exception with the BC Provider's implementation of PSS. This has been fixed.
    BCJSSE: TrustManager now tolerates having no trusted certificates.
    BCJSSE: Choice of credentials and signing algorithm now respect the peer's signature_algorithms extension properly.
    BCJSSE: KeyManager for KeyStoreBuilderParameters no longer leaks memory.

    Additional Features and Functionality

    LMS and HSS (RFC 8554) support has been added to the low level library and the PQC provider.
    SipHash128 support has been added to the low level library and the JCE provider.
    BCJSSE: BC API now supports explicitly specifying the session to resume.
    BCJSSE: Ed25519, Ed448 are now supported when TLS 1.2 or higher is negotiated (except in FIPS mode).
    BCJSSE: Added support for extended_master_secret system properties: jdk.tls.allowLegacyMasterSecret, jdk.tls.allowLegacyResumption, jdk.tls.useExtendedMasterSecret .
    BCJSSE: Ed25519, Ed448 are now supported when TLS 1.2 or higher is negotiated (except in FIPS mode).
    BCJSSE: KeyManager and TrustManager now check algorithm constraints for keys and certificate chains.
    BCJSSE: KeyManager selection of server credentials now prefers matching SNI hostname (if any).
    BCJSSE: KeyManager may now fallback to imperfect credentials (expired, SNI mismatch).
    BCJSSE: Client-side OCSP stapling support (beta version: via status_request extension only, provides jdk.tls.client.enableStatusRequestExtension, and requires CertPathBuilder support).
    TLS: DSA in JcaTlsCrypto now falls back to stream signing to work around NoneWithDSA limitations in default provider.

https://www.bouncycastle.org/releasenotes.html