### PR TITLE
Fix single failing graal test

### DIFF
--- a/native-image-tests/src/main/kotlin/okhttp3/DotListener.kt
+++ b/native-image-tests/src/main/kotlin/okhttp3/DotListener.kt
@@ -44,7 +44,7 @@ object DotListener: TestExecutionListener {
   ) {
     if (!testIdentifier.isContainer) {
       when (testExecutionResult.status!!) {
-        TestExecutionResult.Status.ABORTED -> printStatus("E")
+        TestExecutionResult.Status.ABORTED -> printStatus("-")
         TestExecutionResult.Status.FAILED -> printStatus("F")
         TestExecutionResult.Status.SUCCESSFUL -> printStatus(".")
       }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/TestUtil.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/TestUtil.kt
@@ -30,8 +30,7 @@ object TestUtil {
   val UNREACHABLE_ADDRESS = InetSocketAddress("198.51.100.1", 8080)
 
   /** See `org.graalvm.nativeimage.ImageInfo`. */
-  @JvmStatic
-  private val isGraalVmImage = System.getProperty("org.graalvm.nativeimage.imagecode") != null
+  @JvmStatic val isGraalVmImage = System.getProperty("org.graalvm.nativeimage.imagecode") != null
 
   @JvmStatic
   fun headerEntries(vararg elements: String?): List<Header> {

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/testing/PlatformRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/testing/PlatformRule.kt
@@ -17,6 +17,7 @@ package okhttp3.testing
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider
 import com.amazon.corretto.crypto.provider.SelfTestStatus
+import okhttp3.TestUtil
 import okhttp3.internal.platform.ConscryptPlatform
 import okhttp3.internal.platform.Jdk8WithJettyBootPlatform
 import okhttp3.internal.platform.Jdk9Platform
@@ -121,11 +122,15 @@ open class PlatformRule @JvmOverloads constructor(
   }
 
   fun expectFailureFromJdkVersion(majorVersion: Int) {
-    expectFailure(fromMajor(majorVersion))
+    if (!TestUtil.isGraalVmImage) {
+      expectFailure(fromMajor(majorVersion))
+    }
   }
 
   fun expectFailureOnJdkVersion(majorVersion: Int) {
-    expectFailure(onMajor(majorVersion))
+    if (!TestUtil.isGraalVmImage) {
+      expectFailure(onMajor(majorVersion))
+    }
   }
 
   private fun expectFailure(
@@ -202,6 +207,8 @@ open class PlatformRule @JvmOverloads constructor(
 
   fun isBouncyCastle() = getPlatformSystemProperty() == BOUNCYCASTLE_PROPERTY
 
+  fun isGraalVMImage() = TestUtil.isGraalVmImage
+
   fun hasHttp2Support() = !isJdk8()
 
   fun assumeConscrypt() {
@@ -238,6 +245,10 @@ open class PlatformRule @JvmOverloads constructor(
 
   fun assumeAndroid() {
     assumeTrue(Platform.isAndroid)
+  }
+
+  fun assumeGraalVMImage() {
+    assumeTrue(isGraalVMImage())
   }
 
   fun assumeNotConscrypt() {
@@ -283,8 +294,13 @@ open class PlatformRule @JvmOverloads constructor(
     assumeFalse(Platform.isAndroid)
   }
 
+  fun assumeNotGraalVMImage() {
+    assumeFalse(isGraalVMImage())
+  }
+
   fun assumeJdkVersion(majorVersion: Int) {
     assumeNotAndroid()
+    assumeNotGraalVMImage()
     assumeTrue(PlatformVersion.majorVersion == majorVersion)
   }
 


### PR DESCRIPTION
```
h2 ✘ Cannot determine correct type for matchesSafely() method.
```

from Hamcrest

```
  fun fromMajor(version: Int): Matcher<PlatformVersion> {
    return object : TypeSafeMatcher<PlatformVersion>() {
      override fun describeTo(description: Description) {
        description.appendText("JDK with version from $version")
      }

      override fun matchesSafely(item: PlatformVersion): Boolean {
        return item.majorVersion >= version
      }
    }
  }
```