### PR TITLE
Make Response.body non-null

### DIFF
--- a/okhttp-brotli/src/main/kotlin/okhttp3/brotli/internal/brotli.kt
+++ b/okhttp-brotli/src/main/kotlin/okhttp3/brotli/internal/brotli.kt
@@ -27,7 +27,7 @@ fun uncompress(response: Response): Response {
   if (!response.promisesBody()) {
     return response
   }
-  val body = response.body ?: return response
+  val body = response.body
   val encoding = response.header("Content-Encoding") ?: return response
 
   val decompressedSource = when {

--- a/okhttp-brotli/src/test/java/okhttp3/brotli/BrotliInterceptorTest.kt
+++ b/okhttp-brotli/src/test/java/okhttp3/brotli/BrotliInterceptorTest.kt
@@ -45,7 +45,7 @@ class BrotliInterceptorTest {
 
     val uncompressed = uncompress(response)
 
-    val responseString = uncompressed.body?.string()
+    val responseString = uncompressed.body.string()
     assertThat(responseString).contains("\"brotli\": true,")
     assertThat(responseString).contains("\"Accept-Encoding\": \"br\"")
   }
@@ -65,7 +65,7 @@ class BrotliInterceptorTest {
 
     val uncompressed = uncompress(response)
 
-    val responseString = uncompressed.body?.string()
+    val responseString = uncompressed.body.string()
     assertThat(responseString).contains("\"gzipped\": true,")
     assertThat(responseString).contains("\"Accept-Encoding\": \"br,gzip\"")
   }
@@ -76,7 +76,7 @@ class BrotliInterceptorTest {
 
     val same = uncompress(response)
 
-    val responseString = same.body?.string()
+    val responseString = same.body.string()
     assertThat(responseString).isEqualTo("XXXX")
   }
 
@@ -88,7 +88,7 @@ class BrotliInterceptorTest {
 
     try {
       val failingResponse = uncompress(response)
-      failingResponse.body?.string()
+      failingResponse.body.string()
 
       fail("expected uncompress error")
     } catch (ioe: IOException) {
@@ -107,7 +107,7 @@ class BrotliInterceptorTest {
 
     val same = uncompress(response)
 
-    val responseString = same.body?.string()
+    val responseString = same.body.string()
     assertThat(responseString).isEmpty()
   }
 

--- a/okhttp-brotli/src/test/java/okhttp3/brotli/BrotliTestMain.kt
+++ b/okhttp-brotli/src/test/java/okhttp3/brotli/BrotliTestMain.kt
@@ -31,6 +31,6 @@ private fun sendRequest(url: String, client: OkHttpClient) {
   val req = Request.Builder().url(url).build()
 
   client.newCall(req).execute().use {
-    println(it.body?.string())
+    println(it.body.string())
   }
 }

--- a/okhttp-coroutines/src/jvmTest/kotlin/okhttp3/SuspendCallTest.kt
+++ b/okhttp-coroutines/src/jvmTest/kotlin/okhttp3/SuspendCallTest.kt
@@ -60,7 +60,7 @@ class SuspendCallTest(
 
       call.executeAsync().use {
         withContext(Dispatchers.IO) {
-          assertThat(it.body?.string()).isEqualTo("abc")
+          assertThat(it.body.string()).isEqualTo("abc")
         }
       }
     }
@@ -81,7 +81,7 @@ class SuspendCallTest(
         withTimeout(1.seconds) {
           call.executeAsync().use {
             withContext(Dispatchers.IO) {
-              it.body?.string()
+              it.body.string()
             }
             fail("No expected to get response")
           }
@@ -109,7 +109,7 @@ class SuspendCallTest(
         call.executeAsync().use {
           call.cancel()
           withContext(Dispatchers.IO) {
-            it.body?.string()
+            it.body.string()
           }
           fail("No expected to get response")
         }
@@ -135,7 +135,7 @@ class SuspendCallTest(
       try {
         call.executeAsync().use {
           withContext(Dispatchers.IO) {
-            it.body?.string()
+            it.body.string()
           }
         }
         fail("No expected to get response")

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
@@ -23,8 +23,8 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
-import okhttp3.internal.EMPTY_RESPONSE
 import okhttp3.internal.connection.RealCall
+import okhttp3.internal.stripBody
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 
@@ -55,7 +55,7 @@ internal class RealEventSource(
         return
       }
 
-      val body = response.body!!
+      val body = response.body
 
       if (!body.isEventStream()) {
         listener.onFailure(this,
@@ -66,10 +66,8 @@ internal class RealEventSource(
       // This is a long-lived response. Cancel full-call timeouts.
       call?.timeoutEarlyExit()
 
-      // Replace the body with an empty one so the callbacks can't see real data.
-      val response = response.newBuilder()
-          .body(EMPTY_RESPONSE)
-          .build()
+      // Replace the body with a stripped one so the callbacks can't see real data.
+      val response = response.stripBody()
 
       val reader = ServerSentEventReader(body.source(), this)
       try {

--- a/okhttp/src/commonMain/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/commonMain/kotlin/okhttp3/Response.kt
@@ -68,7 +68,7 @@ expect class Response : Closeable {
    * This always returns null on responses returned from [cacheResponse], [networkResponse],
    * and [priorResponse].
    */
-  val body: ResponseBody?
+  val body: ResponseBody
 
   /**
    * Returns the raw response received from the network. Will be null if this response didn't use
@@ -152,8 +152,8 @@ expect class Response : Closeable {
   /**
    * Closes the response body. Equivalent to `body().close()`.
    *
-   * It is an error to close a response that is not eligible for a body. This includes the
-   * responses returned from [cacheResponse], [networkResponse], and [priorResponse].
+   * Prior to OkHttp 5.0, it was an error to close a response that is not eligible for a body. This
+   * includes the responses returned from [cacheResponse], [networkResponse], and [priorResponse].
    */
   override fun close()
 
@@ -166,7 +166,7 @@ expect class Response : Closeable {
     internal var message: String?
     // internal var handshake: Handshake? = null
     internal var headers: Headers.Builder
-    internal var body: ResponseBody?
+    internal var body: ResponseBody
     internal var networkResponse: Response?
     internal var cacheResponse: Response?
     internal var priorResponse: Response?
@@ -204,7 +204,7 @@ expect class Response : Closeable {
     /** Removes all headers on this builder and adds [headers]. */
     open fun headers(headers: Headers): Builder
 
-    open fun body(body: ResponseBody?): Builder
+    open fun body(body: ResponseBody): Builder
 
     open fun networkResponse(networkResponse: Response?): Builder
 

--- a/okhttp/src/commonMain/kotlin/okhttp3/internal/-UtilCommon.kt
+++ b/okhttp/src/commonMain/kotlin/okhttp3/internal/-UtilCommon.kt
@@ -20,6 +20,8 @@ import okhttp3.Headers
 import okhttp3.OkHttp
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.ArrayIndexOutOfBoundsException
 import okio.Buffer
 import okio.BufferedSink
@@ -376,6 +378,7 @@ internal fun checkOffsetAndCount(arrayLength: Long, offset: Long, count: Long) {
 
 val commonEmptyHeaders: Headers = Headers.headersOf()
 val commonEmptyRequestBody: RequestBody = EMPTY_BYTE_ARRAY.toRequestBody()
+val commonEmptyResponse: ResponseBody = EMPTY_BYTE_ARRAY.toResponseBody()
 
 internal fun <T> interleave(a: Iterable<T>, b: Iterable<T>): List<T> {
   val ia = a.iterator()

--- a/okhttp/src/jsTest/kotlin/okhttp3/SuspendCallTest.kt
+++ b/okhttp/src/jsTest/kotlin/okhttp3/SuspendCallTest.kt
@@ -51,7 +51,7 @@ class SuspendCallTest {
 
     val response = call.executeAsync()
     response.use {
-      assertThat(it.body?.string()).isEqualTo("abc")
+      assertThat(it.body.string()).isEqualTo("abc")
     }
 
     assertThat(response.code).isEqualTo(200)

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Cache.kt
@@ -188,7 +188,7 @@ class Cache(
 
     val response = entry.response(snapshot)
     if (!entry.matches(request, response)) {
-      response.body?.closeQuietly()
+      response.body.closeQuietly()
       return null
     }
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Response.kt
@@ -26,6 +26,7 @@ import okhttp3.internal.commonCacheControl
 import okhttp3.internal.commonCacheResponse
 import okhttp3.internal.commonClose
 import okhttp3.internal.commonCode
+import okhttp3.internal.commonEmptyResponse
 import okhttp3.internal.commonHeader
 import okhttp3.internal.commonHeaders
 import okhttp3.internal.commonIsRedirect
@@ -60,7 +61,7 @@ actual class Response internal constructor(
   /** Returns the HTTP headers. */
   @get:JvmName("headers") actual val headers: Headers,
 
-  @get:JvmName("body") actual val body: ResponseBody?,
+  @get:JvmName("body") actual val body: ResponseBody,
 
   @get:JvmName("networkResponse") actual val networkResponse: Response?,
 
@@ -145,7 +146,7 @@ actual class Response internal constructor(
 
   @Throws(IOException::class)
   actual fun peekBody(byteCount: Long): ResponseBody {
-    val peeked = body!!.source().peek()
+    val peeked = body.source().peek()
     val buffer = Buffer()
     peeked.request(byteCount)
     buffer.write(peeked, minOf(byteCount, peeked.buffer.size))
@@ -157,7 +158,7 @@ actual class Response internal constructor(
       message = "moved to val",
       replaceWith = ReplaceWith(expression = "body"),
       level = DeprecationLevel.ERROR)
-  fun body(): ResponseBody? = body
+  fun body() = body
 
   actual fun newBuilder(): Builder = commonNewBuilder()
 
@@ -241,7 +242,7 @@ actual class Response internal constructor(
     internal actual var message: String? = null
     internal var handshake: Handshake? = null
     internal actual var headers: Headers.Builder
-    internal actual var body: ResponseBody? = null
+    internal actual var body: ResponseBody = commonEmptyResponse
     internal actual var networkResponse: Response? = null
     internal actual var cacheResponse: Response? = null
     internal actual var priorResponse: Response? = null
@@ -289,7 +290,7 @@ actual class Response internal constructor(
 
     actual open fun headers(headers: Headers) = commonHeaders(headers)
 
-    actual open fun body(body: ResponseBody?) = commonBody(body)
+    actual open fun body(body: ResponseBody) = commonBody(body)
 
     actual open fun networkResponse(networkResponse: Response?) = commonNetworkResponse(networkResponse)
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/-UtilJvm.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/-UtilJvm.kt
@@ -39,7 +39,6 @@ import okhttp3.OkHttpClient
 import okhttp3.RequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody
-import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.internal.http2.Header
 import okio.Buffer
 import okio.BufferedSource
@@ -50,7 +49,7 @@ val EMPTY_HEADERS: Headers = commonEmptyHeaders
 @JvmField
 val EMPTY_REQUEST: RequestBody = commonEmptyRequestBody
 @JvmField
-val EMPTY_RESPONSE: ResponseBody = EMPTY_BYTE_ARRAY.toResponseBody()
+val EMPTY_RESPONSE: ResponseBody = commonEmptyResponse
 
 actual typealias HttpUrlRepresentation = HttpUrl
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealRoutePlanner.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealRoutePlanner.kt
@@ -27,7 +27,6 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
-import okhttp3.internal.EMPTY_RESPONSE
 import okhttp3.internal.canReuseConnectionFor
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.connection.RoutePlanner.Plan
@@ -245,7 +244,6 @@ class RealRoutePlanner(
       .protocol(Protocol.HTTP_1_1)
       .code(HttpURLConnection.HTTP_PROXY_AUTH)
       .message("Preemptive Authenticate")
-      .body(EMPTY_RESPONSE)
       .sentRequestAtMillis(-1L)
       .receivedResponseAtMillis(-1L)
       .header("Proxy-Authenticate", "OkHttp-Preemptive")

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
@@ -19,8 +19,8 @@ import java.io.IOException
 import java.net.ProtocolException
 import okhttp3.Interceptor
 import okhttp3.Response
-import okhttp3.internal.EMPTY_RESPONSE
 import okhttp3.internal.http2.ConnectionShutdownException
+import okhttp3.internal.stripBody
 import okio.buffer
 
 /** This is the last interceptor in the chain. It makes a network call to the server. */
@@ -123,9 +123,7 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
 
       response = if (forWebSocket && code == 101) {
         // Connection is upgrading, but we need to ensure interceptors see a non-null response body.
-        response.newBuilder()
-            .body(EMPTY_RESPONSE)
-            .build()
+        response.stripBody()
       } else {
         response.newBuilder()
             .body(exchange.openResponseBody(response))
@@ -135,9 +133,9 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
           "close".equals(response.header("Connection"), ignoreCase = true)) {
         exchange.noNewExchangesOnConnection()
       }
-      if ((code == 204 || code == 205) && (response.body?.contentLength() ?: -1L) > 0L) {
+      if ((code == 204 || code == 205) && response.body.contentLength() > 0L) {
         throw ProtocolException(
-            "HTTP $code had non-zero Content-Length: ${response.body?.contentLength()}")
+            "HTTP $code had non-zero Content-Length: ${response.body.contentLength()}")
       }
       return response
     } catch (e: IOException) {

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RealInterceptorChain.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RealInterceptorChain.kt
@@ -115,8 +115,6 @@ class RealInterceptorChain(
       }
     }
 
-    check(response.body != null) { "interceptor $interceptor returned a response with no body" }
-
     return response
   }
 }

--- a/okhttp/src/jvmTest/java/okhttp3/CacheCorruptionTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/CacheCorruptionTest.kt
@@ -88,7 +88,7 @@ class CacheCorruptionTest(
       }
     }
 
-    assertThat(response.body!!.string()).isEqualTo("ABC.1") // cached
+    assertThat(response.body.string()).isEqualTo("ABC.1") // cached
     assertThat(cache.requestCount()).isEqualTo(2)
     assertThat(cache.networkCount()).isEqualTo(1)
     assertThat(cache.hitCount()).isEqualTo(1)
@@ -105,7 +105,7 @@ class CacheCorruptionTest(
       }
     }
 
-    assertThat(response.body!!.string()).isEqualTo("ABC.2") // not cached
+    assertThat(response.body.string()).isEqualTo("ABC.2") // not cached
     assertThat(cache.requestCount()).isEqualTo(2)
     assertThat(cache.networkCount()).isEqualTo(2)
     assertThat(cache.hitCount()).isEqualTo(0)
@@ -119,7 +119,7 @@ class CacheCorruptionTest(
       }
     }
 
-    assertThat(response.body!!.string()).isEqualTo("ABC.2") // not cached
+    assertThat(response.body.string()).isEqualTo("ABC.2") // not cached
     assertThat(cache.requestCount()).isEqualTo(2)
     assertThat(cache.networkCount()).isEqualTo(2)
     assertThat(cache.hitCount()).isEqualTo(0)
@@ -163,7 +163,7 @@ class CacheCorruptionTest(
       .build()
     val request: Request = Request.Builder().url(server.url("/")).build()
     val response1: Response = client.newCall(request).execute()
-    val bodySource = response1.body!!.source()
+    val bodySource = response1.body.source()
     assertThat(bodySource.readUtf8()).isEqualTo("ABC.1")
 
     corruptor()

--- a/okhttp/src/jvmTest/java/okhttp3/CallKotlinTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/CallKotlinTest.kt
@@ -75,8 +75,8 @@ class CallKotlinTest(
     val cloned = call.clone()
     val response2 = cloned.execute()
 
-    assertThat("abc").isEqualTo(response1.body!!.string())
-    assertThat("def").isEqualTo(response2.body!!.string())
+    assertThat("abc").isEqualTo(response1.body.string())
+    assertThat("def").isEqualTo(response2.body.string())
   }
 
   @Test
@@ -209,7 +209,7 @@ class CallKotlinTest(
         .build()
     val responseA = client.newCall(requestA).execute()
 
-    assertThat(responseA.body!!.string()).isEqualTo("a")
+    assertThat(responseA.body.string()).isEqualTo("a")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
 
     // Give the socket a chance to become stale.
@@ -221,7 +221,7 @@ class CallKotlinTest(
         .post("b".toRequestBody("text/plain".toMediaType()))
         .build()
     val responseB = client.newCall(requestB).execute()
-    assertThat(responseB.body!!.string()).isEqualTo("b")
+    assertThat(responseB.body.string()).isEqualTo("b")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
   }
 

--- a/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
@@ -264,7 +264,7 @@ open class CallTest(
       .build()
     val response = client.newCall(headRequest).execute()
     assertThat(response.code).isEqualTo(200)
-    assertArrayEquals(ByteArray(0), response.body!!.bytes())
+    assertArrayEquals(ByteArray(0), response.body.bytes())
     val getRequest = Request.Builder()
       .url(server.url("/"))
       .build()
@@ -407,7 +407,7 @@ open class CallTest(
       .build()
     val response = client.newCall(request).execute()
     assertThat(response.code).isEqualTo(200)
-    response.body!!.close()
+    response.body.close()
     val recordedRequest1 = server.takeRequest()
     assertThat(recordedRequest1.method).isEqualTo("POST")
     assertThat(recordedRequest1.body.readUtf8()).isEqualTo(body)
@@ -604,7 +604,7 @@ open class CallTest(
       .build()
     val call = client.newCall(request)
     val response = call.execute()
-    response.body!!.close()
+    response.body.close()
     try {
       call.execute()
       fail<Unit>()
@@ -658,8 +658,8 @@ open class CallTest(
     val response1 = call.execute()
     val cloned = call.clone()
     val response2 = cloned.execute()
-    assertThat("abc").isEqualTo(response1.body!!.string())
-    assertThat("def").isEqualTo(response2.body!!.string())
+    assertThat("abc").isEqualTo(response1.body.string())
+    assertThat("def").isEqualTo(response2.body.string())
   }
 
   @Test fun legalToExecuteTwiceCloning_Async() {
@@ -802,7 +802,7 @@ open class CallTest(
       }
 
       override fun onResponse(call: Call, response: Response) {
-        val bytes = response.body!!.byteStream()
+        val bytes = response.body.byteStream()
         assertThat(bytes.read()).isEqualTo('a'.code)
         assertThat(bytes.read()).isEqualTo('b'.code)
         assertThat(bytes.read()).isEqualTo('c'.code)
@@ -834,7 +834,7 @@ open class CallTest(
       .build()
     val request = Request.Builder().url(server.url("/b")).build()
     val response = client.newCall(request).execute()
-    val bodySource = response.body!!.source()
+    val bodySource = response.body.source()
     assertThat(bodySource.readByte()).isEqualTo('d'.code.toByte())
 
     // The second byte of this request will be delayed by 750ms so we should time out after 250ms.
@@ -1035,14 +1035,14 @@ open class CallTest(
     // Call 1: set a deadline on the response body.
     val request1 = Request.Builder().url(server.url("/")).build()
     val response1 = client.newCall(request1).execute()
-    val body1 = response1.body!!.source()
+    val body1 = response1.body.source()
     assertThat(body1.readUtf8()).isEqualTo("abc")
     body1.timeout().deadline(5, TimeUnit.SECONDS)
 
     // Call 2: check for the absence of a deadline on the request body.
     val request2 = Request.Builder().url(server.url("/")).build()
     val response2 = client.newCall(request2).execute()
-    val body2 = response2.body!!.source()
+    val body2 = response2.body.source()
     assertThat(body2.readUtf8()).isEqualTo("def")
     assertThat(body2.timeout().hasDeadline()).isFalse
 
@@ -1365,7 +1365,7 @@ open class CallTest(
     val request = Request.Builder().url(server.url("/")).build()
     val response = client.newCall(request).execute()
     assertThat(response.code).isEqualTo(301)
-    response.body!!.close()
+    response.body.close()
   }
 
   @Test fun matchingPinnedCertificate() {
@@ -1383,7 +1383,7 @@ open class CallTest(
         server.hostName, pin(certificate)
       )
     }
-    response1.body!!.close()
+    response1.body.close()
 
     // Make another request with certificate pinning. It should complete normally.
     client = client.newBuilder()
@@ -1394,7 +1394,7 @@ open class CallTest(
     assertThat(response1.handshake).isNotSameAs(
       response2.handshake
     )
-    response2.body!!.close()
+    response2.body.close()
   }
 
   @Test fun unmatchingPinnedCertificate() {
@@ -1448,7 +1448,7 @@ open class CallTest(
     // Seed the connection pool so we have something that can fail.
     val request1 = Request.Builder().url(server.url("/")).build()
     val response1 = client.newCall(request1).execute()
-    assertThat(response1.body!!.string()).isEqualTo("abc")
+    assertThat(response1.body.string()).isEqualTo("abc")
 
     listener.clearAllEvents()
 
@@ -1471,7 +1471,7 @@ open class CallTest(
     listener.clearAllEvents()
 
     val response3 = client.newCall(request1).execute()
-    assertThat(response3.body!!.string()).isEqualTo("abc")
+    assertThat(response3.body.string()).isEqualTo("abc")
 
     assertThat(listener.recordedEventTypes()).containsExactly(
       "CallStart", "ProxySelectStart", "ProxySelectEnd", "DnsStart", "DnsEnd", "ConnectStart",
@@ -1499,13 +1499,13 @@ open class CallTest(
     // Seed the connection pool so we have something that can fail.
     val request1 = Request.Builder().url(server.url("/")).build()
     val response1 = client.newCall(request1).execute()
-    assertThat(response1.body!!.string()).isEqualTo("abc")
+    assertThat(response1.body.string()).isEqualTo("abc")
     val request2 = Request.Builder()
       .url(server.url("/"))
       .post("body!".toRequestBody("text/plain".toMediaType()))
       .build()
     val response2 = client.newCall(request2).execute()
-    assertThat(response2.body!!.string()).isEqualTo("def")
+    assertThat(response2.body.string()).isEqualTo("def")
     val get = server.takeRequest()
     assertThat(get.sequenceNumber).isEqualTo(0)
     val post1 = server.takeRequest()
@@ -1835,7 +1835,7 @@ open class CallTest(
         .post("Request Body".toRequestBody("text/plain".toMediaType()))
         .build()
     ).execute()
-    assertThat(response.body!!.string()).isEqualTo("Page 2")
+    assertThat(response.body.string()).isEqualTo("Page 2")
     val page1 = server.takeRequest()
     assertThat(page1.requestLine).isEqualTo("POST /page1 HTTP/1.1")
     assertThat(page1.body.readUtf8()).isEqualTo("Request Body")
@@ -1856,7 +1856,7 @@ open class CallTest(
       .url(server.url("/"))
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("Body")
+    assertThat(response.body.string()).isEqualTo("Body")
   }
 
   @Test fun getClientRequestTimeoutWithBackPressure() {
@@ -1872,7 +1872,7 @@ open class CallTest(
       .url(server.url("/"))
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("You took too long!")
+    assertThat(response.body.string()).isEqualTo("You took too long!")
   }
 
   @Test fun requestBodyRetransmittedOnClientRequestTimeout() {
@@ -1889,7 +1889,7 @@ open class CallTest(
       .post("Hello".toRequestBody("text/plain".toMediaType()))
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("Body")
+    assertThat(response.body.string()).isEqualTo("Body")
     val request1 = server.takeRequest()
     assertThat(request1.body.readUtf8()).isEqualTo("Hello")
     val request2 = server.takeRequest()
@@ -1935,7 +1935,7 @@ open class CallTest(
       .build()
     val response = client.newCall(request).execute()
     assertThat(response.code).isEqualTo(408)
-    assertThat(response.body!!.string()).isEqualTo("You took too long!")
+    assertThat(response.body.string()).isEqualTo("You took too long!")
     assertThat(server.requestCount).isEqualTo(2)
   }
 
@@ -1961,7 +1961,7 @@ open class CallTest(
       .build()
     val response = client.newCall(request).execute()
     assertThat(response.code).isEqualTo(503)
-    assertThat(response.body!!.string()).isEqualTo("You took too long!")
+    assertThat(response.body.string()).isEqualTo("You took too long!")
     assertThat(server.requestCount).isEqualTo(2)
   }
 
@@ -1979,7 +1979,7 @@ open class CallTest(
       .url(server.url("/"))
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("Body")
+    assertThat(response.body.string()).isEqualTo("Body")
   }
 
   @Test fun canRetryNormalRequestBody() {
@@ -2008,7 +2008,7 @@ open class CallTest(
       .build()
     val response = client.newCall(request).execute()
     assertThat(response.code).isEqualTo(200)
-    assertThat(response.body!!.string()).isEqualTo("thank you for retrying")
+    assertThat(response.body.string()).isEqualTo("thank you for retrying")
     assertThat(server.takeRequest().body.readUtf8()).isEqualTo("attempt 0")
     assertThat(server.takeRequest().body.readUtf8()).isEqualTo("attempt 1")
     assertThat(server.requestCount).isEqualTo(2)
@@ -2044,7 +2044,7 @@ open class CallTest(
       .build()
     val response = client.newCall(request).execute()
     assertThat(response.code).isEqualTo(503)
-    assertThat(response.body!!.string()).isEqualTo("please retry")
+    assertThat(response.body.string()).isEqualTo("please retry")
     assertThat(server.takeRequest().body.readUtf8()).isEqualTo("attempt 0")
     assertThat(server.requestCount).isEqualTo(1)
   }
@@ -2068,7 +2068,7 @@ open class CallTest(
     ).execute()
 
     // then
-    assertThat(response.body!!.string()).isEqualTo("Page 2")
+    assertThat(response.body.string()).isEqualTo("Page 2")
     val page1 = server.takeRequest()
     assertThat(page1.requestLine).isEqualTo("PROPFIND /page1 HTTP/1.1")
     assertThat(page1.body.readUtf8()).isEqualTo("Request Body")
@@ -2133,7 +2133,7 @@ open class CallTest(
         .url(server.url("/page1"))
         .build()
     ).execute()
-    assertThat(response.body!!.string()).isEqualTo("Page 2")
+    assertThat(response.body.string()).isEqualTo("Page 2")
     val request1 = server.takeRequest()
     assertThat(request1.getHeader("Cookie")).isEqualTo("c=cookie")
     val request2 = server2.takeRequest()
@@ -2156,7 +2156,7 @@ open class CallTest(
       .build()
     val request = Request.Builder().url(server.url("/a")).build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("Page 2")
+    assertThat(response.body.string()).isEqualTo("Page 2")
     val redirectRequest = server2.takeRequest()
     assertThat(redirectRequest.getHeader("Authorization")).isNull()
     assertThat(redirectRequest.path).isEqualTo("/b")
@@ -2417,7 +2417,7 @@ open class CallTest(
     Thread.sleep(100) // wait for it to go in flight.
     call.cancel()
     try {
-      result.get()!!.body!!.bytes()
+      result.get()!!.body.bytes()
       fail<Unit>()
     } catch (expected: IOException) {
     }
@@ -2538,7 +2538,7 @@ open class CallTest(
       override fun onResponse(call: Call, response: Response) {
         call.cancel()
         try {
-          bodyRef.set(response.body!!.string())
+          bodyRef.set(response.body.string())
         } catch (e: IOException) { // It is ok if this broke the stream.
           bodyRef.set("A")
           throw e // We expect to not loop into onFailure in this case.
@@ -2645,7 +2645,7 @@ open class CallTest(
     // The response is not decompressed.
     val response = call.execute()
     assertThat(response.header("Content-Encoding")).isEqualTo("gzip")
-    assertThat(response.body!!.source().readByteString()).isEqualTo(
+    assertThat(response.body.source().readByteString()).isEqualTo(
       gzippedBody.snapshot()
     )
 
@@ -2677,7 +2677,7 @@ open class CallTest(
     })
     val response = responseRef.take()
     assertThat(response.code).isEqualTo(200)
-    assertThat(response.body!!.string()).isEqualTo("abc")
+    assertThat(response.body.string()).isEqualTo("abc")
 
     // Make another request just to confirm that that connection can be reused...
     executeSynchronously("/").assertBody("def")
@@ -2687,7 +2687,7 @@ open class CallTest(
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
 
     // ... even before we close the response body!
-    response.body!!.close()
+    response.body.close()
   }
 
   @Test fun userAgentIsIncludedByDefault() {
@@ -2969,7 +2969,7 @@ open class CallTest(
     )
     call.execute().use { response ->
       assertThat(response.code).isEqualTo(200)
-      assertThat(response.body!!.string()).isNotBlank
+      assertThat(response.body.string()).isNotBlank
     }
     if (!platform.isJdk8()) {
       val connectCount = listener.eventSequence.stream()
@@ -3006,7 +3006,7 @@ open class CallTest(
       .header("User-Agent", "App 1.0")
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo(
+    assertThat(response.body.string()).isEqualTo(
       "encrypted response from the origin server"
     )
     val connect = server.takeRequest()
@@ -3081,7 +3081,7 @@ open class CallTest(
       .url("https://android.com/foo")
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
     val connect1 = server.takeRequest()
     assertThat(connect1.requestLine).isEqualTo("CONNECT android.com:443 HTTP/1.1")
     assertThat(connect1.getHeader("Proxy-Authorization")).isNull()
@@ -3112,7 +3112,7 @@ open class CallTest(
       .url("http://android.com/foo")
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
     val get1 = server.takeRequest()
     assertThat(get1.requestLine).isEqualTo("GET http://android.com/foo HTTP/1.1")
     assertThat(get1.getHeader("Proxy-Authorization")).isNull()
@@ -3156,7 +3156,7 @@ open class CallTest(
       .url("https://android.com/foo")
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
 
     // First CONNECT call needs a new connection.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
@@ -3227,7 +3227,7 @@ open class CallTest(
       .header("Proxy-Authorization", "password")
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
     val connect1 = server.takeRequest()
     assertThat(connect1.getHeader("Proxy-Authorization")).isNull()
     val connect2 = server.takeRequest()
@@ -3534,7 +3534,7 @@ open class CallTest(
       .url(url)
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
     val connect = server.takeRequest()
     assertThat(connect.requestLine).isEqualTo("CONNECT [::1]:$port HTTP/1.1")
     assertThat(connect.getHeader("Host")).isEqualTo("[::1]:$port")
@@ -3561,7 +3561,7 @@ open class CallTest(
       .url(url)
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
     val connect = server.takeRequest()
     assertThat(connect.requestLine).isEqualTo(
       "CONNECT [::1]:$port HTTP/1.1"
@@ -3594,7 +3594,7 @@ open class CallTest(
       .url(url)
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
     val connect = server.takeRequest()
     assertThat(connect.requestLine).isEqualTo(
       "CONNECT 127.0.0.1:$port HTTP/1.1"
@@ -3627,7 +3627,7 @@ open class CallTest(
       .url(url)
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
     val connect = server.takeRequest()
     assertThat(connect.requestLine).isEqualTo("CONNECT 127.0.0.1:$port HTTP/1.1")
     assertThat(connect.getHeader("Host")).isEqualTo("127.0.0.1:$port")
@@ -3654,7 +3654,7 @@ open class CallTest(
       .url(url)
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
     val connect = server.takeRequest()
     assertThat(connect.requestLine).isEqualTo("CONNECT any-host-name:$port HTTP/1.1")
     assertThat(connect.getHeader("Host")).isEqualTo("any-host-name:$port")
@@ -3681,7 +3681,7 @@ open class CallTest(
       .url(url)
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("response body")
+    assertThat(response.body.string()).isEqualTo("response body")
     val connect = server.takeRequest()
     assertThat(connect.requestLine).isEqualTo("CONNECT any-host-name:$port HTTP/1.1")
     assertThat(connect.getHeader("Host")).isEqualTo("any-host-name:$port")
@@ -3907,7 +3907,7 @@ open class CallTest(
         .build()
     )
     val response = call.execute()
-    val source = response.body!!.source()
+    val source = response.body.source()
     assertThat(response.header("h1")).isEqualTo("v1")
     assertThat(response.header("h2")).isEqualTo("v2")
     assertThat(source.readUtf8(5)).isEqualTo("Hello")
@@ -3934,7 +3934,7 @@ open class CallTest(
         .build()
     )
     call.execute().use { response ->
-      val source = response.body!!.source()
+      val source = response.body.source()
       assertThat(response.header("h1")).isEqualTo("v1")
       assertThat(response.header("h2")).isEqualTo("v2")
       assertThat(source.readUtf8(5)).isEqualTo("Hello")
@@ -4007,7 +4007,7 @@ open class CallTest(
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("abc")
+    assertThat(response.body.string()).isEqualTo("abc")
     executeSynchronously("/").assertCode(200)
   }
 
@@ -4022,7 +4022,7 @@ open class CallTest(
       .addInterceptor(Interceptor { chain ->
         val response = chain.proceed(chain.request())
         chain.call().cancel() // Cancel after we have the response.
-        val closeTrackingSource = object : ForwardingSource(response.body!!.source()) {
+        val closeTrackingSource = object : ForwardingSource(response.body.source()) {
           override fun close() {
             closed.set(true)
             super.close()
@@ -4035,6 +4035,33 @@ open class CallTest(
       .build()
     executeSynchronously("/").assertFailure("Canceled")
     assertThat(closed.get()).isTrue
+  }
+
+  @Test fun priorResponseBodyNotReadable() {
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(301)
+        .addHeader("Location: /b")
+        .addHeader("Content-Type: text/plain; charset=UTF-8")
+        .addHeader("Test", "Redirect from /a to /b")
+        .setBody("/a has moved!")
+    )
+    server.enqueue(MockResponse()
+      .setBody("this is the redirect target"))
+
+    val call = client.newCall(Request.Builder()
+      .url(server.url("/"))
+      .build())
+    val response = call.execute()
+    assertThat(response.body.string()).isEqualTo("this is the redirect target")
+    assertThat(response.priorResponse?.body?.contentType())
+      .isEqualTo("text/plain; charset=UTF-8".toMediaType())
+    try {
+      response.priorResponse?.body?.string()
+      fail<Unit>()
+    } catch (expected: IllegalStateException) {
+      assertThat(expected.message).contains("Unreadable ResponseBody!")
+    }
   }
 
   private fun makeFailingCall() {
@@ -4081,7 +4108,7 @@ open class CallTest(
     val call = client.newCall(request)
     return try {
       val response = call.execute()
-      val bodyString = response.body!!.string()
+      val bodyString = response.body.string()
       RecordedResponse(request, response, null, bodyString, null)
     } catch (e: IOException) {
       RecordedResponse(request, null, null, null, e)

--- a/okhttp/src/jvmTest/java/okhttp3/ConnectionReuseTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/ConnectionReuseTest.kt
@@ -152,7 +152,7 @@ class ConnectionReuseTest {
       .url(server.url("/"))
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("b")
+    assertThat(response.body.string()).isEqualTo("b")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
   }
@@ -173,7 +173,7 @@ class ConnectionReuseTest {
       .url(server.url("/"))
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("b")
+    assertThat(response.body.string()).isEqualTo("b")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
   }
@@ -186,10 +186,10 @@ class ConnectionReuseTest {
       .url(server.url("/"))
       .build()
     val responseA = client.newCall(request).execute()
-    assertThat(responseA.body!!.string()).isEqualTo("a")
+    assertThat(responseA.body.string()).isEqualTo("a")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     val responseB = client.newCall(request).execute()
-    assertThat(responseB.body!!.string()).isEqualTo("b")
+    assertThat(responseB.body.string()).isEqualTo("b")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
   }
@@ -204,8 +204,8 @@ class ConnectionReuseTest {
       .build()
     val response1 = client.newCall(request).execute()
     val response2 = client.newCall(request).execute()
-    response1.body!!.string() // Discard the response body.
-    response2.body!!.string() // Discard the response body.
+    response1.body.string() // Discard the response body.
+    response2.body.string() // Discard the response body.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
   }
@@ -220,12 +220,12 @@ class ConnectionReuseTest {
       .url(server.url("/"))
       .build()
     val response1 = client.newCall(request).execute()
-    assertThat(response1.body!!.string()).isEqualTo("a")
+    assertThat(response1.body.string()).isEqualTo("a")
 
     // Give the thread pool a chance to evict.
     Thread.sleep(500)
     val response2 = client.newCall(request).execute()
-    assertThat(response2.body!!.string()).isEqualTo("b")
+    assertThat(response2.body.string()).isEqualTo("b")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
   }
@@ -239,7 +239,7 @@ class ConnectionReuseTest {
       .url(server.url("/"))
       .build()
     val response = client.newCall(request).execute()
-    response.body!!.close()
+    response.body.close()
 
     // This client shares a connection pool but has a different SSL socket factory.
     val handshakeCertificates2 = HandshakeCertificates.Builder().build()
@@ -266,14 +266,14 @@ class ConnectionReuseTest {
       .url(server.url("/"))
       .build()
     val response1 = client.newCall(request).execute()
-    response1.body!!.close()
+    response1.body.close()
 
     // This client shares a connection pool but has a different SSL socket factory.
     val anotherClient = client.newBuilder()
       .hostnameVerifier(RecordingHostnameVerifier())
       .build()
     val response2 = anotherClient.newCall(request).execute()
-    response2.body!!.close()
+    response2.body.close()
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
   }
@@ -323,7 +323,7 @@ class ConnectionReuseTest {
     val call = client.newCall(request)
     call.execute().use { response ->
       assertThat(
-        response.body!!.string()
+        response.body.string()
       ).isEqualTo("unrelated response body!")
     }
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
@@ -359,7 +359,7 @@ class ConnectionReuseTest {
   private fun assertConnectionReused(vararg requests: Request?) {
     for (i in requests.indices) {
       val response = client.newCall(requests[i]!!).execute()
-      response.body!!.string() // Discard the response body.
+      response.body.string() // Discard the response body.
       assertThat(server.takeRequest().sequenceNumber).isEqualTo(i)
     }
   }
@@ -367,7 +367,7 @@ class ConnectionReuseTest {
   private fun assertConnectionNotReused(vararg requests: Request?) {
     for (request in requests) {
       val response = client.newCall(request!!).execute()
-      response.body!!.string() // Discard the response body.
+      response.body.string() // Discard the response body.
       assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     }
   }

--- a/okhttp/src/jvmTest/java/okhttp3/FastFallbackTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/FastFallbackTest.kt
@@ -127,7 +127,7 @@ class FastFallbackTest {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("hello from IPv6")
+    assertThat(response.body.string()).isEqualTo("hello from IPv6")
 
     // In the process we made one successful connection attempt.
     assertThat(listener.recordedEventTypes().filter { it == "ConnectStart" }).hasSize(1)
@@ -156,7 +156,7 @@ class FastFallbackTest {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("hello from IPv6")
+    assertThat(response.body.string()).isEqualTo("hello from IPv6")
 
     // In the process we made one successful connection attempt.
     assertThat(listener.recordedEventTypes().filter { it == "ConnectStart" }).hasSize(1)
@@ -177,7 +177,7 @@ class FastFallbackTest {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("hello from IPv4")
+    assertThat(response.body.string()).isEqualTo("hello from IPv4")
 
     // In the process we made one successful connection attempt.
     assertThat(listener.recordedEventTypes().filter { it == "ConnectStart" }).hasSize(2)
@@ -199,7 +199,7 @@ class FastFallbackTest {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("hello from IPv6")
+    assertThat(response.body.string()).isEqualTo("hello from IPv6")
 
     // In the process we made two connection attempts including one failure.
     assertThat(listener.recordedEventTypes().filter { it == "ConnectStart" }).hasSize(1)
@@ -245,7 +245,7 @@ class FastFallbackTest {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("hello from IPv4")
+    assertThat(response.body.string()).isEqualTo("hello from IPv4")
 
     // In the process we made two connection attempts including one failure.
     assertThat(listener.recordedEventTypes().filter { it == "ConnectStart" }).hasSize(2)
@@ -347,7 +347,7 @@ class FastFallbackTest {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("this was the 2nd request on IPv4")
+    assertThat(response.body.string()).isEqualTo("this was the 2nd request on IPv4")
     assertThat(serverIpv4.takeRequest().sequenceNumber).isEqualTo(0)
     assertThat(serverIpv4.takeRequest().sequenceNumber).isEqualTo(1)
   }

--- a/okhttp/src/jvmTest/java/okhttp3/InterceptorTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/InterceptorTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
 import static okhttp3.TestUtil.assertSuppressed;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -633,56 +632,6 @@ public final class InterceptorTest {
 
     Response response = client.newCall(request).execute();
     response.body().close();
-  }
-
-  @Test public void applicationInterceptorResponseMustHaveBody() throws Exception {
-    server.enqueue(new MockResponse());
-
-    Interceptor interceptor = chain -> {
-      Response response = chain.proceed(chain.request());
-      return response.newBuilder()
-          .body(null)
-          .build();
-    };
-    client = client.newBuilder()
-        .addInterceptor(interceptor)
-        .build();
-
-    Request request = new Request.Builder()
-        .url(server.url("/"))
-        .build();
-    try {
-      client.newCall(request).execute();
-      fail();
-    } catch (IllegalStateException expected) {
-      assertThat(expected.getMessage()).isEqualTo(
-          ("interceptor " + interceptor + " returned a response with no body"));
-    }
-  }
-
-  @Test public void networkInterceptorResponseMustHaveBody() throws Exception {
-    server.enqueue(new MockResponse());
-
-    Interceptor interceptor = chain -> {
-      Response response = chain.proceed(chain.request());
-      return response.newBuilder()
-          .body(null)
-          .build();
-    };
-    client = client.newBuilder()
-        .addNetworkInterceptor(interceptor)
-        .build();
-
-    Request request = new Request.Builder()
-        .url(server.url("/"))
-        .build();
-    try {
-      client.newCall(request).execute();
-      fail();
-    } catch (IllegalStateException expected) {
-      assertThat(expected.getMessage()).isEqualTo(
-          ("interceptor " + interceptor + " returned a response with no body"));
-    }
   }
 
   @Test public void connectTimeout() throws Exception {

--- a/okhttp/src/jvmTest/java/okhttp3/KotlinSourceModernTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/KotlinSourceModernTest.kt
@@ -1057,7 +1057,6 @@ class KotlinSourceModernTest {
     builder = builder.removeHeader("")
     builder = builder.headers(headersOf())
     builder = builder.body("".toResponseBody(null))
-    builder = builder.body(null)
     builder = builder.networkResponse(Response.Builder().build())
     builder = builder.networkResponse(null)
     builder = builder.cacheResponse(Response.Builder().build())

--- a/okhttp/src/jvmTest/java/okhttp3/OkHttpClientTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/OkHttpClientTest.kt
@@ -224,7 +224,7 @@ class OkHttpClientTest {
       .url(server!!.url("/"))
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("abc")
+    assertThat(response.body.string()).isEqualTo("abc")
   }
 
   @Test fun sslSocketFactorySetAsSocketFactory() {

--- a/okhttp/src/jvmTest/java/okhttp3/RecordedResponse.java
+++ b/okhttp/src/jvmTest/java/okhttp3/RecordedResponse.java
@@ -105,7 +105,6 @@ public final class RecordedResponse {
   public RecordedResponse priorResponse() {
     Response priorResponse = response.priorResponse();
     assertThat(priorResponse).isNotNull();
-    assertThat(priorResponse.body()).isNull();
     return new RecordedResponse(priorResponse.request(), priorResponse, null, null, null);
   }
 
@@ -115,7 +114,6 @@ public final class RecordedResponse {
   public RecordedResponse networkResponse() {
     Response networkResponse = response.networkResponse();
     assertThat(networkResponse).isNotNull();
-    assertThat(networkResponse.body()).isNull();
     return new RecordedResponse(networkResponse.request(), networkResponse, null, null, null);
   }
 
@@ -137,7 +135,6 @@ public final class RecordedResponse {
   public RecordedResponse cacheResponse() {
     Response cacheResponse = response.cacheResponse();
     assertThat(cacheResponse).isNotNull();
-    assertThat(cacheResponse.body()).isNull();
     return new RecordedResponse(cacheResponse.request(), cacheResponse, null, null, null);
   }
 

--- a/okhttp/src/jvmTest/java/okhttp3/ResponseTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/ResponseTest.java
@@ -18,11 +18,11 @@ package okhttp3;
 import java.io.IOException;
 import okio.Buffer;
 import okio.BufferedSource;
+import okio.ByteString;
 import okio.Okio;
 import okio.Source;
 import okio.Timeout;
 import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -70,6 +70,25 @@ public final class ResponseTest {
   @Test public void zeroStatusCodeIsValid() {
     Response response = newResponse(responseBody("set status code 0"), 0);
     assertThat(response.code()).isEqualTo(0);
+  }
+
+  @Test public void defaultResponseBodyIsEmpty() throws Exception {
+    Response response = new Response.Builder()
+      .request(new Request.Builder()
+        .url("https://example.com/")
+        .build())
+      .protocol(Protocol.HTTP_1_1)
+      .code(200)
+      .message("OK")
+      .build();
+    assertThat(response.body().contentType()).isNull();
+    assertThat(response.body().contentLength()).isEqualTo(0L);
+    assertThat(response.body().byteString()).isEqualTo(ByteString.EMPTY);
+  }
+
+  @Test public void nullResponseBody() {
+    assertThatThrownBy(() -> new Response.Builder().body(null))
+      .isInstanceOf(NullPointerException.class);
   }
 
   /**

--- a/okhttp/src/jvmTest/java/okhttp3/ServerTruncatesRequestTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/ServerTruncatesRequestTest.kt
@@ -80,7 +80,7 @@ class ServerTruncatesRequestTest(
     )
 
     call.execute().use { response ->
-      assertThat(response.body!!.string()).isEqualTo("abc")
+      assertThat(response.body.string()).isEqualTo("abc")
     }
 
     val expectedEvents = mutableListOf<String>()
@@ -136,7 +136,7 @@ class ServerTruncatesRequestTest(
     )
 
     call.execute().use { response ->
-      assertThat(response.body!!.string()).isEqualTo("abc")
+      assertThat(response.body.string()).isEqualTo("abc")
       val requestBodyOut = requestBody.takeSink()
       try {
         SlowRequestBody.writeTo(requestBodyOut)
@@ -188,7 +188,7 @@ class ServerTruncatesRequestTest(
     )
 
     call.execute().use { response ->
-      assertThat(response.body!!.string()).isEqualTo("abc")
+      assertThat(response.body.string()).isEqualTo("abc")
       assertThat(response.trailers()).isEqualTo(headersOf("caboose", "xyz"))
     }
   }
@@ -223,7 +223,7 @@ class ServerTruncatesRequestTest(
     )
 
     call1.execute().use { response ->
-      assertThat(response.body!!.string()).isEqualTo("Req1")
+      assertThat(response.body.string()).isEqualTo("Req1")
       assertThat(response.handshake).isNotNull
       assertThat(response.protocol == Protocol.HTTP_1_1)
     }
@@ -276,7 +276,7 @@ class ServerTruncatesRequestTest(
         .build()
     )
     callB.execute().use { response ->
-      assertThat(response.body!!.string()).isEqualTo("abc")
+      assertThat(response.body.string()).isEqualTo("abc")
     }
   }
 
@@ -288,7 +288,7 @@ class ServerTruncatesRequestTest(
         .build()
     )
     callB.execute().use { response ->
-      assertThat(response.body!!.string()).isEqualTo("healthy")
+      assertThat(response.body.string()).isEqualTo("healthy")
     }
   }
 

--- a/okhttp/src/jvmTest/java/okhttp3/SocketChannelTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/SocketChannelTest.kt
@@ -171,7 +171,7 @@ class SocketChannelTest(
 
     assertThat(response).isNotNull()
 
-    assertThat(response.body!!.string()).isNotBlank()
+    assertThat(response.body.string()).isNotBlank()
 
     if (socketMode is TlsInstance) {
       assertThat(response.handshake!!.tlsVersion).isEqualTo(socketMode.tlsVersion)

--- a/okhttp/src/jvmTest/java/okhttp3/URLConnectionTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/URLConnectionTest.kt
@@ -175,7 +175,7 @@ class URLConnectionTest {
     assertThat(responseHeaders.value(1)).isEqualTo("d")
     assertThat(responseHeaders.name(2)).isEqualTo("A")
     assertThat(responseHeaders.value(2)).isEqualTo("e")
-    response.body!!.close()
+    response.body.close()
   }
 
   @Test fun serverSendsInvalidStatusLine() {
@@ -344,7 +344,7 @@ class URLConnectionTest {
     server.enqueue(responseAfter)
     server.enqueue(responseAfter) // Enqueue 2x because the broken connection may be reused.
     val response1 = getResponse(newRequest("/a"))
-    response1.body!!.source().timeout().timeout(100, TimeUnit.MILLISECONDS)
+    response1.body.source().timeout().timeout(100, TimeUnit.MILLISECONDS)
     assertContent("This connection won't pool properly", response1)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
 
@@ -352,7 +352,7 @@ class URLConnectionTest {
     // client has received the response.
     Thread.sleep(500)
     val response2 = getResponse(newRequest("/b"))
-    response1.body!!.source().timeout().timeout(100, TimeUnit.MILLISECONDS)
+    response1.body.source().timeout().timeout(100, TimeUnit.MILLISECONDS)
     assertContent("This comes after a busted connection", response2)
 
     // Check that a fresh connection was created, either immediately or after attempting reuse.
@@ -712,7 +712,7 @@ class URLConnectionTest {
     )
     try {
       val response = getResponse(newRequest("/"))
-      response.body!!.source().readUtf8(5)
+      response.body.source().readUtf8(5)
       fail<Any>()
     } catch (expected: ProtocolException) {
     }
@@ -803,7 +803,7 @@ class URLConnectionTest {
     server.enqueue(mockResponse)
     try {
       val response = getResponse(newRequest("/"))
-      response.body!!.source().readUtf8(7)
+      response.body.source().readUtf8(7)
       fail<Any>()
     } catch (expected: IOException) {
     }
@@ -1101,7 +1101,7 @@ class URLConnectionTest {
     )
     val call = client.newCall(newRequest("/"))
     val response = call.execute()
-    val inputStream = response.body!!.byteStream()
+    val inputStream = response.body.byteStream()
     assertThat(inputStream.read().toChar()).isEqualTo('A')
     call.cancel()
     try {
@@ -1192,7 +1192,7 @@ class URLConnectionTest {
     transferKind.setBody(response, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", 1024)
     server.enqueue(response)
     server.enqueue(response)
-    val inputStream = getResponse(newRequest("/")).body!!.byteStream()
+    val inputStream = getResponse(newRequest("/")).body.byteStream()
     assertThat(inputStream.markSupported())
       .overridingErrorMessage("This implementation claims to support mark().")
       .isFalse
@@ -1227,7 +1227,7 @@ class URLConnectionTest {
     assertThat(response.code).isEqualTo(401)
     assertThat(response.code).isEqualTo(401)
     assertThat(server.requestCount).isEqualTo(1)
-    response.body!!.close()
+    response.body.close()
   }
 
   @Test fun nonHexChunkSize() {
@@ -1239,7 +1239,7 @@ class URLConnectionTest {
     )
     try {
       getResponse(newRequest("/")).use { response ->
-        response.body!!.string()
+        response.body.string()
         fail<Any>()
       }
     } catch (expected: IOException) {
@@ -1255,7 +1255,7 @@ class URLConnectionTest {
     )
     try {
       getResponse(newRequest("/")).use { response ->
-        readAscii(response.body!!.byteStream(), Int.MAX_VALUE)
+        readAscii(response.body.byteStream(), Int.MAX_VALUE)
         fail<Any>()
       }
     } catch (expected: IOException) {
@@ -1282,7 +1282,7 @@ class URLConnectionTest {
     )
     try {
       getResponse(newRequest("/")).use { response ->
-        readAscii(response.body!!.byteStream(), Int.MAX_VALUE)
+        readAscii(response.body.byteStream(), Int.MAX_VALUE)
         fail<Any>()
       }
     } catch (expected: IOException) {
@@ -1300,11 +1300,11 @@ class URLConnectionTest {
         .addHeader("Content-Encoding: gzip")
     )
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo(
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE)).isEqualTo(
       "ABCABCABC"
     )
     assertThat(response.header("Content-Encoding")).isNull()
-    assertThat(response.body!!.contentLength()).isEqualTo(-1L)
+    assertThat(response.body.contentLength()).isEqualTo(-1L)
     val request = server.takeRequest()
     assertThat(request.getHeader("Accept-Encoding")).isEqualTo("gzip")
   }
@@ -1322,9 +1322,9 @@ class URLConnectionTest {
         .header("Accept-Encoding", "gzip")
         .build()
     )
-    val gunzippedIn: InputStream = GZIPInputStream(response.body!!.byteStream())
+    val gunzippedIn: InputStream = GZIPInputStream(response.body.byteStream())
     assertThat(readAscii(gunzippedIn, Int.MAX_VALUE)).isEqualTo("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-    assertThat(response.body!!.contentLength()).isEqualTo(bodyBytes.size)
+    assertThat(response.body.contentLength()).isEqualTo(bodyBytes.size)
     val request = server.takeRequest()
     assertThat(request.getHeader("Accept-Encoding")).isEqualTo("gzip")
   }
@@ -1357,7 +1357,7 @@ class URLConnectionTest {
         .header("Accept-Encoding", "custom")
         .build()
     )
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo("ABCDE")
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE)).isEqualTo("ABCDE")
     val request = server.takeRequest()
     assertThat(request.getHeader("Accept-Encoding")).isEqualTo("custom")
   }
@@ -1393,7 +1393,7 @@ class URLConnectionTest {
         .url(server.url("/"))
         .build()
     )
-    val gunzippedIn: InputStream = GZIPInputStream(response1.body!!.byteStream())
+    val gunzippedIn: InputStream = GZIPInputStream(response1.body.byteStream())
     assertThat(readAscii(gunzippedIn, Int.MAX_VALUE)).isEqualTo("one (gzipped)")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     val response2 = getResponse(
@@ -1401,7 +1401,7 @@ class URLConnectionTest {
         .url(server.url("/"))
         .build()
     )
-    assertThat(readAscii(response2.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo("two (identity)")
+    assertThat(readAscii(response2.body.byteStream(), Int.MAX_VALUE)).isEqualTo("two (identity)")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
   }
 
@@ -1460,13 +1460,13 @@ class URLConnectionTest {
     server.enqueue(mockResponse2)
     val call1 = client.newCall(newRequest("/"))
     val response1 = call1.execute()
-    val in1 = response1.body!!.byteStream()
+    val in1 = response1.body.byteStream()
     assertThat(readAscii(in1, 5)).isEqualTo("ABCDE")
     in1.close()
     call1.cancel()
     val call2 = client.newCall(newRequest("/"))
     val response2 = call2.execute()
-    val in2 = response2.body!!.byteStream()
+    val in2 = response2.body.byteStream()
     assertThat(readAscii(in2, 5)).isEqualTo("LMNOP")
     in2.close()
     call2.cancel()
@@ -1488,7 +1488,7 @@ class URLConnectionTest {
     )
     val startNanos = System.nanoTime()
     val connection1 = getResponse(newRequest("/"))
-    val inputStream = connection1.body!!.byteStream()
+    val inputStream = connection1.body.byteStream()
     inputStream.close()
     val elapsedNanos = System.nanoTime() - startNanos
     val elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos)
@@ -1596,7 +1596,7 @@ class URLConnectionTest {
         .build()
     )
     assertThat(response.code).isEqualTo(200)
-    response.body!!.byteStream().close()
+    response.body.byteStream().close()
     val recordedRequest1 = server.takeRequest()
     assertThat(recordedRequest1.method).isEqualTo("POST")
     assertThat(recordedRequest1.body.readUtf8()).isEqualTo(body)
@@ -1685,7 +1685,7 @@ class URLConnectionTest {
       response = getResponse(newRequest("/"))
     }
     assertThat(response.code).isEqualTo(responseCode)
-    response.body!!.byteStream().close()
+    response.body.byteStream().close()
     return authenticator.calls
   }
 
@@ -1824,7 +1824,7 @@ class URLConnectionTest {
         .post(streamingMode.newRequestBody("ABCD"))
         .build()
     )
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo(
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE)).isEqualTo(
       "Success!"
     )
     val request = server.takeRequest()
@@ -1861,7 +1861,7 @@ class URLConnectionTest {
         .post("ABCD".toRequestBody(null))
         .build()
     )
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo(
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE)).isEqualTo(
       "Successful auth!"
     )
 
@@ -1899,7 +1899,7 @@ class URLConnectionTest {
       .authenticator(JavaNetAuthenticator())
       .build()
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("Successful auth!")
 
     // No authorization header for the first request...
@@ -1941,7 +1941,7 @@ class URLConnectionTest {
       .authenticator(JavaNetAuthenticator())
       .build()
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("Successful auth!")
 
     // No authorization header for the first request...
@@ -1980,7 +1980,7 @@ class URLConnectionTest {
       .authenticator(JavaNetAuthenticator())
       .build()
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("Successful auth!")
 
     // no authorization header for the first request...
@@ -2014,7 +2014,7 @@ class URLConnectionTest {
       .authenticator(JavaNetAuthenticator())
       .build()
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("Successful auth!")
   }
 
@@ -2041,7 +2041,7 @@ class URLConnectionTest {
         .setBody("This is the new location!")
     )
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo(
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE)).isEqualTo(
       "This is the new location!"
     )
     val first = server.takeRequest()
@@ -2074,7 +2074,7 @@ class URLConnectionTest {
       .hostnameVerifier(RecordingHostnameVerifier())
       .build()
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo(
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE)).isEqualTo(
       "This is the new location!"
     )
     val first = server.takeRequest()
@@ -2102,7 +2102,7 @@ class URLConnectionTest {
       .hostnameVerifier(RecordingHostnameVerifier())
       .build()
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("This page has moved!")
   }
 
@@ -2117,7 +2117,7 @@ class URLConnectionTest {
       .followSslRedirects(false)
       .build()
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("This page has moved!")
   }
 
@@ -2326,7 +2326,7 @@ class URLConnectionTest {
         .post(transferKind.newRequestBody("ABCD"))
         .build()
     )
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("Page 2")
     val page1 = server.takeRequest()
     assertThat(page1.requestLine).isEqualTo("POST /page1 HTTP/1.1")
@@ -2352,7 +2352,7 @@ class URLConnectionTest {
         .header("Transfer-Encoding", "identity")
         .build()
     )
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("Page 2")
     assertThat(server.takeRequest().requestLine)
       .isEqualTo("POST /page1 HTTP/1.1")
@@ -2376,7 +2376,7 @@ class URLConnectionTest {
     )
     val response = getResponse(newRequest("/foo"))
     // Fails on the RI, which gets "Proxy Response".
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("This page has moved!")
     val page1 = server.takeRequest()
     assertThat(page1.requestLine).isEqualTo("GET /foo HTTP/1.1")
@@ -2459,7 +2459,7 @@ class URLConnectionTest {
       .url(server.url("/page1"))
     requestBuilder.post("ABCD".toRequestBody(null))
     val response = getResponse(requestBuilder.build())
-    val responseString = readAscii(response.body!!.byteStream(), Int.MAX_VALUE)
+    val responseString = readAscii(response.body.byteStream(), Int.MAX_VALUE)
     val page1 = server.takeRequest()
     assertThat(page1.requestLine).isEqualTo("POST /page1 HTTP/1.1")
     assertThat(page1.body.readUtf8()).isEqualTo("ABCD")
@@ -2480,7 +2480,7 @@ class URLConnectionTest {
       .url(server.url("/page1"))
     requestBuilder.post("ABCD".toRequestBody(null))
     val response = getResponse(requestBuilder.build())
-    val responseString = readAscii(response.body!!.byteStream(), Int.MAX_VALUE)
+    val responseString = readAscii(response.body.byteStream(), Int.MAX_VALUE)
     val page1 = server.takeRequest()
     assertThat(page1.requestLine).isEqualTo("POST /page1 HTTP/1.1")
     assertThat(page1.body.readUtf8()).isEqualTo("ABCD")
@@ -2510,7 +2510,7 @@ class URLConnectionTest {
       requestBuilder.method(method, null)
     }
     val response = getResponse(requestBuilder.build())
-    val responseString = readAscii(response.body!!.byteStream(), Int.MAX_VALUE)
+    val responseString = readAscii(response.body.byteStream(), Int.MAX_VALUE)
     val page1 = server.takeRequest()
     assertThat(page1.requestLine).isEqualTo(
       "$method /page1 HTTP/1.1"
@@ -2599,7 +2599,7 @@ class URLConnectionTest {
     enqueueClientRequestTimeoutResponses()
     val response = getResponse(newRequest("/"))
     assertThat(response.code).isEqualTo(200)
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("Body")
   }
 
@@ -2626,7 +2626,7 @@ class URLConnectionTest {
         .build()
     )
     assertThat(response.code).isEqualTo(200)
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("Body")
     val request1 = server.takeRequest()
     assertThat(request1.body.readUtf8()).isEqualTo("Hello")
@@ -2663,7 +2663,7 @@ class URLConnectionTest {
         .setBody("unused")
     ) // to keep the server alive
     val response = getResponse(newRequest("/"))
-    val source = response.body!!.source()
+    val source = response.body.source()
     source.timeout().timeout(1000, TimeUnit.MILLISECONDS)
     assertThat(source.readByte()).isEqualTo('A'.code.toByte())
     assertThat(source.readByte()).isEqualTo('B'.code.toByte())
@@ -2787,7 +2787,7 @@ class URLConnectionTest {
         .setBody("This is the new location!")
     )
     val response = getResponse(newRequest("/"))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo(
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE)).isEqualTo(
       "This is the new location!"
     )
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
@@ -2842,7 +2842,7 @@ class URLConnectionTest {
         )
     )
     val response = getResponse(newRequest("/"))
-    val inputStream = response.body!!.byteStream()
+    val inputStream = response.body.byteStream()
     assertThat(inputStream.read()).isEqualTo(254)
     assertThat(inputStream.read()).isEqualTo(255)
     assertThat(inputStream.read()).isEqualTo(-1)
@@ -2882,7 +2882,7 @@ class URLConnectionTest {
         })
         .build()
     )
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE))
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE))
       .isEqualTo("abc")
     try {
       sinkReference.get().flush()
@@ -2937,7 +2937,7 @@ class URLConnectionTest {
 
     // The request should work once and then fail.
     val connection1 = getResponse(newRequest("/"))
-    val source1 = connection1.body!!.source()
+    val source1 = connection1.body.source()
     source1.timeout().timeout(100, TimeUnit.MILLISECONDS)
     assertThat(readAscii(source1.inputStream(), Int.MAX_VALUE)).isEqualTo("ABC")
     server.shutdown()
@@ -2958,7 +2958,7 @@ class URLConnectionTest {
         .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END)
     )
     val response = getResponse(newRequest("/"))
-    val `in` = response.body!!.byteStream()
+    val `in` = response.body.byteStream()
     assertThat(readAscii(`in`, 3)).isEqualTo("ABC")
     assertThat(`in`.read()).isEqualTo(-1)
     // throws IOException in Gingerbread.
@@ -2987,10 +2987,10 @@ class URLConnectionTest {
         .post("ABC".toRequestBody(null))
         .build()
     )
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo("A")
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE)).isEqualTo("A")
     val request = server.takeRequest()
     assertThat(request.getHeader("Content-Length")).isEqualTo("3")
-    response.body!!.close()
+    response.body.close()
   }
 
  @Test fun getContentLengthConnects() {
@@ -2999,8 +2999,8 @@ class URLConnectionTest {
         .setBody("ABC")
     )
     val response = getResponse(newRequest("/"))
-    assertThat(response.body!!.contentLength()).isEqualTo(3L)
-    response.body!!.close()
+    assertThat(response.body.contentLength()).isEqualTo(3L)
+    response.body.close()
   }
 
   @Test fun getContentTypeConnects() {
@@ -3010,10 +3010,10 @@ class URLConnectionTest {
         .setBody("ABC")
     )
     val response = getResponse(newRequest("/"))
-    assertThat(response.body!!.contentType()).isEqualTo(
+    assertThat(response.body.contentType()).isEqualTo(
       "text/plain".toMediaType()
     )
-    response.body!!.close()
+    response.body.close()
   }
 
   @Test fun getContentEncodingConnects() {
@@ -3024,7 +3024,7 @@ class URLConnectionTest {
     )
     val response = getResponse(newRequest("/"))
     assertThat(response.header("Content-Encoding")).isEqualTo("identity")
-    response.body!!.close()
+    response.body.close()
   }
 
   @Test fun urlContainsQueryButNoPath() {
@@ -3034,7 +3034,7 @@ class URLConnectionTest {
     )
     val url = server.url("?query")
     val response = getResponse(newRequest(url))
-    assertThat(readAscii(response.body!!.byteStream(), Int.MAX_VALUE)).isEqualTo("A")
+    assertThat(readAscii(response.body.byteStream(), Int.MAX_VALUE)).isEqualTo("A")
     val request = server.takeRequest()
     assertThat(request.requestLine).isEqualTo("GET /?query HTTP/1.1")
   }
@@ -3069,7 +3069,7 @@ class URLConnectionTest {
     transferKind.setBody(mockResponse, body, 4)
     server.enqueue(mockResponse)
     val response = getResponse(newRequest("/"))
-    val inputStream = response.body!!.byteStream()
+    val inputStream = response.body.byteStream()
     for (i in 0 until body.length) {
       assertThat(inputStream.available()).isGreaterThanOrEqualTo(0)
       assertThat(inputStream.read()).isEqualTo(body[i].code)
@@ -3295,7 +3295,7 @@ class URLConnectionTest {
     val response = getResponse(newRequest("/"))
     assertThat(response.code).isEqualTo(200)
     assertThat(response.header("")).isEqualTo("A")
-    response.body!!.close()
+    response.body.close()
   }
 
   @Test fun requestHeaderValidationIsStrict() {
@@ -3864,7 +3864,7 @@ class URLConnectionTest {
     response: Response,
     limit: Int = Int.MAX_VALUE
   ) {
-    assertThat(readAscii(response.body!!.byteStream(), limit)).isEqualTo(expected)
+    assertThat(readAscii(response.body.byteStream(), limit)).isEqualTo(expected)
   }
 
   private fun newSet(vararg elements: String): Set<String> {

--- a/okhttp/src/jvmTest/java/okhttp3/internal/http/CancelTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/http/CancelTest.kt
@@ -194,7 +194,7 @@ class CancelTest {
     )
     val response = call.execute()
     cancelLater(call, 500)
-    val responseBody = response.body!!.byteStream()
+    val responseBody = response.body.byteStream()
     val buffer = ByteArray(1024)
     try {
       while (responseBody.read(buffer) != -1) {
@@ -228,7 +228,7 @@ class CancelTest {
     val call = client.newCall(Request.Builder().url(server.url("/")).build())
     val response = call.execute()
     val cancelLatch = cancelLater(call, 500)
-    val responseBody = response.body!!.byteStream()
+    val responseBody = response.body.byteStream()
     val buffer = ByteArray(1024)
     try {
       while (responseBody.read(buffer) != -1) {
@@ -256,7 +256,7 @@ class CancelTest {
 
     val call2 = client.newCall(Request.Builder().url(server.url("/")).build())
     call2.execute().use {
-      assertEquals(".", it.body!!.string())
+      assertEquals(".", it.body.string())
     }
 
     val events2 = listener.eventSequence.filter { isConnectionEvent(it) }.map { it.name }

--- a/okhttp/src/jvmTest/java/okhttp3/internal/http/ExternalHttp2Example.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/http/ExternalHttp2Example.kt
@@ -35,11 +35,11 @@ object ExternalHttp2Example {
       println(response.code)
       println("PROTOCOL ${response.protocol}")
       var line: String?
-      while (response.body!!.source().readUtf8Line().also { line = it } != null) {
+      while (response.body.source().readUtf8Line().also { line = it } != null) {
         println(line)
       }
     } finally {
-      response.body!!.close()
+      response.body.close()
     }
     client.connectionPool.evictAll()
   }

--- a/okhttp/src/jvmTest/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -166,7 +166,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABCDE")
+    assertThat(response.body.string()).isEqualTo("ABCDE")
     assertThat(response.code).isEqualTo(200)
     assertThat(response.message).isEqualTo("")
     assertThat(response.protocol).isEqualTo(protocol)
@@ -191,8 +191,8 @@ class HttpOverHttp2Test {
     val response = call.execute()
 
     // Body contains nothing.
-    assertThat(response.body!!.bytes().size).isEqualTo(0)
-    assertThat(response.body!!.contentLength()).isEqualTo(0)
+    assertThat(response.body.bytes().size).isEqualTo(0)
+    assertThat(response.body.contentLength()).isEqualTo(0)
 
     // Content-Length header doesn't exist in a 204 response.
     assertThat(response.header("content-length")).isNull()
@@ -216,8 +216,8 @@ class HttpOverHttp2Test {
     val response = call.execute()
 
     // Body contains nothing.
-    assertThat(response.body!!.bytes().size).isEqualTo(0)
-    assertThat(response.body!!.contentLength()).isEqualTo(0)
+    assertThat(response.body.bytes().size).isEqualTo(0)
+    assertThat(response.body.contentLength()).isEqualTo(0)
 
     // Content-Length header stays correctly.
     assertThat(response.header("content-length")).isEqualTo("5")
@@ -235,8 +235,8 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.byteStream().read()).isEqualTo(-1)
-    response.body!!.close()
+    assertThat(response.body.byteStream().read()).isEqualTo(-1)
+    response.body.close()
   }
 
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
@@ -257,7 +257,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABCDE")
+    assertThat(response.body.string()).isEqualTo("ABCDE")
     val request = server.takeRequest()
     assertThat(request.requestLine).isEqualTo("POST /foo HTTP/1.1")
     org.junit.jupiter.api.Assertions.assertArrayEquals(postBytes, request.body.readByteArray())
@@ -284,7 +284,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABCDE")
+    assertThat(response.body.string()).isEqualTo("ABCDE")
     val request = server.takeRequest()
     assertThat(request.requestLine).isEqualTo("POST /foo HTTP/1.1")
     org.junit.jupiter.api.Assertions.assertArrayEquals(postBytes, request.body.readByteArray())
@@ -317,7 +317,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABCDE")
+    assertThat(response.body.string()).isEqualTo("ABCDE")
     val request = server.takeRequest()
     assertThat(request.requestLine).isEqualTo("POST /foo HTTP/1.1")
     org.junit.jupiter.api.Assertions.assertArrayEquals(postBytes, request.body.readByteArray())
@@ -342,10 +342,10 @@ class HttpOverHttp2Test {
     )
     val response1 = call1.execute()
     val response2 = call2.execute()
-    assertThat(response1.body!!.source().readUtf8(3)).isEqualTo("ABC")
-    assertThat(response2.body!!.source().readUtf8(3)).isEqualTo("GHI")
-    assertThat(response1.body!!.source().readUtf8(3)).isEqualTo("DEF")
-    assertThat(response2.body!!.source().readUtf8(3)).isEqualTo("JKL")
+    assertThat(response1.body.source().readUtf8(3)).isEqualTo("ABC")
+    assertThat(response2.body.source().readUtf8(3)).isEqualTo("GHI")
+    assertThat(response1.body.source().readUtf8(3)).isEqualTo("DEF")
+    assertThat(response2.body.source().readUtf8(3)).isEqualTo("JKL")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
     response1.close()
@@ -374,7 +374,7 @@ class HttpOverHttp2Test {
     // Cancel the call and discard what we've buffered for the response body. This should free up
     // the connection flow-control window so new requests can proceed.
     call1.cancel()
-    assertThat(response1.body!!.source().discard(1, TimeUnit.SECONDS))
+    assertThat(response1.body.source().discard(1, TimeUnit.SECONDS))
       .overridingErrorMessage("Call should not have completed successfully.")
       .isFalse
     val call2 = client.newCall(
@@ -383,7 +383,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response2 = call2.execute()
-    assertThat(response2.body!!.string()).isEqualTo("abc")
+    assertThat(response2.body.string()).isEqualTo("abc")
   }
 
   /** Wait for the client to receive `dataLength` DATA frames.  */
@@ -432,7 +432,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response2 = call2.execute()
-    assertThat(response2.body!!.string()).isEqualTo("abc")
+    assertThat(response2.body.string()).isEqualTo("abc")
   }
 
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
@@ -455,10 +455,10 @@ class HttpOverHttp2Test {
     )
     val response1 = call1.execute()
     waitForDataFrames(Http2Connection.OKHTTP_CLIENT_WINDOW_SIZE)
-    assertThat(response1.body!!.contentLength()).isEqualTo(
+    assertThat(response1.body.contentLength()).isEqualTo(
       Http2Connection.OKHTTP_CLIENT_WINDOW_SIZE.toLong()
     )
-    val read = response1.body!!.source().read(ByteArray(8192))
+    val read = response1.body.source().read(ByteArray(8192))
     assertThat(read).isEqualTo(8192)
 
     // Make a second call that should transmit the response headers. The response body won't be
@@ -474,7 +474,7 @@ class HttpOverHttp2Test {
     // Close the response body. This should discard the buffered data and update the connection
     // flow-control window.
     response1.close()
-    assertThat(response2.body!!.string()).isEqualTo("abc")
+    assertThat(response2.body.string()).isEqualTo("abc")
   }
 
   /** https://github.com/square/okhttp/issues/373  */
@@ -507,7 +507,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABCABCABC")
+    assertThat(response.body.string()).isEqualTo("ABCABCABC")
   }
 
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
@@ -533,7 +533,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("Successful auth!")
+    assertThat(response.body.string()).isEqualTo("Successful auth!")
     val denied = server.takeRequest()
     assertThat(denied.getHeader("Authorization")).isNull()
     val accepted = server.takeRequest()
@@ -556,7 +556,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("This is the new location!")
+    assertThat(response.body.string()).isEqualTo("This is the new location!")
     val request1 = server.takeRequest()
     assertThat(request1.path).isEqualTo("/")
     val request2 = server.takeRequest()
@@ -573,7 +573,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    val inputStream = response.body!!.byteStream()
+    val inputStream = response.body.byteStream()
     assertThat(inputStream.read()).isEqualTo('A'.code)
     assertThat(inputStream.read()).isEqualTo('B'.code)
     assertThat(inputStream.read()).isEqualTo('C'.code)
@@ -611,7 +611,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response2 = call2.execute()
-    assertThat(response2.body!!.string()).isEqualTo("A")
+    assertThat(response2.body.string()).isEqualTo("A")
 
     // Confirm that the connection was reused.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
@@ -641,7 +641,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo(String(body))
+    assertThat(response.body.string()).isEqualTo(String(body))
   }
 
   /**
@@ -675,7 +675,7 @@ class HttpOverHttp2Test {
     )
     val response1 = call1.execute()
     try {
-      response1.body!!.string()
+      response1.body.string()
       fail<Any?>("Should have timed out!")
     } catch (expected: SocketTimeoutException) {
       assertThat(expected.message).isEqualTo("timeout")
@@ -688,7 +688,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response2 = call2.execute()
-    assertThat(response2.body!!.string()).isEqualTo(body)
+    assertThat(response2.body.string()).isEqualTo(body)
 
     // Confirm that the connection was reused.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
@@ -722,7 +722,7 @@ class HttpOverHttp2Test {
           .build()
       )
     val response1 = call1.execute()
-    assertThat(response1.body!!.string()).isEqualTo("A")
+    assertThat(response1.body.string()).isEqualTo("A")
     try {
       call2.execute()
       fail<Any?>()
@@ -751,7 +751,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response1 = call1.execute()
-    assertThat(response1.body!!.string()).isEqualTo("A")
+    assertThat(response1.body.string()).isEqualTo("A")
     assertThat(cache.requestCount()).isEqualTo(1)
     assertThat(cache.networkCount()).isEqualTo(1)
     assertThat(cache.hitCount()).isEqualTo(0)
@@ -761,14 +761,14 @@ class HttpOverHttp2Test {
         .build()
     )
     val response2 = call2.execute()
-    assertThat(response2.body!!.string()).isEqualTo("A")
+    assertThat(response2.body.string()).isEqualTo("A")
     val call3 = client.newCall(
       Request.Builder()
         .url(server.url("/"))
         .build()
     )
     val response3 = call3.execute()
-    assertThat(response3.body!!.string()).isEqualTo("A")
+    assertThat(response3.body.string()).isEqualTo("A")
     assertThat(cache.requestCount()).isEqualTo(3)
     assertThat(cache.networkCount()).isEqualTo(1)
     assertThat(cache.hitCount()).isEqualTo(2)
@@ -795,7 +795,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response1 = call1.execute()
-    assertThat(response1.body!!.string()).isEqualTo("A")
+    assertThat(response1.body.string()).isEqualTo("A")
     assertThat(cache.requestCount()).isEqualTo(1)
     assertThat(cache.networkCount()).isEqualTo(1)
     assertThat(cache.hitCount()).isEqualTo(0)
@@ -805,7 +805,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response2 = call2.execute()
-    assertThat(response2.body!!.string()).isEqualTo("A")
+    assertThat(response2.body.string()).isEqualTo("A")
     assertThat(cache.requestCount()).isEqualTo(2)
     assertThat(cache.networkCount()).isEqualTo(2)
     assertThat(cache.hitCount()).isEqualTo(1)
@@ -833,16 +833,16 @@ class HttpOverHttp2Test {
         .build()
     )
     val response1 = call1.execute()
-    assertThat(response1.body!!.source().readUtf8(2)).isEqualTo("AB")
-    response1.body!!.close()
+    assertThat(response1.body.source().readUtf8(2)).isEqualTo("AB")
+    response1.body.close()
     val call2 = client.newCall(
       Request.Builder()
         .url(server.url("/"))
         .build()
     )
     val response2 = call2.execute()
-    assertThat(response2.body!!.source().readUtf8()).isEqualTo("ABCD")
-    response2.body!!.close()
+    assertThat(response2.body.source().readUtf8()).isEqualTo("ABCD")
+    response2.body.close()
   }
 
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
@@ -865,7 +865,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("")
+    assertThat(response.body.string()).isEqualTo("")
     val request = server.takeRequest()
     assertThat(request.getHeader("Cookie")).isEqualTo("a=b")
   }
@@ -887,7 +887,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("")
+    assertThat(response.body.string()).isEqualTo("")
     cookieJar.assertResponseCookies("a=b; path=/")
   }
 
@@ -920,7 +920,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response2 = call2.execute()
-    assertThat(response2.body!!.string()).isEqualTo("def")
+    assertThat(response2.body.string()).isEqualTo("def")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
 
     // Clean up the connection.
@@ -976,7 +976,7 @@ class HttpOverHttp2Test {
       .url(server.url("/"))
       .build()
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("abc")
+    assertThat(response.body.string()).isEqualTo("abc")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
 
     // Note that although we have two routes available, we only use one. The retry is permitted
@@ -1052,7 +1052,7 @@ class HttpOverHttp2Test {
 
     // Second call succeeds on the pooled connection.
     val response = client.newCall(request).execute()
-    assertThat(response.body!!.string()).isEqualTo("abc")
+    assertThat(response.body.string()).isEqualTo("abc")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
   }
 
@@ -1095,13 +1095,13 @@ class HttpOverHttp2Test {
     // Second call attempts the pooled connection, and it fails. Then it retries a new route which
     // succeeds.
     val response2 = client.newCall(request).execute()
-    assertThat(response2.body!!.string()).isEqualTo("abc")
+    assertThat(response2.body.string()).isEqualTo("abc")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1) // Pooled connection.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0) // New connection.
 
     // Third call reuses the second connection.
     val response3 = client.newCall(request).execute()
-    assertThat(response3.body!!.string()).isEqualTo("def")
+    assertThat(response3.body.string()).isEqualTo("def")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1) // New connection.
   }
 
@@ -1175,7 +1175,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("abc")
+    assertThat(response.body.string()).isEqualTo("abc")
 
     // New connection.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
@@ -1211,7 +1211,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("abc")
+    assertThat(response.body.string()).isEqualTo("abc")
 
     // New connection.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
@@ -1255,7 +1255,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("def")
+    assertThat(response.body.string()).isEqualTo("def")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(1)
   }
 
@@ -1301,7 +1301,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ghi")
+    assertThat(response.body.string()).isEqualTo("ghi")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(2)
   }
 
@@ -1435,7 +1435,7 @@ class HttpOverHttp2Test {
     val latch = CountDownLatch(1)
     val responses: BlockingQueue<String?> = SynchronousQueue()
     val authenticator = okhttp3.Authenticator { route: Route?, response: Response? ->
-      responses.offer(response!!.body!!.string())
+      responses.offer(response!!.body.string())
       try {
         latch.await()
       } catch (e: InterruptedException) {
@@ -1452,7 +1452,7 @@ class HttpOverHttp2Test {
       }
 
       override fun onResponse(call: Call, response: Response) {
-        responses.offer(response.body!!.string())
+        responses.offer(response.body.string())
       }
     }
 
@@ -1520,7 +1520,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABCDE")
+    assertThat(response.body.string()).isEqualTo("ABCDE")
     assertThat(response.code).isEqualTo(200)
     assertThat(response.message).isEqualTo("")
     val request = server.takeRequest()
@@ -1553,7 +1553,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABCDE")
+    assertThat(response.body.string()).isEqualTo("ABCDE")
     assertThat(response.code).isEqualTo(200)
     assertThat(response.message).isEqualTo("")
     val request = server.takeRequest()
@@ -1583,7 +1583,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABC")
+    assertThat(response.body.string()).isEqualTo("ABC")
     assertThat(response.protocol).isEqualTo(protocol)
     val logs = testLogHandler.takeAll()
     assertThat(firstFrame(logs, "HEADERS"))
@@ -1605,7 +1605,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABC")
+    assertThat(response.body.string()).isEqualTo("ABC")
     assertThat(response.protocol).isEqualTo(protocol)
     val logs = testLogHandler.takeAll()
     assertThat(firstFrame(logs, "HEADERS"))
@@ -1640,7 +1640,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("ABC")
+    assertThat(response.body.string()).isEqualTo("ABC")
     assertThat(response.protocol).isEqualTo(protocol)
 
     // Confirm a single ping was sent and received, and its reply was sent and received.
@@ -1758,7 +1758,7 @@ class HttpOverHttp2Test {
     )
     call3.execute().use { response ->
       assertThat(
-        response.body!!.string()
+        response.body.string()
       ).isEqualTo("fresh connection")
     }
   }
@@ -1791,7 +1791,7 @@ class HttpOverHttp2Test {
     )
     try {
       call1.execute().use { response ->
-        response.body!!.string()
+        response.body.string()
         fail<Any?>()
       }
     } catch (expected: SocketTimeoutException) {
@@ -1805,7 +1805,7 @@ class HttpOverHttp2Test {
     )
     call2.execute().use { response ->
       assertThat(
-        response.body!!.string()
+        response.body.string()
       ).isEqualTo("b")
     }
 
@@ -1818,7 +1818,7 @@ class HttpOverHttp2Test {
     )
     call3.execute().use { response ->
       assertThat(
-        response.body!!.string()
+        response.body.string()
       ).isEqualTo("c")
     }
 
@@ -1865,7 +1865,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("")
+    assertThat(response.body.string()).isEqualTo("")
     server.enqueue(
       MockResponse()
         .setBody("ABC")
@@ -1896,9 +1896,9 @@ class HttpOverHttp2Test {
         .build()
     )
     val response3 = call3.execute()
-    assertThat(response1.body!!.string()).isEqualTo("ABC")
-    assertThat(response2.body!!.string()).isEqualTo("DEF")
-    assertThat(response3.body!!.string()).isEqualTo("GHI")
+    assertThat(response1.body.string()).isEqualTo("ABC")
+    assertThat(response2.body.string()).isEqualTo("DEF")
+    assertThat(response3.body.string()).isEqualTo("GHI")
     // Settings connection.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     // Reuse settings connection.
@@ -1938,7 +1938,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response1 = call1.execute()
-    assertThat(response1.body!!.string()).isEqualTo("ABC")
+    assertThat(response1.body.string()).isEqualTo("ABC")
 
     // Add delays for DISCONNECT_AT_END to propogate
     waitForConnectionShutdown(connections[0])
@@ -1948,7 +1948,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response2 = call2.execute()
-    assertThat(response2.body!!.string()).isEqualTo("DEF")
+    assertThat(response2.body.string()).isEqualTo("DEF")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
   }
@@ -1996,7 +1996,7 @@ class HttpOverHttp2Test {
                 .build()
             )
             val response = call.execute()
-            assertThat(response.body!!.string()).isEqualTo("ABC")
+            assertThat(response.body.string()).isEqualTo("ABC")
             // Wait until the GOAWAY has been processed.
             val connection = chain.connection() as RealConnection?
             while (connection!!.isHealthy(false));
@@ -2011,7 +2011,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("DEF")
+    assertThat(response.body.string()).isEqualTo("DEF")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
   }
@@ -2034,7 +2034,7 @@ class HttpOverHttp2Test {
     val bodies: BlockingQueue<String?> = LinkedBlockingQueue()
     val callback: Callback = object : Callback {
       override fun onResponse(call: Call, response: Response) {
-        bodies.add(response.body!!.string())
+        bodies.add(response.body.string())
         latch.countDown()
       }
 
@@ -2112,7 +2112,7 @@ class HttpOverHttp2Test {
                 .build()
             )
             val response2 = call2.execute()
-            assertThat(response2.body!!.string()).isEqualTo("call2 response")
+            assertThat(response2.body.string()).isEqualTo("call2 response")
           } catch (e: IOException) {
             throw RuntimeException(e)
           }
@@ -2135,7 +2135,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response2 = call1.execute()
-    assertThat(response2.body!!.string()).isEqualTo("call1 response")
+    assertThat(response2.body.string()).isEqualTo("call1 response")
     val call1Connect = server.takeRequest()
     assertThat(call1Connect.method).isEqualTo("CONNECT")
     assertThat(call1Connect.sequenceNumber).isEqualTo(0)
@@ -2172,7 +2172,7 @@ class HttpOverHttp2Test {
         .build()
     )
     val response = call.execute()
-    assertThat(response.body!!.string()).isEqualTo("")
+    assertThat(response.body.string()).isEqualTo("")
     val recordedRequest = server.takeRequest()
     assertThat(recordedRequest.getHeader(":authority")).isEqualTo("privateobject.com")
   }
@@ -2197,7 +2197,7 @@ class HttpOverHttp2Test {
             .build()
         )
         val response = call.execute()
-        assertThat(response.body!!.string()).isEqualTo("A")
+        assertThat(response.body.string()).isEqualTo("A")
         countDownLatch.countDown()
       } catch (e: Exception) {
         throw RuntimeException(e)

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -42,6 +42,7 @@ import okhttp3.TestLogHandler;
 import okhttp3.TestUtil;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
+import okhttp3.internal.UnreadableResponseBody;
 import okhttp3.internal.concurrent.TaskRunner;
 import okhttp3.testing.Flaky;
 import okhttp3.testing.PlatformRule;
@@ -54,7 +55,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
 import static java.util.Arrays.asList;
 import static okhttp3.TestUtil.repeat;
 import static okhttp3.tls.internal.TlsUtil.localhost;
@@ -399,7 +399,7 @@ public final class WebSocketHttpTest {
           assertThat(chain.request().body()).isNull();
           Response response = chain.proceed(chain.request());
           assertThat(response.header("Connection")).isEqualTo("Upgrade");
-          assertThat(response.body().source().exhausted()).isTrue();
+          assertThat(response.body()).isInstanceOf(UnreadableResponseBody.class);
           interceptedCount.incrementAndGet();
           return response;
         })

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketRecorder.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketRecorder.java
@@ -26,7 +26,6 @@ import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 import okhttp3.internal.platform.Platform;
 import okio.ByteString;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class WebSocketRecorder extends WebSocketListener {
@@ -264,7 +263,7 @@ public final class WebSocketRecorder extends WebSocketListener {
       this.t = t;
       this.response = response;
       String responseBody = null;
-      if (response != null) {
+      if (response != null && response.code() != 101) {
         try {
           responseBody = response.body().string();
         } catch (IOException ignored) {

--- a/okhttp/src/nonJvmMain/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/nonJvmMain/kotlin/okhttp3/Response.kt
@@ -20,6 +20,7 @@ import okhttp3.internal.commonBody
 import okhttp3.internal.commonCacheControl
 import okhttp3.internal.commonCacheResponse
 import okhttp3.internal.commonCode
+import okhttp3.internal.commonEmptyResponse
 import okhttp3.internal.commonHeader
 import okhttp3.internal.commonHeaders
 import okhttp3.internal.commonIsRedirect
@@ -77,7 +78,7 @@ actual class Response internal constructor(
    * This always returns null on responses returned from [cacheResponse], [networkResponse],
    * and [priorResponse].
    */
-  actual val body: ResponseBody?,
+  actual val body: ResponseBody,
 
   /**
    * Returns the raw response received from the network. Will be null if this response didn't use
@@ -143,11 +144,11 @@ actual class Response internal constructor(
   /**
    * Closes the response body. Equivalent to `body().close()`.
    *
-   * It is an error to close a response that is not eligible for a body. This includes the
-   * responses returned from [cacheResponse], [networkResponse], and [priorResponse].
+   * Prior to OkHttp 5.0, it was an error to close a response that is not eligible for a body. This
+   * includes the responses returned from [cacheResponse], [networkResponse], and [priorResponse].
    */
   actual override fun close() {
-    checkNotNull(body) { "response is not eligible for a body and must not be closed" }.close()
+    body.close()
   }
 
   actual override fun toString(): String =
@@ -159,7 +160,7 @@ actual class Response internal constructor(
     internal actual var code = -1
     internal actual var message: String? = null
     internal actual var headers: Headers.Builder
-    internal actual var body: ResponseBody? = null
+    internal actual var body: ResponseBody = commonEmptyResponse
     internal actual var networkResponse: Response? = null
     internal actual var cacheResponse: Response? = null
     internal actual var priorResponse: Response? = null
@@ -206,7 +207,7 @@ actual class Response internal constructor(
     /** Removes all headers on this builder and adds [headers]. */
     actual open fun headers(headers: Headers) = commonHeaders(headers)
 
-    actual open fun body(body: ResponseBody?) = commonBody(body)
+    actual open fun body(body: ResponseBody) = commonBody(body)
 
     actual open fun networkResponse(networkResponse: Response?) = commonNetworkResponse(networkResponse)
 

--- a/samples/compare/src/test/kotlin/okhttp3/compare/OkHttpClientTest.kt
+++ b/samples/compare/src/test/kotlin/okhttp3/compare/OkHttpClientTest.kt
@@ -46,7 +46,7 @@ class OkHttpClientTest {
         .build()
     val response = client.newCall(request).execute()
     assertThat(response.code).isEqualTo(200)
-    assertThat(response.body!!.string()).isEqualTo("hello, OkHttp")
+    assertThat(response.body.string()).isEqualTo("hello, OkHttp")
 
     val recorded = server.takeRequest()
     assertThat(recorded.getHeader("Accept")).isEqualTo("text/plain")

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/AsynchronousGet.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/AsynchronousGet.kt
@@ -43,7 +43,7 @@ class AsynchronousGet {
             println("$name: $value")
           }
 
-          println(response.body!!.string())
+          println(response.body.string())
         }
       }
     })

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/Authenticate.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/Authenticate.kt
@@ -50,7 +50,7 @@ class Authenticate {
     client.newCall(request).execute().use { response ->
       if (!response.isSuccessful) throw IOException("Unexpected code $response")
 
-      println(response.body!!.string())
+      println(response.body.string())
     }
   }
 }

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/CacheResponse.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/CacheResponse.kt
@@ -40,7 +40,7 @@ class CacheResponse(cacheDirectory: File) {
       println("Response 1 response:          $it")
       println("Response 1 cache response:    ${it.cacheResponse}")
       println("Response 1 network response:  ${it.networkResponse}")
-      return@use it.body!!.string()
+      return@use it.body.string()
     }
 
     val response2Body = client.newCall(request).execute().use {
@@ -49,7 +49,7 @@ class CacheResponse(cacheDirectory: File) {
       println("Response 2 response:          $it")
       println("Response 2 cache response:    ${it.cacheResponse}")
       println("Response 2 network response:  ${it.networkResponse}")
-      return@use it.body!!.string()
+      return@use it.body.string()
     }
 
     println("Response 2 equals Response 1? " + (response1Body == response2Body))

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/CustomTrust.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/CustomTrust.kt
@@ -161,7 +161,7 @@ class CustomTrust {
             }
             throw IOException("Unexpected code $response")
           }
-          println(response.body!!.string())
+          println(response.body.string())
 
           for (peerCertificate in response.handshake?.peerCertificates.orEmpty()) {
             println((peerCertificate as X509Certificate).subjectDN)

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/PostFile.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/PostFile.kt
@@ -36,7 +36,7 @@ class PostFile {
     client.newCall(request).execute().use { response ->
       if (!response.isSuccessful) throw IOException("Unexpected code $response")
 
-      println(response.body!!.string())
+      println(response.body.string())
     }
   }
 

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/PostForm.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/PostForm.kt
@@ -35,7 +35,7 @@ class PostForm {
     client.newCall(request).execute().use { response ->
       if (!response.isSuccessful) throw IOException("Unexpected code $response")
 
-      println(response.body!!.string())
+      println(response.body.string())
     }
   }
 }

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/PostMultipart.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/PostMultipart.kt
@@ -44,7 +44,7 @@ class PostMultipart {
     client.newCall(request).execute().use { response ->
       if (!response.isSuccessful) throw IOException("Unexpected code $response")
 
-      println(response.body!!.string())
+      println(response.body.string())
     }
   }
 

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/PostPath.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/PostPath.kt
@@ -43,7 +43,7 @@ class PostPath {
       if (!response.isSuccessful) throw IOException("Unexpected code $response")
 
       fileSystem.sink(path).use {
-        response.body!!.source().readAll(it)
+        response.body.source().readAll(it)
       }
 
       println(fileSystem.source(path).buffer().readUtf8())

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/PostStreaming.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/PostStreaming.kt
@@ -54,7 +54,7 @@ class PostStreaming {
     client.newCall(request).execute().use { response ->
       if (!response.isSuccessful) throw IOException("Unexpected code $response")
 
-      println(response.body!!.string())
+      println(response.body.string())
     }
   }
 

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/PostString.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/PostString.kt
@@ -42,7 +42,7 @@ class PostString {
     client.newCall(request).execute().use { response ->
       if (!response.isSuccessful) throw IOException("Unexpected code $response")
 
-      println(response.body!!.string())
+      println(response.body.string())
     }
   }
 

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/SynchronousGet.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/SynchronousGet.kt
@@ -34,7 +34,7 @@ class SynchronousGet {
         println("$name: $value")
       }
 
-      println(response.body!!.string())
+      println(response.body.string())
     }
   }
 }

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/WiresharkExample.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/WiresharkExample.kt
@@ -307,7 +307,7 @@ class WiresharkExample(tlsVersions: List<TlsVersion>, private val launch: Launch
       client.newCall(request)
           .execute()
           .use {
-            val firstLine = it.body!!.string()
+            val firstLine = it.body.string()
                 .lines()
                 .first()
             if (this.launch != CommandLine) {

--- a/samples/guide/src/main/java/okhttp3/recipes/kt/YubikeyClientAuth.kt
+++ b/samples/guide/src/main/java/okhttp3/recipes/kt/YubikeyClientAuth.kt
@@ -88,7 +88,7 @@ class YubikeyClientAuth {
     client.newCall(request).execute().use { response ->
       if (!response.isSuccessful) throw IOException("Unexpected code $response")
 
-      println(response.body!!.string())
+      println(response.body.string())
     }
   }
 }


### PR DESCRIPTION
This is a source-incompatible API change. In particular, Response.body(null)
is no longer source-compatible for Kotlin source.

The upside is tremendous: no need for callers to use !! on Response.body
on every single API call. In the rare cases where a Response doesn't have
a body we use a runtime error. This is unlikely to cause problems in
practice; users don't have reason to read the response body on supporting
responses.