### PR TITLE
Fix build on windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,8 +123,6 @@ subprojects { project ->
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 
-  compileJava.options.encoding = 'UTF-8'
-
   tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,12 @@ subprojects { project ->
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 
+  compileJava.options.encoding = 'UTF-8'
+
+  tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+  }
+
   checkstyleMain.exclude '**/CipherSuite.java'
   configurations {
     checkstyleConfig


### PR DESCRIPTION
See stackoverflow for why this is required, related to the gradle daemon.

https://stackoverflow.com/a/34717160/1542667

I don't currently have any concern that their is a logic bug with string encodings in src/main, but rather that strings in tests are compiled assuming the wrong file encoding, changing the test meaning.