### PR TITLE
Fix publishing of javadocs

### DIFF
--- a/mockwebserver-deprecated/build.gradle.kts
+++ b/mockwebserver-deprecated/build.gradle.kts
@@ -48,5 +48,5 @@ tasks.register<JapicmpTask>("japicmp") {
 
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/mockwebserver-junit4/build.gradle.kts
+++ b/mockwebserver-junit4/build.gradle.kts
@@ -21,5 +21,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/mockwebserver-junit5/build.gradle.kts
+++ b/mockwebserver-junit5/build.gradle.kts
@@ -30,5 +30,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/mockwebserver/build.gradle.kts
+++ b/mockwebserver/build.gradle.kts
@@ -24,5 +24,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/okcurl/build.gradle.kts
+++ b/okcurl/build.gradle.kts
@@ -62,7 +62,7 @@ graal {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }
 
 tasks.register<Copy>("copyResourcesTemplates") {

--- a/okhttp-brotli/build.gradle.kts
+++ b/okhttp-brotli/build.gradle.kts
@@ -25,5 +25,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/okhttp-dnsoverhttps/build.gradle.kts
+++ b/okhttp-dnsoverhttps/build.gradle.kts
@@ -27,5 +27,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/okhttp-logging-interceptor/build.gradle.kts
+++ b/okhttp-logging-interceptor/build.gradle.kts
@@ -41,5 +41,5 @@ tasks.register<JapicmpTask>("japicmp") {
 }.let(tasks.check::dependsOn)
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/okhttp-sse/build.gradle.kts
+++ b/okhttp-sse/build.gradle.kts
@@ -43,5 +43,5 @@ tasks.register<JapicmpTask>("japicmp") {
 }.let(tasks.check::dependsOn)
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/okhttp-tls/build.gradle.kts
+++ b/okhttp-tls/build.gradle.kts
@@ -49,5 +49,5 @@ tasks.register<JapicmpTask>("japicmp") {
 }.let(tasks.check::dependsOn)
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/okhttp-urlconnection/build.gradle.kts
+++ b/okhttp-urlconnection/build.gradle.kts
@@ -44,5 +44,5 @@ tasks.register<JapicmpTask>("japicmp") {
 
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -171,7 +171,7 @@ tasks.register<JapicmpTask>("japicmp") {
 }.let(tasks.check::dependsOn)
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
 }
 
 tasks.register<Copy>("copyJavaTemplates") {


### PR DESCRIPTION
This appears to fix (locally) https://github.com/square/okhttp/issues/6450

But unclear if it's the right fix, since we want dokkaGfm for the website.  

@Goooler @swankjesse Is there a model square project to replicate?