### PR TITLE
Change list to mutableList to avoid creating a new list.

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
@@ -61,7 +61,7 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
     var followUpCount = 0
     var priorResponse: Response? = null
     var newExchangeFinder = true
-    var recoveredFailures = listOf<IOException>()
+    val recoveredFailures = mutableListOf<IOException>()
     while (true) {
       call.enterNetworkInterceptorExchange(request, newExchangeFinder)
 


### PR DESCRIPTION
'+=' of `_Collection.kt` create new list under the hood:

```
/**
 * Returns a list containing all elements of the original collection and then the given [element].
 */
public operator fun <T> Collection<T>.plus(element: T): List<T> {
    val result = ArrayList<T>(size + 1)
    result.addAll(this)
    result.add(element)
    return result
}
```

And `MutableCollection.kt` only adds the specified [element] to this mutable collection.

```
/**
 * Adds the specified [element] to this mutable collection.
 */
@kotlin.internal.InlineOnly
public inline operator fun <T> MutableCollection<in T>.plusAssign(element: T) {
    this.add(element)
}
```


