### PR TITLE
Add module version check

### DIFF
--- a/mockwebserver/build.gradle
+++ b/mockwebserver/build.gradle
@@ -6,6 +6,21 @@ jar {
   }
 }
 
+sourceSets {
+  main.java.srcDirs += "$buildDir/generated/sources/java-templates/java/main"
+}
+
+compileKotlin {
+  dependsOn 'copyJavaTemplates'
+}
+
+task copyJavaTemplates(type: Copy) {
+  from 'src/main/java-templates'
+  into "$buildDir/generated/sources/java-templates/java/main"
+  expand('projectVersion': "${project.version}")
+  filteringCharset = 'UTF-8'
+}
+
 dependencies {
   api project(':okhttp')
   api deps.junit

--- a/mockwebserver/src/main/java-templates/okhttp3.mockwebserver/MockWebServerVersion.kt
+++ b/mockwebserver/src/main/java-templates/okhttp3.mockwebserver/MockWebServerVersion.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.mockwebserver
+
+internal object MockWebServerVersion {
+  /**
+   * Version for checking compatibility with OkHttp core.
+   */
+  const val VERSION = "$projectVersion"
+}

--- a/mockwebserver/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
@@ -47,6 +47,7 @@ import javax.net.ssl.X509TrustManager
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.HttpUrl
+import okhttp3.OkHttp
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
@@ -98,6 +99,10 @@ import org.junit.rules.ExternalResource
  * in sequence.
  */
 class MockWebServer : ExternalResource(), Closeable {
+  init {
+    OkHttp.checkVersion("okhttp-mockwebserver", MockWebServerVersion.VERSION)
+  }
+
   private val taskRunnerBackend = TaskRunner.RealBackend(
       threadFactory("MockWebServer TaskRunner", daemon = false))
   private val taskRunner = TaskRunner(taskRunnerBackend)

--- a/mockwebserver/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
@@ -100,7 +100,7 @@ import org.junit.rules.ExternalResource
  */
 class MockWebServer : ExternalResource(), Closeable {
   init {
-    OkHttp.checkVersion("okhttp-mockwebserver", MockWebServerVersion.VERSION)
+    OkHttp.checkVersion("mockwebserver", MockWebServerVersion.VERSION)
   }
 
   private val taskRunnerBackend = TaskRunner.RealBackend(

--- a/okhttp/src/main/java-templates/okhttp3/OkHttp.kt
+++ b/okhttp/src/main/java-templates/okhttp3/OkHttp.kt
@@ -39,7 +39,7 @@ object OkHttp {
   fun checkVersion(module: String, moduleVersion: String, okhttpVersion: String = VERSION) {
     if (moduleVersion != okhttpVersion) {
       if (okhttpVersion.isRelease && moduleVersion.isRelease) {
-        check(moduleVersion == okhttpVersion) { "com.squareup.okhttp3:okhttp:\$okhttpVersion not compatible with com.squareup.okhttp3:\$module:\$moduleVersion" }
+        check(moduleVersion == okhttpVersion) { "com.squareup.okhttp3:okhttp:\$okhttpVersion is not compatible with com.squareup.okhttp3:\$module:\$moduleVersion" }
       }
     }
   }

--- a/okhttp/src/main/java-templates/okhttp3/OkHttp.kt
+++ b/okhttp/src/main/java-templates/okhttp3/OkHttp.kt
@@ -32,4 +32,15 @@ object OkHttp {
    * [semver]: https://semver.org
    */
   const val VERSION = "$projectVersion"
+
+  internal val String.isRelease: Boolean
+  get() = matches("\\\\d+\\\\.\\\\d+\\\\.\\\\d+".toRegex())
+
+  fun checkVersion(module: String, moduleVersion: String, okhttpVersion: String = VERSION) {
+    if (moduleVersion != okhttpVersion) {
+      if (okhttpVersion.isRelease && moduleVersion.isRelease) {
+        check(moduleVersion == okhttpVersion) { "com.squareup.okhttp3:okhttp:\$okhttpVersion not compatible with com.squareup.okhttp3:\$module:\$moduleVersion" }
+      }
+    }
+  }
 }

--- a/okhttp/src/test/java/okhttp3/OkHttpTest.kt
+++ b/okhttp/src/test/java/okhttp3/OkHttpTest.kt
@@ -35,11 +35,11 @@ class OkHttpTest {
   fun testReleaseVersionIncompatibity() {
     try {
       OkHttp.checkVersion(
-          module = "okhttp-mockwebserver", moduleVersion = "4.20.0", okhttpVersion = "4.21.0"
+          module = "mockwebserver", moduleVersion = "4.20.0", okhttpVersion = "4.21.0"
       )
       fail()
     } catch (ise: IllegalStateException) {
-      assertEquals("com.squareup.okhttp3:okhttp:4.21.0 not compatible with com.squareup.okhttp3:okhttp-mockwebserver:4.20.0", ise.message)
+      assertEquals("com.squareup.okhttp3:okhttp:4.21.0 is not compatible with com.squareup.okhttp3:mockwebserver:4.20.0", ise.message)
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/OkHttpTest.kt
+++ b/okhttp/src/test/java/okhttp3/OkHttpTest.kt
@@ -16,11 +16,45 @@
 package okhttp3
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Test
 
 class OkHttpTest {
   @Test
   fun testVersion() {
     assertThat(OkHttp.VERSION).matches("[0-9]+\\.[0-9]+\\.[0-9]+(-.+)?")
+  }
+
+  @Test
+  fun testReleaseVersionCompatibity() {
+    OkHttp.checkVersion(module = "okhttp-mockwebserver", moduleVersion = "4.20.0", okhttpVersion = "4.20.0")
+  }
+
+  @Test
+  fun testReleaseVersionIncompatibity() {
+    try {
+      OkHttp.checkVersion(
+          module = "okhttp-mockwebserver", moduleVersion = "4.20.0", okhttpVersion = "4.21.0"
+      )
+      fail()
+    } catch (ise: IllegalStateException) {
+      assertEquals("com.squareup.okhttp3:okhttp:4.21.0 not compatible with com.squareup.okhttp3:okhttp-mockwebserver:4.20.0", ise.message)
+    }
+  }
+
+  @Test
+  fun testSnapshotVersionCompatibity() {
+    OkHttp.checkVersion(module = "okhttp-mockwebserver", moduleVersion = "4.20.0-SNAPSHOT", okhttpVersion = "4.20.0-SNAPSHOT")
+  }
+
+  @Test
+  fun testSnapshotReleaseVersionIncompatibity() {
+    OkHttp.checkVersion(module = "okhttp-mockwebserver", moduleVersion = "4.20.0", okhttpVersion = "4.21.0-SNAPSHOT")
+  }
+
+  @Test
+  fun testSnapshotDevVersionIncompatibity() {
+    OkHttp.checkVersion(module = "okhttp-mockwebserver", moduleVersion = "dev", okhttpVersion = "4.21.0-SNAPSHOT")
   }
 }


### PR DESCRIPTION
Test a strict version check, initially only with MockWebServer if two release builds of okhttp jars are used.  Any snapshot or dev builds are allowed and may or may not fail for other incompatibility reasons.  But mixing release builds is enforced as a failure.

Support for actual breaking changes has been pretty light recently, so occasional reports of users confused by version incompatibilities when mixing versions is more notceable.  I hope this PR just removes a class of bug reports and stackoverflow questions, since the error is immediately obvious.

If any snapshot versions are used, then I don't want to stop people working around issues, so strictly doing this with released versions.