### PR TITLE
Patch doc shareinstance / new builder

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -89,7 +89,7 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * ```
  *
  * This example shows a call with a short 500 millisecond read timeout and a 1000 millisecond 
- * write timout. Original configuration is kept, but can be overriden.
+ * write timeout. Original configuration is kept, but can be overriden.
  *
  * ```
  * OkHttpClient eagerClient = client.newBuilder()

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -77,9 +77,16 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  *
  * You can customize a shared OkHttpClient instance with [newBuilder]. This builds a client that
  * shares the same connection pool, thread pools, and configuration. Use the builder methods to
- * configure the derived client for a specific purpose.
+ * add configurotion to the derived client for a specific purpose.
  *
- * This example shows a call with a short 500 millisecond timeout:
+ * public final OkHttpClient client = new OkHttpClient.Builder()
+ *     .readTimeout(1000, TimeUnit.MILLISECONDS)
+ *     .writeTimeout(1000, TimeUnit.MILLISECONDS)
+ *     .build();
+ * ```
+ *
+ * This example shows a call with a short 500 millisecond read timeout and a 1000 millisecond 
+ * write timout. Original configuration is kept but can be overriden.
  *
  * ```
  * OkHttpClient eagerClient = client.newBuilder()

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -77,8 +77,11 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  *
  * You can customize a shared OkHttpClient instance with [newBuilder]. This builds a client that
  * shares the same connection pool, thread pools, and configuration. Use the builder methods to
- * add configurotion to the derived client for a specific purpose.
+ * add configuration to the derived client for a specific purpose.
  *
+ * This example shows the single instance with default configurations.
+ * 
+ * ```
  * public final OkHttpClient client = new OkHttpClient.Builder()
  *     .readTimeout(1000, TimeUnit.MILLISECONDS)
  *     .writeTimeout(1000, TimeUnit.MILLISECONDS)
@@ -86,7 +89,7 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * ```
  *
  * This example shows a call with a short 500 millisecond read timeout and a 1000 millisecond 
- * write timout. Original configuration is kept but can be overriden.
+ * write timout. Original configuration is kept, but can be overriden.
  *
  * ```
  * OkHttpClient eagerClient = client.newBuilder()


### PR DESCRIPTION
Add extra explication and context to better understand newBuilder impact.

inform that the configuration of the original instance is kept
inform that a configuration of the original instance may be overriden