### PR TITLE
Kapt picocliCompiler in okcurl module

### DIFF
--- a/okcurl/build.gradle.kts
+++ b/okcurl/build.gradle.kts
@@ -3,6 +3,7 @@ import java.nio.charset.StandardCharsets
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
+  kotlin("kapt")
   id("com.palantir.graal")
   id("com.github.johnrengelman.shadow")
 }
@@ -36,14 +37,19 @@ tasks.getByName<Jar>("sourcesJar") {
   dependsOn("copyResourcesTemplates")
 }
 
+kapt {
+  arguments {
+    arg("project", "${project.group}/${project.name}")
+  }
+}
+
 dependencies {
   api(project(":okhttp"))
   api(project(":okhttp-logging-interceptor"))
   implementation(Dependencies.picocli)
   implementation(Dependencies.guava)
 
-  implementation(Dependencies.picocliCompiler)
-  annotationProcessor(Dependencies.picocliCompiler)
+  kapt(Dependencies.picocliCompiler)
 
   testImplementation(project(":okhttp-testing-support"))
   testImplementation(Dependencies.junit5Api)

--- a/okcurl/build.gradle.kts
+++ b/okcurl/build.gradle.kts
@@ -37,12 +37,6 @@ tasks.getByName<Jar>("sourcesJar") {
   dependsOn("copyResourcesTemplates")
 }
 
-kapt {
-  arguments {
-    arg("project", "${project.group}/${project.name}")
-  }
-}
-
 dependencies {
   api(project(":okhttp"))
   api(project(":okhttp-logging-interceptor"))


### PR DESCRIPTION
According to the [picocli-codegen document](https://github.com/remkop/picocli/blob/master/picocli-codegen/README.adoc#kotlin-projects-using-gradle), the `picocliCompiler` should be used with `kapt`.