### PR TITLE
UnsupportedOperationException from JDK8 252 onwards [3.14.x]

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
+++ b/okhttp/src/main/java/okhttp3/internal/platform/Jdk9Platform.java
@@ -64,7 +64,15 @@ final class Jdk9Platform extends Platform {
       }
 
       return protocol;
-    } catch (IllegalAccessException | InvocationTargetException e) {
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof UnsupportedOperationException) {
+        // Handle UnsupportedOperationException as it is defined in the public API
+        // https://docs.oracle.com/javase/9/docs/api/javax/net/ssl/SSLSocket.html#getApplicationProtocol--
+        return null;
+      }
+
+      throw new AssertionError("failed to get ALPN selected protocol", e);
+    } catch (IllegalAccessException e) {
       throw new AssertionError("failed to get ALPN selected protocol", e);
     }
   }
@@ -79,7 +87,7 @@ final class Jdk9Platform extends Platform {
   }
 
   public static Jdk9Platform buildIfSupported() {
-    // Find JDK 9 new methods
+    // Find JDK 9 new methods, also present on JDK8 after build 252.
     try {
       Method setProtocolMethod =
           SSLParameters.class.getMethod("setApplicationProtocols", String[].class);


### PR DESCRIPTION
Fix for #5970

This will fix the exception when throw in Azul Zulu JVM.  There is likely a fix to come from them to not throw, but this is defined in public API, so should be handled.

Will need to be backported to 3.12.x