### PR TITLE
Cache Events

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/CallEvent.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/CallEvent.kt
@@ -205,7 +205,7 @@ sealed class CallEvent {
     val ioe: IOException
   ) : CallEvent()
 
-  data class CacheFailure(
+  data class SatisfactionFailure(
     override val timestampNs: Long,
     override val call: Call
   ) : CallEvent()
@@ -216,6 +216,11 @@ sealed class CallEvent {
   ) : CallEvent()
 
   data class CacheMiss(
+    override val timestampNs: Long,
+    override val call: Call
+  ) : CallEvent()
+
+  data class CacheConditionalHit(
     override val timestampNs: Long,
     override val call: Call
   ) : CallEvent()

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/CallEvent.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/CallEvent.kt
@@ -204,4 +204,19 @@ sealed class CallEvent {
     override val call: Call,
     val ioe: IOException
   ) : CallEvent()
+
+  data class CacheFailed(
+    override val timestampNs: Long,
+    override val call: Call
+  ) : CallEvent()
+
+  data class CacheHit(
+    override val timestampNs: Long,
+    override val call: Call
+  ) : CallEvent()
+
+  data class CacheMiss(
+    override val timestampNs: Long,
+    override val call: Call
+  ) : CallEvent()
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/CallEvent.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/CallEvent.kt
@@ -205,7 +205,7 @@ sealed class CallEvent {
     val ioe: IOException
   ) : CallEvent()
 
-  data class CacheFailed(
+  data class CacheFailure(
     override val timestampNs: Long,
     override val call: Call
   ) : CallEvent()

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
@@ -259,10 +259,10 @@ class ClientRuleEventListener(
     delegate.cacheHit(call, response)
   }
 
-  override fun cacheConditionalHit(call: Call, response: Response) {
+  override fun cacheConditionalHit(call: Call, cachedResponse: Response) {
     logWithTime("cacheConditionalHit")
 
-    delegate.cacheConditionalHit(call, response)
+    delegate.cacheConditionalHit(call, cachedResponse)
   }
 
   private fun logWithTime(message: String) {

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
@@ -241,6 +241,24 @@ class ClientRuleEventListener(
     delegate.canceled(call)
   }
 
+  override fun cacheFailure(call: Call, response: Response) {
+    logWithTime("cacheFailure")
+
+    delegate.cacheFailure(call, response)
+  }
+
+  override fun cacheMiss(call: Call, response: Response) {
+    logWithTime("cacheMiss")
+
+    delegate.cacheMiss(call, response)
+  }
+
+  override fun cacheHit(call: Call, response: Response) {
+    logWithTime("cacheHit")
+
+    delegate.cacheHit(call, response)
+  }
+
   private fun logWithTime(message: String) {
     val timeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs)
     logger.invoke("[$timeMs ms] $message")

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
@@ -241,22 +241,28 @@ class ClientRuleEventListener(
     delegate.canceled(call)
   }
 
-  override fun cacheFailure(call: Call, response: Response) {
-    logWithTime("cacheFailure")
+  override fun satisfactionFailure(call: Call, response: Response) {
+    logWithTime("satisfactionFailure")
 
-    delegate.cacheFailure(call, response)
+    delegate.satisfactionFailure(call, response)
   }
 
-  override fun cacheMiss(call: Call, response: Response) {
+  override fun cacheMiss(call: Call) {
     logWithTime("cacheMiss")
 
-    delegate.cacheMiss(call, response)
+    delegate.cacheMiss(call)
   }
 
   override fun cacheHit(call: Call, response: Response) {
     logWithTime("cacheHit")
 
     delegate.cacheHit(call, response)
+  }
+
+  override fun cacheConditionalHit(call: Call, response: Response) {
+    logWithTime("cacheConditionalHit")
+
+    delegate.cacheConditionalHit(call, response)
   }
 
   private fun logWithTime(message: String) {

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
@@ -22,7 +22,7 @@ import java.net.Proxy
 import java.util.Deque
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.TimeUnit
-import okhttp3.CallEvent.CacheFailure
+import okhttp3.CallEvent.CacheConditionalHit
 import okhttp3.CallEvent.CacheHit
 import okhttp3.CallEvent.CacheMiss
 import okhttp3.CallEvent.CallEnd
@@ -48,6 +48,7 @@ import okhttp3.CallEvent.ResponseBodyStart
 import okhttp3.CallEvent.ResponseFailed
 import okhttp3.CallEvent.ResponseHeadersEnd
 import okhttp3.CallEvent.ResponseHeadersStart
+import okhttp3.CallEvent.SatisfactionFailure
 import okhttp3.CallEvent.SecureConnectEnd
 import okhttp3.CallEvent.SecureConnectStart
 import org.assertj.core.api.Assertions.assertThat
@@ -264,18 +265,20 @@ open class RecordingEventListener : EventListener() {
     call: Call
   ) = logEvent(Canceled(System.nanoTime(), call))
 
-  override fun cacheFailure(
+  override fun satisfactionFailure(
     call: Call,
     response: Response
-  ) = logEvent(CacheFailure(System.nanoTime(), call))
+  ) = logEvent(SatisfactionFailure(System.nanoTime(), call))
 
   override fun cacheMiss(
-    call: Call,
-    response: Response
+    call: Call
   ) = logEvent(CacheMiss(System.nanoTime(), call))
 
   override fun cacheHit(
     call: Call,
     response: Response
   ) = logEvent(CacheHit(System.nanoTime(), call))
+
+  override fun cacheConditionalHit(call: Call, response: Response) =
+    logEvent(CacheConditionalHit(System.nanoTime(), call))
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
@@ -22,6 +22,9 @@ import java.net.Proxy
 import java.util.Deque
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.TimeUnit
+import okhttp3.CallEvent.CacheFailed
+import okhttp3.CallEvent.CacheHit
+import okhttp3.CallEvent.CacheMiss
 import okhttp3.CallEvent.CallEnd
 import okhttp3.CallEvent.CallFailed
 import okhttp3.CallEvent.CallStart
@@ -260,4 +263,19 @@ open class RecordingEventListener : EventListener() {
   override fun canceled(
     call: Call
   ) = logEvent(Canceled(System.nanoTime(), call))
+
+  override fun cacheFailure(
+    call: Call,
+    response: Response
+  ) = logEvent(CacheFailed(System.nanoTime(), call))
+
+  override fun cacheMiss(
+    call: Call,
+    response: Response
+  ) = logEvent(CacheMiss(System.nanoTime(), call))
+
+  override fun cacheHit(
+    call: Call,
+    response: Response
+  ) = logEvent(CacheHit(System.nanoTime(), call))
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
@@ -15,6 +15,13 @@
  */
 package okhttp3
 
+import java.io.IOException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.util.Deque
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.TimeUnit
 import okhttp3.CallEvent.CacheFailure
 import okhttp3.CallEvent.CacheHit
 import okhttp3.CallEvent.CacheMiss
@@ -46,13 +53,6 @@ import okhttp3.CallEvent.SecureConnectStart
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
 import org.junit.Assert.assertTrue
-import java.io.IOException
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.net.Proxy
-import java.util.Deque
-import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.concurrent.TimeUnit
 
 open class RecordingEventListener : EventListener() {
   val eventSequence: Deque<CallEvent> = ConcurrentLinkedDeque()

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
@@ -15,14 +15,7 @@
  */
 package okhttp3
 
-import java.io.IOException
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.net.Proxy
-import java.util.Deque
-import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.concurrent.TimeUnit
-import okhttp3.CallEvent.CacheFailed
+import okhttp3.CallEvent.CacheFailure
 import okhttp3.CallEvent.CacheHit
 import okhttp3.CallEvent.CacheMiss
 import okhttp3.CallEvent.CallEnd
@@ -53,6 +46,13 @@ import okhttp3.CallEvent.SecureConnectStart
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
 import org.junit.Assert.assertTrue
+import java.io.IOException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.util.Deque
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.TimeUnit
 
 open class RecordingEventListener : EventListener() {
   val eventSequence: Deque<CallEvent> = ConcurrentLinkedDeque()
@@ -267,7 +267,7 @@ open class RecordingEventListener : EventListener() {
   override fun cacheFailure(
     call: Call,
     response: Response
-  ) = logEvent(CacheFailed(System.nanoTime(), call))
+  ) = logEvent(CacheFailure(System.nanoTime(), call))
 
   override fun cacheMiss(
     call: Call,

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
@@ -279,6 +279,6 @@ open class RecordingEventListener : EventListener() {
     response: Response
   ) = logEvent(CacheHit(System.nanoTime(), call))
 
-  override fun cacheConditionalHit(call: Call, response: Response) =
+  override fun cacheConditionalHit(call: Call, cachedResponse: Response) =
     logEvent(CacheConditionalHit(System.nanoTime(), call))
 }

--- a/okhttp/src/main/kotlin/okhttp3/EventListener.kt
+++ b/okhttp/src/main/kotlin/okhttp3/EventListener.kt
@@ -422,6 +422,28 @@ abstract class EventListener {
   ) {
   }
 
+  /**
+   * Invoked when a call fails due to cache rules. e.g. onlyIfCached and no cache entry.
+   */
+  open fun cacheFailure(call: Call, response: Response) {
+  }
+
+  /**
+   * Invoked when a result is served from the cache. n.b The response should be used
+   * to determine exactly how the cache came to be used, e.g. with a conditional cache response
+   * from the network.
+   */
+  open fun cacheMiss(call: Call, response: Response) {
+  }
+
+  /**
+   * Invoked when a response is served from the network. n.b The response should be used
+   * to determine exactly how the cache came to be used, e.g. with a conditional cache response
+   * from the network.
+   */
+  open fun cacheHit(call: Call, response: Response) {
+  }
+
   interface Factory {
     /**
      * Creates an instance of the [EventListener] for a particular [Call]. The returned

--- a/okhttp/src/main/kotlin/okhttp3/EventListener.kt
+++ b/okhttp/src/main/kotlin/okhttp3/EventListener.kt
@@ -430,19 +430,19 @@ abstract class EventListener {
   }
 
   /**
-   * Invoked when a result is served from the cache. The Response is provided since there may
-   * not be the normal event sequences received.
+   * Invoked when a result is served from the cache. The Response provided is the top level
+   * Response and normal event sequences will not be received.
    *
-   * Events will only be received when a Cache is configured for the client.
+   * This event will only be received when a Cache is configured for the client.
    */
   open fun cacheHit(call: Call, response: Response) {
   }
 
   /**
    * Invoked when a response will be served from the network. The Response will be
-   * available via following events.
+   * available from normal event sequences.
    *
-   * Events will only be received when a Cache is configured for the client.
+   * This event will only be received when a Cache is configured for the client.
    */
   open fun cacheMiss(call: Call) {
   }
@@ -452,7 +452,7 @@ abstract class EventListener {
    * cached Response freshness. Will be followed by cacheHit or cacheMiss after the network
    * Response is available.
    *
-   * Events will only be received when a Cache is configured for the client.
+   * This event will only be received when a Cache is configured for the client.
    */
   open fun cacheConditionalHit(call: Call, cachedResponse: Response) {
   }

--- a/okhttp/src/main/kotlin/okhttp3/EventListener.kt
+++ b/okhttp/src/main/kotlin/okhttp3/EventListener.kt
@@ -430,9 +430,8 @@ abstract class EventListener {
   }
 
   /**
-   * Invoked when a result is served from the cache. n.b The response should be used
-   * to determine exactly how the cache came to be used, e.g. with a conditional cache response
-   * from the network.
+   * Invoked when a result is served from the cache. The Response is provided since their may
+   * not be the normal event sequences received.
    *
    * Events will only be received when a Cache is configured for the client.
    */

--- a/okhttp/src/main/kotlin/okhttp3/EventListener.kt
+++ b/okhttp/src/main/kotlin/okhttp3/EventListener.kt
@@ -424,6 +424,8 @@ abstract class EventListener {
 
   /**
    * Invoked when a call fails due to cache rules. e.g. onlyIfCached and no cache entry.
+   *
+   * Events will only be received when a Cache is configured for the client.
    */
   open fun cacheFailure(call: Call, response: Response) {
   }
@@ -432,6 +434,8 @@ abstract class EventListener {
    * Invoked when a result is served from the cache. n.b The response should be used
    * to determine exactly how the cache came to be used, e.g. with a conditional cache response
    * from the network.
+   *
+   * Events will only be received when a Cache is configured for the client.
    */
   open fun cacheMiss(call: Call, response: Response) {
   }
@@ -440,6 +444,8 @@ abstract class EventListener {
    * Invoked when a response is served from the network. n.b The response should be used
    * to determine exactly how the cache came to be used, e.g. with a conditional cache response
    * from the network.
+   *
+   * Events will only be received when a Cache is configured for the client.
    */
   open fun cacheHit(call: Call, response: Response) {
   }

--- a/okhttp/src/main/kotlin/okhttp3/EventListener.kt
+++ b/okhttp/src/main/kotlin/okhttp3/EventListener.kt
@@ -423,11 +423,10 @@ abstract class EventListener {
   }
 
   /**
-   * Invoked when a call fails due to cache rules. e.g. onlyIfCached and no cache entry.
-   *
-   * Events will only be received when a Cache is configured for the client.
+   * Invoked when a call fails due to cache rules.
+   * For example, we're forbidden from using the network and the cache is insufficient
    */
-  open fun cacheFailure(call: Call, response: Response) {
+  open fun satisfactionFailure(call: Call, response: Response) {
   }
 
   /**
@@ -437,17 +436,26 @@ abstract class EventListener {
    *
    * Events will only be received when a Cache is configured for the client.
    */
-  open fun cacheMiss(call: Call, response: Response) {
+  open fun cacheHit(call: Call, response: Response) {
   }
 
   /**
-   * Invoked when a response is served from the network. n.b The response should be used
-   * to determine exactly how the cache came to be used, e.g. with a conditional cache response
-   * from the network.
+   * Invoked when a response will be served from the network. The Response will be
+   * available via following events.
    *
    * Events will only be received when a Cache is configured for the client.
    */
-  open fun cacheHit(call: Call, response: Response) {
+  open fun cacheMiss(call: Call) {
+  }
+
+  /**
+   * Invoked when a response will be served from the cache or network based on validating the
+   * cached Response freshness. Will be followed by cacheHit or cacheMiss after the network
+   * Response is available.
+   *
+   * Events will only be received when a Cache is configured for the client.
+   */
+  open fun cacheConditionalHit(call: Call, cachedResponse: Response) {
   }
 
   interface Factory {

--- a/okhttp/src/main/kotlin/okhttp3/EventListener.kt
+++ b/okhttp/src/main/kotlin/okhttp3/EventListener.kt
@@ -430,7 +430,7 @@ abstract class EventListener {
   }
 
   /**
-   * Invoked when a result is served from the cache. The Response is provided since their may
+   * Invoked when a result is served from the cache. The Response is provided since there may
    * not be the normal event sequences received.
    *
    * Events will only be received when a Cache is configured for the client.

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -729,30 +729,30 @@ open class OkHttpClient internal constructor(
       this.socketFactory = socketFactory
     }
 
-    /**
-     * Sets the socket factory used to secure HTTPS connections. If unset, the system default will
-     * be used.
-     *
-     * @deprecated [SSLSocketFactory] does not expose its [X509TrustManager], which is a field that
-     *     OkHttp needs to build a clean certificate chain. This method instead must use reflection
-     *     to extract the trust manager. Applications should prefer to call
-     *     `sslSocketFactory(SSLSocketFactory, X509TrustManager)`, which avoids such reflection.
-     */
-    @Deprecated(
-        message = "Use the sslSocketFactory overload that accepts a X509TrustManager.",
-        level = DeprecationLevel.ERROR
-    )
-    fun sslSocketFactory(sslSocketFactory: SSLSocketFactory) = apply {
-      if (sslSocketFactory != this.sslSocketFactoryOrNull) {
-        this.routeDatabase = null
-      }
+      /**
+       * Sets the socket factory used to secure HTTPS connections. If unset, the system default will
+       * be used.
+       *
+       * @deprecated [SSLSocketFactory] does not expose its [X509TrustManager], which is a field that
+       *     OkHttp needs to build a clean certificate chain. This method instead must use reflection
+       *     to extract the trust manager. Applications should prefer to call
+       *     `sslSocketFactory(SSLSocketFactory, X509TrustManager)`, which avoids such reflection.
+       */
+      @Deprecated(
+          message = "Use the sslSocketFactory overload that accepts a X509TrustManager.",
+          level = DeprecationLevel.ERROR
+      )
+      fun sslSocketFactory(sslSocketFactory: SSLSocketFactory) = apply {
+        if (sslSocketFactory != this.sslSocketFactoryOrNull) {
+          this.routeDatabase = null
+        }
 
-      this.sslSocketFactoryOrNull = sslSocketFactory
-      this.x509TrustManagerOrNull = Platform.get().trustManager(sslSocketFactory) ?: throw IllegalStateException(
-          "Unable to extract the trust manager on ${Platform.get()}, " +
-              "sslSocketFactory is ${sslSocketFactory.javaClass}")
-      this.certificateChainCleaner = Platform.get().buildCertificateChainCleaner(x509TrustManagerOrNull!!)
-    }
+        this.sslSocketFactoryOrNull = sslSocketFactory
+        this.x509TrustManagerOrNull = Platform.get().trustManager(sslSocketFactory) ?: throw IllegalStateException(
+            "Unable to extract the trust manager on ${Platform.get()}, " +
+                "sslSocketFactory is ${sslSocketFactory.javaClass}")
+        this.certificateChainCleaner = Platform.get().buildCertificateChainCleaner(x509TrustManagerOrNull!!)
+      }
 
     /**
      * Sets the socket factory and trust manager used to secure HTTPS connections. If unset, the

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -729,30 +729,30 @@ open class OkHttpClient internal constructor(
       this.socketFactory = socketFactory
     }
 
-      /**
-       * Sets the socket factory used to secure HTTPS connections. If unset, the system default will
-       * be used.
-       *
-       * @deprecated [SSLSocketFactory] does not expose its [X509TrustManager], which is a field that
-       *     OkHttp needs to build a clean certificate chain. This method instead must use reflection
-       *     to extract the trust manager. Applications should prefer to call
-       *     `sslSocketFactory(SSLSocketFactory, X509TrustManager)`, which avoids such reflection.
-       */
-      @Deprecated(
-          message = "Use the sslSocketFactory overload that accepts a X509TrustManager.",
-          level = DeprecationLevel.ERROR
-      )
-      fun sslSocketFactory(sslSocketFactory: SSLSocketFactory) = apply {
-        if (sslSocketFactory != this.sslSocketFactoryOrNull) {
-          this.routeDatabase = null
-        }
-
-        this.sslSocketFactoryOrNull = sslSocketFactory
-        this.x509TrustManagerOrNull = Platform.get().trustManager(sslSocketFactory) ?: throw IllegalStateException(
-            "Unable to extract the trust manager on ${Platform.get()}, " +
-                "sslSocketFactory is ${sslSocketFactory.javaClass}")
-        this.certificateChainCleaner = Platform.get().buildCertificateChainCleaner(x509TrustManagerOrNull!!)
+    /**
+     * Sets the socket factory used to secure HTTPS connections. If unset, the system default will
+     * be used.
+     *
+     * @deprecated [SSLSocketFactory] does not expose its [X509TrustManager], which is a field that
+     *     OkHttp needs to build a clean certificate chain. This method instead must use reflection
+     *     to extract the trust manager. Applications should prefer to call
+     *     `sslSocketFactory(SSLSocketFactory, X509TrustManager)`, which avoids such reflection.
+     */
+    @Deprecated(
+        message = "Use the sslSocketFactory overload that accepts a X509TrustManager.",
+        level = DeprecationLevel.ERROR
+    )
+    fun sslSocketFactory(sslSocketFactory: SSLSocketFactory) = apply {
+      if (sslSocketFactory != this.sslSocketFactoryOrNull) {
+        this.routeDatabase = null
       }
+
+      this.sslSocketFactoryOrNull = sslSocketFactory
+      this.x509TrustManagerOrNull = Platform.get().trustManager(sslSocketFactory) ?: throw IllegalStateException(
+          "Unable to extract the trust manager on ${Platform.get()}, " +
+              "sslSocketFactory is ${sslSocketFactory.javaClass}")
+      this.certificateChainCleaner = Platform.get().buildCertificateChainCleaner(x509TrustManagerOrNull!!)
+    }
 
     /**
      * Sets the socket factory and trust manager used to secure HTTPS connections. If unset, the

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
@@ -81,9 +81,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
       return cacheResponse!!.newBuilder()
           .cacheResponse(stripBody(cacheResponse))
           .build().also {
-            if (cache != null) {
-              listener.cacheHit(call, it)
-            }
+            listener.cacheHit(call, it)
           }
     }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
@@ -21,6 +21,8 @@ import java.net.HttpURLConnection.HTTP_GATEWAY_TIMEOUT
 import java.net.HttpURLConnection.HTTP_NOT_MODIFIED
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import okhttp3.Cache
+import okhttp3.EventListener
+import okhttp3.EventListener.Companion
 import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.Protocol
@@ -53,7 +55,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
     val cacheResponse = strategy.cacheResponse
 
     cache?.trackResponse(strategy)
-    val listener = (call as RealCall).eventListener
+    val listener = (call as? RealCall)?.eventListener ?: EventListener.NONE
 
     if (cacheCandidate != null && cacheResponse == null) {
       // The cache candidate wasn't applicable. Close it.

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
@@ -22,7 +22,6 @@ import java.net.HttpURLConnection.HTTP_NOT_MODIFIED
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import okhttp3.Cache
 import okhttp3.EventListener
-import okhttp3.EventListener.Companion
 import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.Protocol

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
@@ -27,6 +27,7 @@ import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.internal.EMPTY_RESPONSE
 import okhttp3.internal.closeQuietly
+import okhttp3.internal.connection.RealCall
 import okhttp3.internal.discard
 import okhttp3.internal.http.ExchangeCodec
 import okhttp3.internal.http.HttpMethod
@@ -42,6 +43,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
 
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
+    val call = chain.call()
     val cacheCandidate = cache?.get(chain.request())
 
     val now = System.currentTimeMillis()
@@ -51,6 +53,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
     val cacheResponse = strategy.cacheResponse
 
     cache?.trackResponse(strategy)
+    val listener = (call as RealCall).eventListener
 
     if (cacheCandidate != null && cacheResponse == null) {
       // The cache candidate wasn't applicable. Close it.
@@ -67,14 +70,22 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
           .body(EMPTY_RESPONSE)
           .sentRequestAtMillis(-1L)
           .receivedResponseAtMillis(System.currentTimeMillis())
-          .build()
+          .build().also {
+            if (cache != null) {
+              listener.cacheFailure(call, it)
+            }
+          }
     }
 
     // If we don't need the network, we're done.
     if (networkRequest == null) {
       return cacheResponse!!.newBuilder()
           .cacheResponse(stripBody(cacheResponse))
-          .build()
+          .build().also {
+            if (cache != null) {
+              listener.cacheHit(call, it)
+            }
+          }
     }
 
     var networkResponse: Response? = null
@@ -104,7 +115,9 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
         // Content-Encoding header (as performed by initContentStream()).
         cache!!.trackConditionalCacheHit()
         cache.update(cacheResponse, response)
-        return response
+        return response.also {
+          listener.cacheHit(call, it)
+        }
       } else {
         cacheResponse.body?.closeQuietly()
       }
@@ -119,7 +132,9 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
       if (response.promisesBody() && CacheStrategy.isCacheable(response, networkRequest)) {
         // Offer this request to the cache.
         val cacheRequest = cache.put(response)
-        return cacheWritingResponse(cacheRequest, response)
+        return cacheWritingResponse(cacheRequest, response).also {
+          listener.cacheMiss(call, it)
+        }
       }
 
       if (HttpMethod.invalidatesCache(networkRequest.method)) {
@@ -131,7 +146,11 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
       }
     }
 
-    return response
+    return response.also {
+      if (cache != null) {
+        listener.cacheMiss(call, response)
+      }
+    }
   }
 
   /**

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
@@ -72,9 +72,8 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
           .sentRequestAtMillis(-1L)
           .receivedResponseAtMillis(System.currentTimeMillis())
           .build().also {
-            if (cache != null) {
-              listener.cacheFailure(call, it)
-            }
+            // unconditionally log a cache related failure
+            listener.cacheFailure(call, it)
           }
     }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -65,7 +65,7 @@ class RealCall(
 ) : Call {
   private val connectionPool: RealConnectionPool = client.connectionPool.delegate
 
-  private val eventListener: EventListener = client.eventListenerFactory.create(this)
+  internal val eventListener: EventListener = client.eventListenerFactory.create(this)
 
   private val timeout = object : AsyncTimeout() {
     override fun timedOut() {

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -66,7 +66,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -1464,10 +1463,10 @@ public final class EventListenerTest {
     assertThat(response.body().string()).isEqualTo("abc");
     response.close();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "CacheMiss",
         "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart",
-        "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd", "CacheMiss",
+        "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd",
         "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased", "CallEnd");
   }
 
@@ -1497,13 +1496,13 @@ public final class EventListenerTest {
     assertThat(response.body().string()).isEqualTo("abc");
     response.close();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "CacheConditionalHit",
         "ConnectionAcquired", "RequestHeadersStart",
         "RequestHeadersEnd", "ResponseHeadersStart", "ResponseHeadersEnd",
         "ResponseBodyStart", "ResponseBodyEnd", "CacheHit", "ConnectionReleased", "CallEnd");
   }
 
-  @Test public void cacheFailed() throws IOException {
+  @Test public void satisfactionFailure() throws IOException {
     enableCache();
 
     Call call = client.newCall(new Request.Builder()
@@ -1514,7 +1513,7 @@ public final class EventListenerTest {
     assertThat(response.code()).isEqualTo(504);
     response.close();
 
-    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "CacheFailure", "CallEnd");
+    assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "SatisfactionFailure", "CallEnd");
   }
 
   @Test public void cacheHit() throws IOException {
@@ -1541,13 +1540,13 @@ public final class EventListenerTest {
     assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "CacheHit", "CallEnd");
   }
 
-  @NotNull private Cache enableCache() throws IOException {
+  private Cache enableCache() throws IOException {
     cache = makeCache();
     client = client.newBuilder().cache(cache).build();
     return cache;
   }
 
-  @NotNull private Cache makeCache() throws IOException {
+  private Cache makeCache() throws IOException {
     File cacheDir = File.createTempFile("cache-", ".dir");
     cacheDir.delete();
     return new Cache(cacheDir, 1024 * 1024);

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -1462,7 +1462,7 @@ public final class EventListenerTest {
     Response response = call.execute();
     assertThat(response.code()).isEqualTo(200);
     assertThat(response.body().string()).isEqualTo("abc");
-    response.body().close();
+    response.close();
 
     assertThat(listener.recordedEventTypes()).containsExactly("CallStart",
         "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
@@ -1496,7 +1496,7 @@ public final class EventListenerTest {
     Response response = call.execute();
     assertThat(response.code()).isEqualTo(200);
     assertThat(response.body().string()).isEqualTo("abc");
-    response.body().close();
+    response.close();
 
     listener.clearAllEvents();
 
@@ -1504,7 +1504,7 @@ public final class EventListenerTest {
     response = call.execute();
     assertThat(response.code()).isEqualTo(200);
     assertThat(response.body().string()).isEqualTo("abc");
-    response.body().close();
+    response.close();
 
     assertThat(listener.recordedEventTypes()).containsExactly("CallStart", "CacheHit", "CallEnd");
   }


### PR DESCRIPTION
Add cache events to Event Listener, mainly to avoid confusing CallStart>CallEnd or CallStart>CallFailed responses due to Cache strategy.