### PR TITLE
Avoid task logger flakes due to shared logger.

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
@@ -16,24 +16,25 @@
 package okhttp3.internal.concurrent
 
 import java.util.logging.Level
+import java.util.logging.Logger
 
-internal inline fun taskLog(
+internal inline fun Logger.taskLog(
   task: Task,
   queue: TaskQueue,
   messageBlock: () -> String
 ) {
-  if (TaskRunner.logger.isLoggable(Level.FINE)) {
+  if (isLoggable(Level.FINE)) {
     log(task, queue, messageBlock())
   }
 }
 
-internal inline fun <T> logElapsed(
+internal inline fun <T> Logger.logElapsed(
   task: Task,
   queue: TaskQueue,
   block: () -> T
 ): T {
   var startNs = -1L
-  val loggingEnabled = TaskRunner.logger.isLoggable(Level.FINE)
+  val loggingEnabled = isLoggable(Level.FINE)
   if (loggingEnabled) {
     startNs = queue.taskRunner.backend.nanoTime()
     log(task, queue, "starting")
@@ -56,8 +57,8 @@ internal inline fun <T> logElapsed(
   }
 }
 
-private fun log(task: Task, queue: TaskQueue, message: String) {
-  TaskRunner.logger.fine("${queue.name} ${String.format("%-22s", message)}: ${task.name}")
+private fun Logger.log(task: Task, queue: TaskQueue, message: String) {
+  fine("${queue.name} ${String.format("%-22s", message)}: ${task.name}")
 }
 
 /**

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskQueue.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskQueue.kt
@@ -62,10 +62,10 @@ class TaskQueue internal constructor(
     synchronized(taskRunner) {
       if (shutdown) {
         if (task.cancelable) {
-          taskLog(task, this) { "schedule canceled (queue is shutdown)" }
+          taskRunner.logger.taskLog(task, this) { "schedule canceled (queue is shutdown)" }
           return
         }
-        taskLog(task, this) { "schedule failed (queue is shutdown)" }
+        taskRunner.logger.taskLog(task, this) { "schedule failed (queue is shutdown)" }
         throw RejectedExecutionException()
       }
 
@@ -152,13 +152,13 @@ class TaskQueue internal constructor(
     val existingIndex = futureTasks.indexOf(task)
     if (existingIndex != -1) {
       if (task.nextExecuteNanoTime <= executeNanoTime) {
-        taskLog(task, this) { "already scheduled" }
+        taskRunner.logger.taskLog(task, this) { "already scheduled" }
         return false
       }
       futureTasks.removeAt(existingIndex) // Already scheduled later: reschedule below!
     }
     task.nextExecuteNanoTime = executeNanoTime
-    taskLog(task, this) {
+    taskRunner.logger.taskLog(task, this) {
       if (recurrence) "run again after ${formatDuration(executeNanoTime - now)}"
       else "scheduled after ${formatDuration(executeNanoTime - now)}"
     }
@@ -207,7 +207,7 @@ class TaskQueue internal constructor(
     var tasksCanceled = false
     for (i in futureTasks.size - 1 downTo 0) {
       if (futureTasks[i].cancelable) {
-        taskLog(futureTasks[i], this) { "canceled" }
+        taskRunner.logger.taskLog(futureTasks[i], this) { "canceled" }
         tasksCanceled = true
         futureTasks.removeAt(i)
       }

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
@@ -40,7 +40,8 @@ import okhttp3.internal.threadFactory
  * Most applications should share a process-wide [TaskRunner] and use queues for per-client work.
  */
 class TaskRunner(
-  val backend: Backend
+  val backend: Backend,
+  internal val logger: Logger = TaskRunner.logger
 ) {
   private var nextQueueName = 10000
   private var coordinatorWaiting = false
@@ -59,7 +60,7 @@ class TaskRunner(
           awaitTaskToRun()
         } ?: return
 
-        logElapsed(task, task.queue!!) {
+        logger.logElapsed(task, task.queue!!) {
           var completedNormally = false
           try {
             runTask(task)
@@ -306,9 +307,9 @@ class TaskRunner(
   }
 
   companion object {
+    val logger: Logger = Logger.getLogger(TaskRunner::class.java.name)
+
     @JvmField
     val INSTANCE = TaskRunner(RealBackend(threadFactory("$okHttpName TaskRunner", daemon = true)))
-
-    val logger: Logger = Logger.getLogger(TaskRunner::class.java.name)
   }
 }

--- a/okhttp/src/test/java/okhttp3/TestLogHandler.java
+++ b/okhttp/src/test/java/okhttp3/TestLogHandler.java
@@ -57,6 +57,10 @@ public final class TestLogHandler implements TestRule, BeforeEachCallback, After
     logger = Logger.getLogger(loggerName.getName());
   }
 
+  public TestLogHandler(Logger logger) {
+    this.logger = logger;
+  }
+
   @Override public void beforeEach(ExtensionContext context) {
     previousLevel = logger.getLevel();
     logger.addHandler(handler);

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskFaker.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskFaker.kt
@@ -16,6 +16,7 @@
 package okhttp3.internal.concurrent
 
 import java.util.concurrent.Executors
+import java.util.logging.Logger
 import okhttp3.internal.assertionsEnabled
 import org.assertj.core.api.Assertions.assertThat
 
@@ -24,7 +25,7 @@ import org.assertj.core.api.Assertions.assertThat
  * deterministic. All tasks are executed on-demand on the test thread by calls to [runTasks] and
  * [advanceUntil].
  */
-class TaskFaker {
+class TaskFaker() {
   @Suppress("NOTHING_TO_INLINE")
   internal inline fun Any.assertThreadHoldsLock() {
     if (assertionsEnabled && !Thread.holdsLock(this)) {
@@ -44,6 +45,8 @@ class TaskFaker {
 
   @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
   internal inline fun Any.notify() = (this as Object).notify()
+
+  internal val logger = Logger.getLogger("TaskFaker." + instance++)
 
   /** Runnables scheduled for execution. These will execute tasks and perform scheduling. */
   private val futureRunnables = mutableListOf<Runnable>()
@@ -117,7 +120,7 @@ class TaskFaker {
         waitingUntilTime = Long.MAX_VALUE
       }
     }
-  })
+  }, logger = logger)
 
   /** Runs all tasks that are ready without advancing the simulated clock. */
   fun runTasks() {
@@ -196,4 +199,8 @@ class TaskFaker {
 
   /** Returns true if no tasks have been scheduled. This runs the coordinator for confirmation. */
   fun isIdle() = taskRunner.activeQueues().isEmpty()
+
+  companion object {
+    var instance = 0
+  }
 }

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
@@ -23,9 +23,10 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.fail
 
 class TaskRunnerTest {
-  @RegisterExtension @JvmField val testLogHandler = TestLogHandler(TaskRunner::class.java)
-
   private val taskFaker = TaskFaker()
+
+  @RegisterExtension @JvmField val testLogHandler = TestLogHandler(taskFaker.logger)
+
   private val taskRunner = taskFaker.taskRunner
   private val log = mutableListOf<String>()
   private val redQueue = taskRunner.newQueue()


### PR DESCRIPTION
Seeing this a lot recently, bleedover from another test with delayed logging.

```
TaskRunnerTest > cancelReturnsTruePreventsNextExecution() FAILED
    java.lang.AssertionError: 
    Expecting:
      <["FINE: Q10000 scheduled after 100 µs: task",
        "FINE: Q10001 finished run in 498 ms: MockWebServer /127.0.0.1:50232",
        "FINE: Q10000 canceled              : task"]>
    to contain exactly (and in same order):
      <["FINE: Q10000 scheduled after 100 µs: task",
        "FINE: Q10000 canceled              : task"]>
    but some elements were not expected:
      <["FINE: Q10001 finished run in 498 ms: MockWebServer /127.0.0.1:50232"]>
        at okhttp3.internal.concurrent.TaskRunnerTest.cancelReturnsTruePreventsNextExecution(TaskRunnerTest.kt:184)
```