### PR TITLE
Another layer of indirection to defer Conscrypt init

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Android10Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Android10Platform.kt
@@ -36,7 +36,7 @@ import okhttp3.internal.tls.CertificateChainCleaner
 class Android10Platform : Platform() {
   private val socketAdapters = listOfNotNull(
       Android10SocketAdapter.buildIfSupported(),
-      DeferredSocketAdapter(AndroidSocketAdapter.factory("com.google.android.gms.org.conscrypt")),
+      DeferredSocketAdapter(AndroidSocketAdapter.playProviderFactory),
       // Delay and Defer any initialisation of Conscrypt and BouncyCastle
       DeferredSocketAdapter(ConscryptSocketAdapter.factory),
       DeferredSocketAdapter(BouncyCastleSocketAdapter.factory)

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Android10Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Android10Platform.kt
@@ -36,8 +36,8 @@ import okhttp3.internal.tls.CertificateChainCleaner
 class Android10Platform : Platform() {
   private val socketAdapters = listOfNotNull(
       Android10SocketAdapter.buildIfSupported(),
-      DeferredSocketAdapter(ConscryptSocketAdapter.factory),
       DeferredSocketAdapter(AndroidSocketAdapter.factory("com.google.android.gms.org.conscrypt")),
+      DeferredSocketAdapter(ConscryptSocketAdapter.factory),
       BouncyCastleSocketAdapter.buildIfSupported()
   ).filter { it.isSupported() }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Android10Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Android10Platform.kt
@@ -37,8 +37,9 @@ class Android10Platform : Platform() {
   private val socketAdapters = listOfNotNull(
       Android10SocketAdapter.buildIfSupported(),
       DeferredSocketAdapter(AndroidSocketAdapter.factory("com.google.android.gms.org.conscrypt")),
+      // Delay and Defer any initialisation of Conscrypt and BouncyCastle
       DeferredSocketAdapter(ConscryptSocketAdapter.factory),
-      BouncyCastleSocketAdapter.buildIfSupported()
+      DeferredSocketAdapter(BouncyCastleSocketAdapter.factory)
   ).filter { it.isSupported() }
 
   override fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? =

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Android10Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Android10Platform.kt
@@ -25,6 +25,7 @@ import okhttp3.Protocol
 import okhttp3.internal.SuppressSignatureCheck
 import okhttp3.internal.platform.android.Android10SocketAdapter
 import okhttp3.internal.platform.android.AndroidCertificateChainCleaner
+import okhttp3.internal.platform.android.AndroidSocketAdapter
 import okhttp3.internal.platform.android.BouncyCastleSocketAdapter
 import okhttp3.internal.platform.android.ConscryptSocketAdapter
 import okhttp3.internal.platform.android.DeferredSocketAdapter
@@ -35,8 +36,8 @@ import okhttp3.internal.tls.CertificateChainCleaner
 class Android10Platform : Platform() {
   private val socketAdapters = listOfNotNull(
       Android10SocketAdapter.buildIfSupported(),
-      ConscryptSocketAdapter.buildIfSupported(),
-      DeferredSocketAdapter("com.google.android.gms.org.conscrypt"),
+      DeferredSocketAdapter(ConscryptSocketAdapter.factory),
+      DeferredSocketAdapter(AndroidSocketAdapter.factory("com.google.android.gms.org.conscrypt")),
       BouncyCastleSocketAdapter.buildIfSupported()
   ).filter { it.isSupported() }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
@@ -46,8 +46,9 @@ class AndroidPlatform : Platform() {
   private val socketAdapters = listOfNotNull(
       StandardAndroidSocketAdapter.buildIfSupported(),
       DeferredSocketAdapter(AndroidSocketAdapter.factory("com.google.android.gms.org.conscrypt")),
+      // Delay and Defer any initialisation of Conscrypt and BouncyCastle
       DeferredSocketAdapter(ConscryptSocketAdapter.factory),
-      BouncyCastleSocketAdapter.buildIfSupported()
+      DeferredSocketAdapter(BouncyCastleSocketAdapter.factory)
   ).filter { it.isSupported() }
 
   private val closeGuard = CloseGuard.get()

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
@@ -45,7 +45,7 @@ import okhttp3.internal.tls.TrustRootIndex
 class AndroidPlatform : Platform() {
   private val socketAdapters = listOfNotNull(
       StandardAndroidSocketAdapter.buildIfSupported(),
-      DeferredSocketAdapter(AndroidSocketAdapter.factory("com.google.android.gms.org.conscrypt")),
+      DeferredSocketAdapter(AndroidSocketAdapter.playProviderFactory),
       // Delay and Defer any initialisation of Conscrypt and BouncyCastle
       DeferredSocketAdapter(ConscryptSocketAdapter.factory),
       DeferredSocketAdapter(BouncyCastleSocketAdapter.factory)

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
@@ -30,6 +30,7 @@ import javax.net.ssl.X509TrustManager
 import okhttp3.Protocol
 import okhttp3.internal.SuppressSignatureCheck
 import okhttp3.internal.platform.android.AndroidCertificateChainCleaner
+import okhttp3.internal.platform.android.AndroidSocketAdapter
 import okhttp3.internal.platform.android.BouncyCastleSocketAdapter
 import okhttp3.internal.platform.android.CloseGuard
 import okhttp3.internal.platform.android.ConscryptSocketAdapter
@@ -44,8 +45,8 @@ import okhttp3.internal.tls.TrustRootIndex
 class AndroidPlatform : Platform() {
   private val socketAdapters = listOfNotNull(
       StandardAndroidSocketAdapter.buildIfSupported(),
-      ConscryptSocketAdapter.buildIfSupported(),
-      DeferredSocketAdapter("com.google.android.gms.org.conscrypt"),
+      DeferredSocketAdapter(ConscryptSocketAdapter.factory),
+      DeferredSocketAdapter(AndroidSocketAdapter.factory("com.google.android.gms.org.conscrypt")),
       BouncyCastleSocketAdapter.buildIfSupported()
   ).filter { it.isSupported() }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
@@ -45,8 +45,8 @@ import okhttp3.internal.tls.TrustRootIndex
 class AndroidPlatform : Platform() {
   private val socketAdapters = listOfNotNull(
       StandardAndroidSocketAdapter.buildIfSupported(),
-      DeferredSocketAdapter(ConscryptSocketAdapter.factory),
       DeferredSocketAdapter(AndroidSocketAdapter.factory("com.google.android.gms.org.conscrypt")),
+      DeferredSocketAdapter(ConscryptSocketAdapter.factory),
       BouncyCastleSocketAdapter.buildIfSupported()
   ).filter { it.isSupported() }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/Android10SocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/Android10SocketAdapter.kt
@@ -27,7 +27,9 @@ import okhttp3.internal.platform.Platform
 import okhttp3.internal.platform.Platform.Companion.isAndroid
 
 /**
- * Simple non-reflection SocketAdapter for Android Q.
+ * Simple non-reflection SocketAdapter for Android Q+.
+ *
+ * These API assumptions make it unsuitable for use on earlier Android versions.
  */
 @SuppressLint("NewApi")
 @SuppressSignatureCheck

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/Android10SocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/Android10SocketAdapter.kt
@@ -21,8 +21,6 @@ import android.os.Build
 import java.io.IOException
 import java.lang.IllegalArgumentException
 import javax.net.ssl.SSLSocket
-import javax.net.ssl.SSLSocketFactory
-import javax.net.ssl.X509TrustManager
 import okhttp3.Protocol
 import okhttp3.internal.SuppressSignatureCheck
 import okhttp3.internal.platform.Platform
@@ -34,8 +32,6 @@ import okhttp3.internal.platform.Platform.Companion.isAndroid
 @SuppressLint("NewApi")
 @SuppressSignatureCheck
 class Android10SocketAdapter : SocketAdapter {
-  override fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? = null
-
   override fun matchesSocket(sslSocket: SSLSocket): Boolean = SSLSockets.isSupportedSocket(sslSocket)
 
   override fun isSupported(): Boolean = Companion.isSupported()

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidSocketAdapter.kt
@@ -94,6 +94,9 @@ open class AndroidSocketAdapter(private val sslSocketClass: Class<in SSLSocket>)
   }
 
   companion object {
+    val playProviderFactory: DeferredSocketAdapter.Factory =
+      factory("com.google.android.gms.org.conscrypt")
+
     /**
      * Builds a SocketAdapter from an observed implementation class, by grabbing the Class
      * reference to perform reflection on at runtime.

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidSocketAdapter.kt
@@ -22,7 +22,6 @@ import javax.net.ssl.SSLSocket
 import okhttp3.Protocol
 import okhttp3.internal.platform.AndroidPlatform
 import okhttp3.internal.platform.Platform
-import org.conscrypt.Conscrypt
 
 /**
  * Modern reflection based SocketAdapter for Conscrypt class SSLSockets.

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidSocketAdapter.kt
@@ -117,8 +117,8 @@ open class AndroidSocketAdapter(private val sslSocketClass: Class<in SSLSocket>)
     }
 
     private fun build(actualSSLSocketClass: Class<in SSLSocket>): AndroidSocketAdapter {
-      var possibleClass: Class<in SSLSocket> = actualSSLSocketClass
-      while (possibleClass.simpleName != "OpenSSLSocketImpl") {
+      var possibleClass: Class<in SSLSocket>? = actualSSLSocketClass
+      while (possibleClass != null && possibleClass.simpleName != "OpenSSLSocketImpl") {
         possibleClass = possibleClass.superclass
 
         if (possibleClass == null) {
@@ -128,7 +128,7 @@ open class AndroidSocketAdapter(private val sslSocketClass: Class<in SSLSocket>)
         }
       }
 
-      return AndroidSocketAdapter(possibleClass)
+      return AndroidSocketAdapter(possibleClass!!)
     }
 
     fun factory(packageName: String): DeferredSocketAdapter.Factory {

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/BouncyCastleSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/BouncyCastleSocketAdapter.kt
@@ -20,6 +20,7 @@ import okhttp3.Protocol
 import okhttp3.internal.platform.BouncyCastlePlatform
 import okhttp3.internal.platform.Platform
 import org.bouncycastle.jsse.BCSSLSocket
+import org.conscrypt.Conscrypt
 
 /**
  * Simple non-reflection SocketAdapter for BouncyCastle.
@@ -57,7 +58,11 @@ class BouncyCastleSocketAdapter : SocketAdapter {
   }
 
   companion object {
-    fun buildIfSupported(): SocketAdapter? =
-        if (BouncyCastlePlatform.isSupported) BouncyCastleSocketAdapter() else null
+    val factory = object : DeferredSocketAdapter.Factory {
+      override fun matchesSocket(sslSocket: SSLSocket): Boolean {
+        return BouncyCastlePlatform.isSupported && sslSocket is BCSSLSocket
+      }
+      override fun create(sslSocket: SSLSocket): SocketAdapter = BouncyCastleSocketAdapter()
+    }
   }
 }

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/BouncyCastleSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/BouncyCastleSocketAdapter.kt
@@ -16,8 +16,6 @@
 package okhttp3.internal.platform.android
 
 import javax.net.ssl.SSLSocket
-import javax.net.ssl.SSLSocketFactory
-import javax.net.ssl.X509TrustManager
 import okhttp3.Protocol
 import okhttp3.internal.platform.BouncyCastlePlatform
 import okhttp3.internal.platform.Platform
@@ -27,8 +25,6 @@ import org.bouncycastle.jsse.BCSSLSocket
  * Simple non-reflection SocketAdapter for BouncyCastle.
  */
 class BouncyCastleSocketAdapter : SocketAdapter {
-  override fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? = null
-
   override fun matchesSocket(sslSocket: SSLSocket): Boolean = sslSocket is BCSSLSocket
 
   override fun isSupported(): Boolean = BouncyCastlePlatform.isSupported

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/BouncyCastleSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/BouncyCastleSocketAdapter.kt
@@ -20,7 +20,6 @@ import okhttp3.Protocol
 import okhttp3.internal.platform.BouncyCastlePlatform
 import okhttp3.internal.platform.Platform
 import org.bouncycastle.jsse.BCSSLSocket
-import org.conscrypt.Conscrypt
 
 /**
  * Simple non-reflection SocketAdapter for BouncyCastle.

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
@@ -54,7 +54,7 @@ class ConscryptSocketAdapter : SocketAdapter {
   companion object {
     val factory = object : DeferredSocketAdapter.Factory {
       override fun matchesSocket(sslSocket: SSLSocket): Boolean {
-        return Conscrypt.isConscrypt(sslSocket)
+        return ConscryptPlatform.isSupported && Conscrypt.isConscrypt(sslSocket)
       }
       override fun create(sslSocket: SSLSocket): SocketAdapter = ConscryptSocketAdapter()
     }

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
@@ -53,11 +53,10 @@ class ConscryptSocketAdapter : SocketAdapter {
 
   companion object {
     val factory = object : DeferredSocketAdapter.Factory {
-      override fun matchesSocket(sslSocket: SSLSocket): Boolean = Conscrypt.isConscrypt(sslSocket)
+      override fun matchesSocket(sslSocket: SSLSocket): Boolean {
+        return Conscrypt.isConscrypt(sslSocket)
+      }
       override fun create(sslSocket: SSLSocket): SocketAdapter = ConscryptSocketAdapter()
     }
-
-    fun buildIfSupported(): SocketAdapter? =
-        if (ConscryptPlatform.isSupported) ConscryptSocketAdapter() else null
   }
 }

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
@@ -22,7 +22,8 @@ import okhttp3.internal.platform.Platform
 import org.conscrypt.Conscrypt
 
 /**
- * Simple non-reflection SocketAdapter for Conscrypt.
+ * Simple non-reflection SocketAdapter for Conscrypt when included as an pplication dependency
+ * directly.
  */
 class ConscryptSocketAdapter : SocketAdapter {
   override fun matchesSocket(sslSocket: SSLSocket): Boolean = Conscrypt.isConscrypt(sslSocket)

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
@@ -16,8 +16,6 @@
 package okhttp3.internal.platform.android
 
 import javax.net.ssl.SSLSocket
-import javax.net.ssl.SSLSocketFactory
-import javax.net.ssl.X509TrustManager
 import okhttp3.Protocol
 import okhttp3.internal.platform.ConscryptPlatform
 import okhttp3.internal.platform.Platform
@@ -27,8 +25,6 @@ import org.conscrypt.Conscrypt
  * Simple non-reflection SocketAdapter for Conscrypt.
  */
 class ConscryptSocketAdapter : SocketAdapter {
-  override fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? = null
-
   override fun matchesSocket(sslSocket: SSLSocket): Boolean = Conscrypt.isConscrypt(sslSocket)
 
   override fun isSupported(): Boolean = ConscryptPlatform.isSupported
@@ -56,6 +52,11 @@ class ConscryptSocketAdapter : SocketAdapter {
   }
 
   companion object {
+    val factory = object : DeferredSocketAdapter.Factory {
+      override fun matchesSocket(sslSocket: SSLSocket): Boolean = Conscrypt.isConscrypt(sslSocket)
+      override fun create(sslSocket: SSLSocket): SocketAdapter = ConscryptSocketAdapter()
+    }
+
     fun buildIfSupported(): SocketAdapter? =
         if (ConscryptPlatform.isSupported) ConscryptSocketAdapter() else null
   }

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/ConscryptSocketAdapter.kt
@@ -22,7 +22,7 @@ import okhttp3.internal.platform.Platform
 import org.conscrypt.Conscrypt
 
 /**
- * Simple non-reflection SocketAdapter for Conscrypt when included as an pplication dependency
+ * Simple non-reflection SocketAdapter for Conscrypt when included as an application dependency
  * directly.
  */
 class ConscryptSocketAdapter : SocketAdapter {

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/DeferredSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/DeferredSocketAdapter.kt
@@ -30,7 +30,6 @@ class DeferredSocketAdapter(private val socketAdapterFactory: Factory) : SocketA
   }
 
   override fun matchesSocket(sslSocket: SSLSocket): Boolean {
-//    return sslSocket.javaClass.name.startsWith(socketPackage)
     if (socketAdapterFactory.matchesSocket(sslSocket)) {
       return true
     }
@@ -51,7 +50,7 @@ class DeferredSocketAdapter(private val socketAdapterFactory: Factory) : SocketA
   }
 
   @Synchronized private fun getDelegate(sslSocket: SSLSocket): SocketAdapter? {
-    if (this.delegate == null) {
+    if (this.delegate == null && socketAdapterFactory.matchesSocket(sslSocket)) {
       this.delegate = socketAdapterFactory.create(sslSocket)
     }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/DeferredSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/DeferredSocketAdapter.kt
@@ -21,6 +21,10 @@ import okhttp3.Protocol
 /**
  * Deferred implementation of SocketAdapter that works by observing the socket
  * and initializing on first use.
+ *
+ * We use this because eager classpath checks cause confusion and excessive logging in Android,
+ * and we can't rely on classnames after proguard, so are probably best served by falling through
+ * to a situation of trying our least likely noisiest options.
  */
 class DeferredSocketAdapter(private val socketAdapterFactory: Factory) : SocketAdapter {
   private var delegate: SocketAdapter? = null
@@ -29,13 +33,8 @@ class DeferredSocketAdapter(private val socketAdapterFactory: Factory) : SocketA
     return true
   }
 
-  override fun matchesSocket(sslSocket: SSLSocket): Boolean {
-    if (socketAdapterFactory.matchesSocket(sslSocket)) {
-      return true
-    }
-
-    return false
-  }
+  override fun matchesSocket(sslSocket: SSLSocket): Boolean =
+    socketAdapterFactory.matchesSocket(sslSocket)
 
   override fun configureTlsExtensions(
     sslSocket: SSLSocket,

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/DeferredSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/DeferredSocketAdapter.kt
@@ -19,7 +19,7 @@ import javax.net.ssl.SSLSocket
 import okhttp3.Protocol
 
 /**
- * Deferred implementation of SocketAdapter that can only work by observing the socket
+ * Deferred implementation of SocketAdapter that works by observing the socket
  * and initializing on first use.
  */
 class DeferredSocketAdapter(private val socketAdapterFactory: Factory) : SocketAdapter {

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/SocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/SocketAdapter.kt
@@ -22,7 +22,7 @@ import okhttp3.Protocol
 
 interface SocketAdapter {
   fun isSupported(): Boolean
-  fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager?
+  fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? = null
   fun matchesSocket(sslSocket: SSLSocket): Boolean
   fun matchesSocketFactory(sslSocketFactory: SSLSocketFactory): Boolean = false
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/StandardAndroidSocketAdapter.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/StandardAndroidSocketAdapter.kt
@@ -23,6 +23,9 @@ import okhttp3.internal.readFieldOrNull
 
 /**
  * Base Android reflection based SocketAdapter for the built in Android SSLSocket.
+ *
+ * It's assumed to always be present with known class names on Android devices, so we build
+ * optimistically via [buildIfSupported].  But it also doesn't assume a compile time API.
  */
 class StandardAndroidSocketAdapter(
   sslSocketClass: Class<in SSLSocket>,

--- a/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
@@ -99,6 +99,7 @@ class AndroidSocketAdapterTest(private val adapter: SocketAdapter) {
     fun data(): Collection<SocketAdapter> {
       return listOfNotNull(
           DeferredSocketAdapter(ConscryptSocketAdapter.factory),
+          DeferredSocketAdapter(AndroidSocketAdapter.factory("org.conscrypt")),
           AndroidSocketAdapter.buildIfSupported("org.conscrypt"),
           StandardAndroidSocketAdapter.buildIfSupported("org.conscrypt")
       )

--- a/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
@@ -98,7 +98,6 @@ class AndroidSocketAdapterTest(private val adapter: SocketAdapter) {
     @Parameterized.Parameters(name = "{0}")
     fun data(): Collection<SocketAdapter> {
       return listOfNotNull(
-          ConscryptSocketAdapter.buildIfSupported(),
           DeferredSocketAdapter(ConscryptSocketAdapter.factory),
           AndroidSocketAdapter.buildIfSupported("org.conscrypt"),
           StandardAndroidSocketAdapter.buildIfSupported("org.conscrypt")

--- a/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
@@ -100,7 +100,6 @@ class AndroidSocketAdapterTest(private val adapter: SocketAdapter) {
       return listOfNotNull(
           DeferredSocketAdapter(ConscryptSocketAdapter.factory),
           DeferredSocketAdapter(AndroidSocketAdapter.factory("org.conscrypt")),
-          AndroidSocketAdapter.buildIfSupported("org.conscrypt"),
           StandardAndroidSocketAdapter.buildIfSupported("org.conscrypt")
       )
     }

--- a/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
@@ -99,7 +99,7 @@ class AndroidSocketAdapterTest(private val adapter: SocketAdapter) {
     fun data(): Collection<SocketAdapter> {
       return listOfNotNull(
           ConscryptSocketAdapter.buildIfSupported(),
-          DeferredSocketAdapter("org.conscrypt"),
+          DeferredSocketAdapter(ConscryptSocketAdapter.factory),
           AndroidSocketAdapter.buildIfSupported("org.conscrypt"),
           StandardAndroidSocketAdapter.buildIfSupported("org.conscrypt")
       )


### PR DESCRIPTION
Avoid https://github.com/square/okhttp/issues/5760, by deferring work from building the platform until when it first encounters an unknown socket type.

This is high priority because the log warning causes a lot of bad stackoverflow advice to add conscrypt dependencies, which is not the intention. https://stackoverflow.com/search?q=org.conscrypt.ConscryptHostnameVerifier