### PR TITLE
Fix tests for android

### DIFF
--- a/android-test/build.gradle
+++ b/android-test/build.gradle
@@ -98,6 +98,7 @@ dependencies {
   androidTestImplementation 'org.apache.httpcomponents.client5:httpclient5:5.0'
   androidTestImplementation 'com.squareup.moshi:moshi:1.12.0'
   androidTestImplementation 'com.squareup.moshi:moshi-kotlin:1.12.0'
+  androidTestImplementation Dependencies.okioFakeFileSystem
 
   androidTestImplementation "androidx.test:runner:1.3.0"
   androidTestImplementation "org.junit.jupiter:junit-jupiter-api:5.7.0"

--- a/okhttp-dnsoverhttps/build.gradle
+++ b/okhttp-dnsoverhttps/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   testImplementation project(':okhttp-testing-support')
   testImplementation project(':mockwebserver-deprecated')
   testImplementation project(':mockwebserver-junit5')
+  testImplementation Dependencies.okioFakeFileSystem
   testImplementation Dependencies.conscrypt
   testImplementation Dependencies.junit
   testImplementation Dependencies.assertj

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.java
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.java
@@ -35,6 +35,9 @@ import okhttp3.Protocol;
 import okhttp3.testing.PlatformRule;
 import okio.Buffer;
 import okio.ByteString;
+import okio.FileSystem;
+import okio.Path;
+import okio.fakefilesystem.FakeFileSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -53,6 +56,7 @@ public class DnsOverHttpsTest {
 
   private MockWebServer server;
   private Dns dns;
+  private FileSystem cacheFs = new FakeFileSystem();
 
   private final OkHttpClient bootstrapClient = new OkHttpClient.Builder()
       .protocols(asList(Protocol.HTTP_2, Protocol.HTTP_1_1))
@@ -167,7 +171,7 @@ public class DnsOverHttpsTest {
   // TODO how closely to follow POST rules on caching?
 
   @Test public void usesCache() throws Exception {
-    Cache cache = new Cache(new File("./target/DnsOverHttpsTest.cache"), 100 * 1024);
+    Cache cache = new Cache(Path.get("cache"), 100 * 1024, cacheFs);
     OkHttpClient cachedClient = bootstrapClient.newBuilder().cache(cache).build();
     DnsOverHttps cachedDns = buildLocalhost(cachedClient, false);
 


### PR DESCRIPTION
DnsOverHttpsTest.usesCache presumably used an invalid path on Android, now using a Fake FileSystem.