### PR TITLE
Add ability to make assertions on raw data sent to MockWebServer

### DIFF
--- a/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
@@ -496,7 +496,7 @@ public final class MockWebServerTest {
 
     RecordedRequest requestWithExpect = server.takeRequest();
     assertThat(requestWithExpect.getBody().readUtf8()).isEqualTo("");
-
+    Thread.sleep(100); // wait for whole response
     String response = client.readResponseUtf8String();
 
     // MockWebServer currently doesn't wait for announced request

--- a/mockwebserver/src/test/java/mockwebserver3/rawsocketclient/RawSocketClient.java
+++ b/mockwebserver/src/test/java/mockwebserver3/rawsocketclient/RawSocketClient.java
@@ -26,13 +26,7 @@ public class RawSocketClient implements AutoCloseable {
     InputStream in = socket.getInputStream();
     byte[] array = new byte[MAX_RESPONSE_CHUNK_SIZE_IN_BYTES];
     int bytesRead = in.read(array);
-    return new String(trimArrayTo(array, bytesRead), UTF_8);
-  }
-
-  private byte[] trimArrayTo(byte[] array, int bytesRead) {
-    byte[] trimmedArray = new byte[bytesRead];
-    System.arraycopy(array, 0, trimmedArray, 0, bytesRead);
-    return trimmedArray;
+    return new String(array, 0, bytesRead, UTF_8);
   }
 
   @Override

--- a/mockwebserver/src/test/java/mockwebserver3/rawsocketclient/RawSocketClient.java
+++ b/mockwebserver/src/test/java/mockwebserver3/rawsocketclient/RawSocketClient.java
@@ -1,0 +1,42 @@
+package mockwebserver3.rawsocketclient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+
+import static java.net.InetAddress.getLoopbackAddress;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class RawSocketClient implements AutoCloseable {
+  private static final int MAX_RESPONSE_CHUNK_SIZE_IN_BYTES = 1000;
+  private static final int MAX_RESPONSE_LATENCY_IN_MS = 5000;
+
+  private final Socket socket;
+
+  public RawSocketClient(int port) throws IOException {
+    this.socket = new Socket(getLoopbackAddress(), port);
+    this.socket.setSoTimeout(MAX_RESPONSE_LATENCY_IN_MS);
+  }
+
+  public void sendInUtf8(String stringToSend) throws IOException {
+    socket.getOutputStream().write(stringToSend.getBytes(UTF_8));
+  }
+
+  public String readResponseUtf8String() throws IOException {
+    InputStream in = socket.getInputStream();
+    byte[] array = new byte[MAX_RESPONSE_CHUNK_SIZE_IN_BYTES];
+    int bytesRead = in.read(array);
+    return new String(trimArrayTo(array, bytesRead), UTF_8);
+  }
+
+  private byte[] trimArrayTo(byte[] array, int bytesRead) {
+    byte[] trimmedArray = new byte[bytesRead];
+    System.arraycopy(array, 0, trimmedArray, 0, bytesRead);
+    return trimmedArray;
+  }
+
+  @Override
+  public void close() throws Exception {
+    socket.close();
+  }
+}


### PR DESCRIPTION
I've added RawSocketClient to test current MockWebServer behavior while using EXPECT_CONTINUE and (in future) CONTINUE_ALWAYS. HttpURLConnection is not sufficient because it hides 100 Continue response and don't wait for it but sends request body immediately.