### PR TITLE
Fix bugs so we can roundtrip certificates

### DIFF
--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/Adapters.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/Adapters.kt
@@ -355,8 +355,8 @@ internal object Adapters {
       ByteString::class to OCTET_STRING,
       Unit::class to NULL,
       Nothing::class to OBJECT_IDENTIFIER,
-      String::class to UTF8_STRING,
-      Nothing::class to PRINTABLE_STRING,
+      Nothing::class to UTF8_STRING,
+      String::class to PRINTABLE_STRING,
       Nothing::class to IA5_STRING,
       Nothing::class to UTC_TIME,
       Long::class to GENERALIZED_TIME

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerAdapter.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerAdapter.kt
@@ -69,11 +69,17 @@ internal interface DerAdapter<T> {
   @Suppress("UNCHECKED_CAST") // read() produces a single element of the expected type.
   fun withExplicitBox(
     tagClass: Int = DerHeader.TAG_CLASS_CONTEXT_SPECIFIC,
-    tag: Long
+    tag: Long,
+    forceConstructed: Boolean? = null
   ): BasicDerAdapter<T> {
     val codec = object : BasicDerAdapter.Codec<T> {
       override fun decode(reader: DerReader) = readValue(reader)
-      override fun encode(writer: DerWriter, value: T) = writeValue(writer, value)
+      override fun encode(writer: DerWriter, value: T) {
+        writeValue(writer, value)
+        if (forceConstructed != null) {
+          writer.constructed = forceConstructed
+        }
+      }
     }
 
     return BasicDerAdapter(

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerWriter.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerWriter.kt
@@ -40,8 +40,11 @@ internal class DerWriter(sink: BufferedSink) {
   /** Names leading to the current location in the ASN.1 document. */
   private val path = mutableListOf<String>()
 
-  /** False unless we made a recursive call to [write] at the current stack frame. */
-  private var constructed = false
+  /**
+   * False unless we made a recursive call to [write] at the current stack frame. The explicit box
+   * adapter can clear this to synthesize non-constructed values that are embedded in octet strings.
+   */
+  var constructed = false
 
   fun write(name: String, tagClass: Int, tag: Long, block: (BufferedSink) -> Unit) {
     val constructedBit: Int

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/ObjectIdentifiers.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/ObjectIdentifiers.kt
@@ -17,6 +17,11 @@ package okhttp3.tls.internal.der
 
 /** ASN.1 object identifiers used internally by this implementation. */
 internal object ObjectIdentifiers {
-  val subjectAltName = "2.5.29.17"
-  val basicConstraints = "2.5.29.19"
+  const val subjectAlternativeName = "2.5.29.17"
+  const val basicConstraints = "2.5.29.19"
+  const val commonName = "2.5.4.3"
+  const val organizationalUnitName = "2.5.4.11"
+  const val rsaEncryption = "1.2.840.113549.1.1.1"
+  const val sha256WithRSAEncryption = "1.2.840.113549.1.1.11"
+  const val ecPublicKey = "1.2.840.10045.2.1"
 }

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/certificates.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/certificates.kt
@@ -21,7 +21,37 @@ internal data class Certificate(
   val tbsCertificate: TbsCertificate,
   val signatureAlgorithm: AlgorithmIdentifier,
   val signatureValue: BitString
-)
+) {
+  val commonName: Any?
+    get() {
+      return tbsCertificate.subject
+          .flatten()
+          .firstOrNull { it.type == ObjectIdentifiers.commonName }
+          ?.value
+    }
+
+  val organizationalUnitName: Any?
+    get() {
+      return tbsCertificate.subject
+          .flatten()
+          .firstOrNull { it.type == ObjectIdentifiers.organizationalUnitName }
+          ?.value
+    }
+
+  val subjectAlternativeNames: Extension
+    get() {
+      return tbsCertificate.extensions.first {
+        it.extnID == ObjectIdentifiers.subjectAlternativeName
+      }
+    }
+
+  val basicConstraints: Extension
+    get() {
+      return tbsCertificate.extensions.first {
+        it.extnID == ObjectIdentifiers.basicConstraints
+      }
+    }
+}
 
 internal data class TbsCertificate(
   /** Version ::= INTEGER { v1(0), v2(1), v3(2) } */

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
@@ -732,8 +732,9 @@ internal class DerTest {
         )
     )
 
-    // Note that the parameters value is omitted from the output because it is optional.
-    assertThat(byteString).isEqualTo("300b06092a864886f70d01010b".decodeHex())
+    // Note that the parameters value is included despite being optional because it's required by
+    // https://tools.ietf.org/html/rfc4055#section-2.1
+    assertThat(byteString).isEqualTo("300d06092a864886f70d01010b0500".decodeHex())
   }
 
   @Test fun `decode bit string`() {
@@ -784,7 +785,7 @@ internal class DerTest {
         false,
         BasicConstraints(true, 4)
     )
-    val bytes = "300f0603551d13240830060101ff020104".decodeHex()
+    val bytes = "300f0603551d13040830060101ff020104".decodeHex()
 
     assertThat(CertificateAdapters.extension.toDer(extension))
         .isEqualTo(bytes)
@@ -794,14 +795,14 @@ internal class DerTest {
 
   @Test fun `extension with type hint for subject alternative names`() {
     val extension = Extension(
-        ObjectIdentifiers.subjectAltName,
+        ObjectIdentifiers.subjectAlternativeName,
         false,
         listOf(
             generalNameDnsName to "cash.app",
             generalNameDnsName to "www.cash.app"
         )
     )
-    val bytes = "30210603551d11241a30188208636173682e617070820c7777772e636173682e617070".decodeHex()
+    val bytes = "30210603551d11041a30188208636173682e617070820c7777772e636173682e617070".decodeHex()
 
     assertThat(CertificateAdapters.extension.toDer(extension))
         .isEqualTo(bytes)


### PR DESCRIPTION
This gets us to the point where the byte-for-byte encoding is equiavalent
to what bouncycastle was producing.

This shook out some bugs:
 - We weren't boxing the version
 - We weren't clearing the constructed bit on boxed extensions
 - We weren't encoding null when we needed to be