### PR TITLE
Allow for dev builds without proguard warnings (for discussion)

### DIFF
--- a/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
+++ b/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
@@ -10,3 +10,8 @@
 # OkHttp platform used only on JVM and when Conscrypt dependency is available.
 -dontwarn okhttp3.internal.platform.ConscryptPlatform
 -dontwarn org.conscrypt.ConscryptHostnameVerifier
+
+# For dev builds, allow for InsecureAndroidTrustManager
+-keepclassmembers class * implements javax.net.ssl.X509TrustManager {
+  public java.util.List checkServerTrusted(java.security.cert.X509Certificate[], java.lang.String, java.lang.String);
+}


### PR DESCRIPTION
Forking off https://github.com/google/conscrypt/issues/881

Should we avoid warning here, or does it add value to stop this working in a release build?