### PR TITLE
Explore a coroutines implementation of Dns over HTTPS

### DIFF
--- a/okhttp-dnsoverhttps/build.gradle
+++ b/okhttp-dnsoverhttps/build.gradle
@@ -12,6 +12,8 @@ jar {
 dependencies {
   api project(':okhttp')
   compileOnly deps.jsr305
+  api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.0-M1'
+//  api 'org.jetbrains.kotlinx:kotlinx-coroutines-flow:1.4.0-M1'
 
   testImplementation project(':okhttp-testing-support')
   testImplementation project(':mockwebserver-deprecated')

--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/AsyncDns.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/AsyncDns.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.dnsoverhttps
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import okhttp3.Dns
+import java.net.InetAddress
+
+/**
+ * A domain name service that resolves IP addresses for host names. Most applications will use the
+ * [system DNS service][SYSTEM], which is the default. Some applications may provide their own
+ * implementation to use a different DNS server, to prefer IPv6 addresses, to prefer IPv4 addresses,
+ * or to force a specific known IP address.
+ *
+ * Implementations of this interface must be safe for concurrent use.
+ */
+interface AsyncDns {
+  /**
+   * Returns the IP addresses of `hostname`, in the order they will be attempted by OkHttp. If a
+   * connection to an address fails, OkHttp will retry the connection with the next address until
+   * either a connection is made, the set of IP addresses is exhausted, or a limit is exceeded.
+   */
+  fun lookup(hostname: String): Flow<InetAddress>
+
+  fun toDns() = object : Dns {
+    override fun lookup(hostname: String): List<InetAddress> {
+      return runBlocking {
+        this@AsyncDns.lookup(hostname).toList()
+      }
+    }
+  }
+
+  companion object {
+    val SYSTEM: AsyncDns = AsyncDnsSystem()
+    private class AsyncDnsSystem : AsyncDns {
+      override fun lookup(hostname: String): Flow<InetAddress> {
+        val system = Dns.SYSTEM
+        return flow {
+          withContext(Dispatchers.IO) {
+            emitAll(system.lookup(hostname).asFlow())
+          }
+        }
+      }
+    }
+  }
+}

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.java
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.java
@@ -161,7 +161,7 @@ public class DnsOverHttpsTest {
   @Test public void usesCache() throws Exception {
     Cache cache = new Cache(new File("./target/DnsOverHttpsTest.cache"), 100 * 1024);
     OkHttpClient cachedClient = bootstrapClient.newBuilder().cache(cache).build();
-    DnsOverHttps cachedDns = buildLocalhost(cachedClient, false);
+    Dns cachedDns = buildLocalhost(cachedClient, false);
 
     server.enqueue(dnsResponse(
         "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c00050001"
@@ -184,7 +184,7 @@ public class DnsOverHttpsTest {
   @Test public void usesCacheOnlyIfFresh() throws Exception {
     Cache cache = new Cache(new File("./target/DnsOverHttpsTest.cache"), 100 * 1024);
     OkHttpClient cachedClient = bootstrapClient.newBuilder().cache(cache).build();
-    DnsOverHttps cachedDns = buildLocalhost(cachedClient, false);
+    Dns cachedDns = buildLocalhost(cachedClient, false);
 
     server.enqueue(dnsResponse(
         "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c00050001"
@@ -222,13 +222,13 @@ public class DnsOverHttpsTest {
         .addHeader("content-length", s.length() / 2);
   }
 
-  private DnsOverHttps buildLocalhost(OkHttpClient bootstrapClient, boolean includeIPv6) {
+  private Dns buildLocalhost(OkHttpClient bootstrapClient, boolean includeIPv6) {
     HttpUrl url = server.url("/lookup?ct");
     return new DnsOverHttps.Builder().client(bootstrapClient)
         .includeIPv6(includeIPv6)
         .resolvePrivateAddresses(true)
         .url(url)
-        .build();
+        .build().toDns();
   }
 
   private static InetAddress address(String host) {

--- a/okhttp/src/main/kotlin/okhttp3/CacheControl.kt
+++ b/okhttp/src/main/kotlin/okhttp3/CacheControl.kt
@@ -156,7 +156,7 @@ class CacheControl private constructor(
         if (onlyIfCached) append("only-if-cached, ")
         if (noTransform) append("no-transform, ")
         if (immutable) append("immutable, ")
-        if (isEmpty()) return ""
+        if (isEmpty) return ""
         delete(length - 2, length)
       }
       headerValue = result


### PR DESCRIPTION
Triggering a discussion - not driven by real requirements. I'm happy to try to get something working and then burn this branch with fire and never speak of it again.

Key questions

1) Are we ok with peripheral features using coroutines? It seems natural here for DNS over HTTPS, which has two requests, and one can complete before the other.
2) What is the right API for drip feed requests? DNS and connection establishment if we wanted to support happy eyeballs (DNS alternatives, multiple connection paths (wifi, cellular), IPv4/6).  DNS over HTTPS currently blocks until it get's both results but doesn't need it.
3) How would we design Dns in a non blocking way, with async results, and tolerance of partial failures.
4) What is the plan for Loom vs Kotlin structured concurrency.

n.b. This was triggered by looking at what would be required if we supported HTTPS Resource Records https://emilymstark.com/2020/10/24/strict-transport-security-vs-https-resource-records-the-showdown.html by querying DNS with an additional request, presumably at the same time as DNS lookup but independent.