### PR TITLE
Avoid duplicate source roots in Intellij

### DIFF
--- a/native-image-tests/build.gradle
+++ b/native-image-tests/build.gradle
@@ -42,7 +42,8 @@ animalsniffer {
   ignoreFailures = true
 }
 
-def isIDE = properties.containsKey('android.injected.invoked.from.ide') || System.getenv("XPC_SERVICE_NAME").contains("intellij")
+def isIDE = properties.containsKey('android.injected.invoked.from.ide') ||
+        (System.getenv("XPC_SERVICE_NAME") ?: "").contains("intellij")
 if (!isIDE) {
   sourceSets {
     // Not included in IDE as this confuses Intellij for obvious reasons.

--- a/native-image-tests/build.gradle
+++ b/native-image-tests/build.gradle
@@ -42,7 +42,8 @@ animalsniffer {
   ignoreFailures = true
 }
 
-if (!properties.containsKey('android.injected.invoked.from.ide')) {
+def isIDE = properties.containsKey('android.injected.invoked.from.ide') || System.getenv("XPC_SERVICE_NAME").contains("intellij")
+if (!isIDE) {
   sourceSets {
     // Not included in IDE as this confuses Intellij for obvious reasons.
     main.java.srcDirs += project.file("../okhttp/src/test/java")


### PR DESCRIPTION
"android.injected.invoked.from.ide" is tied to the Android plugin.  XPC_SERVICE_NAME seems to be set by Intellij.

https://stackoverflow.com/questions/64726619/how-to-detect-if-gradle-plugin-is-running-inside-of-intellij/64726656#64726656