### PR TITLE
webSocketListener extensions

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/ws/WebSocketListenerExtensions.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/ws/WebSocketListenerExtensions.kt
@@ -1,6 +1,10 @@
 package okhttp3.internal.ws
 
-import okhttp3.*
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
 import okio.ByteString
 
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/ws/WebSocketListenerExtensions.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/ws/WebSocketListenerExtensions.kt
@@ -1,0 +1,78 @@
+package okhttp3.internal.ws
+
+import okhttp3.*
+import okio.ByteString
+
+
+fun OkHttpClient.newWebSocket(request: Request, block: WebSocketListenerExt.() -> Unit): WebSocket {
+  val listener = WebSocketListenerImpl().apply(block)
+  return this.newWebSocket(request, listener)
+}
+
+interface WebSocketListenerExt {
+  fun onOpen(block: (webSocket: WebSocket, response: Response) -> Unit)
+  fun onFailure(block: (webSocket: WebSocket, t: Throwable, response: Response?) -> Unit)
+  fun onClosing(block: (webSocket: WebSocket, code: Int, reason: String) -> Unit)
+  fun onMessage(block: (webSocket: WebSocket, text: String) -> Unit)
+  fun onMessageByte(block: (webSocket: WebSocket, bytes: ByteString) -> Unit)
+  fun onClosed(block: (webSocket: WebSocket, code: Int, reason: String) -> Unit)
+}
+
+private class WebSocketListenerImpl : WebSocketListener(), WebSocketListenerExt {
+
+  private var _onOpen: ((webSocket: WebSocket, response: Response) -> Unit)? = null
+  private var _onFailure: ((webSocket: WebSocket, t: Throwable, response: Response?) -> Unit)? =
+      null
+  private var _onClosing: ((webSocket: WebSocket, code: Int, reason: String) -> Unit)? = null
+  private var _onMessage: ((webSocket: WebSocket, text: String) -> Unit)? = null
+  private var _onMessageByte: ((webSocket: WebSocket, bytes: ByteString) -> Unit)? = null
+  private var _onClosed: ((webSocket: WebSocket, code: Int, reason: String) -> Unit)? = null
+
+  override fun onOpen(webSocket: WebSocket, response: Response) {
+    _onOpen?.invoke(webSocket, response)
+  }
+
+  override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+    _onFailure?.invoke(webSocket, t, response)
+  }
+
+  override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+    _onClosing?.invoke(webSocket, code, reason)
+  }
+
+  override fun onMessage(webSocket: WebSocket, text: String) {
+    _onMessage?.invoke(webSocket, text)
+  }
+
+  override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+    _onMessageByte?.invoke(webSocket, bytes)
+  }
+
+  override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+    _onClosed?.invoke(webSocket, code, reason)
+  }
+
+  override fun onOpen(block: (webSocket: WebSocket, response: Response) -> Unit) {
+    _onOpen = block
+  }
+
+  override fun onFailure(block: (webSocket: WebSocket, t: Throwable, response: Response?) -> Unit) {
+    _onFailure = block
+  }
+
+  override fun onClosing(block: (webSocket: WebSocket, code: Int, reason: String) -> Unit) {
+    _onClosing = block
+  }
+
+  override fun onMessage(block: (webSocket: WebSocket, text: String) -> Unit) {
+    _onMessage = block
+  }
+
+  override fun onMessageByte(block: (webSocket: WebSocket, bytes: ByteString) -> Unit) {
+    _onMessageByte = block
+  }
+
+  override fun onClosed(block: (webSocket: WebSocket, code: Int, reason: String) -> Unit) {
+    _onClosed = block
+  }
+}


### PR DESCRIPTION
The purpose of this PR is to provide a painless Kotlin DSL able to catch the lifecycle event of a WebSocket

Ex. with all the call-back

```
client.newWebSocket(request){
    onOpen{ webSocket, response -> ... }
    onMessage { webSocket, text -> ... }
    onMessageByte { webSocket, bytes -> ... }
    onClosing { webSocket, code, reason -> ... }
    onClosed { webSocket, code, reason -> ...  }
    onFailure { webSocket, t, response -> ... }
}
```

For instance, if I'm interested to receive only the `onOpen` and the `OnMessage` events I'll declare only what I need, ex:

```
client.newWebSocket(request){
    onOpen{ webSocket, response -> ... }
    onMessage { webSocket, text -> ... }
}
```