### PR TITLE
Slightly more generous timeout in HttpOverHttp2Test

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -1810,8 +1810,8 @@ public final class HttpOverHttp2Test {
     client.newCall(new Request.Builder().url(server.url("/")).build()).enqueue(callback);
     client.newCall(new Request.Builder().url(server.url("/")).build()).enqueue(callback);
 
-    assertThat(bodies.poll(2, SECONDS)).isEqualTo("DEF");
-    assertThat(bodies.poll(2, SECONDS)).isEqualTo("ABC");
+    assertThat(bodies.poll(3, SECONDS)).isEqualTo("DEF");
+    assertThat(bodies.poll(3, SECONDS)).isEqualTo("ABC");
     assertThat(server.getRequestCount()).isEqualTo(2);
   }
 


### PR DESCRIPTION
Seeing this in CI a few times

```
HttpOverHttp2Test > responseHeadersAfterGoaway(Protocol, MockWebServer) > okhttp3.internal.http2.HttpOverHttp2Test.responseHeadersAfterGoaway(Protocol, MockWebServer)[2] FAILED
    org.opentest4j.AssertionFailedError: 
    Expecting:
     <null>
    to be equal to:
     <"ABC">
    but was not.
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at okhttp3.internal.http2.HttpOverHttp2Test.responseHeadersAfterGoaway(HttpOverHttp2Test.java:1814)
```