### PR TITLE
Rethrow original failure in OkHttpClientTestRule

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -19,6 +19,7 @@ import java.net.InetAddress
 import java.util.concurrent.TimeUnit
 import java.util.logging.Handler
 import java.util.logging.Level
+import java.util.logging.LogManager
 import java.util.logging.LogRecord
 import java.util.logging.Logger
 import okhttp3.internal.concurrent.TaskRunner
@@ -165,6 +166,7 @@ class OkHttpClientTestRule : TestRule {
           applyLogger {
             addHandler(testLogHandler)
             level = Level.FINEST
+            useParentHandlers = false
           }
 
           base.evaluate()
@@ -177,10 +179,7 @@ class OkHttpClientTestRule : TestRule {
           logEvents()
           throw t
         } finally {
-          applyLogger {
-            removeHandler(testLogHandler)
-            level = Level.INFO
-          }
+          LogManager.getLogManager().reset()
 
           Thread.setDefaultUncaughtExceptionHandler(defaultUncaughtExceptionHandler)
           try {

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -188,15 +188,17 @@ class OkHttpClientTestRule : TestRule {
           } catch (ae: AssertionError) {
             if (!failed) {
               // Prefer keeping the inflight failure, but don't release this in-use client.
+              failed = true
               throw ae
             }
-          }
-          try {
-            ensureAllTaskQueuesIdle()
-          } catch (ae: AssertionError) {
-            if (!failed) {
-              // Prefer keeping the inflight failure.
-              throw ae
+          } finally {
+            try {
+              ensureAllTaskQueuesIdle()
+            } catch (ae: AssertionError) {
+              if (!failed) {
+                // Prefer keeping the inflight failure.
+                throw ae
+              }
             }
           }
         }

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
@@ -57,9 +57,7 @@ internal inline fun <T> logElapsed(
 }
 
 private fun log(task: Task, queue: TaskQueue, message: String) {
-  if (TaskRunner.logger.isLoggable(Level.FINE)) {
-    TaskRunner.logger.fine("${queue.name} ${String.format("%-22s", message)}: ${task.name}")
-  }
+  TaskRunner.logger.fine("${queue.name} ${String.format("%-22s", message)}: ${task.name}")
 }
 
 /**

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
@@ -57,7 +57,9 @@ internal inline fun <T> logElapsed(
 }
 
 private fun log(task: Task, queue: TaskQueue, message: String) {
-  TaskRunner.logger.fine("${queue.name} ${String.format("%-22s", message)}: ${task.name}")
+  if (TaskRunner.logger.isLoggable(Level.FINE)) {
+    TaskRunner.logger.fine("${queue.name} ${String.format("%-22s", message)}: ${task.name}")
+  }
 }
 
 /**

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -72,6 +72,7 @@ import okio.Buffer;
 import okio.BufferedSink;
 import okio.GzipSink;
 import okio.Okio;
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -112,7 +113,7 @@ public final class HttpOverHttp2Test {
   }
 
   private final PlatformRule platform = new PlatformRule();
-  private final OkHttpClientTestRule clientTestRule = new OkHttpClientTestRule();
+  private final OkHttpClientTestRule clientTestRule = configureClientTestRule();
   @Rule public final TestRule chain = RuleChain.outerRule(platform)
       .around(new Timeout(60, SECONDS))
       .around(clientTestRule);
@@ -127,6 +128,13 @@ public final class HttpOverHttp2Test {
 
   public HttpOverHttp2Test(Protocol protocol) {
     this.protocol = protocol;
+  }
+
+
+  @NotNull private OkHttpClientTestRule configureClientTestRule() {
+    OkHttpClientTestRule clientTestRule = new OkHttpClientTestRule();
+    clientTestRule.setRecordTaskRunner(true);
+    return clientTestRule;
   }
 
   @Before public void setUp() {

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -53,6 +53,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import static java.util.Arrays.asList;
 import static okhttp3.TestUtil.repeat;
@@ -66,8 +67,10 @@ public final class WebSocketHttpTest {
   // Flaky https://github.com/square/okhttp/issues/4515
   // Flaky https://github.com/square/okhttp/issues/4953
 
-  @Rule public final MockWebServer webServer = new MockWebServer();
-  @Rule public final OkHttpClientTestRule clientTestRule = new OkHttpClientTestRule();
+  final MockWebServer webServer = new MockWebServer();
+  final OkHttpClientTestRule clientTestRule = configureClientTestRule();
+
+  @Rule public final RuleChain orderedRules = RuleChain.outerRule(clientTestRule).around(webServer);
   @Rule public final PlatformRule platform = new PlatformRule();
   @Rule public final TestLogHandler testLogHandler = new TestLogHandler(OkHttpClient.class);
 
@@ -85,6 +88,12 @@ public final class WebSocketHttpTest {
         return response;
       })
       .build();
+
+  private OkHttpClientTestRule configureClientTestRule() {
+    OkHttpClientTestRule clientTestRule = new OkHttpClientTestRule();
+    clientTestRule.setRecordTaskRunner(true);
+    return clientTestRule;
+  }
 
   @Before public void setUp() {
     platform.assumeNotOpenJSSE();


### PR DESCRIPTION
Related to https://github.com/square/okhttp/issues/6033

Want to avoid failures like

```
okhttp3.internal.ws.WebSocketHttpTest > serverMaxWindowBitsTooHigh FAILED
    java.lang.AssertionError: expected:<0> but was:<1>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:120)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at okhttp3.OkHttpClientTestRule.ensureAllConnectionsReleased(OkHttpClientTestRule.kt:134)
        at okhttp3.OkHttpClientTestRule$apply$1.evaluate(OkHttpClientTestRule.kt:178)
        at okhttp3.testing.PlatformRule$apply$1.evaluate(PlatformRule.kt:69)
        at okhttp3.TestLogHandler$1.evaluate(TestLogHandler.java:50)
        at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
```