### PR TITLE
Handle strict module handling on JDK17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,8 +89,7 @@ jobs:
 
   testopenjdk8:
     runs-on: ubuntu-latest
-    # TODO revert
-#    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,8 @@ jobs:
 
   testopenjdk8:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    # TODO revert
+#    if: github.ref == 'refs/heads/master'
 
     steps:
       - name: Checkout

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
@@ -39,6 +39,7 @@ import okhttp3.internal.tls.BasicTrustRootIndex
 import okhttp3.internal.tls.CertificateChainCleaner
 import okhttp3.internal.tls.TrustRootIndex
 import okio.Buffer
+import java.lang.reflect.InaccessibleObjectException
 
 /**
  * Access to platform-specific features.
@@ -94,6 +95,10 @@ open class Platform {
       val context = readFieldOrNull(sslSocketFactory, sslContextClass, "context") ?: return null
       readFieldOrNull(context, X509TrustManager::class.java, "trustManager")
     } catch (e: ClassNotFoundException) {
+      null
+    } catch (e: InaccessibleObjectException) {
+      // Throws InaccessibleObjectException (added in JDK9) on JDK 17 due to
+      // JEP 403 Strongly Encapsulate JDK Internals.
       null
     }
   }

--- a/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/platform/Platform.kt
@@ -39,7 +39,6 @@ import okhttp3.internal.tls.BasicTrustRootIndex
 import okhttp3.internal.tls.CertificateChainCleaner
 import okhttp3.internal.tls.TrustRootIndex
 import okio.Buffer
-import java.lang.reflect.InaccessibleObjectException
 
 /**
  * Access to platform-specific features.
@@ -96,9 +95,13 @@ open class Platform {
       readFieldOrNull(context, X509TrustManager::class.java, "trustManager")
     } catch (e: ClassNotFoundException) {
       null
-    } catch (e: InaccessibleObjectException) {
+    } catch (e: RuntimeException) {
       // Throws InaccessibleObjectException (added in JDK9) on JDK 17 due to
       // JEP 403 Strongly Encapsulate JDK Internals.
+      if (e.javaClass.name != "java.lang.reflect.InaccessibleObjectException") {
+        throw e
+      }
+
       null
     }
   }


### PR DESCRIPTION
After confirmed results on original bug report, this will need to be backported to 4.9.x and 3.12.x

https://github.com/square/okhttp/issues/6694