### PR TITLE
UnsupportedOperationException from JDK8 252 onwards

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
@@ -66,9 +66,9 @@ open class Jdk9Platform : Platform() {
     val isAvailable: Boolean
 
     init {
-      val jdkVersion = System.getProperty("java.specification.version")
+      val jdkVersion: String? = System.getProperty("java.specification.version")
 
-      val majorVersion = jdkVersion.toIntOrNull()
+      val majorVersion = jdkVersion?.toIntOrNull()
 
       isAvailable = if (majorVersion != null) {
         majorVersion >= 9

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
@@ -66,8 +66,21 @@ open class Jdk9Platform : Platform() {
     val isAvailable: Boolean
 
     init {
-      val majorVersion: Int = Integer.getInteger("java.specification.version") ?: 8
-      isAvailable = majorVersion >= 9
+      val jdkVersion = System.getProperty("java.specification.version")
+
+      val majorVersion = jdkVersion.toIntOrNull()
+
+      isAvailable = if (majorVersion != null) {
+        majorVersion >= 9
+      } else {
+        try {
+          // also present on JDK8 after build 252.
+          SSLSocket::class.java.getMethod("getApplicationProtocol")
+          true
+        } catch (nsme: NoSuchMethodException) {
+          false
+        }
+      }
     }
 
     fun buildIfSupported(): Jdk9Platform? = if (isAvailable) Jdk9Platform() else null

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
@@ -40,11 +40,16 @@ open class Jdk9Platform : Platform() {
 
   @SuppressSignatureCheck
   override fun getSelectedProtocol(sslSocket: SSLSocket): String? {
-    // SSLSocket.getApplicationProtocol returns "" if application protocols values will not
-    // be used. Observed if you didn't specify SSLParameters.setApplicationProtocols
-    return when (val protocol = sslSocket.applicationProtocol) {
-      null, "" -> null
-      else -> protocol
+    try {
+      // SSLSocket.getApplicationProtocol returns "" if application protocols values will not
+      // be used. Observed if you didn't specify SSLParameters.setApplicationProtocols
+      return when (val protocol = sslSocket.applicationProtocol) {
+        null, "" -> null
+        else -> protocol
+      }
+    } catch (UnsupportedOperationException e) {
+      // https://docs.oracle.com/javase/9/docs/api/javax/net/ssl/SSLSocket.html#getApplicationProtocol--
+      return null;
     }
   }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
@@ -47,7 +47,7 @@ open class Jdk9Platform : Platform() {
         null, "" -> null
         else -> protocol
       }
-    } catch (UnsupportedOperationException e) {
+    } catch (e: UnsupportedOperationException) {
       // https://docs.oracle.com/javase/9/docs/api/javax/net/ssl/SSLSocket.html#getApplicationProtocol--
       return null;
     }

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
@@ -49,7 +49,7 @@ open class Jdk9Platform : Platform() {
       }
     } catch (e: UnsupportedOperationException) {
       // https://docs.oracle.com/javase/9/docs/api/javax/net/ssl/SSLSocket.html#getApplicationProtocol--
-      return null;
+      return null
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
@@ -55,6 +55,8 @@ public class Jdk9PlatformTest {
 
   @Test
   public void selectedProtocolIsNullWhenSslSocketThrowsExceptionForApplicationProtocol() {
+    platform.assumeJdk9();
+
     assertThat(new Jdk9Platform().getSelectedProtocol(
         new SSLSocket() {
           @Override public String getApplicationProtocol() {

--- a/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
@@ -15,6 +15,10 @@
  */
 package okhttp3.internal.platform;
 
+import java.io.IOException;
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
 import okhttp3.testing.PlatformRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,15 +26,91 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class Jdk9PlatformTest {
-  @Rule public final PlatformRule platform = new PlatformRule("jdk9");
+  @Rule public final PlatformRule platform = new PlatformRule();
 
   @Test
   public void buildsWhenJdk9() {
+    platform.assumeJdk9();
     assertThat(Jdk9Platform.Companion.buildIfSupported()).isNotNull();
   }
 
   @Test
   public void testToStringIsClassname() {
     assertThat(new Jdk9Platform().toString()).isEqualTo("Jdk9Platform");
+  }
+
+  @Test
+  public void selectedProtocolIsNullWhenSslSocketThrowsExceptionForApplicationProtocol() {
+    assertThat(new Jdk9Platform().getSelectedProtocol(
+        new SSLSocket() {
+          @Override public String getApplicationProtocol() {
+            throw new UnsupportedOperationException("Mock exception");
+          }
+
+          // Implement abstract methods.
+          @Override public String[] getSupportedCipherSuites() {
+            return new String[0];
+          }
+
+          @Override public String[] getEnabledCipherSuites() {
+            return new String[0];
+          }
+
+          @Override public void setEnabledCipherSuites(String[] suites) {
+          }
+
+          @Override public String[] getSupportedProtocols() {
+            return new String[0];
+          }
+
+          @Override public String[] getEnabledProtocols() {
+            return new String[0];
+          }
+
+          @Override public void setEnabledProtocols(String[] protocols) {
+          }
+
+          @Override public SSLSession getSession() {
+            return null;
+          }
+
+          @Override public void addHandshakeCompletedListener(HandshakeCompletedListener listener) {
+          }
+
+          @Override
+          public void removeHandshakeCompletedListener(HandshakeCompletedListener listener) {
+          }
+
+          @Override public void startHandshake() throws IOException {
+          }
+
+          @Override public void setUseClientMode(boolean mode) {
+          }
+
+          @Override public boolean getUseClientMode() {
+            return false;
+          }
+
+          @Override public void setNeedClientAuth(boolean need) {
+          }
+
+          @Override public boolean getNeedClientAuth() {
+            return false;
+          }
+
+          @Override public void setWantClientAuth(boolean want) {
+          }
+
+          @Override public boolean getWantClientAuth() {
+            return false;
+          }
+
+          @Override public void setEnableSessionCreation(boolean flag) {
+          }
+
+          @Override public boolean getEnableSessionCreation() {
+            return false;
+          }
+        })).isNull();
   }
 }

--- a/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
@@ -35,6 +35,20 @@ public class Jdk9PlatformTest {
   }
 
   @Test
+  public void buildsWhenJdk8() {
+    platform.assumeJdk8();
+
+    try {
+      SSLSocket.class.getMethod("getApplicationProtocol");
+
+      // also present on JDK8 after build 252.
+      assertThat(Jdk9Platform.Companion.buildIfSupported()).isNotNull();
+    } catch (NoSuchMethodException nsme) {
+      assertThat(Jdk9Platform.Companion.buildIfSupported()).isNull();
+    }
+  }
+
+  @Test
   public void testToStringIsClassname() {
     assertThat(new Jdk9Platform().toString()).isEqualTo("Jdk9Platform");
   }


### PR DESCRIPTION
Fix for https://github.com/square/okhttp/issues/5970

Activates Jdk9Platform on Java 8 when the new methods are present (builds 252+).  Also handles the UnsupportedOperationException.