### PR TITLE
Attempt to minimise WebSocket test flakiness

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
@@ -266,7 +266,12 @@ class ClientRuleEventListener(
   }
 
   private fun logWithTime(message: String) {
-    val timeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs)
+    val timeMs = if (startNs == 0L) {
+      0L
+    } else {
+      TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs)
+    }
+
     logger.invoke("[$timeMs ms] $message")
   }
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
@@ -26,7 +26,7 @@ class ClientRuleEventListener(
   var logger: (String) -> Unit
 ) : EventListener(),
     EventListener.Factory {
-  private var startNs: Long = 0
+  private var startNs: Long? = null
 
   override fun create(call: Call): EventListener = this
 
@@ -266,7 +266,9 @@ class ClientRuleEventListener(
   }
 
   private fun logWithTime(message: String) {
-    val timeMs = if (startNs == 0L) {
+    val startNs = startNs
+    val timeMs = if (startNs == null) {
+      // Event occurred before start, for an example an early cancel.
       0L
     } else {
       TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs)

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -43,6 +43,7 @@ class OkHttpClientTestRule : TestRule {
   private var testClient: OkHttpClient? = null
   private var uncaughtException: Throwable? = null
   var logger: Logger? = null
+  lateinit var testName: String
 
   var recordEvents = true
   var recordTaskRunner = false
@@ -156,6 +157,8 @@ class OkHttpClientTestRule : TestRule {
   ): Statement {
     return object : Statement() {
       override fun evaluate() {
+        testName = description.methodName
+
         val defaultUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { _, throwable ->
           initUncaughtException(throwable)
@@ -233,7 +236,7 @@ class OkHttpClientTestRule : TestRule {
   @Synchronized private fun logEvents() {
     // Will be ineffective if test overrides the listener
     synchronized(clientEventsList) {
-      println("Events (${clientEventsList.size})")
+      println("$testName Events (${clientEventsList.size})")
 
       for (e in clientEventsList) {
         println(e)

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -132,7 +132,16 @@ class OkHttpClientTestRule : TestRule {
   fun ensureAllConnectionsReleased() {
     testClient?.let {
       val connectionPool = it.connectionPool
+
       connectionPool.evictAll()
+      if (connectionPool.connectionCount() > 0) {
+        // Minimise test flakiness due to possible race conditions with connections closing.
+        // Some number of tests will report here, but not fail due to this delay.
+        println("Delaying to avoid flakes")
+        Thread.sleep(500L)
+        println("After delay: " + connectionPool.connectionCount())
+      }
+
       assertEquals(0, connectionPool.connectionCount())
     }
   }

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -71,7 +71,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 
 import static java.util.Arrays.asList;

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -114,15 +114,6 @@ public final class EventListenerTest {
     if (cache != null) {
       cache.delete();
     }
-
-    client.connectionPool().evictAll();
-    if (client.connectionPool().connectionCount() > 0) {
-      // Minimise test flakiness due to possible race conditions with connections closing.
-      // Some number of tests will report here, but not fail due to this delay.
-      System.out.println("Delaying to avoid flakes");
-      Thread.sleep(500L);
-      System.out.println("After delay: " + client.connectionPool().connectionCount());
-    }
   }
 
   @Test public void successfulCallEventSequence() throws IOException {

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -71,6 +71,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 
 import static java.util.Arrays.asList;
@@ -90,6 +91,7 @@ public final class EventListenerTest {
   @Rule public final MockWebServer server = new MockWebServer();
   @Rule public final OkHttpClientTestRule clientTestRule = new OkHttpClientTestRule();
   @Rule public final Timeout timeoutRule = new Timeout(20, TimeUnit.SECONDS);
+  @Rule public final TestName testName = new TestName();
 
   private final RecordingEventListener listener = new RecordingEventListener();
   private final HandshakeCertificates handshakeCertificates = localhost();
@@ -114,6 +116,13 @@ public final class EventListenerTest {
     }
     if (cache != null) {
       cache.delete();
+    }
+
+    if (client.connectionPool().connectionCount() > 0) {
+      // Minimise test flakiness due to possible race conditions with connections closing.
+      // Some number of tests will report here, but not fail due to this delay.
+      System.out.println("Delaying to avoid flakes: " + testName.getMethodName());
+      Thread.sleep(500L);
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -79,7 +79,6 @@ import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
@@ -91,7 +90,6 @@ public final class EventListenerTest {
   @Rule public final MockWebServer server = new MockWebServer();
   @Rule public final OkHttpClientTestRule clientTestRule = new OkHttpClientTestRule();
   @Rule public final Timeout timeoutRule = new Timeout(20, TimeUnit.SECONDS);
-  @Rule public final TestName testName = new TestName();
 
   private final RecordingEventListener listener = new RecordingEventListener();
   private final HandshakeCertificates handshakeCertificates = localhost();
@@ -122,7 +120,7 @@ public final class EventListenerTest {
     if (client.connectionPool().connectionCount() > 0) {
       // Minimise test flakiness due to possible race conditions with connections closing.
       // Some number of tests will report here, but not fail due to this delay.
-      System.out.println("Delaying to avoid flakes: " + testName.getMethodName());
+      System.out.println("Delaying to avoid flakes");
       Thread.sleep(500L);
       System.out.println("After delay: " + client.connectionPool().connectionCount());
     }

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -118,11 +118,13 @@ public final class EventListenerTest {
       cache.delete();
     }
 
+    client.connectionPool().evictAll();
     if (client.connectionPool().connectionCount() > 0) {
       // Minimise test flakiness due to possible race conditions with connections closing.
       // Some number of tests will report here, but not fail due to this delay.
       System.out.println("Delaying to avoid flakes: " + testName.getMethodName());
       Thread.sleep(500L);
+      System.out.println("After delay: " + client.connectionPool().connectionCount());
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -102,15 +102,6 @@ public final class WebSocketHttpTest {
 
   @After public void tearDown() throws InterruptedException {
     clientListener.assertExhausted();
-
-    client.connectionPool().evictAll();
-    if (client.connectionPool().connectionCount() > 0) {
-      // Minimise test flakiness due to possible race conditions with connections closing.
-      // Some number of tests will report here, but not fail due to this delay.
-      System.out.println("Delaying to avoid flakes");
-      Thread.sleep(500L);
-      System.out.println("After delay: " + client.connectionPool().connectionCount());
-    }
   }
 
   @Test public void textMessage() {

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -108,7 +108,7 @@ public final class WebSocketHttpTest {
     if (client.connectionPool().connectionCount() > 0) {
       // Minimise test flakiness due to possible race conditions with connections closing.
       // Some number of tests will report here, but not fail due to this delay.
-      System.out.println(testName.getMethodName());
+      System.out.println("Delaying to avoid flakes: " + testName.getMethodName());
       Thread.sleep(500L);
     }
   }
@@ -579,8 +579,6 @@ public final class WebSocketHttpTest {
 
     clientListener.assertFailure(SocketTimeoutException.class, "timeout", "Read timed out");
     assertThat(webSocket.close(1000, null)).isFalse();
-
-    System.out.println(client.connectionPool().connectionCount());
   }
 
   @Test public void readTimeoutDoesNotApplyAcrossFrames() throws Exception {

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -54,6 +54,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TestName;
 
 import static java.util.Arrays.asList;
 import static okhttp3.TestUtil.repeat;
@@ -73,6 +74,7 @@ public final class WebSocketHttpTest {
   @Rule public final RuleChain orderedRules = RuleChain.outerRule(clientTestRule).around(webServer);
   @Rule public final PlatformRule platform = new PlatformRule();
   @Rule public final TestLogHandler testLogHandler = new TestLogHandler(OkHttpClient.class);
+  @Rule public final TestName testName = new TestName();
 
   private final HandshakeCertificates handshakeCertificates = localhost();
   private final WebSocketRecorder clientListener = new WebSocketRecorder("client");
@@ -103,8 +105,10 @@ public final class WebSocketHttpTest {
   @After public void tearDown() throws InterruptedException {
     clientListener.assertExhausted();
 
-    if (client.connectionPool().connectionCount() > 1) {
-      // Minimise test flakiness due to possible race conditions with connections closing
+    if (client.connectionPool().connectionCount() > 0) {
+      // Minimise test flakiness due to possible race conditions with connections closing.
+      // Some number of tests will report here, but not fail due to this delay.
+      System.out.println(testName.getMethodName());
       Thread.sleep(500L);
     }
   }

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -105,11 +105,13 @@ public final class WebSocketHttpTest {
   @After public void tearDown() throws InterruptedException {
     clientListener.assertExhausted();
 
+    client.connectionPool().evictAll();
     if (client.connectionPool().connectionCount() > 0) {
       // Minimise test flakiness due to possible race conditions with connections closing.
       // Some number of tests will report here, but not fail due to this delay.
       System.out.println("Delaying to avoid flakes: " + testName.getMethodName());
       Thread.sleep(500L);
+      System.out.println("After delay: " + client.connectionPool().connectionCount());
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -100,8 +100,13 @@ public final class WebSocketHttpTest {
     platform.assumeNotBouncyCastle();
   }
 
-  @After public void tearDown() {
+  @After public void tearDown() throws InterruptedException {
     clientListener.assertExhausted();
+
+    if (client.connectionPool().connectionCount() > 1) {
+      // Minimise test flakiness due to possible race conditions with connections closing
+      Thread.sleep(500L);
+    }
   }
 
   @Test public void textMessage() {
@@ -570,6 +575,8 @@ public final class WebSocketHttpTest {
 
     clientListener.assertFailure(SocketTimeoutException.class, "timeout", "Read timed out");
     assertThat(webSocket.close(1000, null)).isFalse();
+
+    System.out.println(client.connectionPool().connectionCount());
   }
 
   @Test public void readTimeoutDoesNotApplyAcrossFrames() throws Exception {

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -54,7 +54,6 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.junit.rules.TestName;
 
 import static java.util.Arrays.asList;
 import static okhttp3.TestUtil.repeat;
@@ -74,7 +73,6 @@ public final class WebSocketHttpTest {
   @Rule public final RuleChain orderedRules = RuleChain.outerRule(clientTestRule).around(webServer);
   @Rule public final PlatformRule platform = new PlatformRule();
   @Rule public final TestLogHandler testLogHandler = new TestLogHandler(OkHttpClient.class);
-  @Rule public final TestName testName = new TestName();
 
   private final HandshakeCertificates handshakeCertificates = localhost();
   private final WebSocketRecorder clientListener = new WebSocketRecorder("client");
@@ -109,7 +107,7 @@ public final class WebSocketHttpTest {
     if (client.connectionPool().connectionCount() > 0) {
       // Minimise test flakiness due to possible race conditions with connections closing.
       // Some number of tests will report here, but not fail due to this delay.
-      System.out.println("Delaying to avoid flakes: " + testName.getMethodName());
+      System.out.println("Delaying to avoid flakes");
       Thread.sleep(500L);
       System.out.println("After delay: " + client.connectionPool().connectionCount());
     }


### PR DESCRIPTION
https://github.com/square/okhttp/issues/6033

Assuming this is due to race conditions immediately after shutdown with websocket, allow for 500ms extra before failing.  Will record which tests see delays, so we can query for this.