### PR TITLE
Ignore early hints for 4.9.x

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Reader.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Reader.kt
@@ -65,7 +65,7 @@ class Http2Reader(
       source = continuation,
       headerTableSizeSetting = 4096
   )
-
+  private const val EARLY_HINTS_CODE = "103"
   @Throws(IOException::class)
   fun readConnectionPreface(handler: Handler) {
     if (client) {
@@ -146,7 +146,10 @@ class Http2Reader(
     headerBlockLength = lengthWithoutPadding(headerBlockLength, flags, padding)
     val headerBlock = readHeaderBlock(headerBlockLength, padding, flags, streamId)
 
-    handler.headers(endStream, streamId, -1, headerBlock)
+    // Ignore early hints
+	  if (!(headerBlockLength != 0 && headerBlock[0].value.utf8().equals(EARLY_HINTS_CODE))) {
+		  handler.headers(endStream, streamId, -1, headerBlock)
+	  }
   }
 
   @Throws(IOException::class)

--- a/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Reader.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Reader.kt
@@ -147,7 +147,7 @@ class Http2Reader(
     val headerBlock = readHeaderBlock(headerBlockLength, padding, flags, streamId)
 
     // Ignore early hints
-	  if (!(headerBlockLength != 0 && headerBlock[0].value.utf8().equals(EARLY_HINTS_CODE))) {
+	  if (!(headerBlockLength != 0 && headerBlock[0].value.equals(EARLY_HINTS_CODE))) {
 		  handler.headers(endStream, streamId, -1, headerBlock)
 	  }
   }


### PR DESCRIPTION
Does the rfc mention if :status: has to be the first response header or not? If it does not, then a for loop to look for the status might be needed. 

Alternatively this change can be put in Http2Connection.headers and we can call .get(":status:") on the headers but I think that might end up requiring more changes than it should.