### PR TITLE
Gradle upgrade, more specific toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,14 +110,6 @@ allprojects {
   project.ext.artifactId = rootProject.ext.publishedArtifactId(project)
   version = '4.10.0-SNAPSHOT'
 
-  repositories {
-    mavenCentral()
-    maven {
-      url 'https://dl.bintray.com/kotlin/dokka'
-    }
-    google()
-  }
-
   task downloadDependencies() {
     description 'Download all dependencies to the Gradle cache'
     doLast {
@@ -164,6 +156,7 @@ subprojects { project ->
   java {
     toolchain {
       languageVersion = JavaLanguageVersion.of(11)
+      vendor = JvmVendorSpec.ADOPTOPENJDK
     }
   }
 
@@ -214,6 +207,7 @@ subprojects { project ->
 
     javaLauncher = javaToolchains.launcherFor {
       languageVersion = JavaLanguageVersion.of(testJavaVersion)
+      vendor = JvmVendorSpec.ADOPTOPENJDK
     }
 
     maxParallelForks Runtime.runtime.availableProcessors() * 2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,3 +32,13 @@ include ':samples:simple-client'
 include ':samples:slack'
 include ':samples:static-server'
 include ':samples:unixdomainsockets'
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven {
+            url 'https://dl.bintray.com/kotlin/dokka'
+        }
+        google()
+    }
+}


### PR DESCRIPTION
Update to Gradle 6.8.1.  Use specific toolchain vendor, and move repositories out of submodules to settings.