### PR TITLE
Avoid actively setting conscrypt

### DIFF
--- a/okhttp/src/test/java/okhttp3/ConscryptTest.kt
+++ b/okhttp/src/test/java/okhttp3/ConscryptTest.kt
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
 class ConscryptTest {
-  @JvmField @RegisterExtension val platform = PlatformRule.conscrypt()
+  @JvmField @RegisterExtension val platform = PlatformRule()
   @JvmField @RegisterExtension val clientTestRule = OkHttpClientTestRule()
 
   private val client = clientTestRule.newClient()

--- a/okhttp/src/test/java/okhttp3/CorrettoTest.kt
+++ b/okhttp/src/test/java/okhttp3/CorrettoTest.kt
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
 class CorrettoTest {
-  @JvmField @RegisterExtension val platform = PlatformRule.conscrypt()
+  @JvmField @RegisterExtension val platform = PlatformRule()
   @JvmField @RegisterExtension val clientTestRule = OkHttpClientTestRule()
 
   private val client = clientTestRule.newClient()

--- a/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/platform/android/AndroidSocketAdapterTest.kt
@@ -30,12 +30,18 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
 class AndroidSocketAdapterTest {
-  @RegisterExtension @JvmField val platform = PlatformRule.conscrypt()
+  @RegisterExtension @JvmField val platform = PlatformRule()
+  
+  @BeforeEach
+  fun setUp() {
+    platform.assumeConscrypt()
+  }
 
   val context by lazy {
     val provider: Provider = Conscrypt.newProviderBuilder().provideTrustManager(true).build()


### PR DESCRIPTION
Avoid a potential source of providers conflict

```
JSSETest > testSupportedProtocols() FAILED
    org.opentest4j.AssertionFailedError:
    Expecting:
     <"org.conscrypt.OpenSSLSocketFactoryImpl">
    to be equal to:
     <"sun.security.ssl.SSLSocketFactoryImpl">
    but was not.
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at okhttp3.JSSETest.testSupportedProtocols(JSSETest.kt:87)
```