### PR TITLE
Changing 'adopt' to 'zulu'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Configure JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: 11
 
       - name: Upload Artifacts


### PR DESCRIPTION
Because Adopt is no longer current.