### PR TITLE
Replace deprecated methods

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -692,7 +692,7 @@ class MockWebServer : Closeable {
           break
         }
         addHeaderLenient(headers, header)
-        val lowercaseHeader = header.toLowerCase(Locale.US)
+        val lowercaseHeader = header.lowercase(Locale.US)
         if (contentLength == -1L && lowercaseHeader.startsWith("content-length:")) {
           contentLength = header.substring(15).trim().toLong()
         }
@@ -909,11 +909,11 @@ class MockWebServer : Closeable {
   override fun close() = shutdown()
 
   /** A buffer wrapper that drops data after [bodyLimit] bytes. */
-  private class TruncatingBuffer internal constructor(
+  private class TruncatingBuffer(
     private var remainingByteCount: Long
   ) : Sink {
-    internal val buffer = Buffer()
-    internal var receivedByteCount = 0L
+    val buffer = Buffer()
+    var receivedByteCount = 0L
 
     @Throws(IOException::class)
     override fun write(source: Buffer, byteCount: Long) {

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -909,11 +909,11 @@ class MockWebServer : Closeable {
   override fun close() = shutdown()
 
   /** A buffer wrapper that drops data after [bodyLimit] bytes. */
-  private class TruncatingBuffer(
+  private class TruncatingBuffer internal constructor(
     private var remainingByteCount: Long
   ) : Sink {
-    val buffer = Buffer()
-    var receivedByteCount = 0L
+    internal val buffer = Buffer()
+    internal var receivedByteCount = 0L
 
     @Throws(IOException::class)
     override fun write(source: Buffer, byteCount: Long) {

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/ServerSentEventReader.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/ServerSentEventReader.kt
@@ -58,7 +58,7 @@ class ServerSentEventReader(
         }
 
         in 5..7 -> {
-          data.writeByte('\n'.toInt()) // 'data' on a line of its own.
+          data.writeByte('\n'.code) // 'data' on a line of its own.
         }
 
         in 8..9 -> {
@@ -144,7 +144,7 @@ class ServerSentEventReader(
 
     @Throws(IOException::class)
     private fun BufferedSource.readData(data: Buffer) {
-      data.writeByte('\n'.toInt())
+      data.writeByte('\n'.code)
       readFully(data, indexOfElement(CRLF))
       select(options) // Skip the newline bytes.
     }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
@@ -129,7 +129,7 @@ open class RecordingEventListener : EventListener() {
     for (lock in forbiddenLocks) {
       assertThat(Thread.holdsLock(lock))
           .overridingErrorMessage(lock.toString())
-          .isFalse
+          .isFalse()
     }
 
     val startEvent = e.closes(-1L)

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
@@ -129,7 +129,7 @@ open class RecordingEventListener : EventListener() {
     for (lock in forbiddenLocks) {
       assertThat(Thread.holdsLock(lock))
           .overridingErrorMessage(lock.toString())
-          .isFalse()
+          .isFalse
     }
 
     val startEvent = e.closes(-1L)

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
@@ -256,7 +256,7 @@ internal class DerReader(source: Source) {
 
   fun readObjectIdentifier(): String {
     val result = Buffer()
-    val dot = '.'.toByte().toInt()
+    val dot = '.'.code.toByte().toInt()
     when (val xy = readVariableLengthLong()) {
       in 0L until 40L -> {
         result.writeDecimalLong(0)
@@ -283,7 +283,7 @@ internal class DerReader(source: Source) {
 
   fun readRelativeObjectIdentifier(): String {
     val result = Buffer()
-    val dot = '.'.toByte().toInt()
+    val dot = '.'.code.toByte().toInt()
     while (byteCount < limit) {
       if (result.size > 0) {
         result.writeByte(dot)

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerWriter.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerWriter.kt
@@ -147,12 +147,12 @@ internal class DerWriter(sink: BufferedSink) {
   fun writeObjectIdentifier(s: String) {
     val utf8 = Buffer().writeUtf8(s)
     val v1 = utf8.readDecimalLong()
-    require(utf8.readByte() == '.'.toByte())
+    require(utf8.readByte() == '.'.code.toByte())
     val v2 = utf8.readDecimalLong()
     writeVariableLengthLong(v1 * 40 + v2)
 
     while (!utf8.exhausted()) {
-      require(utf8.readByte() == '.'.toByte())
+      require(utf8.readByte() == '.'.code.toByte())
       val vN = utf8.readDecimalLong()
       writeVariableLengthLong(vN)
     }
@@ -161,11 +161,11 @@ internal class DerWriter(sink: BufferedSink) {
   fun writeRelativeObjectIdentifier(s: String) {
     // Add a leading dot so each subidentifier has a dot prefix.
     val utf8 = Buffer()
-        .writeByte('.'.toByte().toInt())
+        .writeByte('.'.code.toByte().toInt())
         .writeUtf8(s)
 
     while (!utf8.exhausted()) {
-      require(utf8.readByte() == '.'.toByte())
+      require(utf8.readByte() == '.'.code.toByte())
       val vN = utf8.readDecimalLong()
       writeVariableLengthLong(vN)
     }

--- a/okhttp/src/main/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Cache.kt
@@ -571,39 +571,39 @@ class Cache(
     @Throws(IOException::class)
     fun writeTo(editor: DiskLruCache.Editor) {
       editor.newSink(ENTRY_METADATA).buffer().use { sink ->
-        sink.writeUtf8(url.toString()).writeByte('\n'.toInt())
-        sink.writeUtf8(requestMethod).writeByte('\n'.toInt())
-        sink.writeDecimalLong(varyHeaders.size.toLong()).writeByte('\n'.toInt())
+        sink.writeUtf8(url.toString()).writeByte('\n'.code)
+        sink.writeUtf8(requestMethod).writeByte('\n'.code)
+        sink.writeDecimalLong(varyHeaders.size.toLong()).writeByte('\n'.code)
         for (i in 0 until varyHeaders.size) {
           sink.writeUtf8(varyHeaders.name(i))
             .writeUtf8(": ")
             .writeUtf8(varyHeaders.value(i))
-            .writeByte('\n'.toInt())
+            .writeByte('\n'.code)
         }
 
-        sink.writeUtf8(StatusLine(protocol, code, message).toString()).writeByte('\n'.toInt())
-        sink.writeDecimalLong((responseHeaders.size + 2).toLong()).writeByte('\n'.toInt())
+        sink.writeUtf8(StatusLine(protocol, code, message).toString()).writeByte('\n'.code)
+        sink.writeDecimalLong((responseHeaders.size + 2).toLong()).writeByte('\n'.code)
         for (i in 0 until responseHeaders.size) {
           sink.writeUtf8(responseHeaders.name(i))
             .writeUtf8(": ")
             .writeUtf8(responseHeaders.value(i))
-            .writeByte('\n'.toInt())
+            .writeByte('\n'.code)
         }
         sink.writeUtf8(SENT_MILLIS)
           .writeUtf8(": ")
           .writeDecimalLong(sentRequestMillis)
-          .writeByte('\n'.toInt())
+          .writeByte('\n'.code)
         sink.writeUtf8(RECEIVED_MILLIS)
           .writeUtf8(": ")
           .writeDecimalLong(receivedResponseMillis)
-          .writeByte('\n'.toInt())
+          .writeByte('\n'.code)
 
         if (url.isHttps) {
-          sink.writeByte('\n'.toInt())
-          sink.writeUtf8(handshake!!.cipherSuite.javaName).writeByte('\n'.toInt())
+          sink.writeByte('\n'.code)
+          sink.writeUtf8(handshake!!.cipherSuite.javaName).writeByte('\n'.code)
           writeCertList(sink, handshake.peerCertificates)
           writeCertList(sink, handshake.localCertificates)
-          sink.writeUtf8(handshake.tlsVersion.javaName).writeByte('\n'.toInt())
+          sink.writeUtf8(handshake.tlsVersion.javaName).writeByte('\n'.code)
         }
       }
     }
@@ -631,11 +631,11 @@ class Cache(
     @Throws(IOException::class)
     private fun writeCertList(sink: BufferedSink, certificates: List<Certificate>) {
       try {
-        sink.writeDecimalLong(certificates.size.toLong()).writeByte('\n'.toInt())
+        sink.writeDecimalLong(certificates.size.toLong()).writeByte('\n'.code)
         for (element in certificates) {
           val bytes = element.encoded
           val line = bytes.toByteString().base64()
-          sink.writeUtf8(line).writeByte('\n'.toInt())
+          sink.writeUtf8(line).writeByte('\n'.code)
         }
       } catch (e: CertificateEncodingException) {
         throw IOException(e.message)

--- a/okhttp/src/main/kotlin/okhttp3/Challenge.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Challenge.kt
@@ -60,7 +60,7 @@ class Challenge(
   init {
     val newAuthParams = mutableMapOf<String?, String>()
     for ((key, value) in authParams) {
-      val newKey = key?.toLowerCase(US)
+      val newKey = key?.lowercase(US)
       newAuthParams[newKey] = value
     }
     this.authParams = unmodifiableMap<String?, String>(newAuthParams)

--- a/okhttp/src/main/kotlin/okhttp3/Cookie.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Cookie.kt
@@ -509,7 +509,7 @@ class Cookie private constructor(
             dayOfMonth = matcher.group(1).toInt()
           }
           month == -1 && matcher.usePattern(MONTH_PATTERN).matches() -> {
-            val monthString = matcher.group(1).toLowerCase(Locale.US)
+            val monthString = matcher.group(1).lowercase(Locale.US)
             month = MONTH_PATTERN.pattern().indexOf(monthString) / 4 // Sneaky! jan=1, dec=12.
           }
           year == -1 && matcher.usePattern(YEAR_PATTERN).matches() -> {
@@ -552,12 +552,12 @@ class Cookie private constructor(
      */
     private fun dateCharacterOffset(input: String, pos: Int, limit: Int, invert: Boolean): Int {
       for (i in pos until limit) {
-        val c = input[i].toInt()
-        val dateCharacter = (c < ' '.toInt() && c != '\t'.toInt() || c >= '\u007f'.toInt() ||
-            c in '0'.toInt()..'9'.toInt() ||
-            c in 'a'.toInt()..'z'.toInt() ||
-            c in 'A'.toInt()..'Z'.toInt() ||
-            c == ':'.toInt())
+        val c = input[i].code
+        val dateCharacter = (c < ' '.code && c != '\t'.code || c >= '\u007f'.code ||
+            c in '0'.code..'9'.code ||
+            c in 'a'.code..'z'.code ||
+            c in 'A'.code..'Z'.code ||
+            c == ':'.code)
         if (dateCharacter == !invert) return i
       }
       return limit

--- a/okhttp/src/main/kotlin/okhttp3/FormBody.kt
+++ b/okhttp/src/main/kotlin/okhttp3/FormBody.kt
@@ -71,9 +71,9 @@ class FormBody internal constructor(
     val buffer: Buffer = if (countBytes) Buffer() else sink!!.buffer
 
     for (i in 0 until encodedNames.size) {
-      if (i > 0) buffer.writeByte('&'.toInt())
+      if (i > 0) buffer.writeByte('&'.code)
       buffer.writeUtf8(encodedNames[i])
-      buffer.writeByte('='.toInt())
+      buffer.writeByte('='.code)
       buffer.writeUtf8(encodedValues[i])
     }
 

--- a/okhttp/src/main/kotlin/okhttp3/Headers.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Headers.kt
@@ -210,7 +210,7 @@ class Headers private constructor(
   fun toMultimap(): Map<String, List<String>> {
     val result = TreeMap<String, MutableList<String>>(String.CASE_INSENSITIVE_ORDER)
     for (i in 0 until size) {
-      val name = name(i).toLowerCase(Locale.US)
+      val name = name(i).lowercase(Locale.US)
       var values: MutableList<String>? = result[name]
       if (values == null) {
         values = ArrayList(2)
@@ -439,7 +439,7 @@ class Headers private constructor(
       for (i in name.indices) {
         val c = name[i]
         require(c in '\u0021'..'\u007e') {
-          format("Unexpected char %#04x at %d in header name: %s", c.toInt(), i, name)
+          format("Unexpected char %#04x at %d in header name: %s", c.code, i, name)
         }
       }
     }
@@ -448,7 +448,7 @@ class Headers private constructor(
       for (i in value.indices) {
         val c = value[i]
         require(c == '\t' || c in '\u0020'..'\u007e') {
-          format("Unexpected char %#04x at %d in %s value", c.toInt(), i, name) +
+          format("Unexpected char %#04x at %d in %s value", c.code, i, name) +
               (if (isSensitiveHeader(name)) "" else ": $value")
         }
       }

--- a/okhttp/src/main/kotlin/okhttp3/HttpUrl.kt
+++ b/okhttp/src/main/kotlin/okhttp3/HttpUrl.kt
@@ -1280,12 +1280,12 @@ class HttpUrl internal constructor(
         authority@ while (true) {
           val componentDelimiterOffset = input.delimiterOffset("@/\\?#", pos, limit)
           val c = if (componentDelimiterOffset != limit) {
-            input[componentDelimiterOffset].toInt()
+            input[componentDelimiterOffset].code
           } else {
             -1
           }
           when (c) {
-            '@'.toInt() -> {
+            '@'.code -> {
               // User info precedes.
               if (!hasPassword) {
                 val passwordColonOffset = input.delimiterOffset(':', pos, componentDelimiterOffset)
@@ -1321,7 +1321,7 @@ class HttpUrl internal constructor(
               pos = componentDelimiterOffset + 1
             }
 
-            -1, '/'.toInt(), '\\'.toInt(), '?'.toInt(), '#'.toInt() -> {
+            -1, '/'.code, '\\'.code, '?'.code, '#'.code -> {
               // Host info precedes.
               val portColonOffset = portColonOffset(input, pos, componentDelimiterOffset)
               if (portColonOffset + 1 < componentDelimiterOffset) {
@@ -1722,7 +1722,7 @@ class HttpUrl internal constructor(
       var i = pos
       while (i < limit) {
         codePoint = encoded.codePointAt(i)
-        if (codePoint == '%'.toInt() && i + 2 < limit) {
+        if (codePoint == '%'.code && i + 2 < limit) {
           val d1 = encoded[i + 1].parseHexDigit()
           val d2 = encoded[i + 2].parseHexDigit()
           if (d1 != -1 && d2 != -1) {
@@ -1731,8 +1731,8 @@ class HttpUrl internal constructor(
             i += Character.charCount(codePoint)
             continue
           }
-        } else if (codePoint == '+'.toInt() && plusIsSpace) {
-          writeByte(' '.toInt())
+        } else if (codePoint == '+'.code && plusIsSpace) {
+          writeByte(' '.code)
           i++
           continue
         }
@@ -1786,9 +1786,9 @@ class HttpUrl internal constructor(
             codePoint == 0x7f ||
             codePoint >= 0x80 && !unicodeAllowed ||
             codePoint.toChar() in encodeSet ||
-            codePoint == '%'.toInt() &&
+            codePoint == '%'.code &&
             (!alreadyEncoded || strict && !isPercentEncoded(i, limit)) ||
-            codePoint == '+'.toInt() && plusIsSpace) {
+            codePoint == '+'.code && plusIsSpace) {
           // Slow path: the character at i requires encoding!
           val out = Buffer()
           out.writeUtf8(this, pos, i)
@@ -1828,20 +1828,20 @@ class HttpUrl internal constructor(
       var i = pos
       while (i < limit) {
         codePoint = input.codePointAt(i)
-        if (alreadyEncoded && (codePoint == '\t'.toInt() || codePoint == '\n'.toInt() ||
-                codePoint == '\u000c'.toInt() || codePoint == '\r'.toInt())) {
+        if (alreadyEncoded && (codePoint == '\t'.code || codePoint == '\n'.code ||
+                codePoint == '\u000c'.code || codePoint == '\r'.code)) {
           // Skip this character.
-        } else if (codePoint == ' '.toInt() && encodeSet === FORM_ENCODE_SET) {
+        } else if (codePoint == ' '.code && encodeSet === FORM_ENCODE_SET) {
           // Encode ' ' as '+'.
           writeUtf8("+")
-        } else if (codePoint == '+'.toInt() && plusIsSpace) {
+        } else if (codePoint == '+'.code && plusIsSpace) {
           // Encode '+' as '%2B' since we permit ' ' to be encoded as either '+' or '%20'.
           writeUtf8(if (alreadyEncoded) "+" else "%2B")
         } else if (codePoint < 0x20 ||
             codePoint == 0x7f ||
             codePoint >= 0x80 && !unicodeAllowed ||
             codePoint.toChar() in encodeSet ||
-            codePoint == '%'.toInt() &&
+            codePoint == '%'.code &&
             (!alreadyEncoded || strict && !input.isPercentEncoded(i, limit))) {
           // Percent encode this character.
           if (encodedCharBuffer == null) {
@@ -1856,9 +1856,9 @@ class HttpUrl internal constructor(
 
           while (!encodedCharBuffer.exhausted()) {
             val b = encodedCharBuffer.readByte().toInt() and 0xff
-            writeByte('%'.toInt())
-            writeByte(HEX_DIGITS[b shr 4 and 0xf].toInt())
-            writeByte(HEX_DIGITS[b and 0xf].toInt())
+            writeByte('%'.code)
+            writeByte(HEX_DIGITS[b shr 4 and 0xf].code)
+            writeByte(HEX_DIGITS[b and 0xf].code)
           }
         } else {
           // This character doesn't need encoding. Just copy it over.

--- a/okhttp/src/main/kotlin/okhttp3/MediaType.kt
+++ b/okhttp/src/main/kotlin/okhttp3/MediaType.kt
@@ -109,8 +109,8 @@ class MediaType private constructor(
     fun String.toMediaType(): MediaType {
       val typeSubtype = TYPE_SUBTYPE.matcher(this)
       require(typeSubtype.lookingAt()) { "No subtype found for: \"$this\"" }
-      val type = typeSubtype.group(1).toLowerCase(Locale.US)
-      val subtype = typeSubtype.group(2).toLowerCase(Locale.US)
+      val type = typeSubtype.group(1).lowercase(Locale.US)
+      val subtype = typeSubtype.group(2).lowercase(Locale.US)
 
       val parameterNamesAndValues = mutableListOf<String>()
       val parameter = PARAMETER.matcher(this)

--- a/okhttp/src/main/kotlin/okhttp3/MultipartBody.kt
+++ b/okhttp/src/main/kotlin/okhttp3/MultipartBody.kt
@@ -314,9 +314,9 @@ class MultipartBody internal constructor(
     @JvmField
     val FORM = "multipart/form-data".toMediaType()
 
-    private val COLONSPACE = byteArrayOf(':'.toByte(), ' '.toByte())
-    private val CRLF = byteArrayOf('\r'.toByte(), '\n'.toByte())
-    private val DASHDASH = byteArrayOf('-'.toByte(), '-'.toByte())
+    private val COLONSPACE = byteArrayOf(':'.code.toByte(), ' '.code.toByte())
+    private val CRLF = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte())
+    private val DASHDASH = byteArrayOf('-'.code.toByte(), '-'.code.toByte())
 
     /**
      * Appends a quoted-string to a StringBuilder.

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/DiskLruCache.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/DiskLruCache.kt
@@ -400,22 +400,22 @@ class DiskLruCache(
     journalWriter?.close()
 
     fileSystem.write(journalFileTmp) {
-      writeUtf8(MAGIC).writeByte('\n'.toInt())
-      writeUtf8(VERSION_1).writeByte('\n'.toInt())
-      writeDecimalLong(appVersion.toLong()).writeByte('\n'.toInt())
-      writeDecimalLong(valueCount.toLong()).writeByte('\n'.toInt())
-      writeByte('\n'.toInt())
+      writeUtf8(MAGIC).writeByte('\n'.code)
+      writeUtf8(VERSION_1).writeByte('\n'.code)
+      writeDecimalLong(appVersion.toLong()).writeByte('\n'.code)
+      writeDecimalLong(valueCount.toLong()).writeByte('\n'.code)
+      writeByte('\n'.code)
 
       for (entry in lruEntries.values) {
         if (entry.currentEditor != null) {
-          writeUtf8(DIRTY).writeByte(' '.toInt())
+          writeUtf8(DIRTY).writeByte(' '.code)
           writeUtf8(entry.key)
-          writeByte('\n'.toInt())
+          writeByte('\n'.code)
         } else {
-          writeUtf8(CLEAN).writeByte(' '.toInt())
+          writeUtf8(CLEAN).writeByte(' '.code)
           writeUtf8(entry.key)
           entry.writeLengths(this)
-          writeByte('\n'.toInt())
+          writeByte('\n'.code)
         }
       }
     }
@@ -448,9 +448,9 @@ class DiskLruCache(
 
     redundantOpCount++
     journalWriter!!.writeUtf8(READ)
-        .writeByte(' '.toInt())
+        .writeByte(' '.code)
         .writeUtf8(key)
-        .writeByte('\n'.toInt())
+        .writeByte('\n'.code)
     if (journalRebuildRequired()) {
       cleanupQueue.schedule(cleanupTask)
     }
@@ -493,9 +493,9 @@ class DiskLruCache(
     // Flush the journal before creating files to prevent file leaks.
     val journalWriter = this.journalWriter!!
     journalWriter.writeUtf8(DIRTY)
-        .writeByte(' '.toInt())
+        .writeByte(' '.code)
         .writeUtf8(key)
-        .writeByte('\n'.toInt())
+        .writeByte('\n'.code)
     journalWriter.flush()
 
     if (hasJournalErrors) {
@@ -567,18 +567,18 @@ class DiskLruCache(
     journalWriter!!.apply {
       if (entry.readable || success) {
         entry.readable = true
-        writeUtf8(CLEAN).writeByte(' '.toInt())
+        writeUtf8(CLEAN).writeByte(' '.code)
         writeUtf8(entry.key)
         entry.writeLengths(this)
-        writeByte('\n'.toInt())
+        writeByte('\n'.code)
         if (success) {
           entry.sequenceNumber = nextSequenceNumber++
         }
       } else {
         lruEntries.remove(entry.key)
-        writeUtf8(REMOVE).writeByte(' '.toInt())
+        writeUtf8(REMOVE).writeByte(' '.code)
         writeUtf8(entry.key)
-        writeByte('\n'.toInt())
+        writeByte('\n'.code)
       }
       flush()
     }
@@ -625,9 +625,9 @@ class DiskLruCache(
         // Mark this entry as 'DIRTY' so that if the process crashes this entry won't be used.
         journalWriter?.let {
           it.writeUtf8(DIRTY)
-          it.writeByte(' '.toInt())
+          it.writeByte(' '.code)
           it.writeUtf8(entry.key)
-          it.writeByte('\n'.toInt())
+          it.writeByte('\n'.code)
           it.flush()
         }
       }
@@ -648,9 +648,9 @@ class DiskLruCache(
     redundantOpCount++
     journalWriter?.let {
       it.writeUtf8(REMOVE)
-      it.writeByte(' '.toInt())
+      it.writeByte(' '.code)
       it.writeUtf8(entry.key)
-      it.writeByte('\n'.toInt())
+      it.writeByte('\n'.code)
     }
     lruEntries.remove(entry.key)
 
@@ -1000,7 +1000,7 @@ class DiskLruCache(
     @Throws(IOException::class)
     internal fun writeLengths(writer: BufferedSink) {
       for (length in lengths) {
-        writer.writeByte(' '.toInt()).writeDecimalLong(length)
+        writer.writeByte(' '.code).writeDecimalLong(length)
       }
     }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/hostnames.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/hostnames.kt
@@ -47,7 +47,7 @@ fun String.toCanonicalHost(): String? {
   }
 
   try {
-    val result = IDN.toASCII(host).toLowerCase(Locale.US)
+    val result = IDN.toASCII(host).lowercase(Locale.US)
     if (result.isEmpty()) return null
 
     // Confirm that the IDN ToASCII result doesn't contain any illegal characters.
@@ -175,7 +175,7 @@ private fun decodeIpv4Suffix(
       val c = input[i]
       if (c < '0' || c > '9') break
       if (value == 0 && groupOffset != i) return false // Reject unnecessary leading '0's.
-      value = value * 10 + c.toInt() - '0'.toInt()
+      value = value * 10 + c.code - '0'.code
       if (value > 255) return false // Value out of range.
       i++
     }
@@ -218,11 +218,11 @@ private fun inet6AddressToAscii(address: ByteArray): String {
   var i = 0
   while (i < address.size) {
     if (i == longestRunOffset) {
-      result.writeByte(':'.toInt())
+      result.writeByte(':'.code)
       i += longestRunLength
-      if (i == 16) result.writeByte(':'.toInt())
+      if (i == 16) result.writeByte(':'.code)
     } else {
-      if (i > 0) result.writeByte(':'.toInt())
+      if (i > 0) result.writeByte(':'.code)
       val group = address[i] and 0xff shl 8 or (address[i + 1] and 0xff)
       result.writeHexadecimalUnsignedLong(group.toLong())
       i += 2

--- a/okhttp/src/main/kotlin/okhttp3/internal/http/HttpHeaders.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http/HttpHeaders.kt
@@ -94,7 +94,7 @@ private fun Buffer.readChallengeHeader(result: MutableList<Challenge>) {
       return
     }
 
-    var eqCount = skipAll('='.toByte())
+    var eqCount = skipAll('='.code.toByte())
     val commaSuffixed = skipCommasAndWhitespace()
 
     // It's a token68 because there isn't a value after it.
@@ -107,19 +107,19 @@ private fun Buffer.readChallengeHeader(result: MutableList<Challenge>) {
 
     // It's a series of parameter names and values.
     val parameters = mutableMapOf<String?, String>()
-    eqCount += skipAll('='.toByte())
+    eqCount += skipAll('='.code.toByte())
     while (true) {
       if (peek == null) {
         peek = readToken()
         if (skipCommasAndWhitespace()) break // We peeked a scheme name followed by ','.
-        eqCount = skipAll('='.toByte())
+        eqCount = skipAll('='.code.toByte())
       }
       if (eqCount == 0) break // We peeked a scheme name.
       if (eqCount > 1) return // Unexpected '=' characters.
       if (skipCommasAndWhitespace()) return // Unexpected ','.
 
       val parameterValue = when {
-        startsWith('"'.toByte()) -> readQuotedString()
+        startsWith('"'.code.toByte()) -> readQuotedString()
         else -> readToken()
       } ?: return // Expected a value.
 
@@ -137,13 +137,13 @@ private fun Buffer.skipCommasAndWhitespace(): Boolean {
   var commaFound = false
   loop@ while (!exhausted()) {
     when (this[0]) {
-      ','.toByte() -> {
+      ','.code.toByte() -> {
         // Consume ','.
         readByte()
         commaFound = true
       }
 
-      ' '.toByte(), '\t'.toByte() -> {
+      ' '.code.toByte(), '\t'.code.toByte() -> {
         readByte()
         // Consume space or tab.
       }
@@ -163,13 +163,13 @@ private fun Buffer.startsWith(prefix: Byte) = !exhausted() && this[0] == prefix
  */
 @Throws(EOFException::class)
 private fun Buffer.readQuotedString(): String? {
-  require(readByte() == '\"'.toByte())
+  require(readByte() == '\"'.code.toByte())
   val result = Buffer()
   while (true) {
     val i = indexOfElement(QUOTED_STRING_DELIMITERS)
     if (i == -1L) return null // Unterminated quoted string.
 
-    if (this[i] == '"'.toByte()) {
+    if (this[i] == '"'.code.toByte()) {
       result.write(this, i)
       // Consume '"'.
       readByte()

--- a/okhttp/src/main/kotlin/okhttp3/internal/http2/Hpack.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http2/Hpack.kt
@@ -610,7 +610,7 @@ object Hpack {
   @Throws(IOException::class)
   fun checkLowercase(name: ByteString): ByteString {
     for (i in 0 until name.size) {
-      if (name[i] in 'A'.toByte()..'Z'.toByte()) {
+      if (name[i] in 'A'.code.toByte()..'Z'.code.toByte()) {
         throw IOException("PROTOCOL_ERROR response malformed: mixed case name: ${name.utf8()}")
       }
     }

--- a/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
@@ -170,7 +170,7 @@ class Http2ExchangeCodec(
 
       for (i in 0 until headers.size) {
         // header names must be lowercase.
-        val name = headers.name(i).toLowerCase(Locale.US)
+        val name = headers.name(i).lowercase(Locale.US)
         if (name !in HTTP_2_SKIPPED_REQUEST_HEADERS ||
             name == TE && headers.value(i) == "trailers") {
           result.add(Header(name, headers.value(i)))

--- a/okhttp/src/main/kotlin/okhttp3/internal/publicsuffix/PublicSuffixDatabase.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/publicsuffix/PublicSuffixDatabase.kt
@@ -239,7 +239,7 @@ class PublicSuffixDatabase {
   companion object {
     const val PUBLIC_SUFFIX_RESOURCE = "publicsuffixes.gz"
 
-    private val WILDCARD_LABEL = byteArrayOf('*'.toByte())
+    private val WILDCARD_LABEL = byteArrayOf('*'.code.toByte())
     private val PREVAILING_RULE = listOf("*")
 
     private const val EXCEPTION_MARKER = '!'
@@ -261,14 +261,14 @@ class PublicSuffixDatabase {
         var mid = (low + high) / 2
         // Search for a '\n' that marks the start of a value. Don't go back past the start of the
         // array.
-        while (mid > -1 && this[mid] != '\n'.toByte()) {
+        while (mid > -1 && this[mid] != '\n'.code.toByte()) {
           mid--
         }
         mid++
 
         // Now look for the ending '\n'.
         var end = 1
-        while (this[mid + end] != '\n'.toByte()) {
+        while (this[mid + end] != '\n'.code.toByte()) {
           end++
         }
         val publicSuffixLength = mid + end - mid
@@ -284,7 +284,7 @@ class PublicSuffixDatabase {
         while (true) {
           val byte0: Int
           if (expectDot) {
-            byte0 = '.'.toInt()
+            byte0 = '.'.code
             expectDot = false
           } else {
             byte0 = labels[currentLabelIndex][currentLabelByteIndex] and 0xff

--- a/okhttp/src/main/kotlin/okhttp3/internal/tls/OkHostnameVerifier.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/tls/OkHostnameVerifier.kt
@@ -80,7 +80,7 @@ object OkHostnameVerifier : HostnameVerifier {
    */
   private fun String.asciiToLowercase(): String {
     return when {
-      isAscii() -> toLowerCase(Locale.US) // This is an ASCII string.
+      isAscii() -> lowercase(Locale.US) // This is an ASCII string.
       else -> this
     }
   }


### PR DESCRIPTION
```kotlin
@Deprecated("Conversion of Char to Number is deprecated. Use Char.code property instead.", ReplaceWith("this.code"))
@DeprecatedSinceKotlin(warningSince = "1.5")
public fun toInt(): Int
```


```kotlin
@Deprecated("Conversion of Char to Number is deprecated. Use Char.code property instead.", ReplaceWith("this.code.toByte()"))
@DeprecatedSinceKotlin(warningSince = "1.5")
public fun toByte(): Byte
```