### PR TITLE
Don't crash on unknown GeneralName types.

### DIFF
--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/BasicDerAdapter.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/BasicDerAdapter.kt
@@ -15,7 +15,7 @@
  */
 package okhttp3.tls.internal.der
 
-import okio.IOException
+import java.net.ProtocolException
 
 /**
  * Handles basic types that always use the same tag. This supports optional types and may set a type
@@ -56,7 +56,7 @@ internal data class BasicDerAdapter<T>(
     val peekedHeader = reader.peekHeader()
     if (peekedHeader == null || peekedHeader.tagClass != tagClass || peekedHeader.tag != tag) {
       if (isOptional) return defaultValue as T
-      throw IOException("expected $this but was $peekedHeader at $reader")
+      throw ProtocolException("expected $this but was $peekedHeader at $reader")
     }
 
     val result = reader.read(name) {

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
@@ -21,7 +21,6 @@ import okio.Buffer
 import okio.BufferedSource
 import okio.ByteString
 import okio.ForwardingSource
-import okio.IOException
 import okio.Source
 import okio.buffer
 
@@ -161,7 +160,7 @@ internal class DerReader(source: Source) {
    * header. It is an error to not consume a full value in [block].
    */
   internal inline fun <T> read(name: String?, block: (DerHeader) -> T): T {
-    if (!hasNext()) throw IOException("expected a value")
+    if (!hasNext()) throw ProtocolException("expected a value")
 
     val header = peekedHeader!!
     peekedHeader = null

--- a/okhttp-tls/src/test/java/okhttp3/tls/HeldCertificateTest.java
+++ b/okhttp-tls/src/test/java/okhttp3/tls/HeldCertificateTest.java
@@ -148,18 +148,18 @@ public final class HeldCertificateTest {
         .rsa2048()
         .build();
 
-    assertThat((""
+    assertThat(""
         + "-----BEGIN CERTIFICATE-----\n"
-        + "MIIBmjCCAQOgAwIBAgIBATANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDEwhjYXNo\n"
-        + "LmFwcDAeFw03MDAxMDEwMDAwMDBaFw03MDAxMDEwMDAwMDFaMBMxETAPBgNVBAMT\n"
+        + "MIIBmjCCAQOgAwIBAgIBATANBgkqhkiG9w0BAQsFADATMREwDwYDVQQDDAhjYXNo\n"
+        + "LmFwcDAeFw03MDAxMDEwMDAwMDBaFw03MDAxMDEwMDAwMDFaMBMxETAPBgNVBAMM\n"
         + "CGNhc2guYXBwMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCApFHhtrLan28q\n"
         + "+oMolZuaTfWBA0V5aMIvq32BsloQu6LlvX1wJ4YEoUCjDlPOtpht7XLbUmBnbIzN\n"
         + "89XK4UJVM6Sqp3K88Km8z7gMrdrfTom/274wL25fICR+yDEQ5fUVYBmJAKXZF1ao\n"
-        + "I0mIoEx0xFsQhIJ637v2MxJDupd61wIDAQABMA0GCSqGSIb3DQEBCwUAA4GBADam\n"
-        + "UVwKh5Ry7es3OxtY3IgQunPUoLc0Gw71gl9Z+7t2FJ5VkcI5gWfutmdxZ2bDXCI8\n"
-        + "8V0vxo1pHXnbBrnxhS/Z3TBerw8RyQqcaWOdp+pBXyIWmR+jHk9cHZCqQveTIBsY\n"
-        + "jaA9VEhgdaVhxBsT2qzUNDsXlOzGsliznDfoqETb\n"
-        + "-----END CERTIFICATE-----\n")).isEqualTo(heldCertificate.certificatePem());
+        + "I0mIoEx0xFsQhIJ637v2MxJDupd61wIDAQABMA0GCSqGSIb3DQEBCwUAA4GBADHT\n"
+        + "vcjwl9Z4I5Cb2R1y7aaa860HkY2k3ThaDK5OJt6GYqJTA9P3LtX7VwQtL1TWqXGc\n"
+        + "+OEfl3zhm0PUqcbckMzhJtqIa7NkDSjNm71BKd843pIhGcEri69DcL/cR8T+eMex\n"
+        + "hadh7aGM9OjeL8gznLeq27Ly6Dj7Vkp5OmOrSKfn\n"
+        + "-----END CERTIFICATE-----\n").isEqualTo(heldCertificate.certificatePem());
 
     assertThat((""
         + "-----BEGIN RSA PRIVATE KEY-----\n"


### PR DESCRIPTION
We don't have API support for all of them, but we shouldn't crash when an
unsupported name is encountered.

Also encode attributes using UTF-8, not PrintableString. Both are permitted,
but UTF-8 supports more data.