### PR TITLE
Don't leak a connection that's canceled before it connects

### DIFF
--- a/docs/features/connections.md
+++ b/docs/features/connections.md
@@ -16,9 +16,9 @@ They're also concrete: each URL identifies a specific path (like `/square/okhttp
 
 ### [Addresses](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-address/)
 
-Addresses specify a webserver (like `github.com`) and all of the **static** configuration necessary to connect to that server: the port number, HTTPS settings, and preferred network protocols (like HTTP/2 or SPDY).
+Addresses specify a webserver (like `github.com`) and all of the **static** configuration necessary to connect to that server: the port number, HTTPS settings, and preferred network protocols (like HTTP/2).
 
-URLs that share the same address may also share the same underlying TCP socket connection. Sharing a connection has substantial performance benefits: lower latency, higher throughput (due to [TCP slow start](https://www.igvita.com/2011/10/20/faster-web-vs-tcp-slow-start/)) and conserved battery. OkHttp uses a [ConnectionPool](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-connection-pool/) that automatically reuses HTTP/1.x connections and multiplexes HTTP/2 and SPDY connections.
+URLs that share the same address may also share the same underlying TCP socket connection. Sharing a connection has substantial performance benefits: lower latency, higher throughput (due to [TCP slow start](https://www.igvita.com/2011/10/20/faster-web-vs-tcp-slow-start/)) and conserved battery. OkHttp uses a [ConnectionPool](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-connection-pool/) that automatically reuses HTTP/1.x connections and multiplexes HTTP/2 connections.
 
 In OkHttp some fields of the address come from the URL (scheme, hostname, port) and the rest come from the [OkHttpClient](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/).
 
@@ -28,6 +28,11 @@ Routes supply the **dynamic** information necessary to actually connect to a web
 
 There may be many routes for a single address. For example, a webserver that is hosted in multiple datacenters may yield multiple IP addresses in its DNS response.
 
+In limited situations OkHttp will retry a route if connecting fails:
+
+ * When making an HTTPS connection through an HTTP proxy, the proxy may issue an authentication challenge. OkHttp will call the proxy [authenticator](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-authenticator/) and try again.
+ * When making TLS connections with multiple [connection specs](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-connection-spec/), these are attempted in sequence until the TLS handshake succeeds.
+
 ### [Connections](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-connection/)
 
 When you request a URL with OkHttp, here's what it does:
@@ -35,9 +40,23 @@ When you request a URL with OkHttp, here's what it does:
  1. It uses the URL and configured OkHttpClient to create an **address**. This address specifies how we'll connect to the webserver.
  2. It attempts to retrieve a connection with that address from the **connection pool**.
  3. If it doesn't find a connection in the pool, it selects a **route** to attempt. This usually means making a DNS request to get the server's IP addresses. It then selects a TLS version and proxy server if necessary.
- 4. If it's a new route, it connects by building either a direct socket connection, a TLS tunnel (for HTTPS over an HTTP proxy), or a direct TLS connection. It does TLS handshakes as necessary.
+ 4. If it's a new route, it connects by building either a direct socket connection, a TLS tunnel (for HTTPS over an HTTP proxy), or a direct TLS connection. It does TLS handshakes as necessary. This step may be retried for tunnel challenges and TLS handshake failures.
  5. It sends the HTTP request and reads the response.
 
 If there's a problem with the connection, OkHttp will select another route and try again. This allows OkHttp to recover when a subset of a server's addresses are unreachable. It's also useful when a pooled connection is stale or if the attempted TLS version is unsupported.
 
 Once the response has been received, the connection will be returned to the pool so it can be reused for a future request. Connections are evicted from the pool after a period of inactivity.
+
+### [Fast Fallback](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/fast-fallback/)
+
+Since version 5.0, `OkHttpClient` supports fast fallback, which is our implementation of Happy Eyeballs [RFC 6555](https://datatracker.ietf.org/doc/html/rfc6555).
+
+With fast fallback, OkHttp attempts to connect to multiple web servers concurrently. It keeps whichever route connects first and cancels all of the others. Its rules are:
+
+ * Prefer to alternate IP addresses from different address families, (IPv6 / IPv4), starting with IPv6.
+ * Don't start a new attempt until 250 ms after the most recent attempt was started.
+ * Keep whichever TCP connection succeeds first and cancel all the others.
+ * Race TCP only. Only attempt a TLS handshake on the winning TCP connection.
+
+If the winner of the TCP handshake race fails to succeed in a TLS handshake, the process is restarted with the remaining routes.
+

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RoutePlanner.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RoutePlanner.kt
@@ -82,7 +82,10 @@ interface RoutePlanner {
 
     fun cancel()
 
-    /** Returns a plan to attempt if canceling this plan was a mistake! */
+    /**
+     * Returns a plan to attempt if canceling this plan was a mistake! The returned plan is not
+     * canceled, even if this plan is canceled.
+     */
     fun retry(): Plan?
   }
 

--- a/okhttp/src/jvmTest/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
@@ -775,16 +775,6 @@ internal class FastFallbackExchangeFinderTest {
     taskFaker.assertNoMoreTasks()
   }
 
-  @Test
-  fun cancelEarlyDuringTcpConnectDoesntLeak() {
-    // TODO(jwilson): change ConnectPlan.cancel() to work even if rawSocket hasn't been created yet.
-  }
-
-  @Test
-  fun routeFailureStatisticsAreTrackedPerRoute() {
-    // TODO(jwilson): we call resetStatistics() in the wrong phrase for racy connects.
-  }
-
   private fun assertEvents(vararg expected: String) {
     val actual = generateSequence { routePlanner.events.poll() }.toList()
     assertThat(actual).containsExactly(*expected)


### PR DESCRIPTION
We had a bug where calling ConnectPlan.cancel() before ConnectPlan.connectTcp()
would drop the cancel. This is because the rawSocket wasn't created yet to
cancel.

Also document fast fallback on our documentation site.