### PR TITLE
Fix trustManager message on JDK 8

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
@@ -59,7 +59,7 @@ open class Jdk9Platform : Platform() {
     // sun.security.ssl.SSLSocketFactoryImpl accessible:  module java.base does not export
     // sun.security.ssl to unnamed module @xxx
     throw UnsupportedOperationException(
-        "clientBuilder.sslSocketFactory(SSLSocketFactory) not supported on JDK 9+")
+        "clientBuilder.sslSocketFactory(SSLSocketFactory) not supported on JDK 8 (>= 252) or JDK 9+")
   }
 
   companion object {


### PR DESCRIPTION
JDK 9 doesn't support reflection to get the trust manager.  (Un)Fortunately this code path is also used on JDK8 now that it supports ALPN, so make the message clearer.