### PR TITLE
Rename okhttp3.internal.sse to okhttp3.sse.internal

### DIFF
--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSources.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSources.kt
@@ -17,7 +17,7 @@ package okhttp3.sse
 
 import okhttp3.OkHttpClient
 import okhttp3.Response
-import okhttp3.internal.sse.RealEventSource
+import okhttp3.sse.internal.RealEventSource
 
 object EventSources {
   @JvmStatic

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.internal.sse
+package okhttp3.sse.internal
 
 import java.io.IOException
 import okhttp3.Call

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/ServerSentEventReader.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/ServerSentEventReader.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.internal.sse
+package okhttp3.sse.internal
 
 import java.io.IOException
 import okhttp3.internal.toLongOrDefault

--- a/okhttp-sse/src/test/java/okhttp3/sse/internal/Event.java
+++ b/okhttp-sse/src/test/java/okhttp3/sse/internal/Event.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.internal.sse;
+package okhttp3.sse.internal;
 
 import java.util.Objects;
 import javax.annotation.Nullable;

--- a/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceHttpTest.java
+++ b/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceHttpTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.internal.sse;
+package okhttp3.sse.internal;
 
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;

--- a/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceRecorder.java
+++ b/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceRecorder.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.internal.sse;
+package okhttp3.sse.internal;
 
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;

--- a/okhttp-sse/src/test/java/okhttp3/sse/internal/ServerSentEventIteratorTest.java
+++ b/okhttp-sse/src/test/java/okhttp3/sse/internal/ServerSentEventIteratorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.internal.sse;
+package okhttp3.sse.internal;
 
 import java.io.IOException;
 import java.util.ArrayDeque;


### PR DESCRIPTION
I think this is slightly neater from an OSGi/JPMS perspective.