### PR TITLE
Simplify our secondary gradle modules

### DIFF
--- a/android-test/build.gradle
+++ b/android-test/build.gradle
@@ -31,10 +31,6 @@ repositories {
   }
 }
 
-def isIDE = properties.containsKey('android.injected.invoked.from.ide') ||
-        (System.getenv("XPC_SERVICE_NAME") ?: "").contains("intellij") ||
-        System.getenv("IDEA_INITIAL_DIRECTORY") != null
-
 android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
@@ -62,18 +58,16 @@ android {
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     testInstrumentationRunnerArguments([
             'runnerBuilder': 'de.mannodermaus.junit5.AndroidJUnit5Builder',
-            'notPackage': 'org.bouncycastle'
+            'notPackage'   : 'org.bouncycastle'
     ])
   }
 
-  if (!isIDE) {
-    sourceSets {
-      named("androidTest") {
-        it.java.srcDirs += project.file("../okhttp-brotli/src/test/java")
-        it.java.srcDirs += project.file("../okhttp-dnsoverhttps/src/test/java")
-        it.java.srcDirs += project.file("../okhttp-logging-interceptor/src/test/java")
-        it.java.srcDirs += project.file("../okhttp-sse/src/test/java")
-      }
+  sourceSets {
+    named("androidTest") {
+      it.java.srcDirs += project.file("../okhttp-brotli/src/test/java")
+      it.java.srcDirs += project.file("../okhttp-dnsoverhttps/src/test/java")
+      it.java.srcDirs += project.file("../okhttp-logging-interceptor/src/test/java")
+      it.java.srcDirs += project.file("../okhttp-sse/src/test/java")
     }
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-image-tests/build.gradle
+++ b/native-image-tests/build.gradle
@@ -43,18 +43,13 @@ animalsniffer {
   ignoreFailures = true
 }
 
-def isIDE = properties.containsKey('android.injected.invoked.from.ide') ||
-        (System.getenv("XPC_SERVICE_NAME") ?: "").contains("intellij") ||
-        System.getenv("IDEA_INITIAL_DIRECTORY") != null
-if (!isIDE) {
-  sourceSets {
-    // Not included in IDE as this confuses Intellij for obvious reasons.
-    main.java.srcDirs += project.file("../okhttp/src/test/java")
-    main.java.srcDirs += project.file("../okhttp-brotli/src/test/java")
-    main.java.srcDirs += project.file("../okhttp-dnsoverhttps/src/test/java")
-    main.java.srcDirs += project.file("../okhttp-logging-interceptor/src/test/java")
-    main.java.srcDirs += project.file("../okhttp-sse/src/test/java")
-  }
+sourceSets {
+  // Not included in IDE as this confuses Intellij for obvious reasons.
+  main.java.srcDirs += project.file("../okhttp/src/test/java")
+  main.java.srcDirs += project.file("../okhttp-brotli/src/test/java")
+  main.java.srcDirs += project.file("../okhttp-dnsoverhttps/src/test/java")
+  main.java.srcDirs += project.file("../okhttp-logging-interceptor/src/test/java")
+  main.java.srcDirs += project.file("../okhttp-sse/src/test/java")
 }
 
 graal {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,14 +5,17 @@ include(":mockwebserver-deprecated")
 include(":mockwebserver-junit4")
 include(":mockwebserver-junit5")
 
-if (System.getProperties().containsKey("android.injected.invoked.from.ide") ||
-        System.getenv("ANDROID_SDK_ROOT") != null) {
-  // Currently incompatible with Intellij, use with Android Studio and from CLI with explicit flag
+val androidBuild: String? by settings
+val graalBuild: String? by settings
+
+if (androidBuild != null) {
   include(":android-test")
   include(":regression-test")
 }
 
-include(":native-image-tests")
+if (graalBuild != null) {
+  include(":native-image-tests")
+}
 
 include(":okcurl")
 include(":okhttp")


### PR DESCRIPTION
Being automatic was a lofty goal that makes the experience in IDE unpredictable.  Particularly while IDE and command line are sharing daemons. Switch to a simpler model.

- By default build in IDE and command line/daemon without Android and Graal builds
- Allow -PandroidBuild or -PgraalBuild to include additional modules and overlapping source paths

This isn't a great situation, but OkHttp has so many different builds to consider
- JDK vs Android vs Graal
- JDK 8, 11, 16
- Platform - JSSE, Conscrypt, etc

And ultimately it seems really tough to get something that works automatically within Intellij without finding weirdness with plugins or on branch switches when reimporting gradle.