### PR TITLE
Initial steps towards running tests in Graalvm

### DIFF
--- a/native-image-tests/README.md
+++ b/native-image-tests/README.md
@@ -1,0 +1,55 @@
+Native Image Tests
+==================
+
+This executes OkHttp's test suite inside a Graalvm image.
+
+Seeding Graalvm Config
+----------------------
+
+This isn't yet integrated into the Graalvm Gradle plugin, so you'll need to install your own
+Graalvm and edit `build.gradle` to set its location.
+
+```
+def graalHome = "/Library/Java/JavaVirtualMachines/graalvm-ce-java11-20.2.0/Contents/Home"
+``` 
+
+The task runs tests in the JVM, collecting information about which classes require reflection 
+metadata. This includes the test classes and some parts of the JUnit framework.
+
+```
+./gradlew --info native-image-tests:seedGraalvmConfig
+```
+
+This will create a directory of metadata:
+
+    okhttp
+    '- native-image-tests
+      '- build
+        '- graalvm
+          '- resources
+            '- META-INF
+              '- native-image
+                |- jni-config.json
+                |- proxy-config.json
+                |- reflect-config.json
+                '- resource-config.json
+
+Build the Native Image
+----------------------
+
+Compile the classes and metadata into a Graalvm native image.
+
+```
+./gradlew --info native-image-tests:nativeImage
+```
+
+
+Execute
+-------
+
+The native image runs JUnit 5's `ConsoleLauncher`.
+
+```
+./native-image-tests/build/graal/ConsoleLauncher --select-class okhttp3.SampleTest
+```
+

--- a/native-image-tests/build.gradle
+++ b/native-image-tests/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+  id "com.palantir.graal" version "0.7.1"
+}
+
+dependencies {
+  implementation deps.assertj
+  implementation "org.junit.jupiter:junit-jupiter-api:5.7.0"
+  implementation "org.junit.jupiter:junit-jupiter-engine:5.7.0"
+  implementation "org.junit.platform:junit-platform-console:1.7.0"
+
+  compileOnly deps.jsr305
+}
+
+animalsniffer {
+  ignoreFailures = true
+}
+
+def graalHome = "/Library/Java/JavaVirtualMachines/graalvm-ce-java11-20.2.0/Contents/Home"
+def graalvmResources = project.file("$buildDir/graalvm/resources")
+def graalvmConfig = project.file("$graalvmResources/META-INF/native-image")
+graalvmConfig.mkdirs()
+
+sourceSets {
+  main.resources.srcDirs += graalvmResources
+}
+
+task seedGraalvmConfig(type: Exec) {
+  dependsOn("classes")
+  commandLine(
+    "$graalHome/bin/java",
+    "-agentlib:native-image-agent=config-output-dir=$graalvmConfig",
+    "-classpath", sourceSets.main.runtimeClasspath.getAsPath(),
+    "org.junit.platform.console.ConsoleLauncher",
+    "--select-class", "okhttp3.SampleTest"
+  )
+}
+
+graal {
+  mainClass "org.junit.platform.console.ConsoleLauncher"
+  outputName "ConsoleLauncher"
+  graalVersion "20.2.0"
+  javaVersion "11"
+
+  option "--enable-https"
+  option "--no-fallback"
+  option "--allow-incomplete-classpath"
+  option "--report-unsupported-elements-at-runtime"
+}

--- a/native-image-tests/src/main/kotlin/okhttp3/SampleTest.kt
+++ b/native-image-tests/src/main/kotlin/okhttp3/SampleTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+
+class SampleTest {
+  @Test
+  fun failingTest() {
+    assertThat("hello").isEqualTo("goodbye")
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ if (properties.containsKey('android.injected.invoked.from.ide') ||
   include ':android-test'
 }
 
+include ':native-image-tests'
 include ':okcurl'
 include ':okhttp'
 include ':okhttp-bom'


### PR DESCRIPTION
I want to confirm all of OkHttp works with Graalvm, and I'm hoping
to demonstrate that by getting the entire test suite running inside
Graalvm.

https://github.com/square/okhttp/issues/6296

 * [ ] Configure seeding to identify tests without executing them (ignore all somehow?)
 * [ ] Seed using the Graal from the Graal Gradle plugin, not the local machine
 * [ ] Run OkHttp tests, not SampleTest (will need the vintage engine, since we’re JUnit 4)

If we get that all working, we’re good. For bonus points it’d be nice to upstream this mechanism into the Graal plugin, or something standalone. It’d be quite rad to make Graalvm unit testing not dramatically more complicated than regular unit testing.
