### PR TITLE
Allow ClientAuthTest changes on JDK8 after security updates.

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static java.util.Arrays.asList;
+import static okhttp3.testing.PlatformRule.JDK9_PROPERTY;
 import static okhttp3.testing.PlatformRule.getPlatformSystemProperty;
 import static okhttp3.tls.internal.TlsUtil.newKeyManager;
 import static okhttp3.tls.internal.TlsUtil.newTrustManager;
@@ -210,10 +211,11 @@ public final class ClientAuthTest {
       call.execute();
       fail();
     } catch (SSLHandshakeException expected) {
+      // JDK 11+
     } catch (SSLException expected) {
+      // javax.net.ssl.SSLException: readRecord
     } catch (SocketException expected) {
-      assertThat(getPlatformSystemProperty()).isIn(PlatformRule.JDK9_PROPERTY,
-          PlatformRule.CONSCRYPT_PROPERTY);
+      // Conscrypt, JDK 8 (>= 292), JDK 9
     } catch (IOException expected) {
       assertThat(expected.getMessage()).isEqualTo("exhausted all routes");
     }
@@ -265,11 +267,11 @@ public final class ClientAuthTest {
       call.execute();
       fail();
     } catch (SSLHandshakeException expected) {
+      // JDK 11+
     } catch (SSLException expected) {
       // javax.net.ssl.SSLException: readRecord
     } catch (SocketException expected) {
-      assertThat(getPlatformSystemProperty()).isIn(PlatformRule.JDK9_PROPERTY,
-          PlatformRule.CONSCRYPT_PROPERTY);
+      // Conscrypt, JDK 8 (>= 292), JDK 9
     } catch (ConnectionShutdownException expected) {
       // It didn't fail until it reached the application layer.
     } catch (IOException expected) {

--- a/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
@@ -43,7 +43,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.internal.http2.ConnectionShutdownException;
 import okhttp3.testing.PlatformRule;
-import okhttp3.testing.PlatformVersion;
 import okhttp3.tls.HandshakeCertificates;
 import okhttp3.tls.HeldCertificate;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,8 +52,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static java.util.Arrays.asList;
-import static okhttp3.testing.PlatformRule.JDK9_PROPERTY;
-import static okhttp3.testing.PlatformRule.getPlatformSystemProperty;
 import static okhttp3.tls.internal.TlsUtil.newKeyManager;
 import static okhttp3.tls.internal.TlsUtil.newTrustManager;
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
With recent JDK 8 changes, some of the JDK 9 behaviour is also seen on JDK 8 also.

This removes some checks last edited here https://github.com/square/okhttp/pull/5263/files for conscrypt.