### PR TITLE
Move Connection.isHealthy() checks to where reuse happens

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -348,14 +348,14 @@ class RealCall(
     val connection = this.connection
     if (connection != null) {
       connection.assertThreadDoesntHoldLock()
-      val socket = synchronized(connection) {
+      val toClose: Socket? = synchronized(connection) {
         releaseConnectionNoEvents() // Sets this.connection to null.
       }
       if (this.connection == null) {
-        socket?.closeQuietly()
+        toClose?.closeQuietly()
         eventListener.connectionReleased(this, connection)
       } else {
-        check(socket == null) // If we still have a connection we shouldn't be closing any sockets.
+        check(toClose == null) // If we still have a connection we shouldn't be closing any sockets.
       }
     }
 

--- a/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
@@ -3900,7 +3900,7 @@ open class CallTest(
       .build()
     executeSynchronously("/")
       .assertFailure(IOException::class.java)
-      .assertFailure("exhausted all routes")
+      .assertFailure("Socket closed", "Socket is closed")
   }
 
   @Test fun requestBodyThrowsUnrelatedToNetwork() {

--- a/okhttp/src/jvmTest/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -79,6 +79,7 @@ import org.assertj.core.data.Offset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Timeout
@@ -928,7 +929,7 @@ class HttpOverHttp2Test {
   }
 
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
-  fun recoverFromOneRefusedStreamReusesConnection(
+  fun noRecoveryFromOneRefusedStream(
     protocol: Protocol, mockWebServer: MockWebServer
   ) {
     setUp(protocol, mockWebServer)
@@ -946,13 +947,163 @@ class HttpOverHttp2Test {
         .url(server.url("/"))
         .build()
     )
-    val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("abc")
+    try {
+      call.execute()
+      fail<Any?>()
+    } catch (expected: StreamResetException) {
+      assertThat(expected.errorCode).isEqualTo(ErrorCode.REFUSED_STREAM)
+    }
+  }
 
-    // New connection.
+  @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
+  fun recoverFromRefusedStreamWhenAnotherRouteExists(
+    protocol: Protocol, mockWebServer: MockWebServer
+  ) {
+    setUp(protocol, mockWebServer)
+    client = client.newBuilder()
+      .dns(DoubleInetAddressDns()) // Two routes!
+      .build()
+    server.enqueue(
+      MockResponse()
+        .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.httpCode)
+    )
+    server.enqueue(
+      MockResponse()
+        .setBody("abc")
+    )
+
+    val request = Request.Builder()
+      .url(server.url("/"))
+      .build()
+    val response = client.newCall(request).execute()
+    assertThat(response.body!!.string()).isEqualTo("abc")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
-    // Reused connection.
+
+    // Note that although we have two routes available, we only use one. The retry is permitted
+    // because there are routes available, but it chooses the existing connection since it isn't
+    // yet considered unhealthy.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
+  }
+
+  @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
+  fun noRecoveryWhenRoutesExhausted(
+    protocol: Protocol, mockWebServer: MockWebServer
+  ) {
+    setUp(protocol, mockWebServer)
+    client = client.newBuilder()
+      .dns(DoubleInetAddressDns()) // Two routes!
+      .build()
+    server.enqueue(
+      MockResponse()
+        .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.httpCode)
+    )
+    server.enqueue(
+      MockResponse()
+        .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.httpCode)
+    )
+    server.enqueue(
+      MockResponse()
+        .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.httpCode)
+    )
+
+    val request = Request.Builder()
+      .url(server.url("/"))
+      .build()
+    try {
+      client.newCall(request).execute()
+      fail<Any?>()
+    } catch (expected: StreamResetException) {
+      assertThat(expected.errorCode).isEqualTo(ErrorCode.REFUSED_STREAM)
+    }
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(0) // New connection.
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(1) // Pooled connection.
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(0) // New connection.
+  }
+
+  @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
+  fun connectionWithOneRefusedStreamIsPooled(
+    protocol: Protocol, mockWebServer: MockWebServer
+  ) {
+    setUp(protocol, mockWebServer)
+    server.enqueue(
+      MockResponse()
+        .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.httpCode)
+    )
+    server.enqueue(
+      MockResponse()
+        .setBody("abc")
+    )
+    val request = Request.Builder()
+      .url(server.url("/"))
+      .build()
+
+    // First call fails because it only has one route.
+    try {
+      client.newCall(request).execute()
+      fail<Any?>()
+    } catch (expected: StreamResetException) {
+      assertThat(expected.errorCode).isEqualTo(ErrorCode.REFUSED_STREAM)
+    }
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
+
+    // Second call succeeds on the pooled connection.
+    val response = client.newCall(request).execute()
+    assertThat(response.body!!.string()).isEqualTo("abc")
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
+  }
+
+  @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
+  fun connectionWithTwoRefusedStreamsIsNotPooled(
+    protocol: Protocol, mockWebServer: MockWebServer
+  ) {
+    setUp(protocol, mockWebServer)
+    server.enqueue(
+      MockResponse()
+        .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.httpCode)
+    )
+    server.enqueue(
+      MockResponse()
+        .setSocketPolicy(SocketPolicy.RESET_STREAM_AT_START)
+        .setHttp2ErrorCode(ErrorCode.REFUSED_STREAM.httpCode)
+    )
+    server.enqueue(
+      MockResponse()
+        .setBody("abc")
+    )
+    server.enqueue(
+      MockResponse()
+        .setBody("def")
+    )
+    val request = Request.Builder()
+      .url(server.url("/"))
+      .build()
+
+    // First call makes a new connection and fails because it is the only route.
+    try {
+      client.newCall(request).execute()
+      fail<Any?>()
+    } catch (expected: StreamResetException) {
+      assertThat(expected.errorCode).isEqualTo(ErrorCode.REFUSED_STREAM)
+    }
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(0) // New connection.
+
+    // Second call attempts the pooled connection, and it fails. Then it retries a new route which
+    // succeeds.
+    val response2 = client.newCall(request).execute()
+    assertThat(response2.body!!.string()).isEqualTo("abc")
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(1) // Pooled connection.
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(0) // New connection.
+
+    // Third call reuses the second connection.
+    val response3 = client.newCall(request).execute()
+    assertThat(response3.body!!.string()).isEqualTo("def")
+    assertThat(server.takeRequest().sequenceNumber).isEqualTo(1) // New connection.
   }
 
   /**
@@ -1919,13 +2070,12 @@ class HttpOverHttp2Test {
    * connections are requested concurrently OkHttp will pessimistically connect multiple times, then
    * close any unnecessary connections. This test confirms that behavior works as intended.
    *
-   *
    * This test uses proxy tunnels to get a hook while a connection is being established.
    */
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
   fun concurrentHttp2ConnectionsDeduplicated(protocol: Protocol, mockWebServer: MockWebServer) {
     setUp(protocol, mockWebServer)
-    Assumptions.assumeTrue(protocol === Protocol.HTTP_2)
+    assumeTrue(protocol === Protocol.HTTP_2)
     server.useHttps(handshakeCertificates!!.sslSocketFactory(), true)
     val queueDispatcher = QueueDispatcher()
     queueDispatcher.enqueueResponse(


### PR DESCRIPTION
One behavior change here is we won't fire connectionAcquired()
followed by connectionReleased() if we take an connection from the
pool only to immediately find it's unhealthy.

I'm working towards moving the loop over connect attempts and
fails from RetryAndFollowUpInterceptor and into ExchangeFinder.
(We'll still need some recovery in RetryAndFollowUpInterceptor,
but not connection recovery.)