### PR TITLE
Use internal visibility for unreadable response bodies

### DIFF
--- a/okhttp/src/commonMain/kotlin/okhttp3/internal/-ResponseCommon.kt
+++ b/okhttp/src/commonMain/kotlin/okhttp3/internal/-ResponseCommon.kt
@@ -64,7 +64,7 @@ internal class UnreadableResponseBody(
   }
 }
 
-internal fun Response.stripBody(): Response {
+fun Response.stripBody(): Response {
   return newBuilder()
     .body(UnreadableResponseBody(body.contentType(), body.contentLength()))
     .build()

--- a/okhttp/src/commonMain/kotlin/okhttp3/internal/-ResponseCommon.kt
+++ b/okhttp/src/commonMain/kotlin/okhttp3/internal/-ResponseCommon.kt
@@ -37,7 +37,7 @@ import okio.Source
 import okio.Timeout
 import okio.buffer
 
-class UnreadableResponseBody(
+internal class UnreadableResponseBody(
   private val mediaType: MediaType?,
   private val contentLength: Long,
 ): ResponseBody(), Source {
@@ -64,7 +64,7 @@ class UnreadableResponseBody(
   }
 }
 
-fun Response.stripBody(): Response {
+internal fun Response.stripBody(): Response {
   return newBuilder()
     .body(UnreadableResponseBody(body.contentType(), body.contentLength()))
     .build()

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -391,6 +391,7 @@ public final class WebSocketHttpTest {
         "Request header not permitted: 'Sec-WebSocket-Extensions'");
   }
 
+  @SuppressWarnings("KotlinInternalInJava")
   @Test public void webSocketAndApplicationInterceptors() {
     final AtomicInteger interceptedCount = new AtomicInteger();
 


### PR DESCRIPTION
https://github.com/square/okhttp/pull/7205