### PR TITLE
Remove maven repos in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,11 +35,3 @@ include(":samples:simple-client")
 include(":samples:slack")
 include(":samples:static-server")
 include(":samples:unixdomainsockets")
-
-dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-        maven(url = "https://dl.bintray.com/kotlin/dokka")
-        google()
-    }
-}


### PR DESCRIPTION
Maven repos declared in `settings.gradle.kts` could be removed as they also appear in `buildscript` and `allprojects`.