### PR TITLE
Add defensive checks for malformed ASN.1 DER

### DIFF
--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/CertificateAdapters.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/CertificateAdapters.kt
@@ -63,7 +63,8 @@ internal object CertificateAdapters {
     }
 
     override fun toDer(writer: DerWriter, value: Long) {
-      if (value < 2_524_608_000_000L) { // 2050-01-01T00:00:00Z
+      // [1950-01-01T00:00:00..2050-01-01T00:00:00Z)
+      if (value in -631_152_000_000L until 2_524_608_000_000L) {
         Adapters.UTC_TIME.toDer(writer, value)
       } else {
         Adapters.GENERALIZED_TIME.toDer(writer, value)

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
@@ -99,7 +99,7 @@ internal class DerReader(source: Source) {
    * Consume the next header in the stream and return it. If there is no header to read because we
    * have reached a limit, this returns [END_OF_DATA].
    */
-  private fun readHeader(): DerHeader {
+  internal fun readHeader(): DerHeader {
     require(peekedHeader == null)
 
     // We've hit a local limit.
@@ -168,22 +168,28 @@ internal class DerReader(source: Source) {
     val pushedLimit = limit
     val pushedConstructed = constructed
 
-    limit = if (header.length != -1L) byteCount + header.length else -1L
+    val newLimit = if (header.length != -1L) byteCount + header.length else -1L
+    if (pushedLimit != -1L && newLimit > pushedLimit) {
+      throw ProtocolException("enclosed object too large")
+    }
+
+    limit = newLimit
     constructed = header.constructed
     if (name != null) path += name
     try {
-      return block(header)
+      val result = block(header)
+
+      // The object processed bytes beyond its range.
+      if (newLimit != -1L && byteCount > newLimit) {
+        throw ProtocolException("unexpected byte count at $this")
+      }
+
+      return result
     } finally {
       peekedHeader = null
       limit = pushedLimit
       constructed = pushedConstructed
       if (name != null) path.removeAt(path.size - 1)
-    }
-  }
-
-  private inline fun readAll(block: (DerHeader) -> Unit) {
-    while (hasNext()) {
-      read(null, block)
     }
   }
 

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerCertificatesTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerCertificatesTest.kt
@@ -729,6 +729,16 @@ internal class DerCertificatesTest {
     assertThat(decoded).isEqualTo(date("2049-12-31T23:59:59.000+0000").time)
   }
 
+  @Test fun `time before 1950 uses GENERALIZED_TIME`() {
+    val generalizedTimeDer = "180f31393439313233313233353935395a".decodeHex()
+
+    val decoded = CertificateAdapters.time.fromDer(generalizedTimeDer)
+    val encoded = CertificateAdapters.time.toDer(decoded)
+
+    assertThat(decoded).isEqualTo(date("1949-12-31T23:59:59.000+0000").time)
+    assertThat(encoded).isEqualTo(generalizedTimeDer)
+  }
+
   @Test
   fun `reencode golden EC certificate`() {
     val certificateByteString = ("MIIBkjCCATmgAwIBAgIBETAKBggqhkjOPQQDAjAwMRYwFAYDVQQLDA1HZW5lIFJ" +


### PR DESCRIPTION
If the date is before 1950-01-01, use a four-digit year

If the self-delimiting object identifer exceeds the enclosing object's
size, fail.

If a nested object exceeds its enclosing object's size, fail.