### PR TITLE
Avoid DefaultImpls bug

### DIFF
--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -110,7 +110,8 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
     companion object {
       /** A [Logger] defaults output appropriate for the current platform. */
       @JvmField
-      val DEFAULT: Logger = object : Logger {
+      val DEFAULT: Logger = DefaultLogger()
+      class DefaultLogger : Logger {
         override fun log(message: String) {
           Platform.get().log(message)
         }
@@ -140,7 +141,8 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
   @Deprecated(
       message = "moved to var",
       replaceWith = ReplaceWith(expression = "level"),
-      level = DeprecationLevel.ERROR)
+      level = DeprecationLevel.ERROR
+  )
   fun getLevel(): Level = level
 
   @Throws(IOException::class)

--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -111,7 +111,7 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
       /** A [Logger] defaults output appropriate for the current platform. */
       @JvmField
       val DEFAULT: Logger = DefaultLogger()
-      class DefaultLogger : Logger {
+      private class DefaultLogger : Logger {
         override fun log(message: String) {
           Platform.get().log(message)
         }

--- a/okhttp/src/main/kotlin/okhttp3/internal/io/FileSystem.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/io/FileSystem.kt
@@ -45,7 +45,7 @@ interface FileSystem {
     /** The host machine's local file system. */
     @JvmField
     val SYSTEM: FileSystem = SystemFileSystem()
-    class SystemFileSystem : FileSystem {
+    private class SystemFileSystem : FileSystem {
       @Throws(FileNotFoundException::class)
       override fun source(file: File): Source = file.source()
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/io/FileSystem.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/io/FileSystem.kt
@@ -44,7 +44,8 @@ interface FileSystem {
   companion object {
     /** The host machine's local file system. */
     @JvmField
-    val SYSTEM: FileSystem = object : FileSystem {
+    val SYSTEM: FileSystem = SystemFileSystem()
+    class SystemFileSystem : FileSystem {
       @Throws(FileNotFoundException::class)
       override fun source(file: File): Source = file.source()
 


### PR DESCRIPTION
Graal and Kotlin don't like interfaces without any default methods. Continuation of https://github.com/square/okhttp/pull/5631/files

https://youtrack.jetbrains.com/issue/KT-33097