### PR TITLE
Ignore legacy okttp versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "extends": [
     "config:base"
+  ],
+  "ignoreDeps": [
+    "com.squareup.okhttp3:okhttp",
+    "com.squareup.okhttp3:okhttp-tls",
+    "com.squareup.okhttp3:mockwebserver"
   ]
 }


### PR DESCRIPTION
Grabbed the identified targets from here https://app.renovatebot.com/dashboard#github/square/okhttp/589151568

And https://docs.renovatebot.com/configuration-options/#ignoredeps