### PR TITLE
Clarify Interceptor timeout docs

### DIFF
--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -124,13 +124,14 @@ Each interceptor chain has relative merits.
  * Observe the application's original intent. Unconcerned with OkHttp-injected headers like `If-None-Match`.
  * Permitted to short-circuit and not call `Chain.proceed()`.
  * Permitted to retry and make multiple calls to `Chain.proceed()`.
+ * Can adjust Call timeouts using withConnectTimeout, withReadTimeout, withWriteTimeout.
 
 **Network Interceptors**
 
  * Able to operate on intermediate responses like redirects and retries.
  * Not invoked for cached responses that short-circuit the network.
  * Observe the data just as it will be transmitted over the network.
- * Access to the `Connection` that carries the request.
+ * Access to the `Connection` that carries the request..
 
 ### Rewriting Requests
 

--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -131,7 +131,7 @@ Each interceptor chain has relative merits.
  * Able to operate on intermediate responses like redirects and retries.
  * Not invoked for cached responses that short-circuit the network.
  * Observe the data just as it will be transmitted over the network.
- * Access to the `Connection` that carries the request..
+ * Access to the `Connection` that carries the request.
 
 ### Rewriting Requests
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/http/RealInterceptorChain.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http/RealInterceptorChain.kt
@@ -60,18 +60,27 @@ class RealInterceptorChain(
 
   override fun connectTimeoutMillis(): Int = connectTimeoutMillis
 
-  override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain =
-      copy(connectTimeoutMillis = checkDuration("connectTimeout", timeout.toLong(), unit))
+  override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+    check(exchange == null) { "Timeouts can't be adjusted in a network interceptor" }
+
+    return copy(connectTimeoutMillis = checkDuration("connectTimeout", timeout.toLong(), unit))
+  }
 
   override fun readTimeoutMillis(): Int = readTimeoutMillis
 
-  override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain =
-      copy(readTimeoutMillis = checkDuration("readTimeout", timeout.toLong(), unit))
+  override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+    check(exchange == null) { "Timeouts can't be adjusted in a network interceptor" }
+
+    return copy(readTimeoutMillis = checkDuration("readTimeout", timeout.toLong(), unit))
+  }
 
   override fun writeTimeoutMillis(): Int = writeTimeoutMillis
 
-  override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain =
-      copy(writeTimeoutMillis = checkDuration("writeTimeout", timeout.toLong(), unit))
+  override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {
+    check(exchange == null) { "Timeouts can't be adjusted in a network interceptor" }
+
+    return copy(writeTimeoutMillis = checkDuration("writeTimeout", timeout.toLong(), unit))
+  }
 
   override fun call(): Call = call
 

--- a/okhttp/src/test/java/okhttp3/InterceptorTest.java
+++ b/okhttp/src/test/java/okhttp3/InterceptorTest.java
@@ -44,6 +44,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public final class InterceptorTest {
@@ -752,6 +753,48 @@ public final class InterceptorTest {
       body.string();
       fail();
     } catch (SocketTimeoutException expected) {
+    }
+  }
+
+  @Test public void networkInterceptorCannotChangeReadTimeout() throws Exception {
+    addInterceptor(true, chain ->
+        chain.withReadTimeout(100, TimeUnit.MILLISECONDS).proceed(chain.request()));
+
+    Request request1 = new Request.Builder().url(server.url("/")).build();
+    Call call = client.newCall(request1);
+    try {
+      call.execute();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertThat(expected.getMessage()).isEqualTo("Timeouts can't be adjusted in a network interceptor");
+    }
+  }
+
+  @Test public void networkInterceptorCannotChangeWriteTimeout() throws Exception {
+    addInterceptor(true, chain ->
+        chain.withWriteTimeout(100, TimeUnit.MILLISECONDS).proceed(chain.request()));
+
+    Request request1 = new Request.Builder().url(server.url("/")).build();
+    Call call = client.newCall(request1);
+    try {
+      call.execute();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertThat(expected.getMessage()).isEqualTo("Timeouts can't be adjusted in a network interceptor");
+    }
+  }
+
+  @Test public void networkInterceptorCannotChangeConnectTimeout() throws Exception {
+    addInterceptor(true, chain ->
+        chain.withConnectTimeout(100, TimeUnit.MILLISECONDS).proceed(chain.request()));
+
+    Request request1 = new Request.Builder().url(server.url("/")).build();
+    Call call = client.newCall(request1);
+    try {
+      call.execute();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertThat(expected.getMessage()).isEqualTo("Timeouts can't be adjusted in a network interceptor");
     }
   }
 


### PR DESCRIPTION
Timeout mostly take effect before we have a connection, so rely on being adjusted in the application interceptors.

Instead of fixing the limitation highlighted here https://github.com/square/okhttp/issues/6100, simplify clarify that adjusting timeouts must be done in application interceptors.

An alternative implementation would simply ignore these updates, but that seems worse longer term for support requests "Why is my timeout ignored".  These are only used in ExchangeFinder before networkInterceptors fire.

