### PR TITLE
Update Response.request docs to track behavior

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Response.kt
@@ -39,13 +39,17 @@ import okio.Buffer
  */
 class Response internal constructor(
   /**
-   * The wire-level request that initiated this HTTP response. This is not necessarily the same
-   * request issued by the application:
+   * The request that initiated this HTTP response. This is not necessarily the same request issued
+   * by the application:
    *
-   * * It may be transformed by the HTTP client. For example, the client may copy headers like
-   *   `Content-Length` from the request body.
+   * * It may be transformed by the user's interceptors. For example, an application interceptor
+   *   may add headers like `User-Agent`.
    * * It may be the request generated in response to an HTTP redirect or authentication
    *   challenge. In this case the request URL may be different than the initial request URL.
+   *
+   * Use the `request` of the [networkResponse] field to get the wire-level request that was
+   * transmitted. In the case of follow-ups and redirects, also look at the `request` of the
+   * [priorResponse] objects, which have its own [priorResponse].
    */
   @get:JvmName("request") val request: Request,
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/BridgeInterceptor.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/BridgeInterceptor.kt
@@ -80,12 +80,13 @@ class BridgeInterceptor(private val cookieJar: CookieJar) : Interceptor {
       requestBuilder.header("User-Agent", userAgent)
     }
 
-    val networkResponse = chain.proceed(requestBuilder.build())
+    val networkRequest = requestBuilder.build()
+    val networkResponse = chain.proceed(networkRequest)
 
-    cookieJar.receiveHeaders(userRequest.url, networkResponse.headers)
+    cookieJar.receiveHeaders(networkRequest.url, networkResponse.headers)
 
     val responseBuilder = networkResponse.newBuilder()
-        .request(userRequest)
+        .request(networkRequest)
 
     if (transparentGzip &&
         "gzip".equals(networkResponse.header("Content-Encoding"), ignoreCase = true) &&

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
@@ -85,14 +85,18 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
           continue
         }
 
+        // Clear out downstream interceptor's additional request headers, cookies, etc.
+        val responseBuilder = response.newBuilder()
+          .request(request)
+
         // Attach the prior response if it exists. Such responses never have a body.
         if (priorResponse != null) {
-          response = response.newBuilder()
-              .priorResponse(priorResponse.newBuilder()
-                  .body(null)
-                  .build())
-              .build()
+          responseBuilder.priorResponse(priorResponse.newBuilder()
+            .body(null)
+            .build())
         }
+
+        response = responseBuilder.build()
 
         val exchange = call.interceptorScopedExchange
         val followUp = followUpRequest(response, exchange)

--- a/okhttp/src/jvmTest/java/okhttp3/CallKotlinTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/CallKotlinTest.kt
@@ -22,6 +22,7 @@ import java.time.Duration
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.SocketPolicy
+import okhttp3.Headers.Companion.headersOf
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.TestUtil.assertSuppressed
@@ -270,5 +271,25 @@ class CallKotlinTest(
         assertThat(suppressed).isNotSameAs(expected)
       }
     }
+  }
+
+  @Test
+  fun responseRequestIsLastRedirect() {
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(302)
+        .addHeader("Location: /b")
+    )
+    server.enqueue(MockResponse())
+
+    val request = Request.Builder()
+      .url(server.url("/"))
+      .build()
+
+    val call = client.newCall(request)
+    val response = call.execute()
+
+    assertThat(response.request.url.encodedPath).isEqualTo("/b")
+    assertThat(response.request.headers).isEqualTo(headersOf())
   }
 }


### PR DESCRIPTION
Also change internal interceptors to explicitly retain the requests
that were forwarded down the chain.