### PR TITLE
DelegatingSSLSocket without reflection

### DIFF
--- a/okhttp/src/test/java/okhttp3/DelegatingSSLSocket.java
+++ b/okhttp/src/test/java/okhttp3/DelegatingSSLSocket.java
@@ -18,14 +18,15 @@ package okhttp3;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.SocketOption;
 import java.nio.channels.SocketChannel;
+import java.util.List;
 import java.util.Set;
+import java.util.function.BiFunction;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
@@ -283,66 +284,43 @@ public abstract class DelegatingSSLSocket extends SSLSocket {
     delegate.setPerformancePreferences(connectionTime, latency, bandwidth);
   }
 
-  // Java 9 methods.
-
-  @SuppressWarnings("MissingOverride") // Can only override with JDK 9+
+  @Override
   public SSLSession getHandshakeSession() {
-    try {
-      return (SSLSession) SSLSocket.class.getMethod("getHandshakeSession").invoke(delegate);
-    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      throw new AssertionError();
-    }
+    return delegate.getHandshakeSession();
   }
 
-  @SuppressWarnings("MissingOverride") // Can only override with JDK 9+
+  @Override
   public String getApplicationProtocol() {
-    try {
-      return (String) SSLSocket.class.getMethod("getApplicationProtocol").invoke(delegate);
-    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      throw new AssertionError();
-    }
+    return delegate.getApplicationProtocol();
   }
 
-  @SuppressWarnings("MissingOverride") // Can only override with JDK 9+
+  @Override
   public String getHandshakeApplicationProtocol() {
-    try {
-      return (String) SSLSocket.class.getMethod("getHandshakeApplicationProtocol").invoke(delegate);
-    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      throw new AssertionError();
-    }
+    return delegate.getHandshakeApplicationProtocol();
   }
 
-  @SuppressWarnings("MissingOverride") // Can only override with JDK 9+
+  @Override
+  public void setHandshakeApplicationProtocolSelector(BiFunction<SSLSocket, List<String>, String> selector) {
+    delegate.setHandshakeApplicationProtocolSelector(selector);
+  }
+
+  @Override
+  public BiFunction<SSLSocket, List<String>, String> getHandshakeApplicationProtocolSelector() {
+    return delegate.getHandshakeApplicationProtocolSelector();
+  }
+
+  @Override
   public <T> Socket setOption(SocketOption<T> name, T value) throws IOException {
-    try {
-      SSLSocket.class.getMethod("setOption", SocketOption.class, Object.class).invoke(delegate, name, value);
-      return this;
-    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      throw new AssertionError();
-    }
+    return delegate.setOption(name, value);
   }
 
-  @SuppressWarnings({
-      "MissingOverride", // Can only override with JDK 9+
-      "unchecked" // Using reflection to delegate.
-  })
+  @Override
   public <T> T getOption(SocketOption<T> name) throws IOException {
-    try {
-      return (T) SSLSocket.class.getMethod("getOption", SocketOption.class).invoke(delegate, name);
-    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      throw new AssertionError();
-    }
+    return delegate.getOption(name);
   }
 
-  @SuppressWarnings({
-      "MissingOverride", // Can only override with JDK 9+
-      "unchecked" // Using reflection to delegate.
-  })
+  @Override
   public Set<SocketOption<?>> supportedOptions() {
-    try {
-      return (Set<SocketOption<?>>) SSLSocket.class.getMethod("supportedOptions").invoke(delegate);
-    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      throw new AssertionError();
-    }
+    return delegate.supportedOptions();
   }
 }


### PR DESCRIPTION
Uses JDK9 methods without reflection since we now build with JDK 11.