### PR TITLE
Disable edit links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_url: https://github.com/square/okhttp
 site_description: "An HTTP & HTTP/2 client for Android and Java applications"
 site_author: Square, Inc.
 remote_branch: gh-pages
+edit_uri: ""
 
 copyright: 'Copyright &copy; 2019 Square, Inc.'
 


### PR DESCRIPTION
https://github.com/square/okhttp/issues/6217#issuecomment-674831404 mentions the removal of edit links, so this closes #6217 

Ran `mkdocs build` locally.

Before:

```
          <div class="md-content">
            <article class="md-content__inner md-typeset">
              
                
                  <a href="https://github.com/square/okhttp/edit/master/docs/interceptors.md" title="Edit this page" class="md-content__button md-icon">
                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z"/></svg>
                  </a>
                
                
                  
                
                
                <h1 id="interceptors">Interceptors<a class="headerlink" href="#interceptors" title="Permanent link">&para;</a></h1>
<p>Interceptors are a powerful mechanism that can monitor, rewrite, and retry calls. Here&rsquo;s a simple interceptor that logs the outgoing request and the incoming response.</p>
```

After:

```
          <div class="md-content">
            <article class="md-content__inner md-typeset">
              
                
                
                <h1 id="interceptors">Interceptors<a class="headerlink" href="#interceptors" title="Permanent link">&para;</a></h1>
<p>Interceptors are a powerful mechanism that can monitor, rewrite, and retry calls. Here&rsquo;s a simple interceptor that logs the outgoing request and the incoming response.</p>
```