### PR TITLE
Tidy up the code that does connection releasing in RealCall

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Cache.kt
@@ -295,9 +295,9 @@ class Cache internal constructor(
   @Throws(IOException::class)
   fun urls(): MutableIterator<String> {
     return object : MutableIterator<String> {
-      val delegate: MutableIterator<DiskLruCache.Snapshot> = cache.snapshots()
-      var nextUrl: String? = null
-      var canRemove = false
+      private val delegate: MutableIterator<DiskLruCache.Snapshot> = cache.snapshots()
+      private var nextUrl: String? = null
+      private var canRemove = false
 
       override fun hasNext(): Boolean {
         if (nextUrl != null) return true

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
@@ -36,7 +36,6 @@ import okhttp3.internal.http.RealResponseBody
 import okhttp3.internal.http.promisesBody
 import okio.Buffer
 import okio.Source
-import okio.Timeout
 import okio.buffer
 
 /** Serves requests from the cache and writes responses to the cache. */
@@ -170,7 +169,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
     val cacheBody = cacheBodyUnbuffered.buffer()
 
     val cacheWritingSource = object : Source {
-      var cacheRequestClosed: Boolean = false
+      private var cacheRequestClosed = false
 
       @Throws(IOException::class)
       override fun read(sink: Buffer, byteCount: Long): Long {
@@ -198,9 +197,7 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
         return bytesRead
       }
 
-      override fun timeout(): Timeout {
-        return source.timeout()
-      }
+      override fun timeout() = source.timeout()
 
       @Throws(IOException::class)
       override fun close() {

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/DiskLruCache.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/DiskLruCache.kt
@@ -746,13 +746,13 @@ class DiskLruCache internal constructor(
     initialize()
     return object : MutableIterator<Snapshot> {
       /** Iterate a copy of the entries to defend against concurrent modification errors. */
-      val delegate = ArrayList(lruEntries.values).iterator()
+      private val delegate = ArrayList(lruEntries.values).iterator()
 
       /** The snapshot to return from [next]. Null if we haven't computed that yet. */
-      var nextSnapshot: Snapshot? = null
+      private var nextSnapshot: Snapshot? = null
 
       /** The snapshot to remove with [remove]. Null if removal is illegal. */
-      var removeSnapshot: Snapshot? = null
+      private var removeSnapshot: Snapshot? = null
 
       override fun hasNext(): Boolean {
         if (nextSnapshot != null) return true
@@ -1031,7 +1031,7 @@ class DiskLruCache internal constructor(
 
       lockingSourceCount++
       return object : ForwardingSource(fileSource) {
-        var closed = false
+        private var closed = false
         override fun close() {
           super.close()
           if (!closed) {


### PR DESCRIPTION
Recent refactorings have made it clear that there's three things
we need to be done before we can release the connection:
 - the request body
 - the response body
 - the series of exchanges

This changes the code to invert these booleans. In a follow-up I'd
like to add some defensive code around duplex calls where the request
and response body could race when they close.