### PR TITLE
Java Net Authenticator

### DIFF
--- a/okhttp-urlconnection/src/main/kotlin/okhttp3/JavaNetAuthenticator.kt
+++ b/okhttp-urlconnection/src/main/kotlin/okhttp3/JavaNetAuthenticator.kt
@@ -15,9 +15,9 @@
  */
 package okhttp3
 
-import okhttp3.Authenticator.Companion.JAVA_NET_AUTHENTICATOR
 import java.io.IOException
 import java.net.Authenticator
+import okhttp3.Authenticator.Companion.JAVA_NET_AUTHENTICATOR
 
 /**
  * Adapts [Authenticator] to [okhttp3.Authenticator]. Configure OkHttp to use [Authenticator] with

--- a/okhttp-urlconnection/src/main/kotlin/okhttp3/JavaNetAuthenticator.kt
+++ b/okhttp-urlconnection/src/main/kotlin/okhttp3/JavaNetAuthenticator.kt
@@ -15,11 +15,9 @@
  */
 package okhttp3
 
+import okhttp3.Authenticator.Companion.JAVA_NET_AUTHENTICATOR
 import java.io.IOException
 import java.net.Authenticator
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.net.Proxy
 
 /**
  * Adapts [Authenticator] to [okhttp3.Authenticator]. Configure OkHttp to use [Authenticator] with
@@ -27,61 +25,6 @@ import java.net.Proxy
  */
 class JavaNetAuthenticator : okhttp3.Authenticator {
   @Throws(IOException::class)
-  override fun authenticate(route: Route?, response: Response): Request? {
-    val challenges = response.challenges()
-    val request = response.request
-    val url = request.url
-    val proxyAuthorization = response.code == 407
-    val proxy = route?.proxy ?: Proxy.NO_PROXY
-
-    for (challenge in challenges) {
-      if (!"Basic".equals(challenge.scheme, ignoreCase = true)) {
-        continue
-      }
-
-      val auth = if (proxyAuthorization) {
-        val proxyAddress = proxy.address() as InetSocketAddress
-        Authenticator.requestPasswordAuthentication(
-            proxyAddress.hostName,
-            proxy.connectToInetAddress(url),
-            proxyAddress.port,
-            url.scheme,
-            challenge.realm,
-            challenge.scheme,
-            url.toUrl(),
-            Authenticator.RequestorType.PROXY
-        )
-      } else {
-        Authenticator.requestPasswordAuthentication(
-            url.host,
-            proxy.connectToInetAddress(url),
-            url.port,
-            url.scheme,
-            challenge.realm,
-            challenge.scheme,
-            url.toUrl(),
-            Authenticator.RequestorType.SERVER
-        )
-      }
-
-      if (auth != null) {
-        val credentialHeader = if (proxyAuthorization) "Proxy-Authorization" else "Authorization"
-        val credential = Credentials.basic(
-            auth.userName, String(auth.password), challenge.charset)
-        return request.newBuilder()
-            .header(credentialHeader, credential)
-            .build()
-      }
-    }
-
-    return null // No challenges were satisfied!
-  }
-
-  @Throws(IOException::class)
-  private fun Proxy.connectToInetAddress(url: HttpUrl): InetAddress {
-    return when {
-      type() == Proxy.Type.DIRECT -> InetAddress.getByName(url.host)
-      else -> (address() as InetSocketAddress).address
-    }
-  }
+  override fun authenticate(route: Route?, response: Response): Request? =
+    JAVA_NET_AUTHENTICATOR.authenticate(route, response)
 }

--- a/okhttp/src/main/kotlin/okhttp3/Authenticator.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Authenticator.kt
@@ -116,7 +116,7 @@ interface Authenticator {
       override fun authenticate(route: Route?, response: Response): Request? = null
     }
 
-    /** An authenticator that knows no credentials and makes no attempt to authenticate. */
+    /** An authenticator that uses the java.net.Authenticator global authenticator. */
     @JvmField
     val JAVA_NET_AUTHENTICATOR: Authenticator = JavaNetAuthenticator()
   }

--- a/okhttp/src/main/kotlin/okhttp3/Authenticator.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Authenticator.kt
@@ -15,8 +15,8 @@
  */
 package okhttp3
 
-import okhttp3.internal.authenticator.JavaNetAuthenticator
 import java.io.IOException
+import okhttp3.internal.authenticator.JavaNetAuthenticator
 
 /**
  * Performs either **preemptive** authentication before connecting to a proxy server, or

--- a/okhttp/src/main/kotlin/okhttp3/Authenticator.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Authenticator.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3
 
+import okhttp3.internal.authenticator.JavaNetAuthenticator
 import java.io.IOException
 
 /**
@@ -114,5 +115,9 @@ interface Authenticator {
     private class AuthenticatorNone : Authenticator {
       override fun authenticate(route: Route?, response: Response): Request? = null
     }
+
+    /** An authenticator that knows no credentials and makes no attempt to authenticate. */
+    @JvmField
+    val JAVA_NET_AUTHENTICATOR: Authenticator = JavaNetAuthenticator()
   }
 }

--- a/okhttp/src/main/kotlin/okhttp3/internal/authenticator/JavaNetAuthenticator.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/authenticator/JavaNetAuthenticator.kt
@@ -16,6 +16,7 @@
 package okhttp3.internal.authenticator
 
 import okhttp3.Credentials
+import okhttp3.Dns
 import okhttp3.HttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -30,7 +31,7 @@ import java.net.Proxy
  * Adapts [Authenticator] to [okhttp3.Authenticator]. Configure OkHttp to use [Authenticator] with
  * [OkHttpClient.Builder.authenticator] or [OkHttpClient.Builder.proxyAuthenticator].
  */
-class JavaNetAuthenticator : okhttp3.Authenticator {
+class JavaNetAuthenticator(private val defaultDns: Dns = Dns.SYSTEM) : okhttp3.Authenticator {
   @Throws(IOException::class)
   override fun authenticate(route: Route?, response: Response): Request? {
     val challenges = response.challenges()
@@ -44,11 +45,12 @@ class JavaNetAuthenticator : okhttp3.Authenticator {
         continue
       }
 
+      val dns = route?.address?.dns ?: defaultDns
       val auth = if (proxyAuthorization) {
         val proxyAddress = proxy.address() as InetSocketAddress
         Authenticator.requestPasswordAuthentication(
             proxyAddress.hostName,
-            proxy.connectToInetAddress(url),
+            proxy.connectToInetAddress(url, dns),
             proxyAddress.port,
             url.scheme,
             challenge.realm,
@@ -59,7 +61,7 @@ class JavaNetAuthenticator : okhttp3.Authenticator {
       } else {
         Authenticator.requestPasswordAuthentication(
             url.host,
-            proxy.connectToInetAddress(url),
+            proxy.connectToInetAddress(url, dns),
             url.port,
             url.scheme,
             challenge.realm,
@@ -83,9 +85,9 @@ class JavaNetAuthenticator : okhttp3.Authenticator {
   }
 
   @Throws(IOException::class)
-  private fun Proxy.connectToInetAddress(url: HttpUrl): InetAddress {
-    return when {
-      type() == Proxy.Type.DIRECT -> InetAddress.getByName(url.host)
+  private fun Proxy.connectToInetAddress(url: HttpUrl, dns: Dns): InetAddress {
+    return when(type()) {
+      Proxy.Type.DIRECT -> dns.lookup(url.host).first()
       else -> (address() as InetSocketAddress).address
     }
   }

--- a/okhttp/src/main/kotlin/okhttp3/internal/authenticator/JavaNetAuthenticator.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/authenticator/JavaNetAuthenticator.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.authenticator
+
+import okhttp3.Credentials
+import okhttp3.HttpUrl
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import java.io.IOException
+import java.net.Authenticator
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+
+/**
+ * Adapts [Authenticator] to [okhttp3.Authenticator]. Configure OkHttp to use [Authenticator] with
+ * [OkHttpClient.Builder.authenticator] or [OkHttpClient.Builder.proxyAuthenticator].
+ */
+class JavaNetAuthenticator : okhttp3.Authenticator {
+  @Throws(IOException::class)
+  override fun authenticate(route: Route?, response: Response): Request? {
+    val challenges = response.challenges()
+    val request = response.request
+    val url = request.url
+    val proxyAuthorization = response.code == 407
+    val proxy = route?.proxy ?: Proxy.NO_PROXY
+
+    for (challenge in challenges) {
+      if (!"Basic".equals(challenge.scheme, ignoreCase = true)) {
+        continue
+      }
+
+      val auth = if (proxyAuthorization) {
+        val proxyAddress = proxy.address() as InetSocketAddress
+        Authenticator.requestPasswordAuthentication(
+            proxyAddress.hostName,
+            proxy.connectToInetAddress(url),
+            proxyAddress.port,
+            url.scheme,
+            challenge.realm,
+            challenge.scheme,
+            url.toUrl(),
+            Authenticator.RequestorType.PROXY
+        )
+      } else {
+        Authenticator.requestPasswordAuthentication(
+            url.host,
+            proxy.connectToInetAddress(url),
+            url.port,
+            url.scheme,
+            challenge.realm,
+            challenge.scheme,
+            url.toUrl(),
+            Authenticator.RequestorType.SERVER
+        )
+      }
+
+      if (auth != null) {
+        val credentialHeader = if (proxyAuthorization) "Proxy-Authorization" else "Authorization"
+        val credential = Credentials.basic(
+            auth.userName, String(auth.password), challenge.charset)
+        return request.newBuilder()
+            .header(credentialHeader, credential)
+            .build()
+      }
+    }
+
+    return null // No challenges were satisfied!
+  }
+
+  @Throws(IOException::class)
+  private fun Proxy.connectToInetAddress(url: HttpUrl): InetAddress {
+    return when {
+      type() == Proxy.Type.DIRECT -> InetAddress.getByName(url.host)
+      else -> (address() as InetSocketAddress).address
+    }
+  }
+}

--- a/okhttp/src/main/kotlin/okhttp3/internal/authenticator/JavaNetAuthenticator.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/authenticator/JavaNetAuthenticator.kt
@@ -15,17 +15,17 @@
  */
 package okhttp3.internal.authenticator
 
+import java.io.IOException
+import java.net.Authenticator
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
 import okhttp3.Credentials
 import okhttp3.Dns
 import okhttp3.HttpUrl
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
-import java.io.IOException
-import java.net.Authenticator
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.net.Proxy
 
 /**
  * Adapts [Authenticator] to [okhttp3.Authenticator]. Configure OkHttp to use [Authenticator] with
@@ -86,7 +86,7 @@ class JavaNetAuthenticator(private val defaultDns: Dns = Dns.SYSTEM) : okhttp3.A
 
   @Throws(IOException::class)
   private fun Proxy.connectToInetAddress(url: HttpUrl, dns: Dns): InetAddress {
-    return when(type()) {
+    return when (type()) {
       Proxy.Type.DIRECT -> dns.lookup(url.host).first()
       else -> (address() as InetSocketAddress).address
     }

--- a/okhttp/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp/src/test/java/okhttp3/URLConnectionTest.java
@@ -1024,7 +1024,7 @@ public final class URLConnectionTest {
         .setBody("A"));
 
     client = client.newBuilder()
-        .proxyAuthenticator(new JavaNetAuthenticator())
+        .proxyAuthenticator(okhttp3.Authenticator.JAVA_NET_AUTHENTICATOR)
         .proxy(server.toProxyAddress())
         .sslSocketFactory(
             handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager())

--- a/okhttp/src/test/java/okhttp3/internal/authenticator/JavaNetAuthenticatorTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/authenticator/JavaNetAuthenticatorTest.kt
@@ -1,0 +1,74 @@
+package okhttp3.internal.authenticator
+
+import okhttp3.Address
+import okhttp3.CertificatePinner
+import okhttp3.ConnectionSpec
+import okhttp3.FakeDns
+import okhttp3.Protocol.HTTP_1_1
+import okhttp3.Protocol.HTTP_2
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import okhttp3.internal.RecordingAuthenticator
+import okhttp3.internal.proxy.NullProxySelector
+import okhttp3.internal.tls.OkHostnameVerifier
+import okhttp3.tls.internal.TlsUtil
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import java.net.Authenticator
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+import javax.net.SocketFactory
+
+// Most tests from URLConnectionTest
+class JavaNetAuthenticatorTest {
+  var authenticator = JavaNetAuthenticator()
+
+  val fakeDns = FakeDns()
+
+  val recordingAuthenticator = RecordingAuthenticator()
+
+  @Before
+  fun setup() {
+    Authenticator.setDefault(recordingAuthenticator)
+  }
+
+  @After
+  fun tearDown() {
+    Authenticator.setDefault(null)
+  }
+
+  @Test
+  fun testBasicAuth() {
+    fakeDns["server"] = listOf(InetAddress.getLocalHost())
+
+    val address = Address(
+        "server", 443, fakeDns, SocketFactory.getDefault(), TlsUtil.localhost()
+        .sslSocketFactory(), OkHostnameVerifier, CertificatePinner.DEFAULT,
+        okhttp3.Authenticator.NONE, Proxy.NO_PROXY, listOf(HTTP_1_1),
+        listOf(ConnectionSpec.MODERN_TLS), NullProxySelector
+    )
+    val route = Route(address, Proxy.NO_PROXY, InetSocketAddress.createUnresolved("server", 443))
+
+    val request = Request.Builder()
+        .url("https://server/robots.txt")
+        .build()
+    val response = Response.Builder()
+        .request(request)
+        .code(401)
+        .header("WWW-Authenticate", "Basic realm=\"User Visible Realm\"")
+        .protocol(HTTP_2)
+        .message("Unauthorized")
+        .build()
+    val authRequest = authenticator.authenticate(route, response)
+
+    assertNotNull(authRequest)
+    assertEquals(
+        "Basic ${RecordingAuthenticator.BASE_64_CREDENTIALS}", authRequest!!.header("Authorization")
+    )
+  }
+}

--- a/okhttp/src/test/java/okhttp3/internal/authenticator/JavaNetAuthenticatorTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/authenticator/JavaNetAuthenticatorTest.kt
@@ -1,5 +1,10 @@
 package okhttp3.internal.authenticator
 
+import java.net.Authenticator
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+import javax.net.SocketFactory
 import okhttp3.Address
 import okhttp3.CertificatePinner
 import okhttp3.ConnectionSpec
@@ -18,11 +23,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
-import java.net.Authenticator
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.net.Proxy
-import javax.net.SocketFactory
 
 // Most tests from URLConnectionTest
 class JavaNetAuthenticatorTest {

--- a/okhttp/src/test/java/okhttp3/internal/authenticator/JavaNetAuthenticatorTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/authenticator/JavaNetAuthenticatorTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okhttp3.internal.authenticator
 
 import java.net.Authenticator
@@ -5,6 +20,7 @@ import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Proxy
 import javax.net.SocketFactory
+import junit.framework.TestCase.assertNull
 import okhttp3.Address
 import okhttp3.CertificatePinner
 import okhttp3.ConnectionSpec
@@ -20,7 +36,6 @@ import okhttp3.internal.tls.OkHostnameVerifier
 import okhttp3.tls.internal.TlsUtil
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 
@@ -66,9 +81,26 @@ class JavaNetAuthenticatorTest {
         .build()
     val authRequest = authenticator.authenticate(route, response)
 
-    assertNotNull(authRequest)
     assertEquals(
         "Basic ${RecordingAuthenticator.BASE_64_CREDENTIALS}", authRequest!!.header("Authorization")
     )
+  }
+
+  @Test
+  fun noSupportForNonBasicAuth() {
+    val request = Request.Builder()
+        .url("https://server/robots.txt")
+        .build()
+
+    val response = Response.Builder()
+        .request(request)
+        .code(401)
+        .header("WWW-Authenticate", "UnsupportedScheme realm=\"User Visible Realm\"")
+        .protocol(HTTP_2)
+        .message("Unauthorized")
+        .build()
+
+    val authRequest = authenticator.authenticate(null, response)
+    assertNull(authRequest)
   }
 }


### PR DESCRIPTION
Refactor the okhttp-urlconnection implementation.  Available as 

```
client.newBuilder()
        .proxyAuthenticator(okhttp3.Authenticator.JAVA_NET_AUTHENTICATOR)
        .build()
```