### PR TITLE
Use OkHttp's certificate creation code

### DIFF
--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/ObjectIdentifiers.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/ObjectIdentifiers.kt
@@ -22,6 +22,7 @@ internal object ObjectIdentifiers {
   const val commonName = "2.5.4.3"
   const val organizationalUnitName = "2.5.4.11"
   const val rsaEncryption = "1.2.840.113549.1.1.1"
-  const val sha256WithRSAEncryption = "1.2.840.113549.1.1.11"
   const val ecPublicKey = "1.2.840.10045.2.1"
+  const val sha256WithRSAEncryption = "1.2.840.113549.1.1.11"
+  const val sha256withEcdsa = "1.2.840.10045.4.3.2"
 }

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/certificates.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/certificates.kt
@@ -16,6 +16,13 @@
 package okhttp3.tls.internal.der
 
 import java.math.BigInteger
+import java.security.GeneralSecurityException
+import java.security.PublicKey
+import java.security.Signature
+import java.security.SignatureException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import okio.Buffer
 
 internal data class Certificate(
   val tbsCertificate: TbsCertificate,
@@ -51,6 +58,32 @@ internal data class Certificate(
         it.extnID == ObjectIdentifiers.basicConstraints
       }
     }
+
+  /** Returns true if the certificate was signed by [issuer]. */
+  @Throws(SignatureException::class)
+  fun checkSignature(issuer: PublicKey): Boolean {
+    val signedData = CertificateAdapters.tbsCertificate.toDer(tbsCertificate)
+
+    val signature = Signature.getInstance(tbsCertificate.signatureAlgorithmName)
+    signature.initVerify(issuer)
+    signature.update(signedData.toByteArray())
+    return signature.verify(signatureValue.byteString.toByteArray())
+  }
+
+  fun toX509Certificate(): X509Certificate {
+    val data = CertificateAdapters.certificate.toDer(this)
+    try {
+      val certificateFactory = CertificateFactory.getInstance("X.509")
+      val certificates = certificateFactory.generateCertificates(Buffer().write(data).inputStream())
+      return certificates.single() as X509Certificate
+    } catch (e: NoSuchElementException) {
+      throw IllegalArgumentException("failed to decode certificate", e)
+    } catch (e: IllegalArgumentException) {
+      throw IllegalArgumentException("failed to decode certificate", e)
+    } catch (e: GeneralSecurityException) {
+      throw IllegalArgumentException("failed to decode certificate", e)
+    }
+  }
 }
 
 internal data class TbsCertificate(
@@ -74,6 +107,19 @@ internal data class TbsCertificate(
   /** Extensions ::= SEQUENCE SIZE (1..MAX) OF Extension */
   val extensions: List<Extension>
 ) {
+  /**
+   * Returns the standard name of this certificate's signature algorithm as specified by
+   * [Signature.getInstance]. Typical values are like "SHA256WithRSA".
+   */
+  val signatureAlgorithmName: String
+    get() {
+      return when (signature.algorithm) {
+        ObjectIdentifiers.sha256WithRSAEncryption -> "SHA256WithRSA"
+        ObjectIdentifiers.sha256withEcdsa -> "SHA256withECDSA"
+        else -> error("unexpected signature algorithm: ${signature.algorithm}")
+      }
+    }
+
   // Avoid Long.hashCode(long) which isn't available on Android 5.
   override fun hashCode(): Int {
     var result = 0

--- a/okhttp-tls/src/test/java/okhttp3/tls/HeldCertificateTest.java
+++ b/okhttp-tls/src/test/java/okhttp3/tls/HeldCertificateTest.java
@@ -208,8 +208,8 @@ public final class HeldCertificateTest {
         .signedBy(root)
         .build();
 
-    assertThat(root.certificate().getSigAlgName()).isEqualTo("SHA256WITHRSA");
-    assertThat(leaf.certificate().getSigAlgName()).isEqualTo("SHA256WITHRSA");
+    assertThat(root.certificate().getSigAlgName()).isEqualToIgnoringCase("SHA256WITHRSA");
+    assertThat(leaf.certificate().getSigAlgName()).isEqualToIgnoringCase("SHA256WITHRSA");
   }
 
   @Test public void rsaSignedByEcdsa() {
@@ -223,8 +223,8 @@ public final class HeldCertificateTest {
         .signedBy(root)
         .build();
 
-    assertThat(root.certificate().getSigAlgName()).isEqualTo("SHA256WITHECDSA");
-    assertThat(leaf.certificate().getSigAlgName()).isEqualTo("SHA256WITHECDSA");
+    assertThat(root.certificate().getSigAlgName()).isEqualToIgnoringCase("SHA256WITHECDSA");
+    assertThat(leaf.certificate().getSigAlgName()).isEqualToIgnoringCase("SHA256WITHECDSA");
   }
 
   @Test public void decodeEcdsa256() throws Exception {


### PR DESCRIPTION
We don't implement the full feature set that Bouncycastle has, but
we also don't need it.

In follow up changes I intend to remove the Bouncycastle dependency
for everything but some test cases.