### PR TITLE
Keep 'compileKotlin' and 'compileJava' task use the same JVM target 11

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-dsl`
@@ -20,6 +21,10 @@ plugins {
 
 repositories {
     mavenCentral()
+}
+
+tasks.withType<KotlinCompile> {
+  kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
 }
 
 dependencies {


### PR DESCRIPTION
Fix a compile warning.
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/7965577/154425595-d4cbac26-c658-4540-a5a7-951aaf0e788c.png">

The warning log can be found in https://github.com/square/okhttp/runs/5214030818?check_suite_focus=true