### PR TITLE
Handle specific test failures on master

### DIFF
--- a/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
@@ -79,6 +79,9 @@ class CallHandshakeTest {
 
   @Test
   fun testDefaultHandshakeCipherSuiteOrderingTls12Restricted() {
+    // We are avoiding making guarantees on ordering of secondary Platforms.
+    platform.assumeNotConscrypt()
+
     val client = makeClient(ConnectionSpec.RESTRICTED_TLS, TlsVersion.TLS_1_2)
 
     val handshake = makeRequest(client)
@@ -98,6 +101,9 @@ class CallHandshakeTest {
 
   @Test
   fun testDefaultHandshakeCipherSuiteOrderingTls12Modern() {
+    // We are avoiding making guarantees on ordering of secondary Platforms.
+    platform.assumeNotConscrypt()
+
     val client = makeClient(ConnectionSpec.MODERN_TLS, TlsVersion.TLS_1_2)
 
     val handshake = makeRequest(client)
@@ -123,9 +129,6 @@ class CallHandshakeTest {
 
   @Test
   fun testDefaultHandshakeCipherSuiteOrderingTls13Modern() {
-    // Requires modern JVM
-    platform.expectFailureOnJdkVersion(8)
-
     val client = makeClient(ConnectionSpec.MODERN_TLS, TlsVersion.TLS_1_3)
 
     val handshake = makeRequest(client)
@@ -152,6 +155,9 @@ class CallHandshakeTest {
 
   @Test
   fun testHandshakeCipherSuiteOrderingWhenReversed() {
+    // We are avoiding making guarantees on ordering of secondary Platforms.
+    platform.assumeNotConscrypt()
+
     val client = makeClient(ConnectionSpec.RESTRICTED_TLS, TlsVersion.TLS_1_2,
       defaultEnabledCipherSuites.asReversed())
 
@@ -193,6 +199,8 @@ class CallHandshakeTest {
   @Test
   fun effectiveOrderInRestrictedJdk11() {
     platform.assumeJdkVersion(11)
+    // We are avoiding making guarantees on ordering of secondary Platforms.
+    platform.assumeNotConscrypt()
 
     val platform = Platform.get()
     val platformDefaultCipherSuites =

--- a/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
@@ -129,6 +129,9 @@ class CallHandshakeTest {
 
   @Test
   fun testDefaultHandshakeCipherSuiteOrderingTls13Modern() {
+    // Requires modern JVM
+    platform.expectFailureOnJdkVersion(8)
+
     val client = makeClient(ConnectionSpec.MODERN_TLS, TlsVersion.TLS_1_3)
 
     val handshake = makeRequest(client)

--- a/okhttp/src/test/java/okhttp3/RecordedResponse.java
+++ b/okhttp/src/test/java/okhttp3/RecordedResponse.java
@@ -58,7 +58,7 @@ public final class RecordedResponse {
   }
 
   public RecordedResponse assertCode(int expectedCode) {
-    assertThat(response.code()).isEqualTo(expectedCode);
+    assertThat(response == null ? null : response.code()).isEqualTo(expectedCode);
     return this;
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.java
@@ -637,6 +637,9 @@ public final class HostnameVerifierTest {
   }
 
   @Test public void specialKInExternalCert() throws Exception {
+    // OpenJDK related test.
+    platform.assumeNotConscrypt();
+
     // $ cat ./cert.cnf
     // [req]
     // distinguished_name=distinguished_name


### PR DESCRIPTION
Failures from unrelated latest build https://github.com/square/okhttp/commit/51211ea63954073908bc21471527a0e01057a4b3

JDK 8 now supporting TLS 1.3 https://www.oracle.com/java/technologies/javase/8u261-relnotes.html
