### PR TITLE
Complies with rfc7231 about statuses 307 and 308

### DIFF
--- a/okhttp/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp/src/test/java/okhttp3/URLConnectionTest.java
@@ -2396,17 +2396,8 @@ public final class URLConnectionTest {
       assertThat(responseString).isEqualTo("Page 2");
     } else if (method.equals("HEAD")) {
       assertThat(responseString).isEqualTo("");
-    } else {
-      // Methods other than GET/HEAD shouldn't follow the redirect.
-      if (method.equals("POST")) {
-        assertThat(page1.getBody().readUtf8()).isEqualTo("ABCD");
-      }
-      assertThat(server.getRequestCount()).isEqualTo(1);
-      assertThat(responseString).isEqualTo("This page has moved!");
-      return;
     }
 
-    // GET/HEAD requests should have followed the redirect with the same method.
     assertThat(server.getRequestCount()).isEqualTo(2);
     RecordedRequest page2 = server.takeRequest();
     assertThat(page2.getRequestLine()).isEqualTo((method + " /page2 HTTP/1.1"));

--- a/okhttp/src/test/java/okhttp3/URLConnectionTest.java
+++ b/okhttp/src/test/java/okhttp3/URLConnectionTest.java
@@ -78,7 +78,6 @@ import okio.BufferedSource;
 import okio.GzipSink;
 import okio.Okio;
 import okio.Utf8;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
@@ -2371,13 +2370,13 @@ public final class URLConnectionTest {
   }
 
   class RevertInterceptor implements Interceptor {
-    @NotNull @Override public Response intercept(@NotNull Chain chain) throws IOException {
+    @Override public Response intercept(Chain chain) throws IOException {
       Response response = chain.proceed(chain.request());
 
       return remapResponse(response);
     }
 
-    @NotNull private Response remapResponse(Response response) {
+    private Response remapResponse(Response response) {
       if (response.request().method().equals("POST") && (response.code() == HTTP_TEMP_REDIRECT || response.code() == HTTP_PERM_REDIRECT)) {
         // special response code to indicate custom rules
         return response.newBuilder().code(response.code() + 10).build();


### PR DESCRIPTION
Fix for #2874 #3111 and #4229

https://tools.ietf.org/html/rfc7231#page-58

> 6.4.7.  307 Temporary Redirect
> 
>    The 307 (Temporary Redirect) status code indicates that the target
>    resource resides temporarily under a different URI and the user agent
>    MUST NOT change the request method if it performs an automatic
>    redirection to that URI.  Since the redirection can change over time,
>    the client ought to continue using the original effective request URI
>    for future requests.

> The user agent MAY
>    use the Location field value for automatic redirection.

https://tools.ietf.org/html/rfc7238

> The user agent MAY use the Location field
>    value for automatic redirection.

> Note: This status code is similar to 301 (Moved Permanently)
> ([RFC7231], Section 6.4.2), except that it does not allow changing
> the request method from POST to GET.