### PR TITLE
When a URL cannot be parsed, add the input to the exception message.

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/HttpUrl.kt
+++ b/okhttp/src/main/kotlin/okhttp3/HttpUrl.kt
@@ -1258,7 +1258,7 @@ class HttpUrl internal constructor(
         this.scheme = base.scheme
       } else {
         throw IllegalArgumentException(
-            "Expected URL scheme 'http' or 'https' but no colon was found")
+            "Expected URL scheme 'http' or 'https' but no colon was found. Input: $input")
       }
 
       // Authority.

--- a/okhttp/src/test/java/okhttp3/HttpUrlTest.java
+++ b/okhttp/src/test/java/okhttp3/HttpUrlTest.java
@@ -144,7 +144,7 @@ public final class HttpUrlTest {
 
     assertInvalid("image640://480.png", "Expected URL scheme 'http' or 'https' but was 'image640'");
     assertInvalid("httpp://host/", "Expected URL scheme 'http' or 'https' but was 'httpp'");
-    assertInvalid("0ttp://host/", "Expected URL scheme 'http' or 'https' but no colon was found");
+    assertInvalid("0ttp://host/", "Expected URL scheme 'http' or 'https' but no colon was found. Input: 0ttp://host/");
     assertInvalid("ht+tp://host/", "Expected URL scheme 'http' or 'https' but was 'ht+tp'");
     assertInvalid("ht.tp://host/", "Expected URL scheme 'http' or 'https' but was 'ht.tp'");
     assertInvalid("ht-tp://host/", "Expected URL scheme 'http' or 'https' but was 'ht-tp'");
@@ -153,11 +153,11 @@ public final class HttpUrlTest {
   }
 
   @Test public void parseNoScheme() throws Exception {
-    assertInvalid("//host", "Expected URL scheme 'http' or 'https' but no colon was found");
-    assertInvalid("/path", "Expected URL scheme 'http' or 'https' but no colon was found");
-    assertInvalid("path", "Expected URL scheme 'http' or 'https' but no colon was found");
-    assertInvalid("?query", "Expected URL scheme 'http' or 'https' but no colon was found");
-    assertInvalid("#fragment", "Expected URL scheme 'http' or 'https' but no colon was found");
+    assertInvalid("//host", "Expected URL scheme 'http' or 'https' but no colon was found. Input: //host");
+    assertInvalid("/path", "Expected URL scheme 'http' or 'https' but no colon was found. Input: /path");
+    assertInvalid("path", "Expected URL scheme 'http' or 'https' but no colon was found. Input: path");
+    assertInvalid("?query", "Expected URL scheme 'http' or 'https' but no colon was found. Input: ?query");
+    assertInvalid("#fragment", "Expected URL scheme 'http' or 'https' but no colon was found. Input: #fragment");
   }
 
   @Test public void newBuilderResolve() throws Exception {


### PR DESCRIPTION
This will greatly help with debugging when stacktraces aren't helpful.