### PR TITLE
Move assertk to tests dependencies

### DIFF
--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -41,13 +41,13 @@ kotlin {
       kotlin.srcDir("$buildDir/generated/sources/kotlinTemplates")
       dependencies {
         api(Dependencies.okio)
-        api(Dependencies.assertk)
       }
     }
     val commonTest by getting {
       dependencies {
         implementation(Dependencies.kotlinTest)
         implementation(Dependencies.kotlinTestAnnotations)
+        implementation(Dependencies.assertk)
       }
     }
     val nonJvmMain = create("nonJvmMain") {


### PR DESCRIPTION
Assertk was previously being brought in as a runtime dependency. It's only used in tests, so let's move it over.