### PR TITLE
Enforce max intermediates in BasicCertificateChainCleaner

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/tls/BasicCertificateChainCleaner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/tls/BasicCertificateChainCleaner.kt
@@ -63,7 +63,7 @@ class BasicCertificateChainCleaner(
         if (result.size > 1 || toVerify != trustedCert) {
           result.add(trustedCert)
         }
-        if (verifySignature(trustedCert, trustedCert)) {
+        if (verifySignature(trustedCert, trustedCert, result.size - 2)) {
           return result // The self-signed cert is a root CA. We're done.
         }
         foundTrustedCertificate = true
@@ -75,7 +75,7 @@ class BasicCertificateChainCleaner(
       val i = queue.iterator()
       while (i.hasNext()) {
         val signingCert = i.next() as X509Certificate
-        if (verifySignature(toVerify, signingCert)) {
+        if (verifySignature(toVerify, signingCert, result.size - 1)) {
           i.remove()
           result.add(signingCert)
           continue@followIssuerChain
@@ -95,10 +95,22 @@ class BasicCertificateChainCleaner(
     throw SSLPeerUnverifiedException("Certificate chain too long: $result")
   }
 
-  /** Returns true if [toVerify] was signed by [signingCert]'s public key. */
-  private fun verifySignature(toVerify: X509Certificate, signingCert: X509Certificate): Boolean {
+  /**
+   * Returns true if [toVerify] was signed by [signingCert]'s public key.
+   *
+   * @param minIntermediates the minimum number of intermediate certificates in [signingCert]. This
+   *     is -1 if signing cert is a lone self-signed certificate.
+   */
+  private fun verifySignature(
+    toVerify: X509Certificate,
+    signingCert: X509Certificate,
+    minIntermediates: Int,
+  ): Boolean {
     if (toVerify.issuerDN != signingCert.subjectDN) {
       return false
+    }
+    if (signingCert.basicConstraints < minIntermediates) {
+      return false // The signer can't have this many intermediates beneath it.
     }
     return try {
       toVerify.verify(signingCert.publicKey)

--- a/okhttp/src/test/java/okhttp3/CertificateChainCleanerTest.java
+++ b/okhttp/src/test/java/okhttp3/CertificateChainCleanerTest.java
@@ -72,9 +72,11 @@ public final class CertificateChainCleanerTest {
   @Test public void orderedChainOfCertificatesWithRoot() throws Exception {
     HeldCertificate root = new HeldCertificate.Builder()
         .serialNumber(1L)
+        .certificateAuthority(1)
         .build();
     HeldCertificate certA = new HeldCertificate.Builder()
         .serialNumber(2L)
+        .certificateAuthority(0)
         .signedBy(root)
         .build();
     HeldCertificate certB = new HeldCertificate.Builder()
@@ -90,9 +92,11 @@ public final class CertificateChainCleanerTest {
   @Test public void orderedChainOfCertificatesWithoutRoot() throws Exception {
     HeldCertificate root = new HeldCertificate.Builder()
         .serialNumber(1L)
+        .certificateAuthority(1)
         .build();
     HeldCertificate certA = new HeldCertificate.Builder()
         .serialNumber(2L)
+        .certificateAuthority(0)
         .signedBy(root)
         .build();
     HeldCertificate certB = new HeldCertificate.Builder()
@@ -109,13 +113,16 @@ public final class CertificateChainCleanerTest {
   @Test public void unorderedChainOfCertificatesWithRoot() throws Exception {
     HeldCertificate root = new HeldCertificate.Builder()
         .serialNumber(1L)
+        .certificateAuthority(2)
         .build();
     HeldCertificate certA = new HeldCertificate.Builder()
         .serialNumber(2L)
+        .certificateAuthority(1)
         .signedBy(root)
         .build();
     HeldCertificate certB = new HeldCertificate.Builder()
         .serialNumber(3L)
+        .certificateAuthority(0)
         .signedBy(certA)
         .build();
     HeldCertificate certC = new HeldCertificate.Builder()
@@ -131,13 +138,16 @@ public final class CertificateChainCleanerTest {
   @Test public void unorderedChainOfCertificatesWithoutRoot() throws Exception {
     HeldCertificate root = new HeldCertificate.Builder()
         .serialNumber(1L)
+        .certificateAuthority(2)
         .build();
     HeldCertificate certA = new HeldCertificate.Builder()
         .serialNumber(2L)
+        .certificateAuthority(1)
         .signedBy(root)
         .build();
     HeldCertificate certB = new HeldCertificate.Builder()
         .serialNumber(3L)
+        .certificateAuthority(0)
         .signedBy(certA)
         .build();
     HeldCertificate certC = new HeldCertificate.Builder()
@@ -153,9 +163,11 @@ public final class CertificateChainCleanerTest {
   @Test public void unrelatedCertificatesAreOmitted() throws Exception {
     HeldCertificate root = new HeldCertificate.Builder()
         .serialNumber(1L)
+        .certificateAuthority(1)
         .build();
     HeldCertificate certA = new HeldCertificate.Builder()
         .serialNumber(2L)
+        .certificateAuthority(0)
         .signedBy(root)
         .build();
     HeldCertificate certB = new HeldCertificate.Builder()
@@ -174,13 +186,16 @@ public final class CertificateChainCleanerTest {
   @Test public void chainGoesAllTheWayToSelfSignedRoot() throws Exception {
     HeldCertificate selfSigned = new HeldCertificate.Builder()
         .serialNumber(1L)
+        .certificateAuthority(2)
         .build();
     HeldCertificate trusted = new HeldCertificate.Builder()
         .serialNumber(2L)
         .signedBy(selfSigned)
+        .certificateAuthority(1)
         .build();
     HeldCertificate certA = new HeldCertificate.Builder()
         .serialNumber(3L)
+        .certificateAuthority(0)
         .signedBy(trusted)
         .build();
     HeldCertificate certB = new HeldCertificate.Builder()
@@ -201,13 +216,16 @@ public final class CertificateChainCleanerTest {
   @Test public void trustedRootNotSelfSigned() throws Exception {
     HeldCertificate unknownSigner = new HeldCertificate.Builder()
         .serialNumber(1L)
+        .certificateAuthority(2)
         .build();
     HeldCertificate trusted = new HeldCertificate.Builder()
         .signedBy(unknownSigner)
+        .certificateAuthority(1)
         .serialNumber(2L)
         .build();
     HeldCertificate intermediateCa = new HeldCertificate.Builder()
         .signedBy(trusted)
+        .certificateAuthority(0)
         .serialNumber(3L)
         .build();
     HeldCertificate certificate = new HeldCertificate.Builder()
@@ -258,6 +276,7 @@ public final class CertificateChainCleanerTest {
     for (int i = 1; i <= length; i++) {
       result.add(0, new HeldCertificate.Builder()
           .signedBy(!result.isEmpty() ? result.get(0) : null)
+          .certificateAuthority(length - i)
           .serialNumber(i)
           .build());
     }


### PR DESCRIPTION
This impacts Conscrypt when the server's presented certificates form both
a trusted-but-unpinned chain and an untrusted-but-pinned chain.

Note that the newly-added test passes without any code changes.

See https://github.com/square/okhttp/issues/6648