### PR TITLE
Add Failsafe to the "works with OkHttp" page

### DIFF
--- a/docs/works_with_okhttp.md
+++ b/docs/works_with_okhttp.md
@@ -7,6 +7,7 @@ Here’s some libraries that work nicely with OkHttp.
  * [Coil](https://github.com/coil-kt/coil): An image loading library for Android backed by Kotlin Coroutines.
  * [Communicator](https://github.com/Taig/Communicator): An OkHttp wrapper for Scala built with Android in mind.
  * [CWAC-NetSecurity](https://github.com/commonsguy/cwac-netsecurity): Simplifying Secure Internet Access.
+ * [Failsafe](https://failsafe.dev/okhttp/): Fault tolerance and resilience patterns. 
  * [Flipper](https://fbflipper.com/): A desktop debugging platform for mobile developers.
  * [Fresco](https://github.com/facebook/fresco): An Android library for managing images and the memory they use.
  * [Glide](https://github.com/bumptech/glide): An image loading and caching library for Android focused on smooth scrolling.


### PR DESCRIPTION
This PR adds [Failsafe](https://failsafe.dev/okhttp/) to the "works with OkHttp" page. I'm not positive what the scope of that page is meant to be, so hopefully this fits, but if not that's cool. 

Also, I'm not sure what the process is for generating actual docs to the gh-pages branch, but if that's something I should do, I can followup with another PR.