### PR TITLE
Workaround native image charset and kotlin issue

### DIFF
--- a/native-image-tests/build.gradle
+++ b/native-image-tests/build.gradle
@@ -67,6 +67,7 @@ graal {
   option "-H:+TraceClassInitialization"
   option "--initialize-at-build-time=kotlin.text.Charsets"
   option "-H:EnableURLProtocols=http,https"
+  option "-H:+AddAllCharsets"
 
   if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     // May be possible without, but autodetection is problematic on Windows 10

--- a/native-image-tests/src/main/kotlin/okhttp3/TestRegistration.kt
+++ b/native-image-tests/src/main/kotlin/okhttp3/TestRegistration.kt
@@ -26,6 +26,21 @@ class TestRegistration : Feature {
     registerKnownTests(access)
 
     registerJupiterClasses(access)
+
+    registerParamProvider(access, "okhttp3.SampleTestProvider")
+    registerParamProvider(access, "okhttp3.internal.http.CancelModelParamProvider")
+    registerParamProvider(access, "okhttp3.internal.cache.FileSystemParamProvider")
+    registerParamProvider(access, "okhttp3.internal.http2.HttpOverHttp2Test\$ProtocolParamProvider")
+    registerParamProvider(access, "okhttp3.internal.io.FileSystemParamProvider")
+  }
+
+  private fun registerParamProvider(access: Feature.BeforeAnalysisAccess, provider: String) {
+    val providerClass = access.findClassByName(provider)
+    if (providerClass != null) {
+      registerTest(access, providerClass)
+    } else {
+      println("Missing $provider")
+    }
   }
 
   private fun registerJupiterClasses(access: Feature.BeforeAnalysisAccess) {

--- a/okhttp/src/main/resources/META-INF/native-image/okhttp/okhttp/reflect-config.json
+++ b/okhttp/src/main/resources/META-INF/native-image/okhttp/okhttp/reflect-config.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "kotlin.internal.jdk8.JDK8PlatformImplementations",
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "kotlin.KotlinVersion",
+    "allPublicMethods": true,
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "kotlin.KotlinVersion[]"
+  },
+  {
+    "name": "kotlin.KotlinVersion$Companion"
+  },
+  {
+    "name": "kotlin.KotlinVersion$Companion[]"
+  }
+]


### PR DESCRIPTION

```
      ├─ noRecoveryFromTwoRefusedStreams(Protocol, MockWebServer) ✔
      │  ├─ [1] h2_prior_knowledge ✘ Could not initialize class kotlin.internal.PlatformImplementationsKt
      │  └─ [2] h2 ✘ Could not initialize class kotlin.internal.PlatformImplementationsKt
```

and

```
   │  ├─ readerBomUtf16Be() ✔
   │  ├─ readerBomUtf16Le() ✔
   │  ├─ readerBomUtf32Be() ✘ UTF-32BE
   │  ├─ readerBomUtf32Le() ✘ UTF-32LE
```