### PR TITLE
Fix Kdoc class path with full package path in JavaNetAuthenticator

### DIFF
--- a/okhttp-urlconnection/src/main/kotlin/okhttp3/JavaNetAuthenticator.kt
+++ b/okhttp-urlconnection/src/main/kotlin/okhttp3/JavaNetAuthenticator.kt
@@ -21,7 +21,7 @@ import okhttp3.Authenticator.Companion.JAVA_NET_AUTHENTICATOR
 
 /**
  * Adapts [Authenticator] to [okhttp3.Authenticator]. Configure OkHttp to use [Authenticator] with
- * [OkHttpClient.Builder.authenticator] or [OkHttpClient.Builder.proxyAuthenticator].
+ * [okhttp3.OkHttpClient.Builder.authenticator] or [okhttp3.OkHttpClient.Builder.proxyAuthenticator].
  */
 class JavaNetAuthenticator : okhttp3.Authenticator {
   @Throws(IOException::class)

--- a/okhttp/src/main/kotlin/okhttp3/internal/authenticator/JavaNetAuthenticator.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/authenticator/JavaNetAuthenticator.kt
@@ -29,7 +29,7 @@ import okhttp3.Route
 
 /**
  * Adapts [Authenticator] to [okhttp3.Authenticator]. Configure OkHttp to use [Authenticator] with
- * [OkHttpClient.Builder.authenticator] or [OkHttpClient.Builder.proxyAuthenticator].
+ * [okhttp3.OkHttpClient.Builder.authenticator] or [okhttp3.OkHttpClient.Builder.proxyAuthenticator].
  */
 class JavaNetAuthenticator(private val defaultDns: Dns = Dns.SYSTEM) : okhttp3.Authenticator {
   @Throws(IOException::class)


### PR DESCRIPTION
Since Kdoc needs a full path to Kotliln class/function, we'll add 'okhttp3' prefix.