### PR TITLE
fix(docs): update broken link on docs homepage

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: OkHttp
-site_url: https://square.github.com/okhttp/
+site_url: https://square.github.io/okhttp/
 repo_name: OkHttp
 repo_url: https://github.com/square/okhttp
 site_description: "An HTTP & HTTP/2 client for Android and Java applications"


### PR DESCRIPTION
Correct broken link on docs homepage

Fix #6878