### PR TITLE
Add debug helper for JSSE Handshakes

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/JsseDebugLogging.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/JsseDebugLogging.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+
+object JsseDebugLogging {
+  data class JsseDebugMessage(val message: String, val param: String?) {
+    enum class Type {
+      Handshake, Plaintext, Encrypted, Setup, Unknown
+    }
+
+    val type: Type
+      get() = when {
+        message == "adding as trusted certificates" -> Type.Setup
+        message == "Raw read" || message == "Raw write" -> Type.Encrypted
+        message == "Plaintext before ENCRYPTION" || message == "Plaintext after DECRYPTION" -> Type.Plaintext
+        message.startsWith("System property ") -> Type.Setup
+        message.startsWith("Reload ") -> Type.Setup
+        message == "No session to resume." -> Type.Handshake
+        message.startsWith("Consuming ") -> Type.Handshake
+        message.startsWith("Produced ") -> Type.Handshake
+        message.startsWith("Negotiated ") -> Type.Handshake
+        else -> Type.Unknown
+      }
+
+    override fun toString(): String {
+      return if (param != null) {
+        message + "\n" + param
+      } else {
+        message
+      }
+    }
+  }
+
+  private fun quietDebug(message: JsseDebugMessage) {
+    if (message.message.startsWith("Ignore")) {
+      return
+    }
+
+    when (message.type) {
+      JsseDebugMessage.Type.Setup, JsseDebugMessage.Type.Encrypted, JsseDebugMessage.Type.Plaintext -> {
+        println(message.message + " (skipped output)")
+      }
+      else -> println(message)
+    }
+  }
+
+  fun enableJsseDebugLogging(debugHandler: (JsseDebugMessage) -> Unit = this::quietDebug) {
+    System.setProperty("javax.net.debug", "")
+    OkHttpDebugLogging.enable("javax.net.ssl", object : Handler() {
+      override fun publish(record: LogRecord) {
+        val param = record.parameters?.firstOrNull() as? String
+        debugHandler(JsseDebugMessage(record.message, param))
+      }
+
+      override fun flush() {
+      }
+
+      override fun close() {
+      }
+    })
+  }
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/JsseDebugLogging.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/JsseDebugLogging.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3
 
+import java.io.Closeable
 import java.util.logging.Handler
 import java.util.logging.LogRecord
 
@@ -63,9 +64,9 @@ object JsseDebugLogging {
     }
   }
 
-  fun enableJsseDebugLogging(debugHandler: (JsseDebugMessage) -> Unit = this::quietDebug) {
+  fun enableJsseDebugLogging(debugHandler: (JsseDebugMessage) -> Unit = this::quietDebug): Closeable {
     System.setProperty("javax.net.debug", "")
-    OkHttpDebugLogging.enable("javax.net.ssl", object : Handler() {
+    return OkHttpDebugLogging.enable("javax.net.ssl", object : Handler() {
       override fun publish(record: LogRecord) {
         val param = record.parameters?.firstOrNull() as? String
         debugHandler(JsseDebugMessage(record.message, param))

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/JsseDebugLogging.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/JsseDebugLogging.kt
@@ -35,6 +35,9 @@ object JsseDebugLogging {
         message.startsWith("Consuming ") -> Type.Handshake
         message.startsWith("Produced ") -> Type.Handshake
         message.startsWith("Negotiated ") -> Type.Handshake
+        message.startsWith("Found resumable session") -> Type.Handshake
+        message.startsWith("Resuming session") -> Type.Handshake
+        message.startsWith("Using PSK to derive early secret") -> Type.Handshake
         else -> Type.Unknown
       }
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpDebugLogging.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpDebugLogging.kt
@@ -17,6 +17,7 @@ package okhttp3
 
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.http2.Http2
+import java.io.Closeable
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.logging.ConsoleHandler
 import java.util.logging.Handler
@@ -42,11 +43,14 @@ object OkHttpDebugLogging {
     }
   }
 
-  fun enable(loggerClass: String, handler: Handler = logHandler()) {
+  fun enable(loggerClass: String, handler: Handler = logHandler()): Closeable {
     val logger = Logger.getLogger(loggerClass)
     if (configuredLoggers.add(logger)) {
       logger.addHandler(handler)
       logger.level = Level.FINEST
+    }
+    return Closeable {
+      logger.removeHandler(handler)
     }
   }
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpDebugLogging.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpDebugLogging.kt
@@ -15,15 +15,16 @@
  */
 package okhttp3
 
+import okhttp3.internal.concurrent.TaskRunner
+import okhttp3.internal.http2.Http2
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.logging.ConsoleHandler
+import java.util.logging.Handler
 import java.util.logging.Level
 import java.util.logging.LogRecord
 import java.util.logging.Logger
 import java.util.logging.SimpleFormatter
 import kotlin.reflect.KClass
-import okhttp3.internal.concurrent.TaskRunner
-import okhttp3.internal.http2.Http2
 
 object OkHttpDebugLogging {
   // Keep references to loggers to prevent their configuration from being GC'd.
@@ -33,16 +34,18 @@ object OkHttpDebugLogging {
 
   fun enableTaskRunner() = enable(TaskRunner::class)
 
-  fun enable(loggerClass: String) {
+  fun logHandler() = ConsoleHandler().apply {
+    level = Level.FINE
+    formatter = object : SimpleFormatter() {
+      override fun format(record: LogRecord) =
+        String.format("[%1\$tF %1\$tT] %2\$s %n", record.millis, record.message)
+    }
+  }
+
+  fun enable(loggerClass: String, handler: Handler = logHandler()) {
     val logger = Logger.getLogger(loggerClass)
     if (configuredLoggers.add(logger)) {
-      logger.addHandler(ConsoleHandler().apply {
-        level = Level.FINE
-        formatter = object : SimpleFormatter() {
-          override fun format(record: LogRecord) =
-            String.format("[%1\$tF %1\$tT] %2\$s %n", record.millis, record.message)
-        }
-      })
+      logger.addHandler(handler)
       logger.level = Level.FINEST
     }
   }


### PR DESCRIPTION
Simplifies the tedious work to setup java.util.logging to capture the useful bits of JSSE handshakes.

Example usage:

```
  val logSubscription = JsseDebugLogging.enableJsseDebugLogging {
    if (it.type == JsseDebugLogging.JsseDebugMessage.Type.Handshake) {
      println(it)
    }
  }

  ...

  logSubscription.close()
```

```
No session to resume.
Produced ClientHello handshake message
"ClientHello": {
  "client version"      : "TLSv1.2",
  "random"              : "00 EA 5D 1C 75 39 7B 1A A4 31 8D 5F CD F8 27 58 74 1C 66 2B 07 3B B4 37 A3 EB F8 8C 2F 30 64 48",
  "session id"          : "66 9B 0D 68 5B 47 CC 8C AB E5 6B 74 4A C7 CD 01 8F 39 0F C2 B1 79 86 A0 E2 D7 92 A6 2B 61 BD AB",
  "cipher suites"       : "[TLS_AES_256_GCM_SHA384(0x1302), TLS_AES_128_GCM_SHA256(0x1301), TLS_CHACHA20_POLY1305_SHA256(0x1303), TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384(0xC02C), TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256(0xC02B), TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256(0xCCA9), TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384(0xC030), TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256(0xCCA8), TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256(0xC02F), TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA(0xC014), TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA(0xC013), TLS_RSA_WITH_AES_256_GCM_SHA384(0x009D), TLS_RSA_WITH_AES_128_GCM_SHA256(0x009C), TLS_RSA_WITH_AES_256_CBC_SHA(0x0035), TLS_RSA_WITH_AES_128_CBC_SHA(0x002F)]",
  "compression methods" : "00",
  "extensions"          : [
    "server_name (0)": {
      type=host_name (0), value=www.google.com
    },
    "status_request (5)": {
      "certificate status type": ocsp
      "OCSP status request": {
        "responder_id": <empty>
        "request extensions": {
          <empty>
        }
      }
    },
    "supported_groups (10)": {
      "versions": [x25519, secp256r1, secp384r1, secp521r1, x448, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192]
    },
    "ec_point_formats (11)": {
      "formats": [uncompressed]
    },
    "signature_algorithms (13)": {
      "signature schemes": [ecdsa_secp256r1_sha256, ecdsa_secp384r1_sha384, ecdsa_secp521r1_sha512, rsa_pss_rsae_sha256, rsa_pss_rsae_sha384, rsa_pss_rsae_sha512, rsa_pss_pss_sha256, rsa_pss_pss_sha384, rsa_pss_pss_sha512, rsa_pkcs1_sha256, rsa_pkcs1_sha384, rsa_pkcs1_sha512, dsa_sha256, ecdsa_sha224, rsa_sha224, dsa_sha224, ecdsa_sha1, rsa_pkcs1_sha1, dsa_sha1]
    },
    "signature_algorithms_cert (50)": {
      "signature schemes": [ecdsa_secp256r1_sha256, ecdsa_secp384r1_sha384, ecdsa_secp521r1_sha512, rsa_pss_rsae_sha256, rsa_pss_rsae_sha384, rsa_pss_rsae_sha512, rsa_pss_pss_sha256, rsa_pss_pss_sha384, rsa_pss_pss_sha512, rsa_pkcs1_sha256, rsa_pkcs1_sha384, rsa_pkcs1_sha512, dsa_sha256, ecdsa_sha224, rsa_sha224, dsa_sha224, ecdsa_sha1, rsa_pkcs1_sha1, dsa_sha1]
    },
    "application_layer_protocol_negotiation (16)": {
      [h2, http/1.1]
    },
    "status_request_v2 (17)": {
      "cert status request": {
        "certificate status type": ocsp_multi
        "OCSP status request": {
          "responder_id": <empty>
          "request extensions": {
            <empty>
          }
        }
      }
    },
    "extended_master_secret (23)": {
      <empty>
    },
    "session_ticket (35)": {
      <empty>
    },
    "supported_versions (43)": {
      "versions": [TLSv1.3, TLSv1.2]
    },
    "psk_key_exchange_modes (45)": {
      "ke_modes": [psk_dhe_ke]
    },
    "key_share (51)": {
      "client_shares": [  
        {
          "named group": x25519
          "key_exchange": {
            0000: 05 63 52 92 0E 99 A8 97   29 73 CA 37 F9 22 3A 6E  .cR.....)s.7.":n
            0010: 33 72 D1 E8 DF 42 BE 8F   92 00 29 5A D4 88 76 21  3r...B....)Z..v!
          }
        },
      ]
    },
    "renegotiation_info (65,281)": {
      "renegotiated connection": [<no renegotiated connection>]
    }
  ]
}
Consuming ServerHello handshake message
"ServerHello": {
  "server version"      : "TLSv1.2",
  "random"              : "BE 7B 8F 4C 2C 7C B1 1C 67 CA BB A0 84 75 57 28 51 C1 CF FF 28 CE 6A 90 0A 33 45 C6 62 92 D0 CD",
  "session id"          : "66 9B 0D 68 5B 47 CC 8C AB E5 6B 74 4A C7 CD 01 8F 39 0F C2 B1 79 86 A0 E2 D7 92 A6 2B 61 BD AB",
  "cipher suite"        : "TLS_AES_256_GCM_SHA384(0x1302)",
  "compression methods" : "00",
  "extensions"          : [
    "key_share (51)": {
      "server_share": {
        "named group": x25519
        "key_exchange": {
          0000: B2 53 A7 8A 7A DA 2A 97   61 67 9A 1E CB 99 12 D4  .S..z.*.ag......
          0010: 70 6C 14 FC 50 B6 B7 39   CB 56 36 43 18 02 B8 1E  pl..P..9.V6C....
        }
      },
    },
    "supported_versions (43)": {
      "selected version": [TLSv1.3]
    }
  ]
}
Negotiated protocol version: TLSv1.3
Mar 06, 2021 3:31:17 PM sun.security.ssl.SSLLogger log
WARNING: Ignore impact of unsupported extension: supported_versions
Mar 06, 2021 3:31:17 PM sun.security.ssl.SSLLogger log
WARNING: Ignore impact of unsupported extension: key_share
Consuming ChangeCipherSpec message
Consuming EncryptedExtensions handshake message
"EncryptedExtensions": [
  "application_layer_protocol_negotiation (16)": {
    [h2]
  }
]
Consuming server Certificate handshake message
"Certificate": {
  "certificate_request_context": "",
...
      <no extension>
    }
  },
]
}
Mar 06, 2021 3:31:17 PM sun.security.ssl.SSLLogger log
WARNING: Ignore impact of unsupported extension: application_layer_protocol_negotiation
Consuming CertificateVerify handshake message
"CertificateVerify": {
  "signature algorithm": ecdsa_secp256r1_sha256
  "signature": {
    0000: 30 46 02 21 00 93 89 1B   2E 4F 28 B3 1E 26 BD 2A  0F.!.....O(..&.*
    0010: 52 51 F7 2D 4F B4 42 4A   9F A7 46 31 49 4E 19 20  RQ.-O.BJ..F1IN. 
    0020: FC 23 BB 1C 8C 02 21 00   DC 72 3A A0 2C 0B D7 D4  .#....!..r:.,...
    0030: 75 85 8B 0C D6 77 5A 93   31 0E 79 23 69 06 EE 00  u....wZ.1.y#i...
    0040: D2 7C CF 28 45 CF 19 FD                            ...(E...
  }
}
Consuming server Finished handshake message
"Finished": {
  "verify data": {
    0000: C7 D5 3A D9 49 5D 7B D4   93 DF DC CF 67 23 04 7F  ..:.I]......g#..
    0010: 04 22 A5 3A 31 2E C1 18   D5 E6 FB D9 B3 FD 2D B8  .".:1.........-.
    0020: D5 A1 2E 77 01 81 1F CC   62 04 26 98 20 CE 43 55  ...w....b.&. .CU
  }'}
Produced client Finished handshake message
"Finished": {
  "verify data": {
    0000: 26 FC 34 40 6E 41 DA 96   6B 6E A4 30 03 43 A5 F6  &.4@nA..kn.0.C..
    0010: E8 4E 5C 55 4D 47 7B 2A   DF 63 72 FB B0 D8 35 44  .N\UMG.*.cr...5D
    0020: D2 F8 55 92 FB A9 48 F0   9D 04 B6 F5 C9 C9 28 DE  ..U...H.......(.
  }'}
Consuming NewSessionTicket message
"NewSessionTicket": {
  "ticket_lifetime"      : "172,800",
...
    }
  ]
}
Consuming NewSessionTicket message
"NewSessionTicket": {
  "ticket_lifetime"      : "172,800",
...
    00F0: 2E B4 
  }  "extensions"           : [
    "unknown extension (19,018)": {
      
    }
  ]
}
```