### PR TITLE
Add internal accessor for connection

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/internal.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/internal.kt
@@ -27,6 +27,8 @@ import okhttp3.Cookie
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.Request
+import okhttp3.Response
+import okhttp3.internal.connection.RealConnection
 
 fun parseCookie(currentTimeMillis: Long, url: HttpUrl, setCookie: String): Cookie? =
     Cookie.parse(currentTimeMillis, url, setCookie)
@@ -52,3 +54,6 @@ fun ConnectionSpec.effectiveCipherSuites(socketEnabledCipherSuites: Array<String
     socketEnabledCipherSuites
   }
 }
+
+val Response.connection: RealConnection
+  get() = this.exchange!!.connection

--- a/okhttp/src/test/java/okhttp3/JSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/JSSETest.kt
@@ -18,6 +18,7 @@ package okhttp3
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import okhttp3.TestUtil.assumeNetwork
+import okhttp3.internal.connection
 import okhttp3.internal.platform.OpenJSSEPlatform
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.internal.TlsUtil
@@ -70,7 +71,7 @@ class JSSETest(
       assertEquals(TlsVersion.TLS_1_3, response.handshake?.tlsVersion)
       assertEquals(Protocol.HTTP_2, response.protocol)
 
-      assertThat(response.exchange!!.connection.socket().javaClass.name).isEqualTo(
+      assertThat(response.connection.socket().javaClass.name).isEqualTo(
         "sun.security.ssl.SSLSocketImpl"
       )
     }


### PR DESCRIPTION
```
$ ./gradlew :native-image-tests:compileKotlin
Starting a Gradle Daemon, 1 stopped Daemon could not be reused, use --status for details

> Task :native-image-tests:compileKotlin
w: /Users/yschimke/workspace/okhttp/native-image-tests/src/main/kotlin/okhttp3/SampleTest.kt: (64, 18): Parameter 'mode' is never used
w: /Users/yschimke/workspace/okhttp/okhttp/src/test/java/okhttp3/SessionReuseTest.kt: (58, 9): Name shadowed: tlsVersion
w: /Users/yschimke/workspace/okhttp/okhttp/src/test/java/okhttp3/SocketChannelTest.kt: (123, 18): 'supportsTlsExtensions(Boolean): ConnectionSpec.Builder' is deprecated. since OkHttp 3.13 all TLS-connections are expected to support TLS extensions.
In a future release setting this to true will be unnecessary and setting it to false
will have no effect.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.1/userguide/command_line_interface.html#sec:command_line_warnings
```