### PR TITLE
The version shouldn't be const

### DIFF
--- a/okhttp/src/main/java-templates/okhttp3/OkHttp.kt
+++ b/okhttp/src/main/java-templates/okhttp3/OkHttp.kt
@@ -31,5 +31,5 @@ object OkHttp {
    *
    * [semver]: https://semver.org
    */
-  const val VERSION = "$projectVersion"
+  val VERSION = "$projectVersion"
 }

--- a/okhttp/src/main/kotlin/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/Util.kt
@@ -670,4 +670,4 @@ internal inline fun <T> Iterable<T>.filterList(predicate: T.() -> Boolean): List
   return result
 }
 
-const val userAgent: String = "okhttp/${OkHttp.VERSION}"
+val userAgent: String = "okhttp/${OkHttp.VERSION}"


### PR DESCRIPTION
Downstream projects should get the current version, even if they're
not recompiled.