### PR TITLE
Change how HTTP 1xx responses work in MockWebServer

### DIFF
--- a/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/bridge.kt
+++ b/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/bridge.kt
@@ -56,7 +56,13 @@ internal fun MockResponse.wrap(): mockwebserver3.MockResponse {
   result.status = status
   result.headers = headers
   result.trailers = trailers
-  result.socketPolicy = socketPolicy.wrap()
+  result.socketPolicy = when (socketPolicy) {
+    SocketPolicy.EXPECT_CONTINUE, SocketPolicy.CONTINUE_ALWAYS -> {
+      result.add100Continue()
+      mockwebserver3.SocketPolicy.KEEP_OPEN
+    }
+    else -> socketPolicy.wrap()
+  }
   result.http2ErrorCode = http2ErrorCode
   result.throttleBody(throttleBytesPerPeriod, getThrottlePeriod(MILLISECONDS), MILLISECONDS)
   result.setBodyDelay(getBodyDelay(MILLISECONDS), MILLISECONDS)

--- a/mockwebserver/api/mockwebserver3.api
+++ b/mockwebserver/api/mockwebserver3.api
@@ -13,18 +13,23 @@ public final class mockwebserver3/MockResponse : java/lang/Cloneable {
 	public final fun -deprecated_getStatus ()Ljava/lang/String;
 	public final fun -deprecated_getTrailers ()Lokhttp3/Headers;
 	public fun <init> ()V
+	public final fun add100Continue ()Lmockwebserver3/MockResponse;
 	public final fun addHeader (Ljava/lang/String;)Lmockwebserver3/MockResponse;
 	public final fun addHeader (Ljava/lang/String;Ljava/lang/Object;)Lmockwebserver3/MockResponse;
 	public final fun addHeaderLenient (Ljava/lang/String;Ljava/lang/Object;)Lmockwebserver3/MockResponse;
+	public final fun addInformationalResponse (Lmockwebserver3/MockResponse;)Lmockwebserver3/MockResponse;
 	public final fun clearHeaders ()Lmockwebserver3/MockResponse;
 	public synthetic fun clone ()Ljava/lang/Object;
 	public fun clone ()Lmockwebserver3/MockResponse;
 	public final fun getBody ()Lokio/Buffer;
 	public final fun getBodyDelay (Ljava/util/concurrent/TimeUnit;)J
+	public final fun getCode ()I
 	public final fun getDuplexResponseBody ()Lmockwebserver3/internal/duplex/DuplexResponseBody;
 	public final fun getHeaders ()Lokhttp3/Headers;
 	public final fun getHeadersDelay (Ljava/util/concurrent/TimeUnit;)J
 	public final fun getHttp2ErrorCode ()I
+	public final fun getInformationalResponses ()Ljava/util/List;
+	public final fun getMessage ()Ljava/lang/String;
 	public final fun getPushPromises ()Ljava/util/List;
 	public final fun getSettings ()Lokhttp3/internal/http2/Settings;
 	public final fun getSocketPolicy ()Lmockwebserver3/SocketPolicy;
@@ -161,14 +166,12 @@ public final class mockwebserver3/RecordedRequest {
 }
 
 public final class mockwebserver3/SocketPolicy : java/lang/Enum {
-	public static final field CONTINUE_ALWAYS Lmockwebserver3/SocketPolicy;
 	public static final field DISCONNECT_AFTER_REQUEST Lmockwebserver3/SocketPolicy;
 	public static final field DISCONNECT_AT_END Lmockwebserver3/SocketPolicy;
 	public static final field DISCONNECT_AT_START Lmockwebserver3/SocketPolicy;
 	public static final field DISCONNECT_DURING_REQUEST_BODY Lmockwebserver3/SocketPolicy;
 	public static final field DISCONNECT_DURING_RESPONSE_BODY Lmockwebserver3/SocketPolicy;
 	public static final field DO_NOT_READ_REQUEST_BODY Lmockwebserver3/SocketPolicy;
-	public static final field EXPECT_CONTINUE Lmockwebserver3/SocketPolicy;
 	public static final field FAIL_HANDSHAKE Lmockwebserver3/SocketPolicy;
 	public static final field HALF_CLOSE_AFTER_REQUEST Lmockwebserver3/SocketPolicy;
 	public static final field KEEP_OPEN Lmockwebserver3/SocketPolicy;

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -44,14 +44,12 @@ import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
-import mockwebserver3.SocketPolicy.CONTINUE_ALWAYS
 import mockwebserver3.SocketPolicy.DISCONNECT_AFTER_REQUEST
 import mockwebserver3.SocketPolicy.DISCONNECT_AT_END
 import mockwebserver3.SocketPolicy.DISCONNECT_AT_START
 import mockwebserver3.SocketPolicy.DISCONNECT_DURING_REQUEST_BODY
 import mockwebserver3.SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY
 import mockwebserver3.SocketPolicy.DO_NOT_READ_REQUEST_BODY
-import mockwebserver3.SocketPolicy.EXPECT_CONTINUE
 import mockwebserver3.SocketPolicy.FAIL_HANDSHAKE
 import mockwebserver3.SocketPolicy.HALF_CLOSE_AFTER_REQUEST
 import mockwebserver3.SocketPolicy.NO_RESPONSE
@@ -87,7 +85,6 @@ import okhttp3.internal.ws.WebSocketProtocol
 import okio.Buffer
 import okio.BufferedSink
 import okio.BufferedSource
-import okio.ByteString.Companion.encodeUtf8
 import okio.Sink
 import okio.Timeout
 import okio.buffer
@@ -719,19 +716,11 @@ class MockWebServer : Closeable {
         ) {
           chunked = true
         }
-        if (lowercaseHeader.startsWith("expect:") &&
-          lowercaseHeader.substring(7).trim().equals("100-continue", ignoreCase = true)
-        ) {
-          expectContinue = true
-        }
       }
 
-      val socketPolicy = dispatcher.peek().socketPolicy
-      if (expectContinue && socketPolicy === EXPECT_CONTINUE || socketPolicy === CONTINUE_ALWAYS) {
-        sink.writeUtf8("HTTP/1.1 100 Continue\r\n")
-        sink.writeUtf8("Content-Length: 0\r\n")
-        sink.writeUtf8("\r\n")
-        sink.flush()
+      val peek = dispatcher.peek()
+      for (response in peek.informationalResponses) {
+        writeHttpResponse(socket, sink, response)
       }
 
       var hasBody = false
@@ -802,10 +791,9 @@ class MockWebServer : Closeable {
       .url("$scheme://$authority/")
       .headers(request.headers)
       .build()
-    val statusParts = response.status.split(' ', limit = 3)
     val fancyResponse = Response.Builder()
-      .code(statusParts[1].toInt())
-      .message(statusParts[2])
+      .code(response.code)
+      .message(response.message)
       .headers(response.headers)
       .request(fancyRequest)
       .protocol(Protocol.HTTP_1_1)
@@ -1049,11 +1037,12 @@ class MockWebServer : Closeable {
       val headers = httpHeaders.build()
 
       val peek = dispatcher.peek()
-      if (peek.socketPolicy === EXPECT_CONTINUE) {
-        val continueHeaders = listOf(Header(Header.RESPONSE_STATUS, "100 Continue".encodeUtf8()))
-        stream.writeHeaders(continueHeaders, outFinished = false, flushHeaders = true)
-        stream.connection.flush()
-        readBody = true
+      for (response in peek.informationalResponses) {
+        sleepIfDelayed(response.getHeadersDelay(TimeUnit.MILLISECONDS))
+        stream.writeHeaders(response.toHttp2Headers(), outFinished = false, flushHeaders = true)
+        if (response.code == 100) {
+          readBody = true
+        }
       }
 
       val body = Buffer()
@@ -1088,6 +1077,15 @@ class MockWebServer : Closeable {
       )
     }
 
+    private fun MockResponse.toHttp2Headers(): List<Header> {
+      val result = mutableListOf<Header>()
+      result += Header(Header.RESPONSE_STATUS, code.toString())
+      for ((name, value) in headers) {
+        result += Header(name, value)
+      }
+      return result
+    }
+
     @Throws(IOException::class)
     private fun writeResponse(
       stream: Http2Stream,
@@ -1100,22 +1098,9 @@ class MockWebServer : Closeable {
       if (response.socketPolicy === NO_RESPONSE) {
         return
       }
-      val http2Headers = mutableListOf<Header>()
-      val statusParts = response.status.split(' ', limit = 3)
-      val headersDelayMs = response.getHeadersDelay(TimeUnit.MILLISECONDS)
+
       val bodyDelayMs = response.getBodyDelay(TimeUnit.MILLISECONDS)
-
-      if (statusParts.size < 2) {
-        throw AssertionError("Unexpected status: ${response.status}")
-      }
-      http2Headers.add(Header(Header.RESPONSE_STATUS, statusParts[1]))
-      val headers = response.headers
-      for ((name, value) in headers) {
-        http2Headers.add(Header(name, value))
-      }
       val trailers = response.trailers
-
-      sleepIfDelayed(headersDelayMs)
       val body = response.getBody()
       val outFinished = (body == null &&
         response.pushPromises.isEmpty() &&
@@ -1124,7 +1109,10 @@ class MockWebServer : Closeable {
       require(!outFinished || trailers.size == 0) {
         "unsupported: no body and non-empty trailers $trailers"
       }
-      stream.writeHeaders(http2Headers, outFinished, flushHeaders)
+
+      sleepIfDelayed(response.getHeadersDelay(TimeUnit.MILLISECONDS))
+      stream.writeHeaders(response.toHttp2Headers(), outFinished, flushHeaders)
+
       if (trailers.size > 0) {
         stream.enqueueTrailers(trailers)
       }

--- a/mockwebserver/src/main/kotlin/mockwebserver3/SocketPolicy.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/SocketPolicy.kt
@@ -121,16 +121,4 @@ enum class SocketPolicy {
    * Fail HTTP/2 requests without processing them by sending an [MockResponse.getHttp2ErrorCode].
    */
   RESET_STREAM_AT_START,
-
-  /**
-   * Transmit a `HTTP/1.1 100 Continue` response before reading the HTTP request body.
-   * Typically this response is sent when a client makes a request with the header `Expect: 100-continue`.
-   */
-  EXPECT_CONTINUE,
-
-  /**
-   * Transmit a `HTTP/1.1 100 Continue` response before reading the HTTP request body even
-   * if the client does not send the header `Expect: 100-continue` in its request.
-   */
-  CONTINUE_ALWAYS
 }

--- a/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
@@ -501,6 +501,25 @@ public final class MockWebServerTest {
     assertThat(request.getBody().readUtf8()).isEqualTo("request");
   }
 
+  @Test public void multiple1xxResponses() throws Exception {
+    server.enqueue(new MockResponse()
+      .add100Continue()
+      .add100Continue()
+      .setBody("response"));
+
+    URL url = server.url("/").url();
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setDoOutput(true);
+    connection.getOutputStream().write("request".getBytes(UTF_8));
+
+    InputStream in = connection.getInputStream();
+    BufferedReader reader = new BufferedReader(new InputStreamReader(in, UTF_8));
+    assertThat(reader.readLine()).isEqualTo("response");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getBody().readUtf8()).isEqualTo("request");
+  }
+
   @Test public void testH2PriorKnowledgeServerFallback() {
     try {
       server.setProtocols(asList(Protocol.H2_PRIOR_KNOWLEDGE, Protocol.HTTP_1_1));

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Headers.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Headers.kt
@@ -45,6 +45,7 @@ import okhttp3.internal.commonValues
 import okhttp3.internal.headersCheckName
 import okhttp3.internal.http.toHttpDateOrNull
 import okhttp3.internal.http.toHttpDateString
+import okhttp3.internal.http2.Header
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 @Suppress("NAME_SHADOWING")

--- a/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
@@ -2716,7 +2716,7 @@ open class CallTest(
   @Test fun expect100ContinueNonEmptyRequestBody() {
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.EXPECT_CONTINUE)
+        .add100Continue()
     )
     val request = Request.Builder()
       .url(server.url("/"))
@@ -2780,7 +2780,7 @@ open class CallTest(
   @Test fun serverRespondsWithUnsolicited100Continue() {
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.EXPECT_CONTINUE)
+        .add100Continue()
     )
     val request = Request.Builder()
       .url(server.url("/"))
@@ -2830,7 +2830,7 @@ open class CallTest(
   @Test fun successfulExpectContinuePermitsConnectionReuse() {
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.EXPECT_CONTINUE)
+        .add100Continue()
     )
     server.enqueue(MockResponse())
     executeSynchronously(

--- a/okhttp/src/jvmTest/java/okhttp3/DuplexTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/DuplexTest.java
@@ -265,7 +265,7 @@ public final class DuplexTest {
     MockDuplexResponseBody mockDuplexResponseBody = enqueueResponseWithBody(
         new MockResponse()
             .clearHeaders()
-            .setSocketPolicy(SocketPolicy.EXPECT_CONTINUE),
+            .add100Continue(),
         new MockDuplexResponseBody()
             .receiveRequest("request body\n")
             .sendResponse("response body\n")

--- a/okhttp/src/jvmTest/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/EventListenerTest.java
@@ -73,14 +73,13 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
 import static java.util.Arrays.asList;
 import static okhttp3.tls.internal.TlsUtil.localhost;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @Flaky // STDOUT logging enabled for test
 @Timeout(30)
@@ -1433,7 +1432,7 @@ public final class EventListenerTest {
   /** Response headers start, then the entire request body, then response headers end. */
   @Test public void expectContinueStartsResponseHeadersEarly() throws Exception {
     server.enqueue(new MockResponse()
-        .setSocketPolicy(SocketPolicy.EXPECT_CONTINUE));
+        .add100Continue());
 
     Request request = new Request.Builder()
         .url(server.url("/"))
@@ -1454,7 +1453,7 @@ public final class EventListenerTest {
   @Test public void timeToFirstByteGapBetweenResponseHeaderStartAndEnd() throws IOException {
     long responseHeadersStartDelay = 250L;
     server.enqueue(new MockResponse()
-        .setSocketPolicy(SocketPolicy.EXPECT_CONTINUE)
+        .add100Continue()
         .setHeadersDelay(responseHeadersStartDelay, TimeUnit.MILLISECONDS));
 
     Request request = new Request.Builder()


### PR DESCRIPTION
Previously this was a SocketPolicy. With this change each
response may carry 0 or more informational responses which
are transmitted before the ultimate response.