### PR TITLE
Fix BrotliInterceptor failing to handle No content response

### DIFF
--- a/okhttp-brotli/src/main/kotlin/okhttp3/brotli/BrotliInterceptor.kt
+++ b/okhttp-brotli/src/main/kotlin/okhttp3/brotli/BrotliInterceptor.kt
@@ -18,6 +18,7 @@ package okhttp3.brotli
 import okhttp3.Interceptor
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
+import okhttp3.internal.http.promisesBody
 import okio.GzipSource
 import okio.buffer
 import okio.source
@@ -44,6 +45,9 @@ object BrotliInterceptor : Interceptor {
       }
 
   internal fun uncompress(response: Response): Response {
+    if (!response.promisesBody()) {
+      return response
+    }
     val body = response.body ?: return response
     val encoding = response.header("Content-Encoding") ?: return response
 

--- a/okhttp-brotli/src/test/java/okhttp3/brotli/BrotliInterceptorTest.kt
+++ b/okhttp-brotli/src/test/java/okhttp3/brotli/BrotliInterceptorTest.kt
@@ -22,6 +22,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.ByteString
+import okio.ByteString.Companion.EMPTY
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
@@ -93,6 +94,20 @@ class BrotliInterceptorTest {
       assertThat(ioe).hasMessage("Brotli stream decoding failed")
       assertThat(ioe.cause?.javaClass?.simpleName).isEqualTo("BrotliRuntimeException")
     }
+  }
+
+  @Test
+  fun testSkipUncompressNoContentResponse() {
+    val response = response("https://httpbin.org/brotli", EMPTY) {
+      header("Content-Encoding", "br")
+      code(204)
+      message("NO CONTENT")
+    }
+
+    val same = BrotliInterceptor.uncompress(response)
+
+    val responseString = same.body?.string()
+    assertThat(responseString).isEmpty()
   }
 
   private fun response(


### PR DESCRIPTION
This PR fix `BrotliInterceptor` error when handle HEAD request, or 204 no content response:
```
java.io.IOException: Brotli stream decoding failed
	at org.brotli.dec.BrotliInputStream.read(BrotliInputStream.java:167)
	at okio.InputStreamSource.read(JvmOkio.kt:90)
	at okio.RealBufferedSource.select(RealBufferedSource.kt:231)
	at okhttp3.internal.Util.readBomAsCharset(Util.kt:259)
	at okhttp3.ResponseBody.string(ResponseBody.kt:187)
	at okhttp3.brotli.BrotliInterceptorTest.testSkipUncompressNoContentResponse(BrotliInterceptorTest.kt:109)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: org.brotli.dec.BrotliRuntimeException: Unused space
	at org.brotli.dec.Decode.readHuffmanCodeLengths(Decode.java:226)
	at org.brotli.dec.Decode.readHuffmanCode(Decode.java:296)
	at org.brotli.dec.HuffmanTreeGroup.decode(HuffmanTreeGroup.java:53)
	at org.brotli.dec.Decode.readMetablockHuffmanCodesAndContextMaps(Decode.java:528)
	at org.brotli.dec.Decode.decompress(Decode.java:621)
	at org.brotli.dec.BrotliInputStream.read(BrotliInputStream.java:161)
	... 30 more
```

Fixes https://github.com/square/okhttp/issues/6074