### PR TITLE
Avoid isEmpty() in CacheControl

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/CacheControl.kt
+++ b/okhttp/src/main/kotlin/okhttp3/CacheControl.kt
@@ -156,7 +156,7 @@ class CacheControl private constructor(
         if (onlyIfCached) append("only-if-cached, ")
         if (noTransform) append("no-transform, ")
         if (immutable) append("immutable, ")
-        if (isEmpty()) return ""
+        if (length == 0) return "" // isEmpty() is problematic with Kotlin 1.4 and JDK 15
         delete(length - 2, length)
       }
       headerValue = result


### PR DESCRIPTION
Building with JDK15 and Kotlin 1.4 is bad juju.

https://youtrack.jetbrains.com/issue/KT-42721