### PR TITLE
read server response if request was partially transferred

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/Exchange.kt
@@ -70,7 +70,7 @@ class Exchange(
   }
 
   @Throws(IOException::class)
-  fun createRequestBody(request: Request, duplex: Boolean): Sink {
+  fun createRequestBody(request: Request, duplex: Boolean): RequestBodySink {
     this.isDuplex = duplex
     val contentLength = request.body!!.contentLength()
     eventListener.requestBodyStart(call)
@@ -203,7 +203,7 @@ class Exchange(
   }
 
   /** A request body that fires events when it completes. */
-  private inner class RequestBodySink(
+  inner class RequestBodySink(
     delegate: Sink,
     /** The exact number of bytes to be written, or -1L if that is unknown. */
     private val contentLength: Long
@@ -211,6 +211,10 @@ class Exchange(
     private var completed = false
     private var bytesReceived = 0L
     private var closed = false
+
+    fun inProgress(): Boolean {
+      return !completed && bytesReceived > 0
+    }
 
     @Throws(IOException::class)
     override fun write(source: Buffer, byteCount: Long) {


### PR DESCRIPTION
Putting up a PR as suggested by @yschimke in https://github.com/square/okhttp/issues/4425#issuecomment-786830186

I am attempting to read the server response if the client did start an exchange but fails to transmit the whole request body. This might happen even if there is no issue with the server connection.

The difficult part was to determine if we did actually start the exchange or not, as okhttp seemingly waits for complete segments before emitting. Please advice if there are better ways to do this than adding RequestBodySink.inProgress().

Also, when not throwing the IOException it seems as if the exchange is not properly cleaned up, probably because catch clauses in RealCall.kt and RetryAndFollowUpInterceptor.kt are not activated. This is detected by OkHttpClientTestRule.ensureAllConnectionsReleased(). Would always closing RequestBodySink inside be the right way to solve this? https://github.com/square/okhttp/pull/6585/files#r593421813

