### PR TITLE
Apply application plugin to crawler sample

### DIFF
--- a/samples/crawler/build.gradle.kts
+++ b/samples/crawler/build.gradle.kts
@@ -1,3 +1,11 @@
+plugins {
+  application
+}
+
+application {
+  mainClass.set("okhttp3.sample.Crawler")
+}
+
 dependencies {
   implementation(project(":okhttp"))
   implementation(Dependencies.jsoup)


### PR DESCRIPTION
@JakeWharton 

Basic usage:
```
$ gradlew samples:crawler:run
Configuration on demand is an incubating feature.

> Task :samples:crawler:run
Usage: Crawler <cache dir> <root>

BUILD SUCCESSFUL in 1s
14 actionable tasks: 1 executed, 13 up-to-date
```

Usage with website:
```
$ gradlew samples:crawler:run

> Task :samples:crawler:run
200: https://jaredsburrows.com/ (cache)
200: https://jaredsburrows.com/presentations (cache)
200: https://jaredsburrows.com/the-road-to-single-dex/ (cache)
```