### PR TITLE
Update MockWebServer.kt to fix runtime crash caused by "okhttp3.mockwebserver.MockWebServer" exceeds limit of 23 characters. 

### DIFF
--- a/mockwebserver/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
@@ -1145,6 +1145,6 @@ class MockWebServer : ExternalResource(), Closeable {
       override fun getAcceptedIssuers(): Array<X509Certificate> = throw AssertionError()
     }
 
-    private val logger = Logger.getLogger(MockWebServer::class.java.name)
+    private val logger = Logger.getLogger(MockWebServer::class.java.simpleName)
   }
 }


### PR DESCRIPTION
Fix bug https://stackoverflow.com/questions/63387807/java-lang-illegalargumentexception-log-tag-okhttp3-mockwebserver-mockwebserver