### PR TITLE
Confirm the original TLS exception is available on client auth failures

### DIFF
--- a/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
+++ b/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.java
@@ -215,6 +215,7 @@ public final class ClientAuthTest {
       // Conscrypt, JDK 8 (>= 292), JDK 9
     } catch (IOException expected) {
       assertThat(expected.getMessage()).isEqualTo("exhausted all routes");
+      assertThat(expected.getSuppressed()).isNotEmpty();
     }
   }
 
@@ -273,6 +274,7 @@ public final class ClientAuthTest {
       // It didn't fail until it reached the application layer.
     } catch (IOException expected) {
       assertThat(expected.getMessage()).isEqualTo("exhausted all routes");
+      assertThat(expected.getSuppressed()).isNotEmpty();
     }
   }
 


### PR DESCRIPTION
When we get an 'exhausted all routes' error, it's important that one of
those exhausted routes is available in the stack trace.

See https://github.com/square/okhttp/pull/6712/files