### PR TITLE
Avoid any chance at NPE in RealWebSocket

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/ws/RealWebSocket.kt
@@ -549,11 +549,11 @@ class RealWebSocket(
   }
 
   internal fun writePingFrame() {
-    val writer: WebSocketWriter?
+    val writer: WebSocketWriter
     val failedPing: Int
     synchronized(this) {
       if (failed) return
-      writer = this.writer
+      writer = this.writer ?: return
       failedPing = if (awaitingPong) sentPingCount else -1
       sentPingCount++
       awaitingPong = true
@@ -566,7 +566,7 @@ class RealWebSocket(
     }
 
     try {
-      writer!!.writePing(ByteString.EMPTY)
+      writer.writePing(ByteString.EMPTY)
     } catch (e: IOException) {
       failWebSocket(e, null)
     }


### PR DESCRIPTION
Pretty sure that with correct locking that this *already* can't be null.  The syncrhonized memory barrier in writePingFrame, which happens via the task runner, should always be after the syncrhonized memory barrier in initReaderAndWriter.

But this subtle change should be a noop but delay the ping if we find ourselves somehow with null.

To address https://github.com/square/okhttp/issues/5705