### PR TITLE
Fix a failing android test and cleanup

### DIFF
--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -631,8 +631,7 @@ class OkHttpTest(val server: MockWebServer) {
       override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
     }
 
-    val sslContext = Platform.get().newSSLContext().apply
-    {
+    val sslContext = Platform.get().newSSLContext().apply {
       init(null, arrayOf(trustManager), null)
     }
     val sslSocketFactory = sslContext.socketFactory

--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -583,6 +583,8 @@ class OkHttpTest(val server: MockWebServer) {
   fun testCustomSSLSocketFactoryWithoutALPN() {
     enableTls()
 
+    server.enqueue(MockResponse().setBody("abc"))
+
     val sslSocketFactory = client.sslSocketFactory
     val trustManager = client.x509TrustManager!!
 

--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -28,6 +28,8 @@ import okhttp3.Cache
 import okhttp3.Call
 import okhttp3.CertificatePinner
 import okhttp3.Connection
+import okhttp3.DelegatingSSLSocket
+import okhttp3.DelegatingSSLSocketFactory
 import okhttp3.EventListener
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
@@ -82,8 +84,6 @@ import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
-import okhttp3.DelegatingSSLSocket
-import okhttp3.DelegatingSSLSocketFactory
 
 /**
  * Run with "./gradlew :android-test:connectedCheck" and make sure ANDROID_SDK_ROOT is set.
@@ -104,8 +104,8 @@ class OkHttpTest(val server: MockWebServer) {
   private var client: OkHttpClient = clientTestRule.newClient()
 
   private val moshi = Moshi.Builder()
-      .add(KotlinJsonAdapterFactory())
-      .build()
+    .add(KotlinJsonAdapterFactory())
+    .build()
 
   private val handshakeCertificates = localhost()
 
@@ -127,26 +127,26 @@ class OkHttpTest(val server: MockWebServer) {
     val request = Request.Builder().url("https://api.twitter.com/robots.txt").build()
 
     val clientCertificates = HandshakeCertificates.Builder()
-        .addPlatformTrustedCertificates()
-        .apply {
-          if (Build.VERSION.SDK_INT >= 24) {
-            addInsecureHost(server.hostName)
-          }
+      .addPlatformTrustedCertificates()
+      .apply {
+        if (Build.VERSION.SDK_INT >= 24) {
+          addInsecureHost(server.hostName)
         }
-        .build()
+      }
+      .build()
 
     client = client.newBuilder()
-        .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
-        .build()
+      .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
+      .build()
 
     val response = client.newCall(request).execute()
 
     response.use {
-      assertEquals(200, response.code)
+      assertEquals(404, response.code)
     }
 
     if (Build.VERSION.SDK_INT >= 24) {
-      localhostInsecureRequest();
+      localhostInsecureRequest()
     }
   }
 
@@ -175,19 +175,21 @@ class OkHttpTest(val server: MockWebServer) {
       var socketClass: String? = null
 
       val clientCertificates = HandshakeCertificates.Builder()
-          .addPlatformTrustedCertificates()
-          .addInsecureHost(server.hostName)
-          .build()
+        .addPlatformTrustedCertificates()
+        .addInsecureHost(server.hostName)
+        .build()
 
       // Need fresh client to reset sslSocketFactoryOrNull
       client = OkHttpClient.Builder()
-          .eventListenerFactory(clientTestRule.wrap(object : EventListener() {
-        override fun connectionAcquired(call: Call, connection: Connection) {
-          socketClass = connection.socket().javaClass.name
-        }
-      }))
-          .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
-          .build()
+        .eventListenerFactory(
+          clientTestRule.wrap(object : EventListener() {
+            override fun connectionAcquired(call: Call, connection: Connection) {
+              socketClass = connection.socket().javaClass.name
+            }
+          })
+        )
+        .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
+        .build()
 
       val response = client.newCall(request).execute()
 
@@ -196,21 +198,21 @@ class OkHttpTest(val server: MockWebServer) {
         assertEquals(200, response.code)
         // see https://github.com/google/conscrypt/blob/b9463b2f74df42d85c73715a5f19e005dfb7b802/android/src/main/java/org/conscrypt/Platform.java#L613
         when {
-            Build.VERSION.SDK_INT >= 24 -> {
-              // Conscrypt 2.5+ defaults to SSLEngine-based SSLSocket
-              assertEquals("org.conscrypt.Java8EngineSocket", socketClass)
-            }
-            Build.VERSION.SDK_INT < 22 -> {
-              assertEquals("org.conscrypt.KitKatPlatformOpenSSLSocketImplAdapter", socketClass)
-            }
-            else -> {
-              assertEquals("org.conscrypt.ConscryptFileDescriptorSocket", socketClass)
-            }
+          Build.VERSION.SDK_INT >= 24 -> {
+            // Conscrypt 2.5+ defaults to SSLEngine-based SSLSocket
+            assertEquals("org.conscrypt.Java8EngineSocket", socketClass)
+          }
+          Build.VERSION.SDK_INT < 22 -> {
+            assertEquals("org.conscrypt.KitKatPlatformOpenSSLSocketImplAdapter", socketClass)
+          }
+          else -> {
+            assertEquals("org.conscrypt.ConscryptFileDescriptorSocket", socketClass)
+          }
         }
         assertEquals(TlsVersion.TLS_1_3, response.handshake?.tlsVersion)
       }
 
-      localhostInsecureRequest();
+      localhostInsecureRequest()
     } finally {
       Security.removeProvider("Conscrypt")
       client.close()
@@ -229,9 +231,9 @@ class OkHttpTest(val server: MockWebServer) {
       }
 
       val clientCertificates = HandshakeCertificates.Builder()
-          .addPlatformTrustedCertificates()
-          .addInsecureHost(server.hostName)
-          .build()
+        .addPlatformTrustedCertificates()
+        .addInsecureHost(server.hostName)
+        .build()
 
       val request = Request.Builder().url("https://facebook.com/robots.txt").build()
 
@@ -239,13 +241,15 @@ class OkHttpTest(val server: MockWebServer) {
 
       // Need fresh client to reset sslSocketFactoryOrNull
       client = OkHttpClient.Builder()
-          .eventListenerFactory(clientTestRule.wrap(object : EventListener() {
-        override fun connectionAcquired(call: Call, connection: Connection) {
-          socketClass = connection.socket().javaClass.name
-        }
-      }))
-          .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
-          .build()
+        .eventListenerFactory(
+          clientTestRule.wrap(object : EventListener() {
+            override fun connectionAcquired(call: Call, connection: Connection) {
+              socketClass = connection.socket().javaClass.name
+            }
+          })
+        )
+        .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
+        .build()
 
       val response = client.newCall(request).execute()
 
@@ -256,7 +260,7 @@ class OkHttpTest(val server: MockWebServer) {
         assertEquals(TlsVersion.TLS_1_2, response.handshake?.tlsVersion)
       }
 
-      localhostInsecureRequest();
+      localhostInsecureRequest()
     } finally {
       Security.removeProvider("GmsCore_OpenSSL")
       client.close()
@@ -285,21 +289,23 @@ class OkHttpTest(val server: MockWebServer) {
     var socketClass: String? = null
 
     val clientCertificates = HandshakeCertificates.Builder()
-        .addPlatformTrustedCertificates().apply {
-          if (Build.VERSION.SDK_INT >= 24) {
-            addInsecureHost(server.hostName)
-          }
+      .addPlatformTrustedCertificates().apply {
+        if (Build.VERSION.SDK_INT >= 24) {
+          addInsecureHost(server.hostName)
         }
-        .build()
+      }
+      .build()
 
     client = client.newBuilder()
-        .eventListenerFactory(clientTestRule.wrap(object : EventListener() {
+      .eventListenerFactory(
+        clientTestRule.wrap(object : EventListener() {
           override fun connectionAcquired(call: Call, connection: Connection) {
             socketClass = connection.socket().javaClass.name
           }
-        }))
-        .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
-        .build()
+        })
+      )
+      .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager)
+      .build()
 
     val response = client.newCall(request).execute()
 
@@ -315,7 +321,7 @@ class OkHttpTest(val server: MockWebServer) {
     }
 
     if (Build.VERSION.SDK_INT >= 24) {
-      localhostInsecureRequest();
+      localhostInsecureRequest()
     }
   }
 
@@ -399,8 +405,10 @@ class OkHttpTest(val server: MockWebServer) {
       assertEquals(Protocol.HTTP_2, response.protocol)
       val tlsVersion = response.handshake?.tlsVersion
       assertTrue(tlsVersion == TlsVersion.TLS_1_2 || tlsVersion == TlsVersion.TLS_1_3)
-      assertEquals("CN=localhost",
-          (response.handshake!!.peerCertificates.first() as X509Certificate).subjectDN.name)
+      assertEquals(
+        "CN=localhost",
+        (response.handshake!!.peerCertificates.first() as X509Certificate).subjectDN.name
+      )
     }
   }
 
@@ -409,8 +417,8 @@ class OkHttpTest(val server: MockWebServer) {
     enableTls()
 
     val certificatePinner = CertificatePinner.Builder()
-        .add(server.hostName, "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-        .build()
+      .add(server.hostName, "sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+      .build()
     client = client.newBuilder().certificatePinner(certificatePinner).build()
 
     server.enqueue(MockResponse().setBody("abc"))
@@ -429,9 +437,11 @@ class OkHttpTest(val server: MockWebServer) {
     enableTls()
 
     val certificatePinner = CertificatePinner.Builder()
-        .add(server.hostName,
-            CertificatePinner.pin(handshakeCertificates.trustManager.acceptedIssuers[0]))
-        .build()
+      .add(
+        server.hostName,
+        CertificatePinner.pin(handshakeCertificates.trustManager.acceptedIssuers[0])
+      )
+      .build()
     client = client.newBuilder().certificatePinner(certificatePinner).build()
 
     server.enqueue(MockResponse().setBody("abc"))
@@ -462,11 +472,16 @@ class OkHttpTest(val server: MockWebServer) {
       assertEquals(200, response.code)
     }
 
-    assertEquals(listOf("CallStart", "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
+    assertEquals(
+      listOf(
+        "CallStart", "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd",
         "ConnectStart", "SecureConnectStart", "SecureConnectEnd", "ConnectEnd",
         "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd", "ResponseHeadersStart",
         "ResponseHeadersEnd", "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased",
-        "CallEnd"), eventListener.recordedEventTypes())
+        "CallEnd"
+      ),
+      eventListener.recordedEventTypes()
+    )
 
     eventListener.clearAllEvents()
 
@@ -474,10 +489,15 @@ class OkHttpTest(val server: MockWebServer) {
       assertEquals(200, response.code)
     }
 
-    assertEquals(listOf("CallStart",
+    assertEquals(
+      listOf(
+        "CallStart",
         "ConnectionAcquired", "RequestHeadersStart", "RequestHeadersEnd", "ResponseHeadersStart",
         "ResponseHeadersEnd", "ResponseBodyStart", "ResponseBodyEnd", "ConnectionReleased",
-        "CallEnd"), eventListener.recordedEventTypes())
+        "CallEnd"
+      ),
+      eventListener.recordedEventTypes()
+    )
   }
 
   @Test
@@ -486,13 +506,15 @@ class OkHttpTest(val server: MockWebServer) {
 
     enableTls()
 
-    client = client.newBuilder().eventListenerFactory(clientTestRule.wrap(object : EventListener() {
-      override fun connectionAcquired(call: Call, connection: Connection) {
-        val sslSocket = connection.socket() as SSLSocket
+    client = client.newBuilder().eventListenerFactory(
+      clientTestRule.wrap(object : EventListener() {
+        override fun connectionAcquired(call: Call, connection: Connection) {
+          val sslSocket = connection.socket() as SSLSocket
 
-        sessionIds.add(sslSocket.session.id.toByteString().hex())
-      }
-    })).build()
+          sessionIds.add(sslSocket.session.id.toByteString().hex())
+        }
+      })
+    ).build()
 
     server.enqueue(MockResponse().setBody("abc1"))
     server.enqueue(MockResponse().setBody("abc2"))
@@ -519,12 +541,12 @@ class OkHttpTest(val server: MockWebServer) {
     assumeNetwork()
 
     client = client.newBuilder()
-        .eventListenerFactory(clientTestRule.wrap(LoggingEventListener.Factory()))
-        .build()
+      .eventListenerFactory(clientTestRule.wrap(LoggingEventListener.Factory()))
+      .build()
 
     val dohDns = buildCloudflareIp(client)
     val dohEnabledClient =
-        client.newBuilder().eventListener(EventListener.NONE).dns(dohDns).build()
+      client.newBuilder().eventListener(EventListener.NONE).dns(dohDns).build()
 
     dohEnabledClient.get("https://www.twitter.com/robots.txt")
     dohEnabledClient.get("https://www.facebook.com/robots.txt")
@@ -550,13 +572,12 @@ class OkHttpTest(val server: MockWebServer) {
     val hostnameVerifier = HostnameVerifier { _, _ -> true }
 
     client = client.newBuilder()
-        .sslSocketFactory(sslSocketFactory, trustManager)
-        .hostnameVerifier(hostnameVerifier)
-        .build()
+      .sslSocketFactory(sslSocketFactory, trustManager)
+      .hostnameVerifier(hostnameVerifier)
+      .build()
 
     client.get("https://www.facebook.com/robots.txt")
   }
-
 
   @Test
   fun testCustomSSLSocketFactoryWithoutALPN() {
@@ -610,7 +631,8 @@ class OkHttpTest(val server: MockWebServer) {
       override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
     }
 
-    val sslContext = Platform.get().newSSLContext().apply {
+    val sslContext = Platform.get().newSSLContext().apply
+    {
       init(null, arrayOf(trustManager), null)
     }
     val sslSocketFactory = sslContext.socketFactory
@@ -618,9 +640,9 @@ class OkHttpTest(val server: MockWebServer) {
     val hostnameVerifier = HostnameVerifier { _, _ -> true }
 
     client = client.newBuilder()
-        .sslSocketFactory(sslSocketFactory, trustManager)
-        .hostnameVerifier(hostnameVerifier)
-        .build()
+      .sslSocketFactory(sslSocketFactory, trustManager)
+      .hostnameVerifier(hostnameVerifier)
+      .build()
 
     client.get("https://www.facebook.com/robots.txt")
 
@@ -638,7 +660,7 @@ class OkHttpTest(val server: MockWebServer) {
     assumeNetwork()
 
     val request =
-        Request.Builder().url("https://example_underscore_123.s3.amazonaws.com/").build()
+      Request.Builder().url("https://example_underscore_123.s3.amazonaws.com/").build()
 
     try {
       client.newCall(request).execute().close()
@@ -679,13 +701,15 @@ class OkHttpTest(val server: MockWebServer) {
       }
 
       client = client.newBuilder()
-          .sslSocketFactory(sslContext.socketFactory, trustManager)
-          .eventListenerFactory(clientTestRule.wrap(object : EventListener() {
+        .sslSocketFactory(sslContext.socketFactory, trustManager)
+        .eventListenerFactory(
+          clientTestRule.wrap(object : EventListener() {
             override fun connectionAcquired(call: Call, connection: Connection) {
               socketClass = connection.socket().javaClass.name
             }
-          }))
-          .build()
+          })
+        )
+        .build()
 
       val request = Request.Builder().url("https://facebook.com/robots.txt").build()
 
@@ -713,7 +737,7 @@ class OkHttpTest(val server: MockWebServer) {
 
       override fun publish(record: LogRecord) {
         calls.getOrPut(record.loggerName) { AtomicInteger(0) }
-            .incrementAndGet()
+          .incrementAndGet()
       }
 
       override fun flush() {
@@ -726,24 +750,24 @@ class OkHttpTest(val server: MockWebServer) {
     }
 
     Logger.getLogger("")
-        .addHandler(testHandler)
+      .addHandler(testHandler)
     Logger.getLogger("okhttp3")
-        .addHandler(testHandler)
+      .addHandler(testHandler)
     Logger.getLogger(Http2::class.java.name)
-        .addHandler(testHandler)
+      .addHandler(testHandler)
     Logger.getLogger(TaskRunner::class.java.name)
-        .addHandler(testHandler)
+      .addHandler(testHandler)
     Logger.getLogger(OkHttpClient::class.java.name)
-        .addHandler(testHandler)
+      .addHandler(testHandler)
 
     server.enqueue(MockResponse().setBody("abc"))
 
     val request = Request.Builder()
-        .url(server.url("/"))
-        .build()
+      .url(server.url("/"))
+      .build()
 
     val response = client.newCall(request)
-        .execute()
+      .execute()
 
     response.use {
       assertEquals(200, response.code)
@@ -768,31 +792,31 @@ class OkHttpTest(val server: MockWebServer) {
 
     try {
       client = client.newBuilder()
-          .cache(cache)
-          .build()
+        .cache(cache)
+        .build()
 
       val request = Request.Builder()
-          .url(server.url("/"))
-          .build()
+        .url(server.url("/"))
+        .build()
 
       client.newCall(request)
-          .execute()
-          .use {
-            assertEquals(200, it.code)
-            assertNull(it.cacheResponse)
-            assertNotNull(it.networkResponse)
+        .execute()
+        .use {
+          assertEquals(200, it.code)
+          assertNull(it.cacheResponse)
+          assertNotNull(it.networkResponse)
 
-            assertEquals(3, it.cacheControl.maxAgeSeconds)
-            assertTrue(it.cacheControl.isPublic)
-          }
+          assertEquals(3, it.cacheControl.maxAgeSeconds)
+          assertTrue(it.cacheControl.isPublic)
+        }
 
       client.newCall(request)
-          .execute()
-          .use {
-            assertEquals(200, it.code)
-            assertNotNull(it.cacheResponse)
-            assertNull(it.networkResponse)
-          }
+        .execute()
+        .use {
+          assertEquals(200, it.code)
+          assertNotNull(it.cacheResponse)
+          assertNull(it.networkResponse)
+        }
 
       assertEquals(1, cache.hitCount())
       assertEquals(1, cache.networkCount())
@@ -813,15 +837,16 @@ class OkHttpTest(val server: MockWebServer) {
 
   fun buildCloudflareIp(bootstrapClient: OkHttpClient): DnsOverHttps {
     return DnsOverHttps.Builder().client(bootstrapClient)
-        .url("https://1.1.1.1/dns-query".toHttpUrl())
-        .build()
+      .url("https://1.1.1.1/dns-query".toHttpUrl())
+      .build()
   }
 
   private fun enableTls() {
     client = client.newBuilder()
-        .sslSocketFactory(
-            handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager)
-        .build()
+      .sslSocketFactory(
+        handshakeCertificates.sslSocketFactory(), handshakeCertificates.trustManager
+      )
+      .build()
     server.useHttps(handshakeCertificates.sslSocketFactory(), false)
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,8 +65,25 @@ allprojects {
 /** Configure building for Java+Kotlin projects. */
 subprojects {
   val project = this@subprojects
-  if (project.name == "android-test") return@subprojects
   if (project.name == "okhttp-bom") return@subprojects
+
+  apply(plugin = "com.diffplug.spotless")
+  configure<SpotlessExtension> {
+    ratchetFrom("origin/master")
+    kotlin {
+      target("**/*.kt")
+      ktlint(libs.versions.ktlint.get()).userData(
+        mapOf(
+          "indent_size" to "2",
+          "disabled_rules" to "filename"
+        )
+      )
+      trimTrailingWhitespace()
+      endWithNewline()
+    }
+  }
+
+  if (project.name == "android-test") return@subprojects
   if (project.name == "regression-test") return@subprojects
 
   apply(plugin = "checkstyle")
@@ -172,23 +189,6 @@ subprojects {
       testRuntimeOnly(rootProject.libs.openjsse)
     }
   }
-
-  apply(plugin = "com.diffplug.spotless")
-  configure<SpotlessExtension> {
-    ratchetFrom("origin/master")
-    kotlin {
-      target("**/*.kt")
-      ktlint(libs.versions.ktlint.get()).userData(
-        mapOf(
-          "indent_size" to "2",
-          "disabled_rules" to "filename"
-        )
-      )
-      trimTrailingWhitespace()
-      endWithNewline()
-    }
-  }
-
 
   tasks.withType<JavaCompile> {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()


### PR DESCRIPTION
```
okhttp.android.test.OkHttpTest > testRequest[test(AVD) - 10] FAILED 
	org.opentest4j.AssertionFailedError: expected: <200> but was: <404>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
```