### PR TITLE
Use Timeout#seconds(long) instead of deprecated Timeout(long) constructor in DiskLruCacheTest

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/cache/DiskLruCacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/cache/DiskLruCacheTest.kt
@@ -54,7 +54,7 @@ class DiskLruCacheTest(
   val tempDir = TemporaryFolder()
 
   @Rule @JvmField
-  val timeout = Timeout(60 * 1000)
+  val timeout = Timeout.seconds(60)
 
   companion object {
     @Parameters(name = "{0}") @JvmStatic


### PR DESCRIPTION
We have the compile warning below.
```
okhttp/okhttp/src/test/java/okhttp3/internal/cache/DiskLruCacheTest.kt: (57, 17): 'constructor Timeout(Int)' is deprecated. Deprecated in Java
```

To fix it, we'll follow the comment in the `Timeout` class.
```
* Instead use {@link #Timeout(long, java.util.concurrent.TimeUnit)},
* {@link Timeout#millis(long)}, or {@link Timeout#seconds(long)}.
```