### PR TITLE
introduced RoboVM platform. Goal to allow use AndroidSocketAdapter with RoboVM

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
@@ -189,6 +189,9 @@ open class Platform {
     val isAndroid: Boolean
         get() = "Dalvik" == System.getProperty("java.vm.name")
 
+    val isRoboVM: Boolean
+      get() = "RoboVM" == System.getProperty("java.vm.name")
+
     private val isConscryptPreferred: Boolean
       get() {
         val preferredProvider = Security.getProviders()[0].name
@@ -208,7 +211,9 @@ open class Platform {
       }
 
     /** Attempt to match the host runtime to a capable Platform implementation. */
-    private fun findPlatform(): Platform = if (isAndroid) {
+    private fun findPlatform(): Platform = if (isRoboVM) {
+      RoboVMPlatform()
+    } else if (isAndroid) {
       findAndroidPlatform()
     } else {
       findJvmPlatform()

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
@@ -189,7 +189,7 @@ open class Platform {
     val isAndroid: Boolean
         get() = "Dalvik" == System.getProperty("java.vm.name")
 
-    val isRoboVM: Boolean
+    val isRoboVm: Boolean
       get() = "RoboVM" == System.getProperty("java.vm.name")
 
     private val isConscryptPreferred: Boolean
@@ -211,8 +211,8 @@ open class Platform {
       }
 
     /** Attempt to match the host runtime to a capable Platform implementation. */
-    private fun findPlatform(): Platform = if (isRoboVM) {
-      RoboVMPlatform()
+    private fun findPlatform(): Platform = if (isRoboVm) {
+      RoboVmPlatform()
     } else if (isAndroid) {
       findAndroidPlatform()
     } else {

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
@@ -189,9 +189,6 @@ open class Platform {
     val isAndroid: Boolean
         get() = "Dalvik" == System.getProperty("java.vm.name")
 
-    val isRoboVm: Boolean
-      get() = "RoboVM" == System.getProperty("java.vm.name")
-
     private val isConscryptPreferred: Boolean
       get() {
         val preferredProvider = Security.getProviders()[0].name
@@ -211,9 +208,7 @@ open class Platform {
       }
 
     /** Attempt to match the host runtime to a capable Platform implementation. */
-    private fun findPlatform(): Platform = if (isRoboVm) {
-      RoboVmPlatform()
-    } else if (isAndroid) {
+    private fun findPlatform(): Platform = if (isAndroid) {
       findAndroidPlatform()
     } else {
       findJvmPlatform()
@@ -261,6 +256,13 @@ open class Platform {
 
       if (jdkWithJettyBoot != null) {
         return jdkWithJettyBoot
+      }
+
+      // RoboVM, Android4 like.
+      val robovm = RoboVmPlatform.buildIfSupported()
+
+      if (robovm != null) {
+        return robovm
       }
 
       return Platform()

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/RoboVMPlatform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/RoboVMPlatform.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.platform
+
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.X509TrustManager
+import okhttp3.Protocol
+import okhttp3.internal.platform.android.CloseGuard
+import okhttp3.internal.platform.android.ConscryptSocketAdapter
+import okhttp3.internal.platform.android.DeferredSocketAdapter
+import okhttp3.internal.platform.android.StandardAndroidSocketAdapter
+
+/** Android 4 based platform for RoboVM */
+class RoboVMPlatform : Platform() {
+  private val socketAdapters = listOfNotNull(
+      StandardAndroidSocketAdapter.buildIfSupported(),
+      // Delay and Defer any initialisation of Conscrypt and BouncyCastle
+      DeferredSocketAdapter(ConscryptSocketAdapter.factory)
+  ).filter { it.isSupported() }
+
+  private val closeGuard = CloseGuard.get()
+
+  @Throws(IOException::class)
+  override fun connectSocket(
+    socket: Socket,
+    address: InetSocketAddress,
+    connectTimeout: Int
+  ) {
+    socket.connect(address, connectTimeout)
+  }
+
+  override fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? =
+      socketAdapters.find { it.matchesSocketFactory(sslSocketFactory) }
+          ?.trustManager(sslSocketFactory)
+
+  override fun configureTlsExtensions(
+    sslSocket: SSLSocket,
+    hostname: String?,
+    protocols: List<@JvmSuppressWildcards Protocol>
+  ) {
+    // No TLS extensions if the socket class is custom.
+    socketAdapters.find { it.matchesSocket(sslSocket) }
+        ?.configureTlsExtensions(sslSocket, hostname, protocols)
+  }
+
+  override fun getSelectedProtocol(sslSocket: SSLSocket) =
+      // No TLS extensions if the socket class is custom.
+      socketAdapters.find { it.matchesSocket(sslSocket) }?.getSelectedProtocol(sslSocket)
+
+  override fun getStackTraceForCloseable(closer: String): Any? = closeGuard.createAndOpen(closer)
+
+  override fun logCloseableLeak(message: String, stackTrace: Any?) {
+    val reported = closeGuard.warnIfOpen(stackTrace)
+    if (!reported) {
+      // Unable to report via CloseGuard. As a last-ditch effort, send it to the logger.
+      log(message, WARN)
+    }
+  }
+}

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/RoboVmPlatform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/RoboVmPlatform.kt
@@ -15,36 +15,20 @@
  */
 package okhttp3.internal.platform
 
-import java.io.IOException
-import java.net.InetSocketAddress
-import java.net.Socket
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
 import okhttp3.Protocol
 import okhttp3.internal.platform.android.CloseGuard
-import okhttp3.internal.platform.android.ConscryptSocketAdapter
-import okhttp3.internal.platform.android.DeferredSocketAdapter
 import okhttp3.internal.platform.android.StandardAndroidSocketAdapter
 
 /** Android 4 based platform for RoboVM */
-class RoboVMPlatform : Platform() {
+class RoboVmPlatform : Platform() {
   private val socketAdapters = listOfNotNull(
-      StandardAndroidSocketAdapter.buildIfSupported(),
-      // Delay and Defer any initialisation of Conscrypt and BouncyCastle
-      DeferredSocketAdapter(ConscryptSocketAdapter.factory)
-  ).filter { it.isSupported() }
+      StandardAndroidSocketAdapter.buildIfSupported()
+  )
 
   private val closeGuard = CloseGuard.get()
-
-  @Throws(IOException::class)
-  override fun connectSocket(
-    socket: Socket,
-    address: InetSocketAddress,
-    connectTimeout: Int
-  ) {
-    socket.connect(address, connectTimeout)
-  }
 
   override fun trustManager(sslSocketFactory: SSLSocketFactory): X509TrustManager? =
       socketAdapters.find { it.matchesSocketFactory(sslSocketFactory) }


### PR DESCRIPTION
RoboVM is android4 based runtime and it shares amount of classes from Android4.
Its important to check for RoboVM platform before Android as RoboVM gets classified as Android  and then okhttp will crash with `java.lang.NoClassDefFoundError: android/os/Build$VERSION`.
RoboVMPlatform class is based on Android one. Unsupported entities were removed.