### PR TITLE
Change Response.request to return the request modified by network interceptors

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/BridgeInterceptor.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/BridgeInterceptor.kt
@@ -85,7 +85,7 @@ class BridgeInterceptor(private val cookieJar: CookieJar) : Interceptor {
     cookieJar.receiveHeaders(userRequest.url, networkResponse.headers)
 
     val responseBuilder = networkResponse.newBuilder()
-        .request(userRequest)
+        .request(networkResponse.request)
 
     if (transparentGzip &&
         "gzip".equals(networkResponse.header("Content-Encoding"), ignoreCase = true) &&


### PR DESCRIPTION
BridgeInterceptor's responsebuilder use real request so it can be passed  back to previous interceptors