### PR TITLE
Fix for insecureHost on Android

### DIFF
--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -301,6 +301,8 @@ class OkHttpTest {
       assertEquals(200, response.code)
       assertTrue(socketClass?.startsWith("com.android.org.conscrypt.") == true)
     }
+
+    localhostRequest();
   }
 
   @Test

--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -140,7 +140,7 @@ class OkHttpTest {
       assertEquals(200, response.code)
     }
 
-    localhostRequest();
+    localhostInsecureRequest();
   }
 
   @Test
@@ -202,7 +202,7 @@ class OkHttpTest {
         assertEquals(TlsVersion.TLS_1_3, response.handshake?.tlsVersion)
       }
 
-      localhostRequest();
+      localhostInsecureRequest();
     } finally {
       Security.removeProvider("Conscrypt")
       client.close()
@@ -248,14 +248,14 @@ class OkHttpTest {
         assertEquals(TlsVersion.TLS_1_2, response.handshake?.tlsVersion)
       }
 
-      localhostRequest();
+      localhostInsecureRequest();
     } finally {
       Security.removeProvider("GmsCore_OpenSSL")
       client.close()
     }
   }
 
-  private fun localhostRequest() {
+  private fun localhostInsecureRequest() {
     enableTls()
 
     server.enqueue(MockResponse().setResponseCode(200))
@@ -264,6 +264,7 @@ class OkHttpTest {
 
     client.newCall(request).execute().use {
       assertEquals(200, it.code)
+      assertEquals(listOf("CN=${server.hostName}"), it.handshake?.peerCertificates?.map { (it as X509Certificate).subjectDN.name })
     }
   }
 
@@ -302,7 +303,7 @@ class OkHttpTest {
       assertTrue(socketClass?.startsWith("com.android.org.conscrypt.") == true)
     }
 
-    localhostRequest();
+    localhostInsecureRequest();
   }
 
   @Test

--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -69,6 +69,7 @@ import java.net.UnknownHostException
 import java.security.KeyStore
 import java.security.SecureRandom
 import java.security.Security
+import java.security.cert.Certificate
 import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 import java.util.concurrent.atomic.AtomicInteger
@@ -127,7 +128,7 @@ class OkHttpTest {
 
     val clientCertificates = HandshakeCertificates.Builder()
         .addPlatformTrustedCertificates()
-        .addInsecureHost("localhost")
+        .addInsecureHost(server.hostName)
         .build()
 
     client = client.newBuilder()
@@ -256,7 +257,7 @@ class OkHttpTest {
   }
 
   private fun localhostInsecureRequest() {
-    enableTls()
+    server.useHttps(handshakeCertificates.sslSocketFactory(), false)
 
     server.enqueue(MockResponse().setResponseCode(200))
 
@@ -264,7 +265,7 @@ class OkHttpTest {
 
     client.newCall(request).execute().use {
       assertEquals(200, it.code)
-      assertEquals(listOf("CN=${server.hostName}"), it.handshake?.peerCertificates?.map { (it as X509Certificate).subjectDN.name })
+      assertEquals(listOf<Certificate>(), it.handshake?.peerCertificates)
     }
   }
 

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/InsecureAndroidTrustManager.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/InsecureAndroidTrustManager.kt
@@ -45,7 +45,7 @@ internal class InsecureAndroidTrustManager(
     try {
       val method = checkServerTrustedMethod
           ?: throw CertificateException("Failed to call checkServerTrusted")
-      return method.invoke(this, chain, authType, host) as List<Certificate>
+      return method.invoke(delegate, chain, authType, host) as List<Certificate>
     } catch (e: InvocationTargetException) {
       throw e.targetException
     }


### PR DESCRIPTION
As raised in https://github.com/square/okhttp/issues/6062 and fix suggested by @mattinger, we had a typo in the Android implementation.