### PR TITLE
Replace deprecated method RequestBody.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ public static final MediaType JSON
 OkHttpClient client = new OkHttpClient();
 
 String post(String url, String json) throws IOException {
-  RequestBody body = RequestBody.create(JSON, json);
+  RequestBody body = RequestBody.create(json, JSON);
   Request request = new Request.Builder()
       .url(url)
       .post(body)


### PR DESCRIPTION
RequestBody.create(MediaType, String) is deprecated you should use RequestBody.create(String, MediaType). So the readme currently have wrong example