### PR TITLE
Refactor Jdk9PlatformTest by using DelegatingSSLSocket

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/platform/Jdk9PlatformTest.java
@@ -15,10 +15,8 @@
  */
 package okhttp3.internal.platform;
 
-import java.io.IOException;
-import javax.net.ssl.HandshakeCompletedListener;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
+import okhttp3.DelegatingSSLSocket;
 import okhttp3.testing.PlatformRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,76 +55,12 @@ public class Jdk9PlatformTest {
   public void selectedProtocolIsNullWhenSslSocketThrowsExceptionForApplicationProtocol() {
     platform.assumeJdk9();
 
-    assertThat(new Jdk9Platform().getSelectedProtocol(
-        new SSLSocket() {
-          @Override public String getApplicationProtocol() {
-            throw new UnsupportedOperationException("Mock exception");
-          }
+    DelegatingSSLSocket applicationProtocolUnsupported = new DelegatingSSLSocket(null) {
+      @Override public String getApplicationProtocol() {
+        throw new UnsupportedOperationException("Mock exception");
+      }
+    };
 
-          // Implement abstract methods.
-          @Override public String[] getSupportedCipherSuites() {
-            return new String[0];
-          }
-
-          @Override public String[] getEnabledCipherSuites() {
-            return new String[0];
-          }
-
-          @Override public void setEnabledCipherSuites(String[] suites) {
-          }
-
-          @Override public String[] getSupportedProtocols() {
-            return new String[0];
-          }
-
-          @Override public String[] getEnabledProtocols() {
-            return new String[0];
-          }
-
-          @Override public void setEnabledProtocols(String[] protocols) {
-          }
-
-          @Override public SSLSession getSession() {
-            return null;
-          }
-
-          @Override public void addHandshakeCompletedListener(HandshakeCompletedListener listener) {
-          }
-
-          @Override
-          public void removeHandshakeCompletedListener(HandshakeCompletedListener listener) {
-          }
-
-          @Override public void startHandshake() throws IOException {
-          }
-
-          @Override public void setUseClientMode(boolean mode) {
-          }
-
-          @Override public boolean getUseClientMode() {
-            return false;
-          }
-
-          @Override public void setNeedClientAuth(boolean need) {
-          }
-
-          @Override public boolean getNeedClientAuth() {
-            return false;
-          }
-
-          @Override public void setWantClientAuth(boolean want) {
-          }
-
-          @Override public boolean getWantClientAuth() {
-            return false;
-          }
-
-          @Override public void setEnableSessionCreation(boolean flag) {
-          }
-
-          @Override public boolean getEnableSessionCreation() {
-            return false;
-          }
-        })).isNull();
+    assertThat(new Jdk9Platform().getSelectedProtocol(applicationProtocolUnsupported)).isNull();
   }
 }


### PR DESCRIPTION
Cont. https://github.com/square/okhttp/pull/5972

We can use `DelegatingSSLSocket` instead of overriding `SSLSocket` abstract class.
Ref. https://github.com/square/okhttp/pull/5972#discussion_r414232090