### PR TITLE
Do not return a nullable header value if a default value is set

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Response.kt
@@ -166,6 +166,13 @@ class Response internal constructor(
 
   fun header(name: String, defaultValue: String): String = header(name) ?: defaultValue
 
+  @JvmName("-deprecated_header")
+  @Deprecated(
+    message = "functionality covered by header(String) and header(String, String)",
+    replaceWith = ReplaceWith(expression = "header(name)"),
+    level = DeprecationLevel.ERROR)
+  fun header(name: String, defaultValue: String?): String? = header(name) ?: defaultValue
+
   @JvmName("-deprecated_headers")
   @Deprecated(
       message = "moved to val",

--- a/okhttp/src/main/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Response.kt
@@ -162,8 +162,9 @@ class Response internal constructor(
 
   fun headers(name: String): List<String> = headers.values(name)
 
-  @JvmOverloads
-  fun header(name: String, defaultValue: String? = null): String? = headers[name] ?: defaultValue
+  fun header(name: String): String? = headers[name]
+
+  fun header(name: String, defaultValue: String): String = header(name) ?: defaultValue
 
   @JvmName("-deprecated_headers")
   @Deprecated(


### PR DESCRIPTION
This PR splits up the `header(name: String, defaultValue: String? = null): String?` method in `Request` into two methods:
 - `fun header(name: String): String?`
 - `fun header(name: String, defaultValue: String): String`

This way, the method does not return a nullable type when a default value is set. 

I deprecated the original method to prevent introducing breaking API changes.