### PR TITLE
Allow exhausted all routes in ClientAuthTest

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
@@ -214,6 +214,8 @@ public final class ClientAuthTest {
     } catch (SocketException expected) {
       assertThat(getPlatformSystemProperty()).isIn(PlatformRule.JDK9_PROPERTY,
           PlatformRule.CONSCRYPT_PROPERTY);
+    } catch (IOException expected) {
+      assertThat(expected.getMessage()).isEqualTo("exhausted all routes");
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
@@ -270,6 +270,8 @@ public final class ClientAuthTest {
           PlatformRule.CONSCRYPT_PROPERTY);
     } catch (ConnectionShutdownException expected) {
       // It didn't fail until it reached the application layer.
+    } catch (IOException expected) {
+      assertThat(expected.getMessage()).isEqualTo("exhausted all routes");
     }
   }
 


### PR DESCRIPTION
Seeing in CI

```
ClientAuthTest > missingClientAuthFailsForNeeds() FAILED
    java.io.IOException: exhausted all routes
        at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.kt:132)
        at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.kt:74)
        at okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:255)
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
        at okhttp3.internal.connection.RealCall.execute(RealCall.kt:154)
        at okhttp3.internal.tls.ClientAuthTest.missingClientAuthFailsForNeeds(ClientAuthTest.java:210)
```