### PR TITLE
Upgrade Kotlin to 1.4.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
       'jnrUnixsocket': '0.28',
       'jsoup': '1.13.1',
       'junit': '4.13',
-      'kotlin': '1.4.10',
+      'kotlin': '1.4.31',
       'moshi': '1.9.2',
       'okio': '2.8.0',
       'ktlint': '0.38.0',
@@ -47,7 +47,7 @@ buildscript {
   ]
 
   dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
     classpath "com.android.tools.build:gradle:4.0.1"
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Kotlin to 1.4.31 (latest release), mostly to get a fix for CVE-2020-29582.

## How was this patch tested?

```
$ ./gradlew clean check
...
BUILD SUCCESSFUL in 3m 55s
130 actionable tasks: 129 executed, 1 up-to-date
```