### PR TITLE
Enable Gradle's type-safe project accessors

### DIFF
--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -48,7 +48,7 @@ android {
 dependencies {
   implementation(Dependencies.kotlinReflect)
   implementation(Dependencies.playServicesSafetynet)
-  implementation(project(":okhttp"))
+  implementation(projects.okhttp)
 
   androidTestImplementation(project(":okhttp-testing-support")) {
     exclude("org.openjsse", "openjsse")

--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
   androidTestImplementation(Dependencies.bouncycastle)
   androidTestImplementation(Dependencies.bouncycastletls)
   androidTestImplementation(Dependencies.conscryptAndroid)
-  androidTestImplementation(project(":mockwebserver3-junit5"))
+  androidTestImplementation(projects.mockwebserver3Junit5)
   androidTestImplementation(project(":okhttp-brotli"))
   androidTestImplementation(project(":okhttp-dnsoverhttps"))
   androidTestImplementation(project(":logging-interceptor"))

--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
   androidTestImplementation(projects.mockwebserver3Junit5)
   androidTestImplementation(project(":okhttp-brotli"))
   androidTestImplementation(project(":okhttp-dnsoverhttps"))
-  androidTestImplementation(project(":logging-interceptor"))
+  androidTestImplementation(projects.loggingInterceptor)
   androidTestImplementation(project(":okhttp-sse"))
   androidTestImplementation(projects.okhttpTestingSupport)
   androidTestImplementation(projects.okhttpTls)

--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
   androidTestImplementation(projects.okhttpBrotli)
   androidTestImplementation(projects.okhttpDnsoverhttps)
   androidTestImplementation(projects.loggingInterceptor)
-  androidTestImplementation(project(":okhttp-sse"))
+  androidTestImplementation(projects.okhttpSse)
   androidTestImplementation(projects.okhttpTestingSupport)
   androidTestImplementation(projects.okhttpTls)
   androidTestImplementation(Dependencies.androidxExtJunit)

--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
   androidTestImplementation(Dependencies.bouncycastletls)
   androidTestImplementation(Dependencies.conscryptAndroid)
   androidTestImplementation(projects.mockwebserver3Junit5)
-  androidTestImplementation(project(":okhttp-brotli"))
+  androidTestImplementation(projects.okhttpBrotli)
   androidTestImplementation(project(":okhttp-dnsoverhttps"))
   androidTestImplementation(projects.loggingInterceptor)
   androidTestImplementation(project(":okhttp-sse"))

--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
   implementation(Dependencies.playServicesSafetynet)
   implementation(projects.okhttp)
 
-  androidTestImplementation(project(":okhttp-testing-support")) {
+  androidTestImplementation(projects.okhttpTestingSupport) {
     exclude("org.openjsse", "openjsse")
     exclude("org.conscrypt", "conscrypt-openjdk-uber")
     exclude("software.amazon.cryptools", "AmazonCorrettoCryptoProvider")
@@ -63,7 +63,7 @@ dependencies {
   androidTestImplementation(project(":okhttp-dnsoverhttps"))
   androidTestImplementation(project(":logging-interceptor"))
   androidTestImplementation(project(":okhttp-sse"))
-  androidTestImplementation(project(":okhttp-testing-support"))
+  androidTestImplementation(projects.okhttpTestingSupport)
   androidTestImplementation(project(":okhttp-tls"))
   androidTestImplementation(Dependencies.androidxExtJunit)
   androidTestImplementation(Dependencies.androidxEspressoCore)

--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
   androidTestImplementation(project(":logging-interceptor"))
   androidTestImplementation(project(":okhttp-sse"))
   androidTestImplementation(projects.okhttpTestingSupport)
-  androidTestImplementation(project(":okhttp-tls"))
+  androidTestImplementation(projects.okhttpTls)
   androidTestImplementation(Dependencies.androidxExtJunit)
   androidTestImplementation(Dependencies.androidxEspressoCore)
   androidTestImplementation(Dependencies.httpclient5)

--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
   androidTestImplementation(Dependencies.conscryptAndroid)
   androidTestImplementation(projects.mockwebserver3Junit5)
   androidTestImplementation(projects.okhttpBrotli)
-  androidTestImplementation(project(":okhttp-dnsoverhttps"))
+  androidTestImplementation(projects.okhttpDnsoverhttps)
   androidTestImplementation(projects.loggingInterceptor)
   androidTestImplementation(project(":okhttp-sse"))
   androidTestImplementation(projects.okhttpTestingSupport)

--- a/mockwebserver-deprecated/build.gradle.kts
+++ b/mockwebserver-deprecated/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   api(Dependencies.junit)
 
   testImplementation(projects.okhttpTestingSupport)
-  testImplementation(project(":okhttp-tls"))
+  testImplementation(projects.okhttpTls)
   testImplementation(Dependencies.assertj)
 }
 

--- a/mockwebserver-deprecated/build.gradle.kts
+++ b/mockwebserver-deprecated/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.jar {
 
 dependencies {
   api(projects.okhttp)
-  api(project(":mockwebserver3"))
+  api(projects.mockwebserver3)
   api(Dependencies.junit)
 
   testImplementation(projects.okhttpTestingSupport)

--- a/mockwebserver-deprecated/build.gradle.kts
+++ b/mockwebserver-deprecated/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   api(project(":mockwebserver3"))
   api(Dependencies.junit)
 
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":okhttp-tls"))
   testImplementation(Dependencies.assertj)
 }

--- a/mockwebserver-deprecated/build.gradle.kts
+++ b/mockwebserver-deprecated/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.jar {
 }
 
 dependencies {
-  api(project(":okhttp"))
+  api(projects.okhttp)
   api(project(":mockwebserver3"))
   api(Dependencies.junit)
 

--- a/mockwebserver-junit4/build.gradle.kts
+++ b/mockwebserver-junit4/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.jar {
 }
 
 dependencies {
-  api(project(":mockwebserver3"))
+  api(projects.mockwebserver3)
   api(Dependencies.junit)
 
   testImplementation(Dependencies.assertj)

--- a/mockwebserver-junit5/build.gradle.kts
+++ b/mockwebserver-junit5/build.gradle.kts
@@ -20,7 +20,7 @@ tasks {
 }
 
 dependencies {
-  api(project(":mockwebserver3"))
+  api(projects.mockwebserver3)
   api(Dependencies.junit5Api)
   compileOnly(Dependencies.animalSniffer)
 

--- a/mockwebserver/build.gradle.kts
+++ b/mockwebserver/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   api(projects.okhttp)
 
   testImplementation(projects.okhttpTestingSupport)
-  testImplementation(project(":okhttp-tls"))
+  testImplementation(projects.okhttpTls)
   testRuntimeOnly(project(":mockwebserver3-junit5"))
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)

--- a/mockwebserver/build.gradle.kts
+++ b/mockwebserver/build.gradle.kts
@@ -16,7 +16,7 @@ tasks.jar {
 dependencies {
   api(projects.okhttp)
 
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":okhttp-tls"))
   testRuntimeOnly(project(":mockwebserver3-junit5"))
   testImplementation(Dependencies.junit)

--- a/mockwebserver/build.gradle.kts
+++ b/mockwebserver/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.jar {
 }
 
 dependencies {
-  api(project(":okhttp"))
+  api(projects.okhttp)
 
   testImplementation(project(":okhttp-testing-support"))
   testImplementation(project(":okhttp-tls"))

--- a/mockwebserver/build.gradle.kts
+++ b/mockwebserver/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
   testImplementation(projects.okhttpTestingSupport)
   testImplementation(projects.okhttpTls)
-  testRuntimeOnly(project(":mockwebserver3-junit5"))
+  testRuntimeOnly(projects.mockwebserver3Junit5)
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)
 }

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation(project(":okhttp-dnsoverhttps"))
   implementation(project(":logging-interceptor"))
   implementation(project(":okhttp-sse"))
-  implementation(project(":okhttp-testing-support"))
+  implementation(projects.okhttpTestingSupport)
   implementation(project(":okhttp-tls"))
   implementation(Dependencies.assertj)
   implementation(project(":mockwebserver3"))

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation(project(":logging-interceptor"))
   implementation(project(":okhttp-sse"))
   implementation(projects.okhttpTestingSupport)
-  implementation(project(":okhttp-tls"))
+  implementation(projects.okhttpTls)
   implementation(Dependencies.assertj)
   implementation(project(":mockwebserver3"))
   implementation(project(":mockwebserver"))

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation(projects.okhttpBrotli)
   implementation(projects.okhttpDnsoverhttps)
   implementation(projects.loggingInterceptor)
-  implementation(project(":okhttp-sse"))
+  implementation(projects.okhttpSse)
   implementation(projects.okhttpTestingSupport)
   implementation(projects.okhttpTls)
   implementation(Dependencies.assertj)

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   implementation(Dependencies.junitPlatformConsole)
   implementation(Dependencies.okioFakeFileSystem)
 
-  implementation(project(":okhttp"))
+  implementation(projects.okhttp)
   implementation(project(":okhttp-brotli"))
   implementation(project(":okhttp-dnsoverhttps"))
   implementation(project(":logging-interceptor"))

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   implementation(projects.mockwebserver3)
   implementation(project(":mockwebserver"))
   implementation(projects.okhttpUrlconnection)
-  implementation(project(":mockwebserver3-junit4"))
+  implementation(projects.mockwebserver3Junit4)
   implementation(projects.mockwebserver3Junit5)
   implementation(Dependencies.bndResolve)
   implementation(Dependencies.junit5Api)

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   implementation(projects.okhttpTestingSupport)
   implementation(projects.okhttpTls)
   implementation(Dependencies.assertj)
-  implementation(project(":mockwebserver3"))
+  implementation(projects.mockwebserver3)
   implementation(project(":mockwebserver"))
   implementation(project(":okhttp-urlconnection"))
   implementation(project(":mockwebserver3-junit4"))

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
   implementation(projects.okhttp)
   implementation(project(":okhttp-brotli"))
   implementation(project(":okhttp-dnsoverhttps"))
-  implementation(project(":logging-interceptor"))
+  implementation(projects.loggingInterceptor)
   implementation(project(":okhttp-sse"))
   implementation(projects.okhttpTestingSupport)
   implementation(projects.okhttpTls)

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   implementation(Dependencies.assertj)
   implementation(projects.mockwebserver3)
   implementation(project(":mockwebserver"))
-  implementation(project(":okhttp-urlconnection"))
+  implementation(projects.okhttpUrlconnection)
   implementation(project(":mockwebserver3-junit4"))
   implementation(projects.mockwebserver3Junit5)
   implementation(Dependencies.bndResolve)

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   implementation(projects.okhttpTls)
   implementation(Dependencies.assertj)
   implementation(projects.mockwebserver3)
-  implementation(project(":mockwebserver"))
+  implementation(projects.mockwebserver)
   implementation(projects.okhttpUrlconnection)
   implementation(projects.mockwebserver3Junit4)
   implementation(projects.mockwebserver3Junit5)

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   implementation(project(":mockwebserver"))
   implementation(project(":okhttp-urlconnection"))
   implementation(project(":mockwebserver3-junit4"))
-  implementation(project(":mockwebserver3-junit5"))
+  implementation(projects.mockwebserver3Junit5)
   implementation(Dependencies.bndResolve)
   implementation(Dependencies.junit5Api)
   implementation(Dependencies.junit5JupiterParams)

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 
   implementation(projects.okhttp)
   implementation(projects.okhttpBrotli)
-  implementation(project(":okhttp-dnsoverhttps"))
+  implementation(projects.okhttpDnsoverhttps)
   implementation(projects.loggingInterceptor)
   implementation(project(":okhttp-sse"))
   implementation(projects.okhttpTestingSupport)

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   implementation(Dependencies.okioFakeFileSystem)
 
   implementation(projects.okhttp)
-  implementation(project(":okhttp-brotli"))
+  implementation(projects.okhttpBrotli)
   implementation(project(":okhttp-dnsoverhttps"))
   implementation(projects.loggingInterceptor)
   implementation(project(":okhttp-sse"))

--- a/okcurl/build.gradle.kts
+++ b/okcurl/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
   kapt(Dependencies.picocliCompiler)
 
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(Dependencies.junit5Api)
   testImplementation(Dependencies.assertj)
 }

--- a/okcurl/build.gradle.kts
+++ b/okcurl/build.gradle.kts
@@ -27,7 +27,7 @@ sourceSets {
 }
 
 dependencies {
-  api(project(":okhttp"))
+  api(projects.okhttp)
   api(project(":logging-interceptor"))
   implementation(Dependencies.picocli)
   implementation(Dependencies.guava)

--- a/okcurl/build.gradle.kts
+++ b/okcurl/build.gradle.kts
@@ -28,7 +28,7 @@ sourceSets {
 
 dependencies {
   api(projects.okhttp)
-  api(project(":logging-interceptor"))
+  api(projects.loggingInterceptor)
   implementation(Dependencies.picocli)
   implementation(Dependencies.guava)
 

--- a/okhttp-brotli/build.gradle.kts
+++ b/okhttp-brotli/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   api(Dependencies.brotli)
   compileOnly(Dependencies.jsr305)
 
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(Dependencies.conscrypt)
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)

--- a/okhttp-brotli/build.gradle.kts
+++ b/okhttp-brotli/build.gradle.kts
@@ -14,7 +14,7 @@ project.applyOsgi(
 )
 
 dependencies {
-  api(project(":okhttp"))
+  api(projects.okhttp)
   api(Dependencies.brotli)
   compileOnly(Dependencies.jsr305)
 

--- a/okhttp-dnsoverhttps/build.gradle.kts
+++ b/okhttp-dnsoverhttps/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   api(projects.okhttp)
   compileOnly(Dependencies.jsr305)
 
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":mockwebserver"))
   testImplementation(project(":mockwebserver3-junit5"))
   testImplementation(Dependencies.okioFakeFileSystem)

--- a/okhttp-dnsoverhttps/build.gradle.kts
+++ b/okhttp-dnsoverhttps/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   compileOnly(Dependencies.jsr305)
 
   testImplementation(projects.okhttpTestingSupport)
-  testImplementation(project(":mockwebserver"))
+  testImplementation(projects.mockwebserver)
   testImplementation(projects.mockwebserver3Junit5)
   testImplementation(Dependencies.okioFakeFileSystem)
   testImplementation(Dependencies.conscrypt)

--- a/okhttp-dnsoverhttps/build.gradle.kts
+++ b/okhttp-dnsoverhttps/build.gradle.kts
@@ -14,7 +14,7 @@ project.applyOsgi(
 )
 
 dependencies {
-  api(project(":okhttp"))
+  api(projects.okhttp)
   compileOnly(Dependencies.jsr305)
 
   testImplementation(project(":okhttp-testing-support"))

--- a/okhttp-dnsoverhttps/build.gradle.kts
+++ b/okhttp-dnsoverhttps/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
   testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":mockwebserver"))
-  testImplementation(project(":mockwebserver3-junit5"))
+  testImplementation(projects.mockwebserver3Junit5)
   testImplementation(Dependencies.okioFakeFileSystem)
   testImplementation(Dependencies.conscrypt)
   testImplementation(Dependencies.junit)

--- a/okhttp-hpacktests/build.gradle.kts
+++ b/okhttp-hpacktests/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   testImplementation(Dependencies.okio)
   testImplementation(Dependencies.moshi)
-  testImplementation(project(":okhttp"))
+  testImplementation(projects.okhttp)
   testImplementation(project(":okhttp-testing-support"))
   testImplementation(project(":mockwebserver"))
   testImplementation(Dependencies.junit)

--- a/okhttp-hpacktests/build.gradle.kts
+++ b/okhttp-hpacktests/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
   testImplementation(Dependencies.okio)
   testImplementation(Dependencies.moshi)
   testImplementation(projects.okhttp)
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":mockwebserver"))
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)

--- a/okhttp-hpacktests/build.gradle.kts
+++ b/okhttp-hpacktests/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
   testImplementation(Dependencies.moshi)
   testImplementation(projects.okhttp)
   testImplementation(projects.okhttpTestingSupport)
-  testImplementation(project(":mockwebserver"))
+  testImplementation(projects.mockwebserver)
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)
 }

--- a/okhttp-logging-interceptor/build.gradle.kts
+++ b/okhttp-logging-interceptor/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   testCompileOnly(Dependencies.jsr305)
   testImplementation(Dependencies.junit)
   testImplementation(project(":mockwebserver3"))
-  testImplementation(project(":mockwebserver3-junit5"))
+  testImplementation(projects.mockwebserver3Junit5)
   testImplementation(projects.okhttpTestingSupport)
   testImplementation(projects.okhttpTls)
   testImplementation(Dependencies.assertj)

--- a/okhttp-logging-interceptor/build.gradle.kts
+++ b/okhttp-logging-interceptor/build.gradle.kts
@@ -17,7 +17,7 @@ project.applyOsgi(
 )
 
 dependencies {
-  api(project(":okhttp"))
+  api(projects.okhttp)
   compileOnly(Dependencies.jsr305)
 
   testCompileOnly(Dependencies.jsr305)

--- a/okhttp-logging-interceptor/build.gradle.kts
+++ b/okhttp-logging-interceptor/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
   testImplementation(project(":mockwebserver3"))
   testImplementation(project(":mockwebserver3-junit5"))
   testImplementation(projects.okhttpTestingSupport)
-  testImplementation(project(":okhttp-tls"))
+  testImplementation(projects.okhttpTls)
   testImplementation(Dependencies.assertj)
 }
 

--- a/okhttp-logging-interceptor/build.gradle.kts
+++ b/okhttp-logging-interceptor/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   testImplementation(Dependencies.junit)
   testImplementation(project(":mockwebserver3"))
   testImplementation(project(":mockwebserver3-junit5"))
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":okhttp-tls"))
   testImplementation(Dependencies.assertj)
 }

--- a/okhttp-logging-interceptor/build.gradle.kts
+++ b/okhttp-logging-interceptor/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
   testCompileOnly(Dependencies.jsr305)
   testImplementation(Dependencies.junit)
-  testImplementation(project(":mockwebserver3"))
+  testImplementation(projects.mockwebserver3)
   testImplementation(projects.mockwebserver3Junit5)
   testImplementation(projects.okhttpTestingSupport)
   testImplementation(projects.okhttpTls)

--- a/okhttp-sse/build.gradle.kts
+++ b/okhttp-sse/build.gradle.kts
@@ -17,7 +17,7 @@ project.applyOsgi(
 )
 
 dependencies {
-  api(project(":okhttp"))
+  api(projects.okhttp)
   compileOnly(Dependencies.jsr305)
 
   testImplementation(project(":okhttp-testing-support"))

--- a/okhttp-sse/build.gradle.kts
+++ b/okhttp-sse/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   api(projects.okhttp)
   compileOnly(Dependencies.jsr305)
 
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":mockwebserver3"))
   testImplementation(project(":mockwebserver3-junit5"))
   testImplementation(Dependencies.junit)

--- a/okhttp-sse/build.gradle.kts
+++ b/okhttp-sse/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
   testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":mockwebserver3"))
-  testImplementation(project(":mockwebserver3-junit5"))
+  testImplementation(projects.mockwebserver3Junit5)
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)
   testCompileOnly(Dependencies.jsr305)

--- a/okhttp-sse/build.gradle.kts
+++ b/okhttp-sse/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   compileOnly(Dependencies.jsr305)
 
   testImplementation(projects.okhttpTestingSupport)
-  testImplementation(project(":mockwebserver3"))
+  testImplementation(projects.mockwebserver3)
   testImplementation(projects.mockwebserver3Junit5)
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)

--- a/okhttp-testing-support/build.gradle.kts
+++ b/okhttp-testing-support/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   api(projects.okhttp)
-  api(project(":okhttp-tls"))
+  api(projects.okhttpTls)
   api(Dependencies.assertj)
   api(Dependencies.bouncycastle)
   implementation(Dependencies.bouncycastlepkix)

--- a/okhttp-testing-support/build.gradle.kts
+++ b/okhttp-testing-support/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  api(project(":okhttp"))
+  api(projects.okhttp)
   api(project(":okhttp-tls"))
   api(Dependencies.assertj)
   api(Dependencies.bouncycastle)

--- a/okhttp-tls/build.gradle.kts
+++ b/okhttp-tls/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   compileOnly(Dependencies.jsr305)
   compileOnly(Dependencies.animalSniffer)
 
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":mockwebserver3-junit5"))
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)

--- a/okhttp-tls/build.gradle.kts
+++ b/okhttp-tls/build.gradle.kts
@@ -19,7 +19,7 @@ project.applyOsgi(
 
 dependencies {
   api(Dependencies.okio)
-  implementation(project(":okhttp"))
+  implementation(projects.okhttp)
   compileOnly(Dependencies.jsr305)
   compileOnly(Dependencies.animalSniffer)
 

--- a/okhttp-tls/build.gradle.kts
+++ b/okhttp-tls/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   compileOnly(Dependencies.animalSniffer)
 
   testImplementation(projects.okhttpTestingSupport)
-  testImplementation(project(":mockwebserver3-junit5"))
+  testImplementation(projects.mockwebserver3Junit5)
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)
 }

--- a/okhttp-urlconnection/build.gradle.kts
+++ b/okhttp-urlconnection/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   compileOnly(Dependencies.jsr305)
   compileOnly(Dependencies.animalSniffer)
 
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(project(":okhttp-tls"))
   testImplementation(project(":mockwebserver"))
   testImplementation(Dependencies.junit)

--- a/okhttp-urlconnection/build.gradle.kts
+++ b/okhttp-urlconnection/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   compileOnly(Dependencies.animalSniffer)
 
   testImplementation(projects.okhttpTestingSupport)
-  testImplementation(project(":okhttp-tls"))
+  testImplementation(projects.okhttpTls)
   testImplementation(project(":mockwebserver"))
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)

--- a/okhttp-urlconnection/build.gradle.kts
+++ b/okhttp-urlconnection/build.gradle.kts
@@ -10,17 +10,15 @@ plugins {
   id("me.champeau.gradle.japicmp")
 }
 
-val mainProj: Project by lazy { project(":okhttp") }
-
 project.applyOsgi(
-  "Fragment-Host: com.squareup.okhttp3; bundle-version=\"\${range;[==,+);\${version_cleanup;${mainProj.version}}}\"",
+  "Fragment-Host: com.squareup.okhttp3; bundle-version=\"\${range;[==,+);\${version_cleanup;${projects.okhttp.version}}}\"",
   "Automatic-Module-Name: okhttp3.urlconnection",
   "Bundle-SymbolicName: com.squareup.okhttp3.urlconnection",
   "-removeheaders: Private-Package"
 )
 
 dependencies {
-  api(mainProj)
+  api(projects.okhttp)
   compileOnly(Dependencies.jsr305)
   compileOnly(Dependencies.animalSniffer)
 

--- a/okhttp-urlconnection/build.gradle.kts
+++ b/okhttp-urlconnection/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 
   testImplementation(projects.okhttpTestingSupport)
   testImplementation(projects.okhttpTls)
-  testImplementation(project(":mockwebserver"))
+  testImplementation(projects.mockwebserver)
   testImplementation(Dependencies.junit)
   testImplementation(Dependencies.assertj)
 }

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -89,7 +89,7 @@ kotlin {
         implementation(projects.mockwebserver3Junit4)
         implementation(projects.mockwebserver3Junit5)
         implementation(projects.mockwebserver)
-        implementation(project(":logging-interceptor"))
+        implementation(projects.loggingInterceptor)
         implementation(project(":okhttp-brotli"))
         implementation(project(":okhttp-dnsoverhttps"))
         implementation(project(":okhttp-sse"))

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -90,7 +90,7 @@ kotlin {
         implementation(projects.mockwebserver3Junit5)
         implementation(projects.mockwebserver)
         implementation(projects.loggingInterceptor)
-        implementation(project(":okhttp-brotli"))
+        implementation(projects.okhttpBrotli)
         implementation(project(":okhttp-dnsoverhttps"))
         implementation(project(":okhttp-sse"))
         implementation(Dependencies.okioFakeFileSystem)

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -84,7 +84,7 @@ kotlin {
         dependsOn(commonTest)
         implementation(projects.okhttpTestingSupport)
         implementation(projects.okhttpTls)
-        implementation(project(":okhttp-urlconnection"))
+        implementation(projects.okhttpUrlconnection)
         implementation(projects.mockwebserver3)
         implementation(project(":mockwebserver3-junit4"))
         implementation(projects.mockwebserver3Junit5)

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -91,7 +91,7 @@ kotlin {
         implementation(projects.mockwebserver)
         implementation(projects.loggingInterceptor)
         implementation(projects.okhttpBrotli)
-        implementation(project(":okhttp-dnsoverhttps"))
+        implementation(projects.okhttpDnsoverhttps)
         implementation(project(":okhttp-sse"))
         implementation(Dependencies.okioFakeFileSystem)
         implementation(Dependencies.conscrypt)

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -85,7 +85,7 @@ kotlin {
         implementation(projects.okhttpTestingSupport)
         implementation(projects.okhttpTls)
         implementation(project(":okhttp-urlconnection"))
-        implementation(project(":mockwebserver3"))
+        implementation(projects.mockwebserver3)
         implementation(project(":mockwebserver3-junit4"))
         implementation(projects.mockwebserver3Junit5)
         implementation(project(":mockwebserver"))

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -88,7 +88,7 @@ kotlin {
         implementation(projects.mockwebserver3)
         implementation(projects.mockwebserver3Junit4)
         implementation(projects.mockwebserver3Junit5)
-        implementation(project(":mockwebserver"))
+        implementation(projects.mockwebserver)
         implementation(project(":logging-interceptor"))
         implementation(project(":okhttp-brotli"))
         implementation(project(":okhttp-dnsoverhttps"))

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -83,7 +83,7 @@ kotlin {
       dependencies {
         dependsOn(commonTest)
         implementation(projects.okhttpTestingSupport)
-        implementation(project(":okhttp-tls"))
+        implementation(projects.okhttpTls)
         implementation(project(":okhttp-urlconnection"))
         implementation(project(":mockwebserver3"))
         implementation(project(":mockwebserver3-junit4"))

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -87,7 +87,7 @@ kotlin {
         implementation(project(":okhttp-urlconnection"))
         implementation(project(":mockwebserver3"))
         implementation(project(":mockwebserver3-junit4"))
-        implementation(project(":mockwebserver3-junit5"))
+        implementation(projects.mockwebserver3Junit5)
         implementation(project(":mockwebserver"))
         implementation(project(":logging-interceptor"))
         implementation(project(":okhttp-brotli"))

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -92,7 +92,7 @@ kotlin {
         implementation(projects.loggingInterceptor)
         implementation(projects.okhttpBrotli)
         implementation(projects.okhttpDnsoverhttps)
-        implementation(project(":okhttp-sse"))
+        implementation(projects.okhttpSse)
         implementation(Dependencies.okioFakeFileSystem)
         implementation(Dependencies.conscrypt)
         implementation(Dependencies.junit)

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -82,7 +82,7 @@ kotlin {
     getByName("jvmTest") {
       dependencies {
         dependsOn(commonTest)
-        implementation(project(":okhttp-testing-support"))
+        implementation(projects.okhttpTestingSupport)
         implementation(project(":okhttp-tls"))
         implementation(project(":okhttp-urlconnection"))
         implementation(project(":mockwebserver3"))

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -86,7 +86,7 @@ kotlin {
         implementation(projects.okhttpTls)
         implementation(projects.okhttpUrlconnection)
         implementation(projects.mockwebserver3)
-        implementation(project(":mockwebserver3-junit4"))
+        implementation(projects.mockwebserver3Junit4)
         implementation(projects.mockwebserver3Junit5)
         implementation(project(":mockwebserver"))
         implementation(project(":logging-interceptor"))

--- a/samples/compare/build.gradle.kts
+++ b/samples/compare/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
   testImplementation(projects.okhttp)
   testImplementation(project(":mockwebserver3"))
   testRuntimeOnly(project(":mockwebserver3-junit5"))
-  testImplementation(project(":okhttp-tls"))
+  testImplementation(projects.okhttpTls)
   testImplementation(projects.okhttpTestingSupport)
   testImplementation(Dependencies.httpclient5)
   testImplementation(Dependencies.jettyClient)

--- a/samples/compare/build.gradle.kts
+++ b/samples/compare/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  testImplementation(project(":okhttp"))
+  testImplementation(projects.okhttp)
   testImplementation(project(":mockwebserver3"))
   testRuntimeOnly(project(":mockwebserver3-junit5"))
   testImplementation(project(":okhttp-tls"))

--- a/samples/compare/build.gradle.kts
+++ b/samples/compare/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
   testImplementation(project(":mockwebserver3"))
   testRuntimeOnly(project(":mockwebserver3-junit5"))
   testImplementation(project(":okhttp-tls"))
-  testImplementation(project(":okhttp-testing-support"))
+  testImplementation(projects.okhttpTestingSupport)
   testImplementation(Dependencies.httpclient5)
   testImplementation(Dependencies.jettyClient)
   testImplementation(Dependencies.junit)

--- a/samples/compare/build.gradle.kts
+++ b/samples/compare/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   testImplementation(projects.okhttp)
   testImplementation(project(":mockwebserver3"))
-  testRuntimeOnly(project(":mockwebserver3-junit5"))
+  testRuntimeOnly(projects.mockwebserver3Junit5)
   testImplementation(projects.okhttpTls)
   testImplementation(projects.okhttpTestingSupport)
   testImplementation(Dependencies.httpclient5)

--- a/samples/compare/build.gradle.kts
+++ b/samples/compare/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
   testImplementation(projects.okhttp)
-  testImplementation(project(":mockwebserver3"))
+  testImplementation(projects.mockwebserver3)
   testRuntimeOnly(projects.mockwebserver3Junit5)
   testImplementation(projects.okhttpTls)
   testImplementation(projects.okhttpTestingSupport)

--- a/samples/crawler/build.gradle.kts
+++ b/samples/crawler/build.gradle.kts
@@ -8,7 +8,7 @@ application {
 }
 
 dependencies {
-  implementation(project(":okhttp"))
+  implementation(projects.okhttp)
   implementation(Dependencies.jsoup)
 }
 

--- a/samples/guide/build.gradle.kts
+++ b/samples/guide/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   implementation(projects.okhttp)
-  implementation(project(":mockwebserver"))
+  implementation(projects.mockwebserver)
   implementation(projects.okhttpTestingSupport)
   implementation(projects.okhttpTls)
   implementation(Dependencies.animalSniffer)

--- a/samples/guide/build.gradle.kts
+++ b/samples/guide/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
   implementation(projects.okhttp)
   implementation(project(":mockwebserver"))
   implementation(projects.okhttpTestingSupport)
-  implementation(project(":okhttp-tls"))
+  implementation(projects.okhttpTls)
   implementation(Dependencies.animalSniffer)
   implementation(Dependencies.moshi)
   kapt(Dependencies.moshiCompiler)

--- a/samples/guide/build.gradle.kts
+++ b/samples/guide/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 dependencies {
   implementation(projects.okhttp)
   implementation(project(":mockwebserver"))
-  implementation(project(":okhttp-testing-support"))
+  implementation(projects.okhttpTestingSupport)
   implementation(project(":okhttp-tls"))
   implementation(Dependencies.animalSniffer)
   implementation(Dependencies.moshi)

--- a/samples/guide/build.gradle.kts
+++ b/samples/guide/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":okhttp"))
+  implementation(projects.okhttp)
   implementation(project(":mockwebserver"))
   implementation(project(":okhttp-testing-support"))
   implementation(project(":okhttp-tls"))

--- a/samples/simple-client/build.gradle.kts
+++ b/samples/simple-client/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":okhttp"))
+  implementation(projects.okhttp)
   implementation(Dependencies.moshi)
 }

--- a/samples/slack/build.gradle.kts
+++ b/samples/slack/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":mockwebserver"))
+  implementation(projects.mockwebserver)
   implementation(Dependencies.moshi)
 }

--- a/samples/static-server/build.gradle.kts
+++ b/samples/static-server/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.jar {
 }
 
 dependencies {
-  implementation(project(":mockwebserver"))
+  implementation(projects.mockwebserver)
 }
 
 tasks.shadowJar {

--- a/samples/unixdomainsockets/build.gradle.kts
+++ b/samples/unixdomainsockets/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":okhttp"))
+  implementation(projects.okhttp)
   implementation(project(":mockwebserver"))
   implementation(Dependencies.jnrUnixsocket)
 }

--- a/samples/unixdomainsockets/build.gradle.kts
+++ b/samples/unixdomainsockets/build.gradle.kts
@@ -4,6 +4,6 @@ plugins {
 
 dependencies {
   implementation(projects.okhttp)
-  implementation(project(":mockwebserver"))
+  implementation(projects.mockwebserver)
   implementation(Dependencies.jnrUnixsocket)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,3 +40,5 @@ include(":samples:simple-client")
 include(":samples:slack")
 include(":samples:static-server")
 include(":samples:unixdomainsockets")
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
https://docs.gradle.org/7.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors

Ref detekt/detekt/pull/3742