### PR TITLE
Get strict about delaying new connect launches

### DIFF
--- a/okhttp/src/jvmTest/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
@@ -58,9 +58,11 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
+    assertEvents(
+      "take plan 0",
+    )
+
     taskFaker.assertNoMoreTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isNull()
   }
 
   @Test
@@ -74,15 +76,17 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(240.ms)
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 0 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 0 TLS connected")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 0 TCP connected",
+      "plan 0 TLS connecting...",
+      "plan 0 TLS connected",
+    )
   }
 
   @Test
@@ -98,25 +102,29 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(250.ms)
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 1",
+      "plan 1 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(260.ms)
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 1 cancel")
-    assertThat(takeEvent()).isEqualTo("plan 0 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 0 TLS connected")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 0 TCP connected",
+      "plan 1 cancel",
+      "plan 0 TLS connecting...",
+      "plan 0 TLS connected",
+    )
 
     taskFaker.advanceUntil(270.ms)
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connect canceled")
-    assertThat(routePlanner.events.poll()).isNull()
+    assertEvents(
+      "plan 1 TCP connect canceled",
+    )
   }
 
   @Test
@@ -132,18 +140,21 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(routePlanner.events.poll()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(routePlanner.events.poll()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(250.ms)
-    assertThat(routePlanner.events.poll()).isEqualTo("take plan 1")
-    assertThat(routePlanner.events.poll()).isEqualTo("plan 0 cancel")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 1",
+      "plan 0 cancel",
+    )
 
     taskFaker.advanceUntil(260.ms)
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect canceled")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 0 TCP connect canceled",
+    )
   }
 
   @Test
@@ -159,25 +170,29 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(250.ms)
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 1",
+      "plan 1 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(260.ms)
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 0 cancel")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connected")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 1 TCP connected",
+      "plan 0 cancel",
+      "plan 1 TLS connecting...",
+      "plan 1 TLS connected",
+    )
 
     taskFaker.advanceUntil(270.ms)
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect canceled")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 0 TCP connect canceled",
+    )
   }
 
   @Test
@@ -195,28 +210,33 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(routePlanner.events.poll()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(routePlanner.events.poll()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(250.ms)
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(routePlanner.events.poll()).isNull()
+    assertEvents(
+      "take plan 1",
+      "plan 1 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(500.ms)
-    assertThat(takeEvent()).isEqualTo("take plan 2")
-    assertThat(takeEvent()).isEqualTo("plan 0 cancel")
-    assertThat(routePlanner.events.poll()).isEqualTo("plan 1 cancel")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 2",
+      "plan 0 cancel",
+      "plan 1 cancel",
+    )
 
     taskFaker.advanceUntil(510.ms)
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connect canceled")
-    assertThat(routePlanner.events.poll()).isNull()
+    assertEvents(
+      "plan 1 TCP connect canceled",
+    )
 
     taskFaker.advanceUntil(520.ms)
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect canceled")
-    assertThat(routePlanner.events.poll()).isNull()
+    assertEvents(
+      "plan 0 TCP connect canceled",
+    )
   }
 
   @Test
@@ -234,10 +254,12 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
+    assertEvents(
+      "take plan 0",
+      "take plan 1",
+    )
+
     taskFaker.assertNoMoreTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isNull()
   }
 
   @Test
@@ -255,12 +277,14 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+      "plan 0 TCP connect failed",
+      "tracking failure: java.io.IOException: boom!",
+    )
+
     taskFaker.assertNoMoreTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect failed")
-    assertThat(takeEvent()).isEqualTo("tracking failure: java.io.IOException: boom!")
-    assertThat(takeEvent()).isNull()
   }
 
   @Test
@@ -276,13 +300,15 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+      "plan 0 TCP connect failed",
+      "tracking failure: java.io.IOException: boom!",
+      "take plan 1",
+    )
+
     taskFaker.assertNoMoreTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect failed")
-    assertThat(takeEvent()).isEqualTo("tracking failure: java.io.IOException: boom!")
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isNull()
   }
 
   @Test
@@ -303,16 +329,18 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+      "plan 0 TCP connect failed",
+      "tracking failure: java.io.IOException: boom 0!",
+      "take plan 1",
+      "plan 1 TCP connecting...",
+      "plan 1 TCP connect failed",
+      "tracking failure: java.io.IOException: boom 1!",
+    )
+
     taskFaker.assertNoMoreTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect failed")
-    assertThat(takeEvent()).isEqualTo("tracking failure: java.io.IOException: boom 0!")
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connect failed")
-    assertThat(takeEvent()).isEqualTo("tracking failure: java.io.IOException: boom 1!")
-    assertThat(takeEvent()).isNull()
   }
 
   @Test
@@ -331,11 +359,13 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+      "plan 0 TCP connect failed",
+    )
+
     taskFaker.assertNoMoreTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect failed")
-    assertThat(takeEvent()).isNull()
   }
 
   @Test
@@ -353,10 +383,12 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
+    assertEvents(
+      "take plan 0",
+      "tracking failure: ${UnknownServiceException("boom!")}",
+    )
+
     taskFaker.assertNoMoreTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("tracking failure: ${UnknownServiceException("boom!")}")
-    assertThat(takeEvent()).isNull()
   }
 
   @Test
@@ -371,15 +403,17 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
+    assertEvents(
+      "take plan 0",
+      "tracking failure: ${UnknownServiceException("boom!")}",
+      "take plan 1",
+      "plan 1 TCP connecting...",
+      "plan 1 TCP connected",
+      "plan 1 TLS connecting...",
+      "plan 1 TLS connected",
+    )
+
     taskFaker.assertNoMoreTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("tracking failure: ${UnknownServiceException("boom!")}")
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connected")
-    assertThat(takeEvent()).isNull()
   }
 
   @Test
@@ -399,33 +433,36 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(250.ms)
-    taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 1",
+      "plan 1 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(260.ms)
-    taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 0 cancel")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connect failed")
-    assertThat(takeEvent()).isEqualTo("tracking failure: java.io.IOException: boom!")
-    assertThat(takeEvent()).isEqualTo("plan 2 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 2 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 2 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 2 TLS connected")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 1 TCP connected",
+      "plan 0 cancel",
+      "plan 1 TLS connecting...",
+      "plan 1 TLS connect failed",
+      "tracking failure: java.io.IOException: boom!",
+      "plan 2 TCP connecting...",
+      "plan 2 TCP connected",
+      "plan 2 TLS connecting...",
+      "plan 2 TLS connected",
+    )
 
     taskFaker.advanceUntil(270.ms)
-    taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect canceled")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 0 TCP connect canceled",
+    )
+
+    taskFaker.assertNoMoreTasks()
   }
 
   @Test
@@ -442,30 +479,35 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(250.ms)
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 1",
+      "plan 1 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(260.ms)
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 0 cancel")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 1 TCP connected",
+      "plan 0 cancel",
+      "plan 1 TLS connecting...",
+    )
 
     taskFaker.advanceUntil(270.ms)
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect canceled")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 0 TCP connect canceled",
+    )
 
     taskFaker.advanceUntil(280.ms)
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connected")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 1 TLS connected",
+    )
 
-    assertThat(routePlanner.events.poll()).isNull()
+    taskFaker.assertNoMoreTasks()
   }
 
   @Test
@@ -479,14 +521,17 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 0 needs follow-up")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connected")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+      "plan 0 needs follow-up",
+      "plan 1 TCP connecting...",
+      "plan 1 TCP connected",
+      "plan 1 TLS connecting...",
+      "plan 1 TLS connected",
+    )
+
+    taskFaker.assertNoMoreTasks()
   }
 
   @Test
@@ -500,16 +545,19 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 0 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 0 needs follow-up")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connected")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+      "plan 0 TCP connected",
+      "plan 0 TLS connecting...",
+      "plan 0 needs follow-up",
+      "plan 1 TCP connecting...",
+      "plan 1 TCP connected",
+      "plan 1 TLS connecting...",
+      "plan 1 TLS connected",
+    )
+
+    taskFaker.assertNoMoreTasks()
   }
 
   /**
@@ -547,52 +595,143 @@ internal class FastFallbackExchangeFinderTest {
     }
 
     taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 0")
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(250.ms)
-    taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("take plan 1")
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 1",
+      "plan 1 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(260.ms)
-    taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("plan 1 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 0 cancel")
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 1 TCP connected",
+      "plan 0 cancel",
+      "plan 1 TLS connecting...",
+    )
 
     taskFaker.advanceUntil(270.ms)
-    taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("plan 1 TLS connect failed")
-    assertThat(takeEvent()).isEqualTo("tracking failure: ${IOException("boom!")}")
-    assertThat(takeEvent()).isEqualTo("plan 2 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 1 TLS connect failed",
+      "tracking failure: ${IOException("boom!")}",
+      "plan 2 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(280.ms)
-    taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("plan 0 TCP connect canceled")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 0 TCP connect canceled",
+    )
 
     taskFaker.advanceUntil(520.ms)
-    taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("plan 3 TCP connecting...")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 3 TCP connecting...",
+    )
 
     taskFaker.advanceUntil(530.ms)
-    taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("plan 3 TCP connected")
-    assertThat(takeEvent()).isEqualTo("plan 2 cancel")
-    assertThat(takeEvent()).isEqualTo("plan 3 TLS connecting...")
-    assertThat(takeEvent()).isEqualTo("plan 3 TLS connected")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "plan 3 TCP connected",
+      "plan 2 cancel",
+      "plan 3 TLS connecting...",
+      "plan 3 TLS connected",
+    )
 
     taskFaker.advanceUntil(540.ms)
+    assertEvents(
+      "plan 2 TCP connect canceled",
+    )
+
+    taskFaker.assertNoMoreTasks()
+  }
+
+  /**
+   * This test puts several connections in flight that all fail at approximately the same time. It
+   * confirms the fast fallback implements these invariants:
+   *
+   *  * if there's no TCP connect in flight, start one.
+   *  * don't start a new TCP connect within 250 ms of the previous TCP connect.
+   */
+  @Test
+  fun minimumDelayEnforcedBetweenConnects() {
+    val plan0 = routePlanner.addPlan()
+    plan0.tcpConnectDelayNanos = 510.ms
+    plan0.tcpConnectThrowable = IOException("boom!")
+    val plan1 = routePlanner.addPlan()
+    plan1.tcpConnectDelayNanos = 270.ms // Connect fail at time = 520 ms.
+    plan1.tcpConnectThrowable = IOException("boom!")
+    val plan2 = routePlanner.addPlan()
+    plan2.tcpConnectDelayNanos = 30.ms // Connect fail at time = 530 ms.
+    plan2.tcpConnectThrowable = IOException("boom!")
+    val plan3 = routePlanner.addPlan()
+    plan3.tcpConnectDelayNanos = 270.ms // Connect at time 800 ms.
+    val plan4 = routePlanner.addPlan()
+    plan4.tcpConnectDelayNanos = 10.ms // Connect at time 790 ms.
+
+    taskRunner.newQueue().execute("connect") {
+      val result0 = finder.find()
+      assertThat(result0).isEqualTo(plan4.connection)
+    }
+
     taskFaker.runTasks()
-    assertThat(takeEvent()).isEqualTo("plan 2 TCP connect canceled")
-    assertThat(takeEvent()).isNull()
+    assertEvents(
+      "take plan 0",
+      "plan 0 TCP connecting...",
+    )
+
+    taskFaker.advanceUntil(250.ms)
+    assertEvents(
+      "take plan 1",
+      "plan 1 TCP connecting...",
+    )
+
+    taskFaker.advanceUntil(500.ms)
+    assertEvents(
+      "take plan 2",
+      "plan 2 TCP connecting...",
+    )
+
+    taskFaker.advanceUntil(510.ms)
+    assertEvents(
+      "plan 0 TCP connect failed",
+      "tracking failure: ${IOException("boom!")}",
+    )
+
+    taskFaker.advanceUntil(520.ms)
+    assertEvents(
+      "plan 1 TCP connect failed",
+      "tracking failure: ${IOException("boom!")}",
+    )
+
+    taskFaker.advanceUntil(530.ms)
+    assertEvents(
+      "plan 2 TCP connect failed",
+      "tracking failure: ${IOException("boom!")}",
+      "take plan 3",
+      "plan 3 TCP connecting...",
+    )
+
+    taskFaker.advanceUntil(780.ms)
+    assertEvents(
+      "take plan 4",
+      "plan 4 TCP connecting...",
+    )
+
+    taskFaker.advanceUntil(790.ms)
+    assertEvents(
+      "plan 4 TCP connected",
+      "plan 3 cancel",
+      "plan 4 TLS connecting...",
+      "plan 4 TLS connected",
+    )
+
+    taskFaker.advanceUntil(800.ms)
+    assertEvents(
+      "plan 3 TCP connect canceled",
+    )
+
+    taskFaker.assertNoMoreTasks()
   }
 
   @Test
@@ -605,7 +744,10 @@ internal class FastFallbackExchangeFinderTest {
     // TODO(jwilson): we call resetStatistics() in the wrong phrase for racy connects.
   }
 
-  private fun takeEvent() = routePlanner.events.poll()
+  private fun assertEvents(vararg expected: String) {
+    val actual = generateSequence { routePlanner.events.poll() }.toList()
+    assertThat(actual).containsExactly(*expected)
+  }
 
   private val Int.ms: Long
     get() = this * 1_000_000L


### PR DESCRIPTION
We had a bug where we'd attempt multiple new connects if previous connects
failed near-simultaneously.