### PR TITLE
Add Monitoring Connections for Error Status Messages

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.java
+++ b/okhttp/src/main/java/okhttp3/internal/http/RealInterceptorChain.java
@@ -157,7 +157,7 @@ public final class RealInterceptorChain implements Interceptor.Chain {
       throw new NullPointerException("interceptor " + interceptor + " returned null");
     }
 
-    if (response.body() == null) {
+    if ((response.code() < 400 || response.code() >= 500) && response.body() == null) {
       throw new IllegalStateException(
           "interceptor " + interceptor + " returned a response with no body");
     }

--- a/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
+++ b/okhttp/src/main/java/okhttp3/internal/http1/Http1Codec.java
@@ -181,7 +181,9 @@ public final class Http1Codec implements HttpCodec {
   }
 
   @Override public Response.Builder readResponseHeaders(boolean expectContinue) throws IOException {
-    if (state != STATE_OPEN_REQUEST_BODY && state != STATE_READ_RESPONSE_HEADERS) {
+    if (state != STATE_WRITING_REQUEST_BODY
+                    && state != STATE_OPEN_REQUEST_BODY
+                    && state != STATE_READ_RESPONSE_HEADERS) {
       throw new IllegalStateException("state: " + state);
     }
 


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc2616#section-8.2.2 An
HTTP/1.1 (or later) client sending a message-body SHOULD
monitor the network connection for an error status while it
is transmitting the request.

Currently, okhttp implements a send request, then read response
if/when request was sent successfully.
This hides early responses such as 413 Payload Too Large
errors from clients.

This commit fixes that by adding a response read in case of an
exception happening while the request is being sent.

This closes #1001 .