### PR TITLE
CircleCI tuning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
           name: Run tests
           command: ./gradlew --build-cache --parallel --continue test
           environment:
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dokhttp.platform=<< parameters.platform >> -Dorg.gradle.workers.max=3 -Xmx1G << parameters.testjdk >>
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dokhttp.platform=<< parameters.platform >> -Dorg.gradle.workers.max=2 -Xmx2G << parameters.testjdk >>
 
       - save_cache:
           paths:
@@ -80,7 +80,7 @@ jobs:
           name: Run tests
           command: ./gradlew --parallel --build-cache test
           environment:
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dokhttp.platform=jdk9 -Dorg.gradle.workers.max=3 -Xmx1G
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dokhttp.platform=jdk9 -Dorg.gradle.workers.max=2 -Xmx2G
 
       - save_cache:
           paths:
@@ -109,7 +109,7 @@ jobs:
           name: Run checks
           command: ./gradlew --parallel --continue --build-cache check -x test
           environment:
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=3 -Xmx1G
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Xmx2G
 
       - run:
           name: Save gradle reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,12 @@ commands:
         type: string
         default: ""
     steps:
-      - restore_cache:
-          keys:
-            # restore compilation and wrapper from previous branch/job build or master
-            - v4-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
-            - v4-master-compile
-
+#       - restore_cache:
+#           keys:
+#             # restore compilation and wrapper from previous branch/job build or master
+#             - v4-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
+#             - v4-master-compile
+# 
       - run:
           name: Run tests
           command: ./gradlew --build-cache --parallel --continue test


### PR DESCRIPTION
Related to https://github.com/square/okhttp/issues/6033, from looking at failures for okhttp3.EventListenerTest

It looks like a lot of failures are generally load related

https://app.circleci.com/pipelines/github/square/okhttp/3086/workflows/8dd4b728-5f6b-4638-bcea-05eaed48dfe0/jobs/12882/steps
https://app.circleci.com/pipelines/github/square/okhttp/3131/workflows/f2e77138-7a11-4621-b0d8-9b78513a7845/jobs/13024/steps
https://app.circleci.com/pipelines/github/square/okhttp/3188/workflows/eed45285-f75b-4d08-9426-7b3469933f1c/jobs/13333/steps
https://app.circleci.com/pipelines/github/square/okhttp/3204/workflows/48168e7c-38f0-4d62-b2cb-8d30fc3528aa/jobs/13424/steps

Guides like

https://circleci.com/docs/2.0/language-android/
https://circleci.com/docs/2.0/language-java/

Tend to limit workers to 2 instead of 3, so trying this.