### PR TITLE
Move isProbablyUtf8 from kotlin internal to package named internal.

### DIFF
--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -26,6 +26,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Response
 import okhttp3.internal.http.promisesBody
 import okhttp3.internal.platform.Platform
+import okhttp3.logging.internal.isProbablyUtf8
 import okio.Buffer
 import okio.GzipSource
 

--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/internal/utf8.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/internal/utf8.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.logging
+package okhttp3.logging.internal
 
 import java.io.EOFException
 import okio.Buffer
@@ -23,7 +23,7 @@ import okio.Buffer
  * sample of code points to detect unicode control characters commonly used in binary file
  * signatures.
  */
-internal fun Buffer.isProbablyUtf8(): Boolean {
+fun Buffer.isProbablyUtf8(): Boolean {
   try {
     val prefix = Buffer()
     val byteCount = size.coerceAtMost(64)

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/IsProbablyUtf8Test.kt
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/IsProbablyUtf8Test.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3.logging
 
+import okhttp3.logging.internal.isProbablyUtf8
 import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test


### PR DESCRIPTION
As part of review comments from https://github.com/square/okhttp/pull/6340/files, cleaning up unrelated changes.