### PR TITLE
When a URL cannot be parsed, add the input to the exception message.

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/HttpUrl.kt
+++ b/okhttp/src/main/kotlin/okhttp3/HttpUrl.kt
@@ -1258,7 +1258,7 @@ class HttpUrl internal constructor(
         this.scheme = base.scheme
       } else {
         throw IllegalArgumentException(
-            "Expected URL scheme 'http' or 'https' but no colon was found")
+            "Expected URL scheme 'http' or 'https' but no colon was found. Input: $input")
       }
 
       // Authority.


### PR DESCRIPTION
Having the input that was not able to be parsed would greatly help debug and understand what URL it is that is failing.