### PR TITLE
Don't interpret headers as trailers after a 100 response

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -1049,9 +1049,8 @@ class MockWebServer : Closeable {
       val headers = httpHeaders.build()
 
       val peek = dispatcher.peek()
-      if (!readBody && peek.socketPolicy === EXPECT_CONTINUE) {
-        val continueHeaders =
-          listOf(Header(Header.RESPONSE_STATUS, "100 Continue".encodeUtf8()))
+      if (peek.socketPolicy === EXPECT_CONTINUE) {
+        val continueHeaders = listOf(Header(Header.RESPONSE_STATUS, "100 Continue".encodeUtf8()))
         stream.writeHeaders(continueHeaders, outFinished = false, flushHeaders = true)
         stream.connection.flush()
         readBody = true

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
@@ -282,7 +282,10 @@ class Http2Stream internal constructor(
 
     val open: Boolean
     synchronized(this) {
-      if (!hasResponseHeaders || !inFinished) {
+      if (!hasResponseHeaders ||
+        headers[Header.RESPONSE_STATUS_UTF8] != null ||
+        headers[Header.TARGET_METHOD_UTF8] != null
+      ) {
         hasResponseHeaders = true
         headersQueue += headers
       } else {

--- a/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
@@ -2780,7 +2780,7 @@ open class CallTest(
   @Test fun serverRespondsWithUnsolicited100Continue() {
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.CONTINUE_ALWAYS)
+        .setSocketPolicy(SocketPolicy.EXPECT_CONTINUE)
     )
     val request = Request.Builder()
       .url(server.url("/"))

--- a/okhttp/src/jvmTest/java/okhttp3/internal/http2/Http2ConnectionTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/http2/Http2ConnectionTest.kt
@@ -1673,8 +1673,10 @@ class Http2ConnectionTest {
     peer.acceptFrame() // ACK
     peer.acceptFrame() // SYN_STREAM
     peer.acceptFrame() // PING
-    peer.sendFrame().headers(false, 3, headerEntries("a", "android"))
-    peer.sendFrame().headers(false, 3, headerEntries("c", "c3po"))
+    peer.sendFrame()
+      .headers(false, 3, headerEntries(Header.RESPONSE_STATUS_UTF8, "HTTP/1.1 100"))
+    peer.sendFrame()
+      .headers(false, 3, headerEntries(Header.RESPONSE_STATUS_UTF8, "HTTP/1.1 200"))
     peer.sendFrame().ping(true, Http2Connection.AWAIT_PING, 0)
     peer.play()
 
@@ -1682,8 +1684,10 @@ class Http2ConnectionTest {
     val connection = connect(peer)
     val stream = connection.newStream(headerEntries("b", "banana"), true)
     connection.writePingAndAwaitPong() // Ensure that the HEADERS has been received.
-    assertThat(stream.takeHeaders()).isEqualTo(headersOf("a", "android"))
-    assertThat(stream.takeHeaders()).isEqualTo(headersOf("c", "c3po"))
+    assertThat(stream.takeHeaders())
+      .isEqualTo(headersOf(Header.RESPONSE_STATUS_UTF8, "HTTP/1.1 100"))
+    assertThat(stream.takeHeaders())
+      .isEqualTo(headersOf(Header.RESPONSE_STATUS_UTF8, "HTTP/1.1 200"))
 
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()


### PR DESCRIPTION
This only occurs when the response body is empty.

Closes: https://github.com/square/okhttp/issues/7167