### PR TITLE
Ignore jenv file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ docs/4.x
 docs/changelog.md
 docs/contributing.md
 docs/index.md
+
+# jenv
+/.java-version


### PR DESCRIPTION
No use configuring as names can vary locally. Since we use gradle toolchains, it's basically only a default for ./gradlew to avoid pain when having a bleeding edge JDK like 16/17 installed.