### PR TITLE
Case insensitive hostname check

### DIFF
--- a/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/RecordedRequest.kt
+++ b/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/RecordedRequest.kt
@@ -23,9 +23,9 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.TlsVersion
 import okio.Buffer
 import java.io.IOException
-import java.net.Inet6Address
 import java.net.Socket
 import javax.net.ssl.SSLSocket
+import mockwebserver3.internal.util.quickHostname
 
 class RecordedRequest {
   val requestLine: String
@@ -88,7 +88,7 @@ class RecordedRequest {
     socket: Socket,
     failure: IOException? = null
   ) {
-    this.requestLine = requestLine;
+    this.requestLine = requestLine
     this.headers = headers
     this.chunkSizes = chunkSizes
     this.bodySize = bodySize
@@ -119,14 +119,7 @@ class RecordedRequest {
       val scheme = if (socket is SSLSocket) "https" else "http"
       val inetAddress = socket.localAddress
 
-      var hostname = inetAddress.hostName
-      if (inetAddress is Inet6Address && hostname.contains(':')) {
-        // hostname is likely some form representing the IPv6 bytes
-        // 2001:0db8:85a3:0000:0000:8a2e:0370:7334
-        // 2001:db8:85a3::8a2e:370:7334
-        // ::1
-        hostname = "[$hostname]"
-      }
+      val hostname = inetAddress.quickHostname()
 
       val localPort = socket.localPort
       // Allow null in failure case to allow for testing bad requests

--- a/mockwebserver-deprecated/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
+++ b/mockwebserver-deprecated/src/test/java/okhttp3/mockwebserver/MockWebServerTest.java
@@ -468,7 +468,7 @@ public final class MockWebServerTest {
 
     HttpUrl requestUrl = request.getRequestUrl();
     assertThat(requestUrl.scheme()).isEqualTo("http");
-    assertThat(requestUrl.host()).isEqualTo(server.getHostName());
+    assertThat(requestUrl.host()).isEqualToIgnoringCase(server.getHostName());
     assertThat(requestUrl.port()).isEqualTo(server.getPort());
     assertThat(requestUrl.encodedPath()).isEqualTo("/a/deep/path");
     assertThat(requestUrl.queryParameter("key")).isEqualTo("foo bar");

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -156,7 +156,12 @@ class MockWebServer : Closeable {
   val hostName: String
     get() {
       before()
-      return inetSocketAddress!!.address.quickHostname()
+
+      val address = inetSocketAddress!!.address
+      return if (address.isLoopbackAddress)
+        "localhost"
+      else
+        address.quickHostname()
     }
 
   private var inetSocketAddress: InetSocketAddress? = null

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -61,6 +61,7 @@ import mockwebserver3.SocketPolicy.SHUTDOWN_SERVER_AFTER_RESPONSE
 import mockwebserver3.SocketPolicy.STALL_SOCKET_AT_START
 import mockwebserver3.SocketPolicy.UPGRADE_TO_SSL_AT_END
 import mockwebserver3.internal.duplex.DuplexResponseBody
+import mockwebserver3.internal.util.quickHostname
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.HttpUrl
@@ -155,7 +156,7 @@ class MockWebServer : Closeable {
   val hostName: String
     get() {
       before()
-      return inetSocketAddress!!.address.canonicalHostName
+      return inetSocketAddress!!.address.quickHostname()
     }
 
   private var inetSocketAddress: InetSocketAddress? = null

--- a/mockwebserver/src/main/kotlin/mockwebserver3/RecordedRequest.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/RecordedRequest.kt
@@ -17,9 +17,9 @@
 package mockwebserver3
 
 import java.io.IOException
-import java.net.Inet6Address
 import java.net.Socket
 import javax.net.ssl.SSLSocket
+import mockwebserver3.internal.util.quickHostname
 import okhttp3.Handshake
 import okhttp3.Handshake.Companion.handshake
 import okhttp3.Headers
@@ -112,14 +112,7 @@ class RecordedRequest @JvmOverloads constructor(
       this.requestUrlFn = {
         val scheme = if (socket is SSLSocket) "https" else "http"
 
-        var hostname = inetAddress.hostName
-        if (inetAddress is Inet6Address && hostname.contains(':')) {
-          // hostname is likely some form representing the IPv6 bytes
-          // 2001:0db8:85a3:0000:0000:8a2e:0370:7334
-          // 2001:db8:85a3::8a2e:370:7334
-          // ::1
-          hostname = "[$hostname]"
-        }
+        val hostname = inetAddress.quickHostname()
 
         val localPort = socket.localPort
         // Allow null in failure case to allow for testing bad requests

--- a/mockwebserver/src/main/kotlin/mockwebserver3/internal/util/util.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/internal/util/util.kt
@@ -23,11 +23,11 @@ import java.net.InetAddress
  * assume 127.0.0.1 is localhost and square bracket encode IPv6 addresses.
  */
 fun InetAddress.quickHostname(): String {
-  if (isLoopbackAddress) {
-    return "localhost"
-  }
+//  if (isLoopbackAddress) {
+//    return "localhost"
+//  }
 
-  var hostname = hostName
+  var hostname = this.hostName
 
   if (this is Inet6Address && hostname.contains(':')) {
     // hostname is likely some form representing the IPv6 bytes
@@ -37,5 +37,5 @@ fun InetAddress.quickHostname(): String {
     hostname = "[$hostname]"
   }
 
-  return hostname
+  return hostname.lowercase()
 }

--- a/mockwebserver/src/main/kotlin/mockwebserver3/internal/util/util.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/internal/util/util.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package mockwebserver3.internal.util
+
+import java.net.Inet6Address
+import java.net.InetAddress
+
+/**
+ * Equivalent of InetAddress.getHostName() but with some tweaks for OkHttp behaviour,
+ * assume 127.0.0.1 is localhost and square bracket encode IPv6 addresses.
+ */
+fun InetAddress.quickHostname(): String {
+  if (isLoopbackAddress) {
+    return "localhost"
+  }
+
+  var hostname = hostName
+
+  if (this is Inet6Address && hostname.contains(':')) {
+    // hostname is likely some form representing the IPv6 bytes
+    // 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+    // 2001:db8:85a3::8a2e:370:7334
+    // ::1
+    hostname = "[$hostname]"
+  }
+
+  return hostname
+}

--- a/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
@@ -456,7 +456,7 @@ public final class MockWebServerTest {
 
     HttpUrl requestUrl = request.getRequestUrl();
     assertThat(requestUrl.scheme()).isEqualTo("http");
-    assertThat(requestUrl.host()).isEqualTo(server.getHostName());
+    assertThat(requestUrl.host()).isEqualToIgnoringCase(server.getHostName());
     assertThat(requestUrl.port()).isEqualTo(server.getPort());
     assertThat(requestUrl.encodedPath()).isEqualTo("/a/deep/path");
     assertThat(requestUrl.queryParameter("key")).isEqualTo("foo bar");


### PR DESCRIPTION
```
MockWebServerTest > requestUrlReconstructed() FAILED
    org.opentest4j.AssertionFailedError: 
    Expecting:
     <"miningmadness.com">
    to be equal to:
     <"MiningMadness.com">
    but was not.
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at mockwebserver3.MockWebServerTest.requestUrlReconstructed(MockWebServerTest.java:459)
```