### PR TITLE
Fix typo in event ordering.

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/EventListener.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/EventListener.kt
@@ -195,7 +195,7 @@ abstract class EventListener {
    * Invoked when a connection attempt fails. This failure is not terminal if further routes are
    * available and failure recovery is enabled.
    *
-   * If the `call` uses HTTPS, this will be invoked after [secureConnectEnd], otherwise it will
+   * If the `call` uses HTTPS, this will be invoked after [secureConnectStart], otherwise it will
    * invoked after [connectStart].
    */
   open fun connectFailed(


### PR DESCRIPTION
If handshake fails we won't have a secureConnectEnd.