### PR TITLE
Add an API to look up media type parameters

### DIFF
--- a/okhttp/src/test/java/okhttp3/MediaTypeTest.java
+++ b/okhttp/src/test/java/okhttp3/MediaTypeTest.java
@@ -16,7 +16,6 @@
  */
 package okhttp3;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import org.junit.Test;
@@ -138,6 +137,14 @@ public class MediaTypeTest {
     assertThat(mediaType.type()).isEqualTo("text");
     assertThat(mediaType.subtype()).isEqualTo("plain");
     assertThat(mediaType.charset().name()).isEqualTo("UTF-8");
+    assertThat(mediaType.parameter("charset")).isEqualTo("utf-8");
+    assertThat(mediaType.parameter("a")).isEqualTo("1");
+    assertThat(mediaType.parameter("b")).isEqualTo("2");
+    assertThat(mediaType.parameter("c")).isEqualTo("3");
+    assertThat(mediaType.parameter("CHARSET")).isEqualTo("utf-8");
+    assertThat(mediaType.parameter("A")).isEqualTo("1");
+    assertThat(mediaType.parameter("B")).isEqualTo("2");
+    assertThat(mediaType.parameter("C")).isEqualTo("3");
   }
 
   @Test public void testCharsetAndQuoting() throws Exception {
@@ -151,9 +158,9 @@ public class MediaTypeTest {
     assertThat(mediaType.charset().name()).isEqualTo("UTF-8");
   }
 
-  @Test public void testMultipleCharsets() {
-    assertInvalid("text/plain; charset=utf-8; charset=utf-16",
-        "Multiple charsets defined: \"utf-8\" and: \"utf-16\" for: \"text/plain; charset=utf-8; charset=utf-16\"");
+  @Test public void testMultipleCharsetsReturnsFirstMatch() {
+    MediaType mediaType = parse("text/plain; charset=utf-8; charset=utf-16");
+    assertThat(mediaType.charset().name()).isEqualTo("UTF-8");
   }
 
   @Test public void testIllegalCharsetName() {
@@ -201,6 +208,26 @@ public class MediaTypeTest {
     assertThat(mediaType.subtype()).isEqualTo("plain");
     assertThat(mediaType.charset()).isNull();
     assertThat(mediaType.toString()).isEqualTo("text/plain;");
+  }
+
+  @Test public void testParameter() throws Exception {
+    MediaType mediaType = parse("multipart/mixed; boundary=\"abcd\"");
+    assertThat(mediaType.parameter("boundary")).isEqualTo("abcd");
+    assertThat(mediaType.parameter("BOUNDARY")).isEqualTo("abcd");
+  }
+
+  @Test public void testMultipleParameters() throws Exception {
+    MediaType mediaType = parse(
+        "Message/Partial; number=2; total=3; id=\"oc=abc@example.com\"");
+    assertThat(mediaType.parameter("number")).isEqualTo("2");
+    assertThat(mediaType.parameter("total")).isEqualTo("3");
+    assertThat(mediaType.parameter("id")).isEqualTo("oc=abc@example.com");
+    assertThat(mediaType.parameter("foo")).isNull();
+  }
+
+  @Test public void testRepeatedParameter() throws Exception {
+    MediaType mediaType = parse("multipart/mixed; number=2; number=3");
+    assertThat(mediaType.parameter("number")).isEqualTo("2");
   }
 
   private void assertMediaType(String string) {


### PR DESCRIPTION
This changes our behavior for repeated charsets. Previously we would
crash; now we return the first value.