### PR TITLE
Add limits to what length values DerReader supports

### DIFF
--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
@@ -134,6 +134,10 @@ internal class DerReader(source: Source) {
         }
 
         var lengthBits = source.readByte().toLong() and 0xff
+        if (lengthBits == 0L || lengthBytes == 1 && lengthBits and 0b1000_0000 == 0L) {
+          throw ProtocolException("Invalid encoding for length")
+        }
+
         for (i in 1 until lengthBytes) {
           lengthBits = lengthBits shl 8
           lengthBits += source.readByte().toInt() and 0xff

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
@@ -129,11 +129,18 @@ internal class DerReader(source: Source) {
       (length0 and 0b1000_0000) == 0b1000_0000 -> {
         // Length specified over multiple bytes.
         val lengthBytes = length0 and 0b0111_1111
+        if (lengthBytes > 8) {
+          throw ProtocolException("Length encoded with more than 8 bytes is not supported")
+        }
+
         var lengthBits = source.readByte().toLong() and 0xff
         for (i in 1 until lengthBytes) {
           lengthBits = lengthBits shl 8
           lengthBits += source.readByte().toInt() and 0xff
         }
+
+        if (lengthBits < 0) throw ProtocolException("Length > Long.MAX_VALUE is not supported")
+
         lengthBits
       }
       else -> {

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
@@ -54,6 +54,39 @@ internal class DerTest {
     assertThat(derReader.hasNext()).isFalse()
   }
 
+  @Test fun `decode length encoded with leading zero byte`() {
+    val buffer = Buffer()
+        .writeByte(0b00000010)
+        .writeByte(0b10000010)
+        .writeByte(0b00000000)
+        .writeByte(0b01111111)
+
+    val derReader = DerReader(buffer)
+
+    try {
+      derReader.read("test") {}
+      fail()
+    } catch (e: ProtocolException) {
+      assertThat(e.message).isEqualTo("Invalid encoding for length")
+    }
+  }
+
+  @Test fun `decode length not encoded in shortest form possible`() {
+    val buffer = Buffer()
+        .writeByte(0b00000010)
+        .writeByte(0b10000001)
+        .writeByte(0b01111111)
+
+    val derReader = DerReader(buffer)
+
+    try {
+      derReader.read("test") {}
+      fail()
+    } catch (e: ProtocolException) {
+      assertThat(e.message).isEqualTo("Invalid encoding for length")
+    }
+  }
+
   @Test fun `decode length equal to Long MAX_VALUE`() {
     val buffer = Buffer()
         .writeByte(0b00000010)

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
@@ -17,6 +17,7 @@ package okhttp3.tls.internal.der
 
 import java.math.BigInteger
 import java.net.InetAddress
+import java.net.ProtocolException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
@@ -33,7 +34,6 @@ import okio.ByteString.Companion.toByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
-import java.net.ProtocolException
 
 internal class DerTest {
   @Test fun `decode tag and length`() {

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
@@ -31,7 +31,9 @@ import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
+import java.net.ProtocolException
 
 internal class DerTest {
   @Test fun `decode tag and length`() {
@@ -50,6 +52,74 @@ internal class DerTest {
     }
 
     assertThat(derReader.hasNext()).isFalse()
+  }
+
+  @Test fun `decode length equal to Long MAX_VALUE`() {
+    val buffer = Buffer()
+        .writeByte(0b00000010)
+        .writeByte(0b10001000)
+        .writeByte(0b01111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+
+    val derReader = DerReader(buffer)
+
+    derReader.read("test") { header ->
+      assertThat(header.length).isEqualTo(Long.MAX_VALUE)
+    }
+  }
+
+  @Test fun `decode length overflowing Long`() {
+    val buffer = Buffer()
+        .writeByte(0b00000010)
+        .writeByte(0b10001000)
+        .writeByte(0b10000000)
+        .writeByte(0b00000000)
+        .writeByte(0b00000000)
+        .writeByte(0b00000000)
+        .writeByte(0b00000000)
+        .writeByte(0b00000000)
+        .writeByte(0b00000000)
+        .writeByte(0b00000000)
+
+    val derReader = DerReader(buffer)
+
+    try {
+      derReader.read("test") {}
+      fail()
+    } catch (e: ProtocolException) {
+      assertThat(e.message).isEqualTo("Length > Long.MAX_VALUE is not supported")
+    }
+  }
+
+  @Test fun `decode length encoded with more than 8 bytes`() {
+    val buffer = Buffer()
+        .writeByte(0b00000010)
+        .writeByte(0b10001001)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+        .writeByte(0b11111111)
+
+    val derReader = DerReader(buffer)
+
+    try {
+      derReader.read("test") {}
+      fail()
+    } catch (e: ProtocolException) {
+      assertThat(e.message).isEqualTo("Length encoded with more than 8 bytes is not supported")
+    }
   }
 
   @Test fun `encode tag and length`() {


### PR DESCRIPTION
With this change `DerReader` doesn't support reading values with a length greater than `Long.MAX_VALUE`. That shouldn't be a problem in practice.