### PR TITLE
Revert to null SecureRandom

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -19,7 +19,6 @@ import java.net.Proxy
 import java.net.ProxySelector
 import java.net.Socket
 import java.security.GeneralSecurityException
-import java.security.SecureRandom
 import java.time.Duration
 import java.util.Collections
 import java.util.Random
@@ -1062,10 +1061,7 @@ open class OkHttpClient internal constructor(
     private fun newSslSocketFactory(trustManager: X509TrustManager): SSLSocketFactory {
       try {
         val sslContext = Platform.get().newSSLContext()
-        // no support for bouncycastle SecureRandom on Android
-        // see JcaTlsCryptoProvider.create
-        val random = SecureRandom()
-        sslContext.init(null, arrayOf<TrustManager>(trustManager), random)
+        sslContext.init(null, arrayOf<TrustManager>(trustManager), null)
         return sslContext.socketFactory
       } catch (e: GeneralSecurityException) {
         throw AssertionError("No System TLS: " + e, e) // The system has no TLS. Just give up.


### PR DESCRIPTION
Safer for most providers, but causes failures for bc-java.