### PR TITLE
Fix the deploy_website script to handle files with spaces in their names

### DIFF
--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -34,21 +34,23 @@ cd $DIR
 # Dokka filenames like `-http-url/index.md` don't work well with MkDocs <title> tags.
 # Assign metadata to the file's first Markdown heading.
 # https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data
-title_markdown_file() {
-  TITLE_PATTERN="s/^[#]+ *(.*)/title: \1 - OkHttp/"
-  echo "---"                                                     > "$1.fixed"
-  cat $1 | sed -E "$TITLE_PATTERN" | grep "title: " | head -n 1 >> "$1.fixed"
-  echo "---"                                                    >> "$1.fixed"
-  echo                                                          >> "$1.fixed"
-  cat $1                                                        >> "$1.fixed"
-  mv "$1.fixed" "$1"
-}
-
 set +x
-for MARKDOWN_FILE in $(find docs/4.x/ -name '*.md'); do
-  echo $MARKDOWN_FILE
-  title_markdown_file $MARKDOWN_FILE
-done
+find docs/4.x/ -name '*.md' -exec sh -c '
+  title_markdown_file() {
+    TITLE_PATTERN="s/^[#]+ *(.*)/title: \1 - OkHttp/"
+    echo "---"                                                     > "$1.fixed"
+    cat $1 | sed -E "$TITLE_PATTERN" | grep "title: " | head -n 1 >> "$1.fixed"
+    echo "---"                                                    >> "$1.fixed"
+    echo                                                          >> "$1.fixed"
+    cat $1                                                        >> "$1.fixed"
+    mv "$1.fixed" "$1"
+  }
+
+  for MARKDOWN_FILE do
+    echo $MARKDOWN_FILE
+    title_markdown_file $MARKDOWN_FILE
+  done
+' exec-sh {} +
 set -x
 
 # Copy in special files that GitHub wants in the project root.


### PR DESCRIPTION
Dokka now generates such files and it's too bad.