### PR TITLE
Fix windows IDE detection

### DIFF
--- a/native-image-tests/build.gradle
+++ b/native-image-tests/build.gradle
@@ -43,7 +43,8 @@ animalsniffer {
 }
 
 def isIDE = properties.containsKey('android.injected.invoked.from.ide') ||
-        (System.getenv("XPC_SERVICE_NAME") ?: "").contains("intellij")
+        (System.getenv("XPC_SERVICE_NAME") ?: "").contains("intellij") ||
+        System.getenv("IDEA_INITIAL_DIRECTORY") != null
 if (!isIDE) {
   sourceSets {
     // Not included in IDE as this confuses Intellij for obvious reasons.


### PR DESCRIPTION
On windows the existing checks aren't enough

https://github.com/JetBrains/intellij-community/blob/f396a4f0777cc1e79908a637f9f814eda794d3f8/native/WinLauncher/WinLauncher/WinLauncher.cpp#L1199