### PR TITLE
Only support ALPN Boot on most recent JDK 8 builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,15 +202,13 @@ subprojects { project ->
 
   if (platform == "jdk8alpn") {
     // Add alpn-boot on Java 8 so we can use HTTP/2 without a stable API.
-    def alpnBootVersion = alpnBootVersion()
-    if (alpnBootVersion != null) {
-      dependencies {
-        testCompile "org.mortbay.jetty.alpn:alpn-boot:$alpnBootVersion"
-      }
-      def alpnBootJar = configurations.testCompile.find { it.name.startsWith("alpn-boot-") }
-      test {
-        jvmArgs += "-Xbootclasspath/p:${alpnBootJar}"
-      }
+    def alpnBootVersion = '8.1.13.v20181017'
+    dependencies {
+      testCompile "org.mortbay.jetty.alpn:alpn-boot:$alpnBootVersion"
+    }
+    def alpnBootJar = configurations.testCompile.find { it.name.startsWith("alpn-boot-") }
+    test {
+      jvmArgs += "-Xbootclasspath/p:${alpnBootJar}"
     }
   } else if (platform == "conscrypt") {
     dependencies {
@@ -321,58 +319,6 @@ subprojects { project ->
 
 tasks.wrapper {
   distributionType = Wrapper.DistributionType.ALL
-}
-
-/**
- * Returns the alpn-boot version specific to this OpenJDK 8 JVM, or null if this is not a Java 8 VM.
- * https://github.com/xjdr/xio/blob/master/alpn-boot.gradle
- */
-def alpnBootVersion() {
-  def version = System.getProperty('alpn.boot.version')
-
-  if (version != null) {
-    return version
-  }
-
-  def javaVersion = System.getProperty("java.version")
-  def patchVersionMatcher = (javaVersion =~ /1\.8\.0_(\d+)(-.*)?/)
-  if (!patchVersionMatcher.find()) return null
-  def patchVersion = Integer.parseInt(patchVersionMatcher.group(1))
-  return alpnBootVersionForPatchVersion(javaVersion, patchVersion)
-}
-
-def alpnBootVersionForPatchVersion(String javaVersion, int patchVersion) {
-  // https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-versions
-  switch (patchVersion) {
-    case 0..24:
-      return '8.1.0.v20141016'
-    case 25..30:
-      return '8.1.2.v20141202'
-    case 31..50:
-      return '8.1.3.v20150130'
-    case 51..59:
-      return '8.1.4.v20150727'
-    case 60..64:
-      return '8.1.5.v20150921'
-    case 65..70:
-      return '8.1.6.v20151105'
-    case 71..77:
-      return '8.1.7.v20160121'
-    case 78..101:
-      return '8.1.8.v20160420'
-    case 102..111:
-      return '8.1.9.v20160720'
-    case 112..120:
-      return '8.1.10.v20161026'
-    case 121..160:
-      return '8.1.11.v20170118'
-    case 161..181:
-      return '8.1.12.v20180117'
-    case 191..242:
-      return '8.1.13.v20181017'
-    default:
-      throw new IllegalStateException("Unexpected Java version: ${javaVersion}")
-  }
 }
 
 /**


### PR DESCRIPTION
For discussion - may as well simplify builds at this point.  Anyone hitting JDK/JSSE related issues with HTTP/2 will be asked to upgrade and will probably find that they have the backported support for ALPN anyway.  So reducing surface area for CI and build complexity.