### PR TITLE
Verify IPv6 hostnames [3.14.x]

### DIFF
--- a/okhttp-tests/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
+++ b/okhttp-tests/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
@@ -516,6 +516,42 @@ public final class HostnameVerifierTest {
     assertThat(verifier.verify("quux.com", session)).isFalse();
   }
 
+  @Test public void subjectAltNameWithIPAddresses() throws Exception {
+    // $ cat ./cert.cnf
+    // [req]
+    // distinguished_name=distinguished_name
+    // req_extensions=req_extensions
+    // x509_extensions=x509_extensions
+    // [distinguished_name]
+    // [req_extensions]
+    // [x509_extensions]
+    // subjectAltName=IP:0:0:0:0:0:0:0:1,IP:2a03:2880:f003:c07:face:b00c::2,IP:0::5,IP:192.168.1.1
+    //
+    // $ openssl req -x509 -nodes -days 36500 -subj '/CN=foo.com' -config ./cert.cnf \
+    //     -newkey rsa:512 -out cert.pem
+    SSLSession session = session(""
+      + "-----BEGIN CERTIFICATE-----\n"
+      + "MIIBaDCCARKgAwIBAgIJALxN+AOBVGwQMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNV\n"
+      + "BAMMB2Zvby5jb20wIBcNMjAwMzIyMTEwNDI4WhgPMjEyMDAyMjcxMTA0MjhaMBIx\n"
+      + "EDAOBgNVBAMMB2Zvby5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAlnVbVfQ9\n"
+      + "4aYjrPCcFuxOpjXuvyOc9Hcha4K7TfXyfsrjhAvCjCBIT/TiLOUVF3sx4yoCAtX8\n"
+      + "wmt404tTbKD6UwIDAQABo0kwRzBFBgNVHREEPjA8hxAAAAAAAAAAAAAAAAAAAAAB\n"
+      + "hxAqAyiA8AMMB/rOsAwAAAAChxAAAAAAAAAAAAAAAAAAAAAFhwTAqAEBMA0GCSqG\n"
+      + "SIb3DQEBCwUAA0EAPSOYHJh7hB4ElBqTCAFW+T5Y7mXsv9nQjBJ7w0YIw83V2PEI\n"
+      + "3KbBIyGTrqHD6lG8QGZy+yNkIcRlodG8OfQRUg==\n"
+      + "-----END CERTIFICATE-----");
+    assertThat(verifier.verify("foo.com", session)).isFalse();
+    assertThat(verifier.verify("::1", session)).isTrue();
+    assertThat(verifier.verify("::2", session)).isFalse();
+    assertThat(verifier.verify("::5", session)).isTrue();
+    assertThat(verifier.verify("2a03:2880:f003:c07:face:b00c::2", session)).isTrue();
+    assertThat(verifier.verify("2a03:2880:f003:c07:face:b00c:0:2", session)).isTrue();
+    assertThat(verifier.verify("2a03:2880:f003:c07:FACE:B00C:0:2", session)).isTrue();
+    assertThat(verifier.verify("2a03:2880:f003:c07:face:b00c:0:3", session)).isFalse();
+    assertThat(verifier.verify("127.0.0.1", session)).isFalse();
+    assertThat(verifier.verify("192.168.1.1", session)).isTrue();
+  }
+
   @Test public void verifyAsIpAddress() {
     // IPv4
     assertThat(Util.verifyAsIpAddress("127.0.0.1")).isTrue();

--- a/okhttp/src/main/java/okhttp3/internal/tls/OkHostnameVerifier.java
+++ b/okhttp/src/main/java/okhttp3/internal/tls/OkHostnameVerifier.java
@@ -28,6 +28,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 
+import static okhttp3.internal.Util.canonicalizeHost;
 import static okhttp3.internal.Util.verifyAsIpAddress;
 
 /**
@@ -60,9 +61,10 @@ public final class OkHostnameVerifier implements HostnameVerifier {
 
   /** Returns true if {@code certificate} matches {@code ipAddress}. */
   private boolean verifyIpAddress(String ipAddress, X509Certificate certificate) {
+    String canonicalIpAddress = canonicalizeHost(ipAddress);
     List<String> altNames = getSubjectAltNames(certificate, ALT_IPA_NAME);
     for (int i = 0, size = altNames.size(); i < size; i++) {
-      if (ipAddress.equalsIgnoreCase(altNames.get(i))) {
+      if (canonicalIpAddress.equals(canonicalizeHost(altNames.get(i)))) {
         return true;
       }
     }


### PR DESCRIPTION
Fix for #5885 (3.14.x)

Backported from d59266778d888ec0ea1f48729b122de4d81f7b91 (#5889)

Relates to https://github.com/fabric8io/kubernetes-client/issues/2632