### PR TITLE
Fix Android Platform init

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
@@ -186,7 +186,8 @@ open class Platform {
 
     // This explicit check avoids activating in Android Studio with Android specific classes
     // available when running plugins inside the IDE.
-    val isAndroid = "Dalvik" == System.getProperty("java.vm.name")
+    val isAndroid: Boolean
+        get() = "Dalvik" == System.getProperty("java.vm.name")
 
     private val isConscryptPreferred: Boolean
       get() {


### PR DESCRIPTION
The Platform Companion ordering means that a Boolean field and the Platform instance field can race.