### PR TITLE
Fix DiskLruCache to work on Windows

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/TestUtil.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/TestUtil.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3
 
+import java.io.File
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.UnknownHostException
@@ -40,6 +41,12 @@ object TestUtil {
     val array = CharArray(count)
     Arrays.fill(array, c)
     return String(array)
+  }
+
+  tailrec fun File.isDescendentOf(directory: File): Boolean {
+    val parentFile = parentFile ?: return false
+    if (parentFile == directory) return true
+    return parentFile.isDescendentOf(directory)
   }
 
   /**

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/io/WindowsFileSystem.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/io/WindowsFileSystem.kt
@@ -17,6 +17,7 @@ package okhttp3.internal.io
 
 import java.io.File
 import java.util.Collections
+import okhttp3.TestUtil.isDescendentOf
 import okio.ForwardingSink
 import okio.ForwardingSource
 import okio.IOException
@@ -63,12 +64,6 @@ class WindowsFileSystem(val delegate: FileSystem) : FileSystem {
     }
     if (openChild != null) throw IOException("file is open $openChild")
     delegate.deleteContents(directory)
-  }
-
-  private tailrec fun File.isDescendentOf(directory: File): Boolean {
-    val parentFile = parentFile ?: return false
-    if (parentFile == directory) return true
-    return parentFile.isDescendentOf(directory)
   }
 
   private inner class FileSink(val file: File, delegate: Sink) : ForwardingSink(delegate) {

--- a/okhttp/src/test/java/okhttp3/internal/io/FaultyFileSystem.java
+++ b/okhttp/src/test/java/okhttp3/internal/io/FaultyFileSystem.java
@@ -107,4 +107,8 @@ public final class FaultyFileSystem implements FileSystem {
       super.write(source, byteCount);
     }
   }
+
+  @Override public String toString() {
+    return "Faulty " + delegate;
+  }
 }


### PR DESCRIPTION
As originally designed DiskLruCache assumes an inode-like
file system, where it's fine to delete files that are
currently being read or written.

On Windows the file system forbids this, so we must be
more careful when deleting and renaming files. These
operations come up a lot internally in the cache:
 - deleting to evict an entry
 - renaming to commit a dirty file to a clean file

The workaround is simple if unsatisfying: we don't
permit concurrent reads and writes on Windows. We
can have multiple concurrent reders, or a single
writer.

One challenge in this implementation is detecting
whether we're running on Windows or a good operating
system. We deliberately don't look at System properties
here because the OS and file system may disagree, such
as when a Windows machine has an ext4 partition, or when
a Linux machine has an NTFS partition. Instead of detecting
we just attempt an edit and see what happens.

Another challenge in this implementation is what to
do when a file needs to be deleted but cannot be because
it is currently open. In such cases we now mark the
cache entry as a 'zombie'. When the files are later
closed they now check for zombie status and delete the
files if necessary. Note that it is not possible to
store a new cache entry while it is a zombie.

Closes: https://github.com/square/okhttp/issues/5761