### PR TITLE
Move tag management in DerAdapters

### DIFF
--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/Adapters.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/Adapters.kt
@@ -27,78 +27,86 @@ import okio.ByteString
  * Built-in adapters for reading standard ASN.1 types.
  */
 internal object Adapters {
-  val BOOLEAN = object : DerAdapter<Boolean>(
+  val BOOLEAN = BasicDerAdapter(
+      name = "BOOLEAN",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 1L
-  ) {
-    override fun encode(writer: DerWriter, value: Boolean) = writer.writeBoolean(value)
+      tag = 1L,
+      codec = object : BasicDerAdapter.Codec<Boolean> {
+        override fun decode(reader: DerReader) = reader.readBoolean()
+        override fun encode(writer: DerWriter, value: Boolean) = writer.writeBoolean(value)
+      }
+  )
 
-    override fun decode(reader: DerReader, header: DerHeader) = reader.readBoolean()
-  }
-
-  val INTEGER_AS_LONG = object : DerAdapter<Long>(
+  val INTEGER_AS_LONG = BasicDerAdapter(
+      name = "INTEGER",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 2L
-  ) {
-    override fun encode(writer: DerWriter, value: Long) = writer.writeLong(value)
+      tag = 2L,
+      codec = object : BasicDerAdapter.Codec<Long> {
+        override fun decode(reader: DerReader) = reader.readLong()
+        override fun encode(writer: DerWriter, value: Long) = writer.writeLong(value)
+      }
+  )
 
-    override fun decode(reader: DerReader, header: DerHeader) = reader.readLong()
-  }
-
-  val INTEGER_AS_BIG_INTEGER = object : DerAdapter<BigInteger>(
+  val INTEGER_AS_BIG_INTEGER = BasicDerAdapter(
+      name = "INTEGER",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 2L
-  ) {
-    override fun encode(writer: DerWriter, value: BigInteger) = writer.writeBigInteger(value)
+      tag = 2L,
+      codec = object : BasicDerAdapter.Codec<BigInteger> {
+        override fun decode(reader: DerReader) = reader.readBigInteger()
+        override fun encode(writer: DerWriter, value: BigInteger) = writer.writeBigInteger(value)
+      }
+  )
 
-    override fun decode(reader: DerReader, header: DerHeader) = reader.readBigInteger()
-  }
-
-  val BIT_STRING = object : DerAdapter<BitString>(
+  val BIT_STRING = BasicDerAdapter(
+      name = "BIT STRING",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 3L
-  ) {
-    override fun encode(writer: DerWriter, value: BitString) = writer.writeBitString(value)
+      tag = 3L,
+      codec = object : BasicDerAdapter.Codec<BitString> {
+        override fun decode(reader: DerReader) = reader.readBitString()
+        override fun encode(writer: DerWriter, value: BitString) = writer.writeBitString(value)
+      }
+  )
 
-    override fun decode(reader: DerReader, header: DerHeader) = reader.readBitString()
-  }
-
-  val OCTET_STRING = object : DerAdapter<ByteString>(
+  val OCTET_STRING = BasicDerAdapter(
+      name = "OCTET STRING",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 4L
-  ) {
-    override fun encode(writer: DerWriter, value: ByteString) = writer.writeOctetString(value)
+      tag = 4L,
+      codec = object : BasicDerAdapter.Codec<ByteString> {
+        override fun decode(reader: DerReader) = reader.readOctetString()
+        override fun encode(writer: DerWriter, value: ByteString) = writer.writeOctetString(value)
+      }
+  )
 
-    override fun decode(reader: DerReader, header: DerHeader) = reader.readOctetString()
-  }
-
-  val NULL = object : DerAdapter<Unit?>(
+  val NULL = BasicDerAdapter(
+      name = "NULL",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 5L
-  ) {
-    override fun encode(writer: DerWriter, value: Unit?) {
-    }
+      tag = 5L,
+      codec = object : BasicDerAdapter.Codec<Unit?> {
+        override fun decode(reader: DerReader) = null
+        override fun encode(writer: DerWriter, value: Unit?) {
+        }
+      }
+  )
 
-    override fun decode(reader: DerReader, header: DerHeader): Unit? = null
-  }
-
-  val OBJECT_IDENTIFIER = object : DerAdapter<String>(
+  val OBJECT_IDENTIFIER = BasicDerAdapter(
+      name = "OBJECT IDENTIFIER",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 6L
-  ) {
-    override fun encode(writer: DerWriter, value: String) = writer.writeObjectIdentifier(value)
+      tag = 6L,
+      codec = object : BasicDerAdapter.Codec<String> {
+        override fun decode(reader: DerReader) = reader.readObjectIdentifier()
+        override fun encode(writer: DerWriter, value: String) = writer.writeObjectIdentifier(value)
+      }
+  )
 
-    override fun decode(reader: DerReader, header: DerHeader) = reader.readObjectIdentifier()
-  }
-
-  val UTF8_STRING = object : DerAdapter<String>(
+  val UTF8_STRING = BasicDerAdapter(
+      name = "UTF8",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 12L
-  ) {
-    override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
-
-    override fun decode(reader: DerReader, header: DerHeader) = reader.readUtf8String()
-  }
+      tag = 12L,
+      codec = object : BasicDerAdapter.Codec<String> {
+        override fun decode(reader: DerReader) = reader.readUtf8String()
+        override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
+      }
+  )
 
   /**
    * Permits alphanumerics, spaces, and these:
@@ -108,47 +116,50 @@ internal object Adapters {
    * ```
    */
   // TODO(jwilson): constrain to printable string characters.
-  val PRINTABLE_STRING = object : DerAdapter<String>(
+  val PRINTABLE_STRING = BasicDerAdapter(
+      name = "PRINTABLE STRING",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 19L
-  ) {
-    override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
-
-    override fun decode(reader: DerReader, header: DerHeader) = reader.readUtf8String()
-  }
+      tag = 19L,
+      codec = object : BasicDerAdapter.Codec<String> {
+        override fun decode(reader: DerReader) = reader.readUtf8String()
+        override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
+      }
+  )
 
   /**
    * Based on International Alphabet No. 5. Note that there are bytes that IA5 and US-ASCII
    * disagree on interpretation.
    */
   // TODO(jwilson): constrain to IA5 characters.
-  val IA5_STRING = object : DerAdapter<String>(
+  val IA5_STRING = BasicDerAdapter(
+      name = "IA5 STRING",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 22L
-  ) {
-    override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
-
-    override fun decode(reader: DerReader, header: DerHeader) = reader.readUtf8String()
-  }
+      tag = 22L,
+      codec = object : BasicDerAdapter.Codec<String> {
+        override fun decode(reader: DerReader) = reader.readUtf8String()
+        override fun encode(writer: DerWriter, value: String) = writer.writeUtf8(value)
+      }
+  )
 
   /**
    * A timestamp like "191216030210Z" or "191215190210-0800" for 2019-12-15T19:02:10-08:00. The
    * cutoff of the 2-digit year is 1950-01-01T00:00:00Z.
    */
-  val UTC_TIME = object : DerAdapter<Long>(
+  val UTC_TIME = BasicDerAdapter(
+      name = "UTC TIME",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 23L
-  ) {
-    override fun encode(writer: DerWriter, value: Long) {
-      val string = formatUtcTime(value)
-      writer.writeUtf8(string)
-    }
-
-    override fun decode(reader: DerReader, header: DerHeader): Long {
-      val string = reader.readUtf8String()
-      return parseUtcTime(string)
-    }
-  }
+      tag = 23L,
+      codec = object : BasicDerAdapter.Codec<Long> {
+        override fun decode(reader: DerReader): Long {
+          val string = reader.readUtf8String()
+          return parseUtcTime(string)
+        }
+        override fun encode(writer: DerWriter, value: Long) {
+          val string = formatUtcTime(value)
+          return writer.writeUtf8(string)
+        }
+      }
+  )
 
   internal fun parseUtcTime(string: String): Long {
     val utc = TimeZone.getTimeZone("GMT")
@@ -175,20 +186,21 @@ internal object Adapters {
    * A timestamp like "191216030210Z" or "20191215190210-0800" for 2019-12-15T19:02:10-08:00. This
    * is the same as [UTC_TIME] with the exception of the 4-digit year.
    */
-  val GENERALIZED_TIME = object : DerAdapter<Long>(
+  val GENERALIZED_TIME = BasicDerAdapter(
+      name = "GENERALIZED TIME",
       tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-      tag = 24L
-  ) {
-    override fun encode(writer: DerWriter, value: Long) {
-      val string = formatGeneralizedTime(value)
-      writer.writeUtf8(string)
-    }
-
-    override fun decode(reader: DerReader, header: DerHeader): Long {
-      val string = reader.readUtf8String()
-      return parseGeneralizedTime(string)
-    }
-  }
+      tag = 24L,
+      codec = object : BasicDerAdapter.Codec<Long> {
+        override fun decode(reader: DerReader): Long {
+          val string = reader.readUtf8String()
+          return parseGeneralizedTime(string)
+        }
+        override fun encode(writer: DerWriter, value: Long) {
+          val string = formatGeneralizedTime(value)
+          return writer.writeUtf8(string)
+        }
+      }
+  )
 
   internal fun parseGeneralizedTime(string: String): Long {
     val utc = TimeZone.getTimeZone("GMT")
@@ -220,142 +232,113 @@ internal object Adapters {
    * TODO: for set ofs, sort by encoded value when encoding.
    */
   fun <T> sequence(
+    name: String,
     vararg members: DerAdapter<*>,
     decompose: (T) -> List<*>,
     construct: (List<*>) -> T
-  ): DerAdapter<T> {
-    return object : DerAdapter<T>(
-        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
-        tag = 16L
-    ) {
-      override fun encode(writer: DerWriter, value: T) {
-        writer.pushTypeHint()
-        try {
-          encodeWithTypeHints(value, writer)
-        } finally {
-          writer.popTypeHint()
-        }
-      }
-
-      private fun encodeWithTypeHints(value: T, writer: DerWriter) {
-        val list = decompose(value)
-
-        for (i in list.indices) {
-          val v = list[i]
-          val adapter = members[i] as DerAdapter<Any?>
-
-          if (adapter.typeHint) {
-            writer.typeHint = v
-          }
-
-          if (adapter.omitInSequence(v)) {
-            // Skip.
-          } else {
-            writer.write(adapter, v)
-          }
-        }
-      }
-
-      override fun decode(reader: DerReader, header: DerHeader): T {
+  ): BasicDerAdapter<T> {
+    val codec = object : BasicDerAdapter.Codec<T> {
+      override fun decode(reader: DerReader): T {
         reader.pushTypeHint()
         try {
-          return decodeWithTypeHints(reader)
+          val list = mutableListOf<Any?>()
+
+          while (list.size < members.size) {
+            val member = members[list.size]
+            list += member.readValue(reader)
+          }
+
+          if (reader.hasNext()) {
+            throw IOException("unexpected ${reader.peekHeader()}")
+          }
+
+          return construct(list)
         } finally {
           reader.popTypeHint()
         }
       }
 
-      private fun decodeWithTypeHints(reader: DerReader): T {
-        val list = mutableListOf<Any?>()
-
-        while (list.size < members.size) {
-          val member = members[list.size]
-
-          val value = when {
-            reader.hasNext() &&
-                member.matches(reader.peekedTagClass, reader.peekedTag) -> {
-              reader.read(member)
-            }
-            member.isOptional -> {
-              member.defaultValue
-            }
-            else -> {
-              throw IOException("expected ${member.tagClass}/${member.tag} " +
-                  "but was ${reader.peekedTagClass}/${reader.peekedTag}")
-            }
+      override fun encode(writer: DerWriter, value: T) {
+        val list = decompose(value)
+        writer.pushTypeHint()
+        try {
+          for (i in list.indices) {
+            val adapter = members[i] as DerAdapter<Any?>
+            adapter.writeValue(writer, list[i])
           }
-
-          if (member.typeHint) {
-            reader.typeHint = value
-          }
-          list += value
+        } finally {
+          writer.popTypeHint()
         }
-
-        if (reader.hasNext()) {
-          throw IOException("unexpected ${reader.peekedTagClass}/${reader.peekedTag}")
-        }
-
-        return construct(list)
       }
     }
+
+    return BasicDerAdapter(
+        name = name,
+        tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
+        tag = 16L,
+        codec = codec
+    )
   }
 
   /** Returns an adapter that decodes as the first of a list of available types. */
   fun choice(vararg choices: DerAdapter<*>): DerAdapter<Pair<DerAdapter<*>, Any?>> {
-    return object : DerAdapter<Pair<DerAdapter<*>, Any?>>(
-        tagClass = -1,
-        tag = -1L
-    ) {
-      override fun matches(tagClass: Int, tag: Long) = choices.any { it.matches(tagClass, tag) }
+    return object : DerAdapter<Pair<DerAdapter<*>, Any?>> {
+      override fun matches(header: DerHeader): Boolean = true
 
-      override fun encode(writer: DerWriter, value: Pair<DerAdapter<*>, Any?>) {
+      override fun readValue(reader: DerReader): Pair<DerAdapter<*>, Any?> {
+        val peekedHeader = reader.peekHeader()
+            ?: throw IOException("expected a value")
+
+        val choice = choices.firstOrNull { it.matches(peekedHeader) }
+            ?: throw IOException("expected a matching choice but was $peekedHeader")
+
+        return choice to choice.readValue(reader)
+      }
+
+      override fun writeValue(writer: DerWriter, value: Pair<DerAdapter<*>, Any?>) {
         val (adapter, v) = value
-        writer.write(adapter as DerAdapter<Any?>, v)
+        (adapter as DerAdapter<Any?>).writeValue(writer, v)
       }
 
-      override fun decode(reader: DerReader, header: DerHeader): Pair<DerAdapter<*>, Any?> {
-        val choice = choices.firstOrNull { it.matches(header.tagClass, header.tag) }
-            ?: throw IOException(
-                "expected a matching choice but was ${header.tagClass}/${header.tag}")
-
-        return choice to choice.decode(reader, header)
-      }
+      override fun toString() = choices.joinToString(separator = " OR ")
     }
   }
 
   /**
-   * This decodes an [OCTET_STRING] value into its contents, which are also expected to be ASN.1.
-   * To determine which type to decode as it uses a preceding member of the same SEQUENCE. For
+   * This decodes a value into its contents using a preceding member of the same SEQUENCE. For
    * example, extensions type IDs specify what types to use for the corresponding values.
    *
    * If the hint is unknown [chooser] should return null which will cause the value to be decoded as
    * an opaque byte string.
+   *
+   * This may optionally wrap the contents in a tag.
    */
-  fun usingTypeHint(chooser: (Any?) -> DerAdapter<*>?): DerAdapter<Any?> {
-    return object : DerAdapter<Any?>(tagClass = OCTET_STRING.tagClass, tag = OCTET_STRING.tag) {
-      override fun encode(writer: DerWriter, value: Any?) {
-        val adapter = chooser(writer.typeHint)
+  fun usingTypeHint(
+    chooser: (Any?) -> DerAdapter<*>?
+  ): DerAdapter<Any?> {
+    return object : DerAdapter<Any?> {
+      override fun matches(header: DerHeader): Boolean = true
 
+      override fun writeValue(writer: DerWriter, value: Any?) {
         // If we don't understand this hint, encode the body as a byte string. The byte string
         // will include a tag and length header as a prefix.
-        if (adapter == null) {
-          (OCTET_STRING as DerAdapter<Any?>).encode(writer, value)
-          return
-        }
+        val adapter = chooser(writer.typeHint)
 
-        writer.write(adapter as DerAdapter<Any?>, value)
+        if (adapter != null) {
+          (adapter as DerAdapter<Any?>).writeValue(writer, value)
+        } else {
+          writer.writeOctetString(value as ByteString)
+        }
       }
 
-      override fun decode(reader: DerReader, header: DerHeader): Any? {
+      override fun readValue(reader: DerReader): Any? {
         val adapter = chooser(reader.typeHint)
 
-        // If we don't understand this hint, decode the body as a byte string. The byte string
-        // will include a tag and length header as a prefix.
-        if (adapter == null) {
-          return OCTET_STRING.decode(reader, header)
+        if (adapter != null) {
+          return (adapter as DerAdapter<Any?>).readValue(reader)
+        } else {
+          return reader.readOctetString()
         }
-
-        return reader.read(adapter as DerAdapter<Any?>)
       }
     }
   }
@@ -380,42 +363,55 @@ internal object Adapters {
   )
 
   fun any(
-    vararg choices: Pair<KClass<*>, DerAdapter<*>> = defaultAnyChoices.toTypedArray()
+    vararg choices: Pair<KClass<*>, DerAdapter<*>> = defaultAnyChoices.toTypedArray(),
+    isOptional: Boolean = false,
+    optionalValue: Any? = null
   ): DerAdapter<Any?> {
-    return object : DerAdapter<Any?>(
-        tagClass = -1,
-        tag = -1L
-    ) {
-      override fun encode(writer: DerWriter, value: Any?) {
-        if (value is AnyValue) {
-          writer.write(withTag(value.tagClass, value.tag)) {
-            writer.writeOctetString(value.bytes)
+    return object : DerAdapter<Any?> {
+      override fun matches(header: DerHeader): Boolean = true
+
+      override fun writeValue(writer: DerWriter, value: Any?) {
+        when {
+          isOptional && value == optionalValue -> {
+            // Write nothing.
           }
-        } else {
-          for ((type, adapter) in choices) {
-            if (type.isInstance(value) || (value == null && type == Unit::class)) {
-              writer.write(adapter as DerAdapter<Any?>, value)
-              return
+
+          value is AnyValue -> {
+            writer.write("ANY", value.tagClass, value.tag) {
+              writer.writeOctetString(value.bytes)
+            }
+          }
+
+          else -> {
+            for ((type, adapter) in choices) {
+              if (type.isInstance(value) || (value == null && type == Unit::class)) {
+                (adapter as DerAdapter<Any?>).writeValue(writer, value)
+                return
+              }
             }
           }
         }
       }
 
-      override fun decode(reader: DerReader, header: DerHeader): Any? {
+      override fun readValue(reader: DerReader): Any? {
+        if (isOptional && !reader.hasNext()) return optionalValue
+
         for ((_, adapter) in choices) {
-          if (adapter.matches(header.tagClass, header.tag)) {
-            return adapter.decode(reader, header)
+          if (adapter.matches(reader.peekHeader()!!)) {
+            return adapter.readValue(reader)
           }
         }
 
-        val bytes = reader.readOctetString()
-        return AnyValue(
-            tagClass = header.tagClass,
-            tag = header.tag,
-            constructed = header.constructed,
-            length = header.length,
-            bytes = bytes
-        )
+        reader.read("ANY") { header ->
+          val bytes = reader.readOctetString()
+          return AnyValue(
+              tagClass = header.tagClass,
+              tag = header.tag,
+              constructed = header.constructed,
+              length = header.length,
+              bytes = bytes
+          )
+        }
       }
     }
   }

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/BasicDerAdapter.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/BasicDerAdapter.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.tls.internal.der
+
+import okio.IOException
+
+/**
+ * Handles basic types that always use the same tag. This supports optional types and may set a type
+ * hint for further adapters to process.
+ *
+ * Types like ANY and CHOICE that don't have a consistent tag cannot use this.
+ */
+internal data class BasicDerAdapter<T>(
+  private val name: String,
+
+  /** The tag class this adapter expects, or -1 to match any tag class. */
+  val tagClass: Int,
+
+  /** The tag this adapter expects, or -1 to match any tag. */
+  val tag: Long,
+
+  /** Encode and decode the value once tags are handled. */
+  private val codec: Codec<T>,
+
+  /** True if the default value should be used if this value is absent during decoding. */
+  val isOptional: Boolean = false,
+
+  /** The value to return if this value is absent. Undefined unless this is optional. */
+  val defaultValue: T? = null,
+
+  /** True to set the encoded or decoded value as the type hint for the current SEQUENCE. */
+  private val typeHint: Boolean = false
+) : DerAdapter<T> {
+
+  init {
+    require(tagClass >= 0)
+    require(tag >= 0)
+  }
+
+  override fun matches(header: DerHeader) = header.tagClass == tagClass && header.tag == tag
+
+  override fun readValue(reader: DerReader): T {
+    val peekedHeader = reader.peekHeader()
+    if (peekedHeader == null || peekedHeader.tagClass != tagClass || peekedHeader.tag != tag) {
+      if (isOptional) return defaultValue as T
+      throw IOException("expected $this but was $peekedHeader at $reader")
+    }
+
+    val result = reader.read(name) {
+      codec.decode(reader)
+    }
+
+    if (typeHint) {
+      reader.typeHint = result
+    }
+
+    return result
+  }
+
+  override fun writeValue(writer: DerWriter, value: T) {
+    if (typeHint) {
+      writer.typeHint = value
+    }
+
+    if (isOptional && value == defaultValue) {
+      // Nothing to write!
+      return
+    }
+
+    writer.write(name, tagClass, tag) {
+      codec.encode(writer, value)
+    }
+  }
+
+  /**
+   * Returns a copy with a context tag. This should be used when the type is ambiguous on its own.
+   * For example, the tags in this schema are 0 and 1:
+   *
+   * ```
+   * Point ::= SEQUENCE {
+   *   x [0] INTEGER OPTIONAL,
+   *   y [1] INTEGER OPTIONAL
+   * }
+   * ```
+   *
+   * You may also specify a tag class like [DerHeader.TAG_CLASS_APPLICATION]. The default tag class
+   * is [DerHeader.TAG_CLASS_CONTEXT_SPECIFIC].
+   *
+   * ```
+   * Point ::= SEQUENCE {
+   *   x [APPLICATION 0] INTEGER OPTIONAL,
+   *   y [APPLICATION 1] INTEGER OPTIONAL
+   * }
+   * ```
+   */
+  fun withTag(
+    tagClass: Int = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
+    tag: Long
+  ) = copy(tagClass = tagClass, tag = tag)
+
+  /** Returns a copy of this adapter that doesn't encode values equal to [defaultValue]. */
+  fun optional(defaultValue: T? = null) = copy(isOptional = true, defaultValue = defaultValue)
+
+  /**
+   * Returns a copy of this adapter that sets the encoded or decoded value as the type hint for the
+   * other adapters on this SEQUENCE to interrogate.
+   */
+  fun asTypeHint() = copy(typeHint = true)
+
+  // Avoid Long.hashCode(long) which isn't available on Android 5.
+  override fun hashCode(): Int {
+    var result = 0
+    result = 31 * result + name.hashCode()
+    result = 31 * result + tagClass
+    result = 31 * result + tag.toInt()
+    result = 31 * result + codec.hashCode()
+    result = 31 * result + (if (isOptional) 1 else 0)
+    result = 31 * result + defaultValue.hashCode()
+    result = 31 * result + (if (typeHint) 1 else 0)
+    return result
+  }
+
+  override fun toString() = "$name [$tagClass/$tag]"
+
+  /** Reads and writes values without knowledge of the enclosing tag, length, or defaults. */
+  interface Codec<T> {
+    fun decode(reader: DerReader): T
+    fun encode(writer: DerWriter, value: T)
+  }
+}

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/CertificateAdapters.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/CertificateAdapters.kt
@@ -16,6 +16,7 @@
 package okhttp3.tls.internal.der
 
 import java.math.BigInteger
+import okhttp3.tls.internal.der.Adapters.OCTET_STRING
 
 /**
  * ASN.1 adapters adapted from the specifications in [RFC 5280][rfc_5280].
@@ -44,7 +45,10 @@ internal object CertificateAdapters {
    * }
    * ```
    */
-  internal val validity = Adapters.sequence(time, time,
+  internal val validity = Adapters.sequence(
+      "Validity",
+      time,
+      time,
       decompose = {
         listOf(
             Adapters.GENERALIZED_TIME to it.notBefore,
@@ -68,8 +72,9 @@ internal object CertificateAdapters {
    * ```
    */
   internal val algorithmIdentifier = Adapters.sequence(
+      "AlgorithmIdentifier",
       Adapters.OBJECT_IDENTIFIER,
-      Adapters.any().optional(),
+      Adapters.any(isOptional = true, optionalValue = null),
       decompose = { listOf(it.algorithm, it.parameters) },
       construct = { AlgorithmIdentifier(it[0] as String, it[1]) }
   )
@@ -83,6 +88,7 @@ internal object CertificateAdapters {
    * ```
    */
   internal val basicConstraints = Adapters.sequence(
+      "BasicConstraints",
       Adapters.BOOLEAN.optional(defaultValue = false),
       Adapters.INTEGER_AS_LONG.optional(),
       decompose = { listOf(it.ca, it.pathLenConstraint) },
@@ -132,7 +138,7 @@ internal object CertificateAdapters {
       ObjectIdentifiers.basicConstraints -> basicConstraints
       else -> null
     }
-  }
+  }.withExplicitBox(tagClass = OCTET_STRING.tagClass, tag = OCTET_STRING.tag)
 
   /**
    * ```
@@ -147,6 +153,7 @@ internal object CertificateAdapters {
    * ```
    */
   internal val extension = Adapters.sequence(
+      "Extension",
       Adapters.OBJECT_IDENTIFIER.asTypeHint(),
       Adapters.BOOLEAN.optional(defaultValue = false),
       extensionValue,
@@ -167,6 +174,7 @@ internal object CertificateAdapters {
    * ```
    */
   internal val attributeTypeAndValue = Adapters.sequence(
+      "AttributeTypeAndValue",
       Adapters.OBJECT_IDENTIFIER,
       Adapters.any(),
       decompose = { listOf(it.type, it.value) },
@@ -203,6 +211,7 @@ internal object CertificateAdapters {
    * ```
    */
   internal val subjectPublicKeyInfo = Adapters.sequence(
+      "SubjectPublicKeyInfo",
       algorithmIdentifier,
       Adapters.BIT_STRING,
       decompose = { listOf(it.algorithm, it.subjectPublicKey) },
@@ -226,6 +235,7 @@ internal object CertificateAdapters {
    * ```
    */
   internal val tbsCertificate = Adapters.sequence(
+      "TBSCertificate",
       Adapters.INTEGER_AS_LONG.withTag(tag = 0L).optional(defaultValue = 0), // v1 == 0
       Adapters.INTEGER_AS_BIG_INTEGER,
       algorithmIdentifier,
@@ -276,6 +286,7 @@ internal object CertificateAdapters {
    * ```
    */
   internal val certificate = Adapters.sequence(
+      "Certificate",
       tbsCertificate,
       algorithmIdentifier,
       Adapters.BIT_STRING,

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerAdapter.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerAdapter.kt
@@ -17,127 +17,43 @@ package okhttp3.tls.internal.der
 
 import okio.Buffer
 import okio.ByteString
-import okio.IOException
 
-/**
- * Reads a DER tag class, tag, length, and value and decodes it as value.
- */
-internal abstract class DerAdapter<T> private constructor(
-  /** The tag class this adapter expects, or -1 to match any tag class. */
-  val tagClass: Int,
-
-  /** The tag this adapter expects, or -1 to match any tag. */
-  val tag: Long,
-
-  /** True if the default value should be used if this value is absent during decoding. */
-  val isOptional: Boolean,
-
-  /** The value to return if this value is absent. Undefined unless this is optional. */
-  val defaultValue: T?,
-
-  /** True to set the encoded or decoded value as the type hint for the current SEQUENCE. */
-  val typeHint: Boolean
-) {
-  internal constructor(tagClass: Int, tag: Long) : this(
-      tagClass = tagClass,
-      tag = tag,
-      isOptional = false,
-      defaultValue = null,
-      typeHint = false
-  )
+internal interface DerAdapter<T> {
+  /** Returns true if this adapter can read [header] in a choice. */
+  fun matches(header: DerHeader): Boolean
 
   /**
-   * Returns true if this adapter decodes values with [tagClass] and [tag]. Most adapters match
-   * exactly one tag class and tag, but ANY adapters match anything and CHOICE adapters match
-   * multiple.
+   * Returns a value from this adapter.
+   *
+   * This must always return a value, though it doesn't necessarily need to consume data from
+   * [reader]. For example, if the reader's peeked tag isn't readable by this adapter, it may return
+   * a default value.
+   *
+   * If this does read a value, it starts with the tag and length, and reads an entire value,
+   * including any potential composed values.
+   *
+   * If there's nothing to read and no default value, this will throw an exception.
    */
-  open fun matches(tagClass: Int, tag: Long): Boolean {
-    if (tagClass == -1 || tag == -1L) return false
-
-    return (this.tagClass == -1 || tagClass == this.tagClass) &&
-        (this.tag == -1L || tag == this.tag)
-  }
+  fun readValue(reader: DerReader): T
 
   /**
-   * Returns true if [value] does not need to be included in the encoded data of a SEQUENCE value.
-   * Such values must be optional and equal to the optional default.
+   * Writes [value] to this adapter, unless it is the default value and can be safely omitted.
+   *
+   * If this does write a value, it will write a tag and a length and a full value.
    */
-  fun omitInSequence(value: T?): Boolean {
-    return isOptional && value == defaultValue
-  }
-
-  abstract fun encode(writer: DerWriter, value: T)
-
-  abstract fun decode(reader: DerReader, header: DerHeader): T
+  fun writeValue(writer: DerWriter, value: T)
 
   fun toDer(value: T): ByteString {
     val buffer = Buffer()
     val writer = DerWriter(buffer)
-    writer.write(this, value)
+    writeValue(writer, value)
     return buffer.readByteString()
   }
 
   fun fromDer(byteString: ByteString): T {
     val buffer = Buffer().write(byteString)
     val reader = DerReader(buffer)
-    return reader.read(this)
-  }
-
-  private fun copy(
-    tagClass: Int = this.tagClass,
-    tag: Long = this.tag,
-    isOptional: Boolean = this.isOptional,
-    defaultValue: T? = this.defaultValue,
-    typeHint: Boolean = this.typeHint
-  ): DerAdapter<T> = object : DerAdapter<T>(tagClass, tag, isOptional, defaultValue, typeHint) {
-    override fun encode(writer: DerWriter, value: T) = this@DerAdapter.encode(writer, value)
-
-    override fun decode(reader: DerReader, header: DerHeader): T =
-      this@DerAdapter.decode(reader, header)
-  }
-
-  /**
-   * Returns a copy with a context tag. This should be used when the type is ambiguous on its own.
-   * For example, the tags in this schema are 0 and 1:
-   *
-   * ```
-   * Point ::= SEQUENCE {
-   *   x [0] INTEGER OPTIONAL,
-   *   y [1] INTEGER OPTIONAL
-   * }
-   * ```
-   *
-   * You may also specify a tag class like [DerHeader.TAG_CLASS_APPLICATION]. The default tag class
-   * is [DerHeader.TAG_CLASS_CONTEXT_SPECIFIC].
-   *
-   * ```
-   * Point ::= SEQUENCE {
-   *   x [APPLICATION 0] INTEGER OPTIONAL,
-   *   y [APPLICATION 1] INTEGER OPTIONAL
-   * }
-   * ```
-   */
-  fun withTag(tagClass: Int = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC, tag: Long): DerAdapter<T> {
-    return copy(
-        tagClass = tagClass,
-        tag = tag
-    )
-  }
-
-  /** Returns a copy of this adapter that doesn't encode values equal to [defaultValue]. */
-  fun optional(defaultValue: T? = null): DerAdapter<T> {
-    return copy(
-        isOptional = true,
-        defaultValue = defaultValue
-    )
-  }
-
-  /**
-   * Returns a copy of this adapter that sets the encoded or decoded value as the type hint for the
-   * other adapters on this SEQUENCE to interrogate.
-   */
-  fun asTypeHint(): DerAdapter<T> {
-    return copy(typeHint = true)
+    return readValue(reader)
   }
 
   /**
@@ -154,51 +70,51 @@ internal abstract class DerAdapter<T> private constructor(
   fun withExplicitBox(
     tagClass: Int = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
     tag: Long
-  ): DerAdapter<T> {
-    return Adapters.sequence(this,
-        decompose = { listOf(it) },
-        construct = { it[0] as T })
-        .withTag(tagClass, tag)
+  ): BasicDerAdapter<T> {
+    val codec = object : BasicDerAdapter.Codec<T> {
+      override fun decode(reader: DerReader) = readValue(reader)
+      override fun encode(writer: DerWriter, value: T) = writeValue(writer, value)
+    }
+
+    return BasicDerAdapter(
+        name = "EXPLICIT",
+        tagClass = tagClass,
+        tag = tag,
+        codec = codec
+    )
   }
 
   /** Returns an adapter that returns a list of values of this type. */
   fun asSequenceOf(
+    name: String = "SEQUENCE OF",
     tagClass: Int = DerHeader.TAG_CLASS_UNIVERSAL,
     tag: Long = 16L
-  ): DerAdapter<List<T>> {
-    val member = this
-    return object : DerAdapter<List<T>>(
-        tagClass = tagClass,
-        tag = tag
-    ) {
+  ): BasicDerAdapter<List<T>> {
+    val codec = object : BasicDerAdapter.Codec<List<T>> {
       override fun encode(writer: DerWriter, value: List<T>) {
         for (v in value) {
-          writer.write(member, v)
+          writeValue(writer, v)
         }
       }
 
-      override fun decode(reader: DerReader, header: DerHeader): List<T> {
+      override fun decode(reader: DerReader): List<T> {
         val result = mutableListOf<T>()
-
         while (reader.hasNext()) {
-          if (!member.matches(reader.peekedTagClass, reader.peekedTag)) {
-            throw IOException("expected ${member.tagClass}/${member.tag} but was $tagClass/$tag")
-          }
-          result += reader.read(member)
+          result += readValue(reader)
         }
-
         return result
       }
     }
+
+    return BasicDerAdapter(name, tagClass, tag, codec)
   }
 
   /** Returns an adapter that returns a set of values of this type. */
-  fun asSetOf(): DerAdapter<List<T>> {
+  fun asSetOf(): BasicDerAdapter<List<T>> {
     return asSequenceOf(
+        name = "SET OF",
         tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
         tag = 17L
     )
   }
-
-  override fun toString() = "$tagClass/$tag"
 }

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerHeader.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerHeader.kt
@@ -52,6 +52,9 @@ internal data class DerHeader(
   /** Length of the message in bytes, or -1L if its length is unknown at the time of encoding. */
   var length: Long
 ) {
+  val isEndOfData: Boolean
+    get() = tagClass == TAG_CLASS_UNIVERSAL && tag == TAG_END_OF_CONTENTS
+
   // Avoid Long.hashCode(long) which isn't available on Android 5.
   override fun hashCode(): Int {
     var result = 0
@@ -61,6 +64,8 @@ internal data class DerHeader(
     result = 31 * result + length.toInt()
     return result
   }
+
+  override fun toString() = "$tagClass/$tag"
 
   companion object {
     const val TAG_CLASS_UNIVERSAL = 0b0000_0000

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
@@ -38,12 +38,12 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
-      assertThat(tag).isEqualTo(30)
-      assertThat(constructed).isFalse()
-      assertThat(length).isEqualTo(201)
-    })
+    derReader.read("test") { header ->
+      assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
+      assertThat(header.tag).isEqualTo(30)
+      assertThat(header.constructed).isFalse()
+      assertThat(header.length).isEqualTo(201)
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -52,8 +52,8 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(tagClass = DerHeader.TAG_CLASS_UNIVERSAL, tag = 30L) {
-      it.writeUtf8("a".repeat(201))
+    derWriter.write("test", tagClass = DerHeader.TAG_CLASS_UNIVERSAL, tag = 30L) {
+      derWriter.writeUtf8("a".repeat(201))
     }
 
     assertThat(buffer.readByteString(3)).isEqualTo("1e81c9".decodeHex())
@@ -66,10 +66,10 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(3L)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(3L)
       assertThat(derReader.readBitString()).isEqualTo(BitString("0A3B5F291CD0".decodeHex(), 4))
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -78,7 +78,7 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(tagClass = DerHeader.TAG_CLASS_UNIVERSAL, tag = 3L) {
+    derWriter.write("test", tagClass = DerHeader.TAG_CLASS_UNIVERSAL, tag = 3L) {
       derWriter.writeBitString(BitString("0A3B5F291CD0".decodeHex(), 4))
     }
 
@@ -94,10 +94,10 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(3L)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(3L)
       assertThat(derReader.readBitString()).isEqualTo(BitString("0A3B5F291CD0".decodeHex(), 4))
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -108,12 +108,12 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(26L)
-      assertThat(constructed).isFalse()
-      assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(26L)
+      assertThat(header.constructed).isFalse()
+      assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
       assertThat(derReader.readOctetString()).isEqualTo("Jones".encodeUtf8())
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -122,7 +122,7 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(tagClass = DerHeader.TAG_CLASS_UNIVERSAL, tag = 26L) {
+    derWriter.write("test", tagClass = DerHeader.TAG_CLASS_UNIVERSAL, tag = 26L) {
       derWriter.writeOctetString("Jones".encodeUtf8())
     }
 
@@ -135,12 +135,12 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(26L)
-      assertThat(constructed).isTrue()
-      assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(26L)
+      assertThat(header.constructed).isTrue()
+      assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
       assertThat(derReader.readOctetString()).isEqualTo("Jones".encodeUtf8())
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -153,11 +153,11 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(3L)
-      assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_APPLICATION)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(3L)
+      assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_APPLICATION)
       assertThat(derReader.readOctetString()).isEqualTo("Jones".encodeUtf8())
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -168,7 +168,7 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(tagClass = DerHeader.TAG_CLASS_APPLICATION, tag = 3L) {
+    derWriter.write("test", tagClass = DerHeader.TAG_CLASS_APPLICATION, tag = 3L) {
       derWriter.writeOctetString("Jones".encodeUtf8())
     }
 
@@ -184,20 +184,20 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(2L)
-      assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_CONTEXT_SPECIFIC)
-      assertThat(length).isEqualTo(7L)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(2L)
+      assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_CONTEXT_SPECIFIC)
+      assertThat(header.length).isEqualTo(7L)
 
-      derReader.read(derAdapter { tagClass, tag, constructed, length ->
-        assertThat(tag).isEqualTo(3L)
-        assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_APPLICATION)
-        assertThat(length).isEqualTo(5L)
+      derReader.read("test") { header ->
+        assertThat(header.tag).isEqualTo(3L)
+        assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_APPLICATION)
+        assertThat(header.length).isEqualTo(5L)
         assertThat(derReader.readOctetString()).isEqualTo("Jones".encodeUtf8())
-      })
+      }
 
       assertThat(derReader.hasNext()).isFalse()
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -209,8 +209,8 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(tagClass = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC, tag = 2L) {
-      derWriter.value(tagClass = DerHeader.TAG_CLASS_APPLICATION, tag = 3L) {
+    derWriter.write("test", tagClass = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC, tag = 2L) {
+      derWriter.write("test", tagClass = DerHeader.TAG_CLASS_APPLICATION, tag = 3L) {
         derWriter.writeOctetString("Jones".encodeUtf8())
       }
     }
@@ -228,20 +228,20 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(7L)
-      assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_APPLICATION)
-      assertThat(length).isEqualTo(7L)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(7L)
+      assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_APPLICATION)
+      assertThat(header.length).isEqualTo(7L)
 
-      derReader.read(derAdapter { tagClass, tag, constructed, length ->
-        assertThat(tag).isEqualTo(3L)
-        assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_APPLICATION)
-        assertThat(length).isEqualTo(5L)
+      derReader.read("test") { header2 ->
+        assertThat(header2.tag).isEqualTo(3L)
+        assertThat(header2.tagClass).isEqualTo(DerHeader.TAG_CLASS_APPLICATION)
+        assertThat(header2.length).isEqualTo(5L)
         assertThat(derReader.readOctetString()).isEqualTo("Jones".encodeUtf8())
-      })
+      }
 
       assertThat(derReader.hasNext()).isFalse()
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -254,8 +254,8 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(tagClass = DerHeader.TAG_CLASS_APPLICATION, tag = 7L) {
-      derWriter.value(tagClass = DerHeader.TAG_CLASS_APPLICATION, tag = 3L) {
+    derWriter.write("test", tagClass = DerHeader.TAG_CLASS_APPLICATION, tag = 7L) {
+      derWriter.write("test", tagClass = DerHeader.TAG_CLASS_APPLICATION, tag = 3L) {
         derWriter.writeOctetString("Jones".encodeUtf8())
       }
     }
@@ -272,12 +272,12 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(2L)
-      assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_CONTEXT_SPECIFIC)
-      assertThat(length).isEqualTo(5L)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(2L)
+      assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_CONTEXT_SPECIFIC)
+      assertThat(header.length).isEqualTo(5L)
       assertThat(derReader.readOctetString()).isEqualTo("Jones".encodeUtf8())
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -289,7 +289,8 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(
+    derWriter.write(
+        name = "test",
         tagClass = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
         tag = 2L
     ) {
@@ -305,12 +306,12 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(6L)
-      assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
-      assertThat(length).isEqualTo(3L)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(6L)
+      assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
+      assertThat(header.length).isEqualTo(3L)
       assertThat(derReader.readObjectIdentifier()).isEqualTo("2.999.3")
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -319,7 +320,8 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(
+    derWriter.write(
+        name = "test",
         tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
         tag = 6L
     ) {
@@ -335,12 +337,12 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(13L)
-      assertThat(tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
-      assertThat(length).isEqualTo(4L)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(13L)
+      assertThat(header.tagClass).isEqualTo(DerHeader.TAG_CLASS_UNIVERSAL)
+      assertThat(header.length).isEqualTo(4L)
       assertThat(derReader.readRelativeObjectIdentifier()).isEqualTo("8571.3.2")
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -349,7 +351,8 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(
+    derWriter.write(
+        name = "test",
         tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
         tag = 13L
     ) {
@@ -370,21 +373,21 @@ internal class DerTest {
 
     val derReader = DerReader(buffer)
 
-    derReader.read(derAdapter { tagClass, tag, constructed, length ->
-      assertThat(tag).isEqualTo(16L)
+    derReader.read("test") { header ->
+      assertThat(header.tag).isEqualTo(16L)
 
-      derReader.read(derAdapter { tagClass, tag, constructed, length ->
-        assertThat(tag).isEqualTo(21L)
+      derReader.read("test") { header2 ->
+        assertThat(header2.tag).isEqualTo(21L)
         assertThat(derReader.readOctetString()).isEqualTo("Smith".encodeUtf8())
-      })
+      }
 
-      derReader.read(derAdapter { tagClass, tag, constructed, length ->
-        assertThat(tag).isEqualTo(1L)
+      derReader.read("test") { header3 ->
+        assertThat(header3.tag).isEqualTo(1L)
         assertThat(derReader.readBoolean()).isTrue()
-      })
+      }
 
       assertThat(derReader.hasNext()).isFalse()
-    })
+    }
 
     assertThat(derReader.hasNext()).isFalse()
   }
@@ -393,19 +396,22 @@ internal class DerTest {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)
 
-    derWriter.value(
+    derWriter.write(
+        name = "test",
         tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
         tag = 16L
     ) {
 
-      derWriter.value(
+      derWriter.write(
+          name = "test",
           tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
           tag = 21L
       ) {
         derWriter.writeOctetString("Smith".encodeUtf8())
       }
 
-      derWriter.value(
+      derWriter.write(
+          name = "test",
           tagClass = DerHeader.TAG_CLASS_UNIVERSAL,
           tag = 1L
       ) {
@@ -817,26 +823,6 @@ internal class DerTest {
         .isEqualTo(extension)
   }
 
-  private fun derAdapter(block: (Int, Long, Boolean, Long) -> Unit): DerAdapter<Unit> {
-    return object : DerAdapter<Unit>(-1, -1L) {
-      override fun encode(writer: DerWriter, value: Unit): Unit = throw error("unsupported")
-
-      override fun decode(reader: DerReader, header: DerHeader) {
-        return block(header.tagClass, header.tag, header.constructed, header.length)
-      }
-    }
-  }
-
-  private fun DerWriter.value(tagClass: Int, tag: Long, block: (DerWriter) -> Unit) {
-    return write(object : DerAdapter<Unit?>(tagClass, tag) {
-      override fun encode(writer: DerWriter, value: Unit?) {
-        block(writer)
-      }
-
-      override fun decode(reader: DerReader, header: DerHeader): Unit? = throw error("unsupported")
-    }, null)
-  }
-
   /**
    * ```
    * Point ::= SEQUENCE {
@@ -851,6 +837,7 @@ internal class DerTest {
   ) {
     companion object {
       val ADAPTER = Adapters.sequence(
+          "Point",
           Adapters.INTEGER_AS_LONG.withTag(tag = 0L).optional(),
           Adapters.INTEGER_AS_LONG.withTag(tag = 1L).optional(),
           decompose = { listOf(it.x, it.y) },


### PR DESCRIPTION
Previously the caller was responsible for decoding the tag on the
adapter it called. This was easy for basic tags, but proved problematic
for tags like CHOICE and ANY and typehint-dependent tags, because the
caller didn't have enough information.

This moves the tag reading and writing into the DerAdapter itself. If
it encounters a tag it can't understand, it assumes it's own value has
been skipped and returns a default.

This turns out to be a bit easier to reason about, and hopefully will
make it easier to implement AlgorithmIdentifier.parameters, which has
values that are optional or not depending on what the type hint is.