### PR TITLE
Simplify kts

### DIFF
--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -18,17 +18,13 @@ kotlin {
   }
 
   sourceSets {
-    val commonMain by getting {
+    commonMain {
       kotlin.srcDir("$buildDir/generated/sources/kotlinTemplates")
-      dependencies {
-      }
     }
-    val commonTest by getting {
-      dependencies {
-      }
+    commonTest {
     }
 
-    val jvmMain by getting {
+    getByName("jvmMain") {
       dependencies {
         api(Dependencies.okio)
         api(Dependencies.kotlinStdlib)
@@ -46,7 +42,7 @@ kotlin {
         compileOnly(Dependencies.nativeImageSvm)
       }
     }
-    val jvmTest by getting {
+    getByName("jvmTest") {
       dependencies {
         implementation(project(":okhttp-testing-support"))
         implementation(project(":okhttp-tls"))
@@ -122,7 +118,7 @@ val copyOsgiTestDeployment by tasks.creating(Copy::class.java) {
   from(osgiTestDeploy)
   into("$buildDir/resources/jvmTest/okhttp3/osgi/deployments")
 }
-val jvmTest by tasks.getting {
+tasks.getByName("jvmTest") {
   dependsOn(copyOsgiTestDeployment)
 }
 


### PR DESCRIPTION
Follow up PR for #6959, to use extensions and replace deprecated `BundleTaskConvention`.

```java
/**
 * BundleTaskConvention for Gradle.
 *
 * @deprecated Replaced by BundleTaskExtension.
 */
@Deprecated
public class BundleTaskConvention
```

copy the constructor from
```java
private static BundleTaskExtension getBundleTaskExtension(org.gradle.api.tasks.bundling.Jar task) {
    BundleTaskExtension extension = task.getExtensions()
	.findByType(BundleTaskExtension.class);
    if (extension != null) {
	return extension;
    }
    return task.getExtensions()
	.create(BundleTaskExtension.NAME, BundleTaskExtension.class, task);
}
```