### PR TITLE
Changed expected exception check by JUnit API usage

### DIFF
--- a/okhttp/src/test/java/okhttp3/CacheControlTest.java
+++ b/okhttp/src/test/java/okhttp3/CacheControlTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class CacheControlTest {
   @Test public void emptyBuilderIsEmpty() throws Exception {
@@ -181,11 +181,9 @@ public final class CacheControlTest {
 
   @Test public void secondsMustBeNonNegative() throws Exception {
     CacheControl.Builder builder = new CacheControl.Builder();
-    try {
+    assertThrows(IllegalArgumentException.class, () ->{
       builder.maxAge(-1, TimeUnit.SECONDS);
-      fail();
-    } catch (IllegalArgumentException expected) {
-    }
+    });
   }
 
   @Test public void timePrecisionIsTruncatedToSeconds() throws Exception {


### PR DESCRIPTION
This is a test refactoring.

**Problem:**
The Exception Handling test smell occurs when the test outcome is manually determined through pass or fail method calls, which are dependent on the production method throwing an exception, generally inside a try/catch block.

**Solution:**
We propose using JUnit's exception handling to automatically pass/fail the test instead of writing custom exception handling code or throwing an exception. In this particular case, JUnit 5 assertThrows() was used to properly handle the expected exception.

**Result:**
_Before:_
```
try {
    builder.maxAge(-1, TimeUnit.SECONDS);
    fail();
} catch (IllegalArgumentException expected) {
}
```

_After:_
```
assertThrows(IllegalArgumentException.class, () ->{
  builder.maxAge(-1, TimeUnit.SECONDS);
});
```