### PR TITLE
Remove Content-Length in MultipartRequest Bodies

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/MultipartBody.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/MultipartBody.kt
@@ -139,7 +139,7 @@ class MultipartBody internal constructor(
       }
 
       val contentLength = body.contentLength()
-      if (contentLength == -1L) {
+      if (contentLength == -1L && countBytes) {
         // We can't measure the body's size without the sizes of its components.
         byteCountBuffer!!.clear()
         return -1L

--- a/okhttp/src/jvmMain/kotlin/okhttp3/MultipartBody.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/MultipartBody.kt
@@ -139,11 +139,7 @@ class MultipartBody internal constructor(
       }
 
       val contentLength = body.contentLength()
-      if (contentLength != -1L) {
-        sink.writeUtf8("Content-Length: ")
-            .writeDecimalLong(contentLength)
-            .write(CRLF)
-      } else if (countBytes) {
+      if (contentLength == -1L) {
         // We can't measure the body's size without the sizes of its components.
         byteCountBuffer!!.clear()
         return -1L


### PR DESCRIPTION
Solves #2604.

This removes the Content-Length header in a part of a multipart request. 

I've tested with Chrome and it doesn't add the Content-Length header.