### PR TITLE
Tidy up ExchangeFinder to split pooling and reuse logic

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -150,6 +150,10 @@ class RealConnection(
   internal val isMultiplexed: Boolean
     get() = http2Connection != null
 
+  /** True if we haven't yet called [connect] on this. */
+  internal val isNew: Boolean
+    get() = protocol == null
+
   /** Prevent further exchanges from being created on this connection. */
   @Synchronized internal fun noNewExchanges() {
     noNewExchanges = true
@@ -173,7 +177,7 @@ class RealConnection(
     call: Call,
     eventListener: EventListener
   ) {
-    check(protocol == null) { "already connected" }
+    check(isNew) { "already connected" }
 
     var routeException: RouteException? = null
     val connectionSpecs = route.address.connectionSpecs


### PR DESCRIPTION
Each exchange has 3 places for a connection
 - the connection on the call (from a previous redirect, auth challenge, etc.)
 - a connection from the pool
 - a fresh connection

We query the pool after each blocking step to give ourselves the maximum
chance or connection reuse.

This changes code structure without changing behavior.