### PR TITLE
Gracefully handle null Conscrypt version

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/ConscryptPlatform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/ConscryptPlatform.kt
@@ -124,7 +124,7 @@ class ConscryptPlatform private constructor() : Platform() {
     fun buildIfSupported(): ConscryptPlatform? = if (isSupported) ConscryptPlatform() else null
 
     fun atLeastVersion(major: Int, minor: Int = 0, patch: Int = 0): Boolean {
-      val conscryptVersion = Conscrypt.version()
+      val conscryptVersion = Conscrypt.version() ?: return false
 
       if (conscryptVersion.major() != major) {
         return conscryptVersion.major() > major


### PR DESCRIPTION
In certain cases, Conscrypt returns a null version. Treat Conscrypt as
not available in these cases, since the version information is unknown.
Fixes #6502.
