### PR TITLE
Generate an okhttp-android baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@ out
 lib
 generated
 
-target
-pom.xml.*
 release.properties
 local.properties
 

--- a/benchmarks/app/benchmark-rules.pro
+++ b/benchmarks/app/benchmark-rules.pro
@@ -1,0 +1,3 @@
+# Benchmark builds should not be obfuscated.
+-dontobfuscate
+

--- a/benchmarks/app/build.gradle
+++ b/benchmarks/app/build.gradle
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id 'com.android.application'
+  id 'kotlin-android'
+}
+
+android {
+  compileSdkVersion 31
+  defaultConfig {
+    applicationId "com.example.macrobenchmark.target"
+    minSdk 21
+    targetSdk 31
+    versionCode 1
+    versionName "1.0"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+  }
+
+  buildTypes {
+    release {
+      minifyEnabled true
+      shrinkResources true
+      proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+    }
+
+    benchmark {
+      initWith buildTypes.release
+      signingConfig signingConfigs.debug
+      matchingFallbacks = ['release']
+      proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'benchmark-rules.pro'
+    }
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8
+  }
+}
+
+dependencies {
+  implementation "com.squareup.okhttp3:okhttp:5.0.0-alpha.6"
+  implementation project(':okhttp-tls')
+  implementation project(':okhttp-android')
+  implementation "com.squareup.okhttp3:okhttp-coroutines:5.0.0-alpha.6"
+  implementation project(':logging-interceptor')
+
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:1.6.10"
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
+  implementation 'androidx.activity:activity-ktx:1.4.0'
+  implementation 'androidx.core:core-ktx:1.7.0'
+  implementation "androidx.profileinstaller:profileinstaller:1.2.0-alpha02"
+
+  testImplementation 'junit:junit:4.13.2'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+}

--- a/benchmarks/app/proguard-rules.pro
+++ b/benchmarks/app/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/benchmarks/app/src/main/AndroidManifest.xml
+++ b/benchmarks/app/src/main/AndroidManifest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2022 Square, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.macrobenchmark.target">
+
+    <application
+        android:label="app_notice">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <profileable android:shell="true" tools:targetApi="q" />
+
+    </application>
+
+</manifest>

--- a/benchmarks/app/src/main/java/com/example/macrobenchmark/target/MainActivity.kt
+++ b/benchmarks/app/src/main/java/com/example/macrobenchmark/target/MainActivity.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example.macrobenchmark.target
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Cache
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.executeAsync
+import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.logging.LoggingEventListener
+import okio.IOException
+
+class MainActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val client = OkHttpClient()
+
+    val cache = Cache(cacheDir.resolve("tmp_cache"), 1000000)
+
+    val clients = buildList {
+      add(client)
+
+      add(
+        client.newBuilder()
+          .protocols(listOf(Protocol.HTTP_1_1))
+          .build()
+      )
+
+      add(
+        client.newBuilder()
+          .cache(cache)
+          .build()
+      )
+
+      add(
+        client.newBuilder()
+          .addInterceptor(HttpLoggingInterceptor())
+          .eventListenerFactory(LoggingEventListener.Factory())
+          .build()
+      )
+    }
+
+    val requests = buildList<Request> {
+      add(Request.Builder().url("http://github.com/robots.txt").build())
+      add(Request.Builder().url("https://github.com/robots.txt").build())
+      add(Request.Builder().url("https://httpbin.org/post").post("{}".toRequestBody()).build())
+    }
+
+    lifecycleScope.launchWhenResumed {
+      withContext(Dispatchers.IO) {
+        repeat(10) {
+          requests.forEach { request ->
+            client.newCall(request).enqueue(object : Callback {
+              override fun onFailure(call: Call, e: IOException) {
+                println("${request.url} $e")
+              }
+
+              override fun onResponse(call: Call, response: Response) {
+                response.use {
+                  println("${request.url} ${response.code} ${response.body!!.string()}")
+                }
+              }
+            })
+          }
+        }
+      }
+    }
+
+    lifecycleScope.launchWhenResumed {
+      withContext(Dispatchers.IO) {
+        clients.forEach {
+          requests.forEach { request ->
+            try {
+              val response = client.newCall(request).executeAsync()
+
+              response.use {
+                println("${request.url} ${response.code} ${response.body!!.string()}")
+              }
+            } catch (e: IOException) {
+              println("${request.url} $e")
+            }
+          }
+        }
+      }
+    }
+
+    lifecycleScope.launchWhenResumed {
+      withContext(Dispatchers.IO) {
+        requests.forEach { request ->
+          try {
+            val response = client.newCall(request).execute()
+
+            response.use {
+              println("${request.url} ${response.code} ${response.body!!.string()}")
+            }
+          } catch (e: IOException) {
+            println("${request.url} $e")
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/macrobenchmark/build.gradle
+++ b/benchmarks/macrobenchmark/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+  id 'com.android.test'
+  id 'kotlin-android'
+}
+
+android {
+  compileSdk 31
+  defaultConfig {
+    minSdk 23
+    targetSdk 31
+
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8
+  }
+  targetProjectPath = ":benchmarks:app"
+  experimentalProperties["android.experimental.self-instrumenting"] = true
+
+  buildTypes {
+    benchmark {
+      isDefault = true
+      debuggable = true
+      signingConfig = debug.signingConfig
+      matchingFallbacks = ['release']
+    }
+  }
+}
+
+androidComponents {
+  beforeVariants(selector().all()) {
+    // enable only the benchmark buildType, since we only want to measure close to release performance
+    enabled = buildType == 'benchmark'
+  }
+}
+
+dependencies {
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:1.6.10"
+  implementation 'androidx.test.ext:junit:1.1.3'
+  implementation 'androidx.test.espresso:espresso-core:3.4.0'
+  implementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+  implementation "androidx.benchmark:benchmark-macro-junit4:1.1.0-beta04"
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions {
+    freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+  }
+}

--- a/benchmarks/macrobenchmark/proguard-rules.pro
+++ b/benchmarks/macrobenchmark/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/benchmarks/macrobenchmark/src/main/AndroidManifest.xml
+++ b/benchmarks/macrobenchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2022 Square, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.macrobenchmark">
+
+    <!-- Requesting legacy storage is needed to be able to write to additionalTestOutputDir on API 29 -->
+    <application android:requestLegacyExternalStorage="true" />
+
+</manifest>

--- a/benchmarks/macrobenchmark/src/main/java/com/example/macrobenchmark/TrivialBaselineProfileBenchmark.kt
+++ b/benchmarks/macrobenchmark/src/main/java/com/example/macrobenchmark/TrivialBaselineProfileBenchmark.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example.macrobenchmark
+
+import androidx.benchmark.macro.ExperimentalBaselineProfilesApi
+import androidx.benchmark.macro.junit4.BaselineProfileRule
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalBaselineProfilesApi::class)
+/**
+ * This benchmark generates a basic baseline profile for the target package.
+ * Refer to the [baseline profile documentation](https://developer.android.com/studio/profile/baselineprofiles)
+ * for more information.
+ */
+class TrivialBaselineProfileBenchmark {
+  @get:Rule
+  val baselineProfileRule = BaselineProfileRule()
+
+  @Test
+  fun startup() = baselineProfileRule.collectBaselineProfile(
+    packageName = TARGET_PACKAGE,
+    profileBlock = {
+      startActivityAndWait()
+      Thread.sleep(10000)
+    }
+  )
+}
+
+const val TARGET_PACKAGE = "com.example.macrobenchmark.target"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,10 @@ subprojects {
   val project = this@subprojects
   if (project.name == "okhttp-bom") return@subprojects
 
+  if (project.name == "app") return@subprojects
+  if (project.name == "macrobenchmark") return@subprojects
+
+  if (project.name == "okhttp-android") return@subprojects
   if (project.name == "android-test") return@subprojects
   if (project.name == "regression-test") return@subprojects
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,4 +42,7 @@ include(":samples:slack")
 include(":samples:static-server")
 include(":samples:unixdomainsockets")
 
+include(":benchmarks:app")
+include(":benchmarks:macrobenchmark")
+
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Evaluating the benefit of a baseline profile for okhttp.

Apps that use baseline profiles, but test the activities rather than network requests would benefit.