### PR TITLE
R8 warning during the build OkHttp 4.9.0 #6299

### DIFF
--- a/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
+++ b/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
@@ -9,3 +9,4 @@
 
 # OkHttp platform used only on JVM and when Conscrypt dependency is available.
 -dontwarn okhttp3.internal.platform.ConscryptPlatform
+-dontwarn org.conscrypt.ConscryptHostnameVerifier


### PR DESCRIPTION
Update Proguard rule to hide the following warning:
`Missing class: org.conscrypt.ConscryptHostnameVerifier`