### PR TITLE
Fix ./okcurl delegate executable

### DIFF
--- a/okcurl/okcurl
+++ b/okcurl/okcurl
@@ -1,5 +1,5 @@
 #!/bin/sh -e
 
-../gradlew -q --console plain installDist
+../gradlew -q --console plain nativeImage
 
-./build/install/okcurl/bin/okcurl "$@"
+./build/graal/okcurl "$@"


### PR DESCRIPTION
The existing script failed to build and use the okcurl CLI with the following exception:

```
okhttp/okcurl on master via ☕ v11.0.14
❯ ./okcurl

FAILURE: Build failed with an exception.

* What went wrong:
Task 'installDist' not found in project ':okcurl'.

* Try:
> Run gradlew tasks to get a list of available tasks.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 883ms
```