### PR TITLE
Added Dispatched.clear() method for testing

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/QueueDispatcher.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/QueueDispatcher.kt
@@ -59,6 +59,10 @@ open class QueueDispatcher : Dispatcher() {
     responseQueue.add(response)
   }
 
+  open fun clear() {
+    responseQueue.clear()
+  }
+
   override fun shutdown() {
     responseQueue.add(DEAD_LETTER)
   }

--- a/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
@@ -257,6 +257,15 @@ public final class MockWebServerTest {
     server.url("/b").url().openConnection().getInputStream(); // Should succeed.
   }
 
+  @Test public void clearDispatcherQueue() throws Exception {
+    server.enqueue(new MockResponse().setBody("A"));
+    ((QueueDispatcher) server.getDispatcher()).clear();
+    server.enqueue(new MockResponse().setBody("B"));
+
+    InputStream in = server.url("/a").url().openConnection().getInputStream();
+    assertThat(in.read()).isEqualTo('B');
+  }
+
   /**
    * Throttle the request body by sleeping 500ms after every 3 bytes. With a 6-byte request, this
    * should yield one sleep for a total delay of 500ms.


### PR DESCRIPTION
Regarding https://github.com/square/okhttp/issues/6620

The main patch is `mockwebserver/src/main/kotlin/mockwebserver3/QueueDispatcher.kt` with the test in `mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java`.

Everything else was just fixed to satisfy the interface class. If you want a smaller patch or do not want a change in the interface I could also make `clear()` with a default implementation that does nothing. The only drawback would be that new implementations of the Dispatcher interface would then miss to override the clear method. But on the other hand, who would ever want to add another implementation anyway. Your choice.