### PR TITLE
Clean up SSL state in OkHttpClient

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/CertificatePinner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/CertificatePinner.kt
@@ -217,7 +217,7 @@ class CertificatePinner internal constructor(
 
   /** Returns a certificate pinner that uses `certificateChainCleaner`. */
   internal fun withCertificateChainCleaner(
-    certificateChainCleaner: CertificateChainCleaner?
+    certificateChainCleaner: CertificateChainCleaner
   ): CertificatePinner {
     return if (this.certificateChainCleaner == certificateChainCleaner) {
       this

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -258,10 +258,10 @@ open class OkHttpClient internal constructor(
       check(x509TrustManager == null)
       check(certificatePinner == CertificatePinner.DEFAULT)
     } else {
-      checkNotNull(sslSocketFactoryOrNull == null)
-      checkNotNull(certificateChainCleaner == null)
-      checkNotNull(x509TrustManager == null)
-      checkNotNull(certificatePinner == CertificatePinner.DEFAULT)
+      checkNotNull(sslSocketFactoryOrNull)
+      checkNotNull(certificateChainCleaner)
+      checkNotNull(x509TrustManager)
+      checkNotNull(certificatePinner)
     }
   }
 

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -258,10 +258,9 @@ open class OkHttpClient internal constructor(
       check(x509TrustManager == null)
       check(certificatePinner == CertificatePinner.DEFAULT)
     } else {
-      checkNotNull(sslSocketFactoryOrNull)
-      checkNotNull(certificateChainCleaner)
-      checkNotNull(x509TrustManager)
-      checkNotNull(certificatePinner)
+      checkNotNull(sslSocketFactoryOrNull) { "sslSocketFactory == null" }
+      checkNotNull(certificateChainCleaner) { "certificateChainCleaner == null" }
+      checkNotNull(x509TrustManager) { "x509TrustManager == null" }
     }
   }
 

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -232,7 +232,7 @@ open class OkHttpClient internal constructor(
     } else if (builder.sslSocketFactoryOrNull != null) {
       this.sslSocketFactoryOrNull = builder.sslSocketFactoryOrNull
       this.certificateChainCleaner = builder.certificateChainCleaner!!
-      this.x509TrustManager = builder.x509TrustManagerOrNull
+      this.x509TrustManager = builder.x509TrustManagerOrNull!!
       this.certificatePinner = builder.certificatePinner
           .withCertificateChainCleaner(certificateChainCleaner!!)
     } else {

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/ConscryptPlatform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/ConscryptPlatform.kt
@@ -15,13 +15,15 @@
  */
 package okhttp3.internal.platform
 
+import java.security.KeyStore
 import java.security.Provider
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 import okhttp3.Protocol
-import okhttp3.internal.readFieldOrNull
 import org.conscrypt.Conscrypt
 
 /**
@@ -41,26 +43,18 @@ class ConscryptPlatform private constructor() : Platform() {
       SSLContext.getInstance("TLS", provider)
 
   override fun platformTrustManager(): X509TrustManager {
-    return Conscrypt.getDefaultX509TrustManager()
+    val trustManagers = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()).apply {
+      init(null as KeyStore?)
+    }.trustManagers!!
+    check(trustManagers.size == 1 && trustManagers[0] is X509TrustManager) {
+      "Unexpected default trust managers: ${trustManagers.contentToString()}"
+    }
+    val x509TrustManager = trustManagers[0] as X509TrustManager
+    Conscrypt.setHostnameVerifier(x509TrustManager) { _, _ -> true }
+    return x509TrustManager
   }
 
-  public override fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? =
-      if (!Conscrypt.isConscrypt(sslSocketFactory)) {
-        super.trustManager(sslSocketFactory)
-      } else {
-        try {
-          // org.conscrypt.SSLParametersImpl
-          val sp = readFieldOrNull(sslSocketFactory, Any::class.java, "sslParameters")
-
-          when {
-            sp != null -> readFieldOrNull(sp, X509TrustManager::class.java, "x509TrustManager")
-            else -> null
-          }
-        } catch (e: Exception) {
-          throw UnsupportedOperationException(
-              "clientBuilder.sslSocketFactory(SSLSocketFactory) not supported on Conscrypt", e)
-        }
-      }
+  override fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? = null
 
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,
@@ -86,16 +80,11 @@ class ConscryptPlatform private constructor() : Platform() {
         super.getSelectedProtocol(sslSocket)
       }
 
-  override fun configureSslSocketFactory(socketFactory: SSLSocketFactory) {
-    if (Conscrypt.isConscrypt(socketFactory)) {
-      Conscrypt.setUseEngineSocket(socketFactory, true)
-    }
-  }
-
-  override fun configureTrustManager(trustManager: X509TrustManager?) {
-    if (Conscrypt.isConscrypt(trustManager)) {
-      // OkHttp will verify
-      Conscrypt.setHostnameVerifier(trustManager) { _, _ -> true }
+  override fun newSslSocketFactory(trustManager: X509TrustManager): SSLSocketFactory {
+    return newSSLContext().apply {
+      init(null, arrayOf<TrustManager>(trustManager), null)
+    }.socketFactory.also {
+      Conscrypt.setUseEngineSocket(it, true)
     }
   }
 


### PR DESCRIPTION
Attempting a fix for https://github.com/square/okhttp/issues/5895.  At worst it should flush out poor behavior from clients or our own edge cases.