### PR TITLE
Arm64 Fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 import java.net.URL
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferExtension
 
@@ -244,4 +245,8 @@ subprojects {
 
 tasks.wrapper {
   distributionType = Wrapper.DistributionType.ALL
+}
+
+rootProject.plugins.withType(NodeJsRootPlugin::class.java) {
+  rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.0.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -247,6 +247,8 @@ tasks.wrapper {
   distributionType = Wrapper.DistributionType.ALL
 }
 
+// Fix until 1.6.20 https://youtrack.jetbrains.com/issue/KT-49109
 rootProject.plugins.withType(NodeJsRootPlugin::class.java) {
-  rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.0.0"
+  rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion =
+    "16.13.0"
 }

--- a/samples/compare/src/test/kotlin/okhttp3/compare/ApacheHttpClientTest.kt
+++ b/samples/compare/src/test/kotlin/okhttp3/compare/ApacheHttpClientTest.kt
@@ -54,6 +54,6 @@ class ApacheHttpClientTest {
     assertThat(recorded.getHeader("Accept")).isEqualTo("text/plain")
     assertThat(recorded.getHeader("Accept-Encoding")).isEqualTo("gzip, x-gzip, deflate")
     assertThat(recorded.getHeader("Connection")).isEqualTo("keep-alive")
-    assertThat(recorded.getHeader("User-Agent")).startsWith("Apache-HttpClient/5.0")
+    assertThat(recorded.getHeader("User-Agent")).startsWith("Apache-HttpClient/")
   }
 }

--- a/samples/guide/build.gradle.kts
+++ b/samples/guide/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(14))
+    languageVersion.set(JavaLanguageVersion.of(17))
   }
 }
 


### PR DESCRIPTION
Installing on new laptop.

Node 14 missing arm64 https://youtrack.jetbrains.com/issue/KT-49109

JDK 14 doesn't have a downloadable build, so bumping to 17.