### PR TITLE
Don't install the Bouncy Castle provider in HeldCertificate

### DIFF
--- a/okhttp-tls/build.gradle
+++ b/okhttp-tls/build.gradle
@@ -9,9 +9,6 @@ jar {
 dependencies {
   api deps.okio
   implementation project(':okhttp')
-  implementation deps.bouncycastle
-  implementation deps.bouncycastlepkix
-  implementation deps.bouncycastletls
   compileOnly deps.jsr305
   compileOnly deps.animalSniffer
 

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/HeldCertificate.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/HeldCertificate.kt
@@ -24,7 +24,6 @@ import java.security.KeyPairGenerator
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.SecureRandom
-import java.security.Security
 import java.security.Signature
 import java.security.cert.X509Certificate
 import java.security.interfaces.ECPublicKey
@@ -54,7 +53,6 @@ import okhttp3.tls.internal.der.Validity
 import okio.ByteString
 import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.toByteString
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 /**
  * A certificate and its private key. These are some properties of certificates that are used with
@@ -464,10 +462,6 @@ class HeldCertificate(
 
     companion object {
       private const val DEFAULT_DURATION_MILLIS = 1000L * 60 * 60 * 24 // 24 hours.
-
-      init {
-        Security.addProvider(BouncyCastleProvider())
-      }
     }
   }
 


### PR DESCRIPTION
This potentially changes behavior for applications requiring security
features that are available in Bouncy Castle but not the platform. To
mitigate this, execute this before such operations:

    Security.addProvider(BouncyCastleProvider())

You will also need to configure this dependency:

    implementation "org.bouncycastle:bcprov-jdk15on:1.65"