### PR TITLE
Rewrite TaskFaker to permit mutiple stalled tasks

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
@@ -16,14 +16,28 @@
 package okhttp3.internal.concurrent
 
 import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.logging.Logger
 import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
 
 /**
  * Runs a [TaskRunner] in a controlled environment so that everything is sequential and
- * deterministic. All tasks are executed on-demand on the test thread by calls to [runTasks] and
- * [advanceUntil].
+ * deterministic.
+ *
+ * This class ensures that at most one thread is running at a time. This is initially the JUnit test
+ * thread, which temporarily shares its execution privilege by calling [runTasks], [runNextTask], or
+ * [advanceUntil]. These methods wait for its task threads to stop executing before it returns.
+ *
+ * Task threads stall execution in these ways:
+ *
+ *  * By being ready to start. Newly-created tasks don't run immediately.
+ *  * By finishing their work. This occurs when [Runnable.run] returns.
+ *  * By requesting to wait by calling [TaskRunner.Backend.coordinatorWait].
+ *
+ * Most test methods start by unblocking task threads, then wait for those task threads to stall
+ * again before returning.
  */
 class TaskFaker {
   @Suppress("NOTHING_TO_INLINE")
@@ -44,157 +58,180 @@ class TaskFaker {
   internal inline fun Any.wait() = (this as Object).wait()
 
   @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
-  internal inline fun Any.notify() = (this as Object).notify()
+  internal inline fun Any.notifyAll() = (this as Object).notifyAll()
 
   val logger = Logger.getLogger("TaskFaker." + instance++)
 
-  /** Runnables scheduled for execution. These will execute tasks and perform scheduling. */
-  private val futureRunnables = mutableListOf<Runnable>()
+  /** Though this executor service may hold many threads, they are not executed concurrently. */
+  private val tasksExecutor = Executors.newCachedThreadPool()
 
-  /** Runnables currently executing. */
-  private val currentRunnables = mutableListOf<Runnable>()
+  /** The number of runnables known to [tasksExecutor]. Guarded by [taskRunner]. */
+  private var tasksRunningCount = 0
 
   /**
-   * Executor service for the runnables above. This executor service should never have more than two
-   * active threads: one for a currently-executing task and one for a currently-sleeping task.
+   * Threads in this list are waiting for either [interruptCoordinatorThread] or [notifyAll].
+   * Guarded by [taskRunner].
    */
-  private val executorService = Executors.newCachedThreadPool()
+  private val stalledTasks = mutableListOf<Thread>()
 
-  /** True if this task faker has ever had multiple tasks scheduled to run concurrently. */
+  /**
+   * Released whenever a thread is either added to [stalledTasks] or completes. The test thread
+   * uses this to wait until all subject threads complete or stall.
+   */
+  private val taskBecameStalled = Semaphore(0)
+
+  /**
+   * True if this task faker has ever had multiple tasks scheduled to run concurrently. Guarded by
+   * [taskRunner].
+   */
   var isParallel = false
 
   /** Guarded by [taskRunner]. */
   var nanoTime = 0L
     private set
 
-  /** The thread currently waiting for time to advance. */
-  private var waitingThread: Thread? = null
-
-  /** Guarded by taskRunner. Time at which we should yield execution to a waiting runnable. */
-  private var waitingUntilTime = Long.MAX_VALUE
-
-  /** Total number of runnables executed. */
-  private var executedRunnableCount = 0
-
-  /** Stall once we've executed this many runnables. */
-  private var executedTaskLimit = Int.MAX_VALUE
+  /** The thread currently waiting for time to advance. Guarded by [taskRunner]. */
+  private var waitingCoordinatorThread: Thread? = null
 
   /** A task runner that posts tasks to this fake. Tasks won't be executed until requested. */
   val taskRunner: TaskRunner = TaskRunner(object : TaskRunner.Backend {
-    override fun beforeTask(taskRunner: TaskRunner) {
+    override fun execute(taskRunner: TaskRunner, runnable: Runnable) {
       taskRunner.assertThreadHoldsLock()
+      val acquiredTaskRunnerLock = AtomicBoolean()
 
-      while (executedRunnableCount >= executedTaskLimit) {
-        coordinatorWait(taskRunner, Long.MAX_VALUE)
+      tasksExecutor.execute {
+        synchronized(taskRunner) {
+          acquiredTaskRunnerLock.set(true)
+          taskRunner.notifyAll()
+
+          tasksRunningCount++
+          if (tasksRunningCount > 1) isParallel = true
+          try {
+            stall(taskRunner)
+            runnable.run()
+          } finally {
+            tasksRunningCount--
+            taskBecameStalled.release()
+          }
+        }
       }
-    }
 
-    override fun execute(runnable: Runnable) {
-      futureRunnables.add(runnable)
+      // Execute() must not return until the launched task reaches stall().
+      while (!acquiredTaskRunnerLock.get()) {
+        taskRunner.wait()
+      }
     }
 
     override fun nanoTime() = nanoTime
 
     override fun coordinatorNotify(taskRunner: TaskRunner) {
       taskRunner.assertThreadHoldsLock()
+      check(waitingCoordinatorThread != null)
 
-      waitingUntilTime = nanoTime
+      stalledTasks.remove(waitingCoordinatorThread)
+      taskRunner.notifyAll()
     }
 
     override fun coordinatorWait(taskRunner: TaskRunner, nanos: Long) {
       taskRunner.assertThreadHoldsLock()
 
-      check(waitingUntilTime == Long.MAX_VALUE)
-      check(waitingThread == null)
+      check(waitingCoordinatorThread == null)
+      if (nanos == 0L) return
 
-      waitingThread = Thread.currentThread()
-      waitingUntilTime = if (nanos < Long.MAX_VALUE) nanoTime + nanos else Long.MAX_VALUE
+      waitingCoordinatorThread = Thread.currentThread()
       try {
-        if (nanoTime < waitingUntilTime) {
-          // Stall because there's no work to do.
-          taskRunner.notify()
+        stall(taskRunner)
+      } finally {
+        waitingCoordinatorThread = null
+      }
+    }
+
+    /** Wait for the test thread to proceed. */
+    private fun stall(taskRunner: TaskRunner) {
+      taskRunner.assertThreadHoldsLock()
+
+      val currentThread = Thread.currentThread()
+      taskBecameStalled.release()
+      stalledTasks += currentThread
+      try {
+        while (currentThread in stalledTasks) {
           taskRunner.wait()
         }
-      } finally {
-        waitingThread = null
-        waitingUntilTime = Long.MAX_VALUE
+      } catch (e: InterruptedException) {
+        stalledTasks.remove(currentThread)
+        throw e
       }
     }
   }, logger = logger)
 
-  /** Runs all tasks that are ready without advancing the simulated clock. */
+  /** Runs all tasks that are ready. Used by the test thread only. */
   fun runTasks() {
     advanceUntil(nanoTime)
   }
 
-  /** Advance the simulated clock and run anything ready at the new time. */
+  /** Advance the simulated clock, then runs tasks that are ready. Used by the test thread only. */
   fun advanceUntil(newTime: Long) {
     taskRunner.assertThreadDoesntHoldLock()
 
     synchronized(taskRunner) {
       nanoTime = newTime
+      stalledTasks.clear()
+      taskRunner.notifyAll()
+    }
 
-      while (true) {
-        runRunnables(taskRunner)
+    waitForTasksToStall()
+  }
 
-        if (waitingUntilTime <= nanoTime) {
-          // Let the coordinator do its business at the new time.
-          taskRunner.notify()
-          taskRunner.wait()
-        } else {
-          return
+  private fun waitForTasksToStall() {
+    taskRunner.assertThreadDoesntHoldLock()
+
+    while (true) {
+      synchronized(taskRunner) {
+        if (tasksRunningCount == stalledTasks.size) {
+          return@waitForTasksToStall // All stalled.
         }
+        taskBecameStalled.drainPermits()
       }
+      taskBecameStalled.acquire()
     }
   }
 
-  /** Returns true if anything was executed. */
-  private fun runRunnables(taskRunner: TaskRunner) {
-    taskRunner.assertThreadHoldsLock()
-
-    while (futureRunnables.isNotEmpty()) {
-      val runnable = futureRunnables.removeAt(0)
-      currentRunnables.add(runnable)
-      if (currentRunnables.size > 1) isParallel = true
-      executorService.execute {
-        try {
-          runnable.run()
-        } finally {
-          currentRunnables.remove(runnable)
-          synchronized(taskRunner) {
-            taskRunner.notify()
-          }
-        }
-      }
-      taskRunner.wait() // Wait for the coordinator to stall.
-    }
-  }
-
+  /** Confirm all tasks have completed. Used by the test thread only. */
   fun assertNoMoreTasks() {
-    assertThat(futureRunnables).isEmpty()
-    assertThat(waitingUntilTime)
-        .withFailMessage("tasks are scheduled to run at $waitingUntilTime")
-        .isEqualTo(Long.MAX_VALUE)
-  }
-
-  fun interruptCoordinatorThread() {
     taskRunner.assertThreadDoesntHoldLock()
 
     synchronized(taskRunner) {
-      check(waitingThread != null) { "no thread currently waiting" }
-      waitingThread!!.interrupt()
-      taskRunner.wait() // Wait for the coordinator to stall.
+      assertThat(stalledTasks).isEmpty()
     }
   }
 
-  /** Advances and runs up to one task. */
-  fun runNextTask() {
-    executedTaskLimit = executedRunnableCount + 1
-    try {
-      advanceUntil(nanoTime)
-    } finally {
-      executedTaskLimit = Int.MAX_VALUE
+  /** Unblock a waiting task thread. Used by the test thread only. */
+  fun interruptCoordinatorThread() {
+    taskRunner.assertThreadDoesntHoldLock()
+
+    // Make sure the coordinator is ready to be interrupted.
+    runTasks()
+
+    synchronized(taskRunner) {
+      val toInterrupt = waitingCoordinatorThread ?: error("no thread currently waiting")
+      taskBecameStalled.drainPermits()
+      toInterrupt.interrupt()
     }
+
+    waitForTasksToStall()
+  }
+
+  /** Ask a single task to proceed. Used by the test thread only. */
+  fun runNextTask() {
+    taskRunner.assertThreadDoesntHoldLock()
+
+    synchronized(taskRunner) {
+      check(stalledTasks.size >= 1) { "no tasks to run" }
+      stalledTasks.removeFirst()
+      taskRunner.notifyAll()
+    }
+
+    waitForTasksToStall()
   }
 
   /** Returns true if no tasks have been scheduled. This runs the coordinator for confirmation. */

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
@@ -21,7 +21,6 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 import okhttp3.internal.addIfAbsent
-import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.concurrent.TaskRunner.Companion.INSTANCE
 import okhttp3.internal.notify
@@ -68,7 +67,9 @@ class TaskRunner(
           } finally {
             // If the task is crashing start another thread to service the queues.
             if (!completedNormally) {
-              backend.execute(this)
+              synchronized(this@TaskRunner) {
+                backend.execute(this@TaskRunner, this)
+              }
             }
           }
         }
@@ -90,7 +91,7 @@ class TaskRunner(
     if (coordinatorWaiting) {
       backend.coordinatorNotify(this@TaskRunner)
     } else {
-      backend.execute(runnable)
+      backend.execute(this@TaskRunner, runnable)
     }
   }
 
@@ -106,8 +107,6 @@ class TaskRunner(
   }
 
   private fun runTask(task: Task) {
-    this.assertThreadDoesntHoldLock()
-
     val currentThread = Thread.currentThread()
     val oldName = currentThread.name
     currentThread.name = task.name
@@ -197,7 +196,7 @@ class TaskRunner(
 
           // Also start another thread if there's more work or scheduling to do.
           if (multipleReadyTasks || !coordinatorWaiting && readyQueues.isNotEmpty()) {
-            backend.execute(runnable)
+            backend.execute(this@TaskRunner, runnable)
           }
 
           return readyTask
@@ -258,11 +257,10 @@ class TaskRunner(
   }
 
   interface Backend {
-    fun beforeTask(taskRunner: TaskRunner)
     fun nanoTime(): Long
     fun coordinatorNotify(taskRunner: TaskRunner)
     fun coordinatorWait(taskRunner: TaskRunner, nanos: Long)
-    fun execute(runnable: Runnable)
+    fun execute(taskRunner: TaskRunner, runnable: Runnable)
   }
 
   class RealBackend(threadFactory: ThreadFactory) : Backend {
@@ -273,9 +271,6 @@ class TaskRunner(
       SynchronousQueue(),
       threadFactory
     )
-
-    override fun beforeTask(taskRunner: TaskRunner) {
-    }
 
     override fun nanoTime() = System.nanoTime()
 
@@ -297,7 +292,7 @@ class TaskRunner(
       }
     }
 
-    override fun execute(runnable: Runnable) {
+    override fun execute(taskRunner: TaskRunner, runnable: Runnable) {
       executor.execute(runnable)
     }
 

--- a/okhttp/src/jvmTest/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
@@ -402,6 +402,7 @@ class TaskRunnerTest {
         "three:run@100000 parallel=true"
     )
 
+    taskFaker.runTasks()
     taskFaker.assertNoMoreTasks()
 
     assertThat(testLogHandler.takeAll()).containsExactly(


### PR DESCRIPTION
In order to deterministically test FastFallbackExchangeFinder I need
a test facet that supports several test coordinating:
 - the call thread is waiting for either a connection to connect
   or for the next-connection timeout (250 ms) to elapse
 - the in-flight connection needs to connect

TaskFaker wasn't up to the task for this because it assumed at most
two threads, the test thread and the task thread.

With this change TaskFaker can coordinate multiple task threads
that each run sequentially, as directed by a test thread.