### PR TITLE
Stop tracking failures in RoutePlanner

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/Exchange.kt
@@ -40,7 +40,7 @@ import okio.buffer
 class Exchange(
   internal val call: RealCall,
   internal val eventListener: EventListener,
-  internal val finder: RoutePlanner,
+  internal val finder: ExchangeFinder,
   private val codec: ExchangeCodec
 ) {
   /** True if the request body need not complete before the response body starts. */
@@ -55,7 +55,7 @@ class Exchange(
     get() = codec.carrier as? RealConnection ?: error("no connection for CONNECT tunnels")
 
   internal val isCoalescedConnection: Boolean
-    get() = finder.address.url.host != codec.carrier.route.address.url.host
+    get() = finder.routePlanner.address.url.host != codec.carrier.route.address.url.host
 
   @Throws(IOException::class)
   fun writeRequestHeaders(request: Request) {
@@ -169,7 +169,6 @@ class Exchange(
 
   private fun trackFailure(e: IOException) {
     hasFailure = true
-    finder.trackFailure(e)
     codec.carrier.trackFailure(call, e)
   }
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RoutePlanner.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RoutePlanner.kt
@@ -51,13 +51,13 @@ interface RoutePlanner {
   @Throws(IOException::class)
   fun plan(): Plan
 
-  fun trackFailure(e: IOException)
-
-  /** Returns true if this planner has received any failures. */
-  fun hasFailure(): Boolean
-
-  /** Returns true if this planner has more routes to try. */
-  fun hasMoreRoutes(): Boolean
+  /**
+   * Returns true if there's more route plans to try.
+   *
+   * @param failedConnection an optional connection that was resulted in a failure. If the failure
+   *     is recoverable, the connection's route may be recovered for the retry.
+   */
+  fun hasNext(failedConnection: RealConnection? = null): Boolean
 
   /**
    * Returns true if the host and port are unchanged from when this was created. This is used to

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/SequentialExchangeFinder.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/SequentialExchangeFinder.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.connection
+
+import java.io.IOException
+
+/** Attempt routes one at a time until one connects. */
+internal class SequentialExchangeFinder(
+  override val routePlanner: RoutePlanner
+) : ExchangeFinder {
+  override fun find(): RealConnection {
+    var firstException: IOException? = null
+    var queuedPlan: RoutePlanner.Plan? = null
+    while (true) {
+      if (routePlanner.isCanceled()) throw IOException("Canceled")
+
+      try {
+        val plan = when {
+          queuedPlan != null -> {
+            val result = queuedPlan
+            queuedPlan = null
+            result
+          }
+          else -> routePlanner.plan()
+        }
+
+        if (!plan.isReady) {
+          val tcpConnectResult = plan.connectTcp()
+          val connectResult = when {
+            tcpConnectResult.isSuccess -> plan.connectTlsEtc()
+            else -> tcpConnectResult
+          }
+
+          val (_, nextPlan, failure) = connectResult
+
+          queuedPlan = nextPlan
+          if (failure != null) throw failure
+          if (nextPlan != null) continue
+        }
+        return plan.handleSuccess()
+      } catch (e: IOException) {
+        if (firstException == null) {
+          firstException = e
+        } else {
+          firstException.addSuppressed(e)
+        }
+        if (queuedPlan == null && !routePlanner.hasNext()) {
+          throw firstException
+        }
+      }
+    }
+  }
+}

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RealInterceptorChain.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RealInterceptorChain.kt
@@ -93,7 +93,7 @@ class RealInterceptorChain(
     calls++
 
     if (exchange != null) {
-      check(exchange.finder.sameHostAndPort(request.url)) {
+      check(exchange.finder.routePlanner.sameHostAndPort(request.url)) {
         "network interceptor ${interceptors[index - 1]} must retain the same host and port"
       }
       check(calls == 1) {

--- a/okhttp/src/jvmTest/java/okhttp3/FakeRoutePlanner.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/FakeRoutePlanner.kt
@@ -19,6 +19,7 @@ import java.io.Closeable
 import java.io.IOException
 import java.util.concurrent.LinkedBlockingDeque
 import okhttp3.internal.concurrent.TaskFaker
+import okhttp3.internal.connection.RealConnection
 import okhttp3.internal.connection.RoutePlanner
 import okhttp3.internal.connection.RoutePlanner.ConnectResult
 
@@ -35,7 +36,6 @@ class FakeRoutePlanner(
 
   val events = LinkedBlockingDeque<String>()
   var canceled = false
-  var hasFailure = false
   private var nextPlanId = 0
   private var nextPlanIndex = 0
   private val plans = mutableListOf<FakePlan>()
@@ -63,14 +63,7 @@ class FakeRoutePlanner(
     return result
   }
 
-  override fun trackFailure(e: IOException) {
-    events += "tracking failure: $e"
-    hasFailure = true
-  }
-
-  override fun hasFailure() = hasFailure
-
-  override fun hasMoreRoutes(): Boolean {
+  override fun hasNext(failedConnection: RealConnection?): Boolean {
     return nextPlanIndex < plans.size
   }
 


### PR DESCRIPTION
This model doesn't work now that we're pulling routes concurrently.
Instead rely on the exchange and connection to track failures.