### PR TITLE
Support HTTP3 draft as h3-29 as an ALPN token

### DIFF
--- a/okhttp/src/commonMain/kotlin/okhttp3/Protocol.kt
+++ b/okhttp/src/commonMain/kotlin/okhttp3/Protocol.kt
@@ -121,8 +121,10 @@ enum class Protocol(private val protocol: String) {
         HTTP_2.protocol -> HTTP_2
         SPDY_3.protocol -> SPDY_3
         QUIC.protocol -> QUIC
-        HTTP_3.protocol -> HTTP_3
-        else -> throw IOException("Unexpected protocol: $protocol")
+        else -> {
+          // Support HTTP3 draft like h3-29
+          if (protocol.startsWith(HTTP_3.protocol)) HTTP_3 else throw IOException("Unexpected protocol: $protocol")
+        }
       }
     }
   }

--- a/okhttp/src/jvmTest/java/okhttp3/ProtocolTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/ProtocolTest.java
@@ -30,6 +30,8 @@ public class ProtocolTest {
     assertThat(Protocol.get("h2")).isEqualTo(Protocol.HTTP_2);
     assertThat(Protocol.get("h2_prior_knowledge")).isEqualTo(Protocol.H2_PRIOR_KNOWLEDGE);
     assertThat(Protocol.get("quic")).isEqualTo(Protocol.QUIC);
+    assertThat(Protocol.get("h3")).isEqualTo(Protocol.HTTP_3);
+    assertThat(Protocol.get("h3-29")).isEqualTo(Protocol.HTTP_3);
   }
 
   @Test
@@ -45,5 +47,6 @@ public class ProtocolTest {
     assertThat(Protocol.HTTP_2.toString()).isEqualTo("h2");
     assertThat(Protocol.H2_PRIOR_KNOWLEDGE.toString()).isEqualTo("h2_prior_knowledge");
     assertThat(Protocol.QUIC.toString()).isEqualTo("quic");
+    assertThat(Protocol.HTTP_3.toString()).isEqualTo("h3");
   }
 }


### PR DESCRIPTION
It is better to support HTTP3 draft like h3-29. We can remove this code when drafts are no longer used.