### PR TITLE
Handle tests that try to log via MockWebServer

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
@@ -83,7 +83,11 @@ object AndroidLog {
     }
   }
 
-  private fun loggerTag(loggerName: String) = knownLoggers[loggerName] ?: loggerName
+  private fun loggerTag(loggerName: String): String {
+    // Handle Long logger names
+    // java.lang.IllegalArgumentException: Log tag "okhttp3.mockwebserver.MockWebServer" exceeds limit of 23 characters
+    return knownLoggers[loggerName] ?: loggerName.take(23)
+  }
 
   fun enable() {
     for ((logger, tag) in knownLoggers) {

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
@@ -84,7 +84,7 @@ object AndroidLog {
   }
 
   private fun loggerTag(loggerName: String): String {
-    // Handle Long logger names
+    // We need to handle long logger names before they hit Log.
     // java.lang.IllegalArgumentException: Log tag "okhttp3.mockwebserver.MockWebServer" exceeds limit of 23 characters
     return knownLoggers[loggerName] ?: loggerName.take(23)
   }


### PR DESCRIPTION
On older Android this causes a crash, other non-test loggers are handled already via AndroidLog mappings.