### PR TITLE
Allow test passing on JDK 8

### DIFF
--- a/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
@@ -131,11 +131,6 @@ class CallHandshakeTest {
 
   @Test
   fun testDefaultHandshakeCipherSuiteOrderingTls13Modern() {
-    if (!platform.isOpenJsse()) {
-      // Requires modern JVM
-      platform.expectFailureOnJdkVersion(8)
-    }
-
     val client = makeClient(ConnectionSpec.MODERN_TLS, TlsVersion.TLS_1_3)
 
     val handshake = makeRequest(client)


### PR DESCRIPTION
Security backports to JDK8 are correcting behaviour on openjdk 1.8.