### PR TITLE
Add Monitoring Connections for Error Status Messages

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -170,7 +170,8 @@ class Http1ExchangeCodec(
   }
 
   override fun readResponseHeaders(expectContinue: Boolean): Response.Builder? {
-    check(state == STATE_OPEN_REQUEST_BODY || state == STATE_READ_RESPONSE_HEADERS) {
+    check(state == STATE_OPEN_REQUEST_BODY || state == STATE_READ_RESPONSE_HEADERS ||
+      state == STATE_WRITING_REQUEST_BODY) {
       "state: $state"
     }
 

--- a/okhttp/src/test/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/test/java/okhttp3/EventListenerTest.java
@@ -1118,7 +1118,7 @@ public final class EventListenerTest {
     assertThat(listener.recordedEventTypes()).containsExactly(
         "CallStart", "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd", "ConnectStart",
         "ConnectEnd", "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd",
-        "RequestBodyStart", "RequestFailed", "ConnectionReleased", "CallFailed");
+        "RequestBodyStart", "RequestFailed", "ResponseFailed", "ConnectionReleased", "CallFailed");
   }
 
   @Test public void requestBodySuccessHttp1OverHttps() throws IOException {


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc2616#section-8.2.2 An
HTTP/1.1 (or later) client sending a message-body SHOULD
monitor the network connection for an error status while it
is transmitting the request.

Currently, okhttp implements a send request, then read response
if/when request was sent successfully.
This hides early responses such as 413 Payload Too Large
errors from clients.

This commit fixes that by adding a response read in case of an
exception happening while the request is being sent.

This closes square#1001 .

Related PR: https://github.com/square/okhttp/pull/6121