### PR TITLE
Make it clear what the host, port and ip are.

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -294,7 +294,10 @@ class RealConnection(
     try {
       Platform.get().connectSocket(rawSocket, route.socketAddress, connectTimeout)
     } catch (e: ConnectException) {
-      throw ConnectException("Failed to connect to ${route.socketAddress}").apply {
+      throw ConnectException(
+        "Failed to connect to: ${route.socketAddress.hostName}:${route.socketAddress.port}" +
+          " (IP: ${route.socketAddress.address.hostAddress})"
+      ).apply {
         initCause(e)
       }
     }


### PR DESCRIPTION
The `toString` method on `InetSocketAddress` returns something that makes the IP address look like part of the path.

It can lead to confusion like this: 
https://github.com/square/retrofit/issues/1204

New error message would be something like:

> Failed to connect to: example.com:443 (IP: 192.0.2.0)

instead of:

> Failed to connect to: example.com/192.0.2.0:443



```
Failed to connect to example.com/192.0.2.0:443
java.net.ConnectException: Failed to connect to example.com/192.0.2.0:443
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:297)
	at okhttp3.internal.connection.RealConnection.connect(RealConnection.kt:207)
	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.kt:226)
	at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.kt:106)
	at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.kt:74)
	at okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:255)
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
	at okhttp3.internal.connection.RealCall.execute(RealCall.kt:154)
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:204)
....
Caused by: java.net.ConnectException: Operation timed out (Connection timed out)
	at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.base/java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:399)
	at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:242)
	at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:224)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.base/java.net.Socket.connect(Socket.java:609)
	at okhttp3.internal.platform.Platform.connectSocket(Platform.kt:120)
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:295)
	... 100 more
```

While I can reproduce this by connecting to a url that is not available in our network, I wasn't able to trigger this exception using a unit test with mockwebserver.
 
Do you know what type of `SocketPolicy` would trigger  `java.net.ConnectException: Operation timed out (Connection timed out)	at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)` ? 