### PR TITLE
Support request priority

### DIFF
--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -470,11 +470,13 @@ public final class okhttp3/Dispatcher {
 	public final fun -deprecated_executorService ()Ljava/util/concurrent/ExecutorService;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/concurrent/ExecutorService;)V
+	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun cancelAll ()V
 	public final fun executorService ()Ljava/util/concurrent/ExecutorService;
 	public final fun getIdleCallback ()Ljava/lang/Runnable;
 	public final fun getMaxRequests ()I
 	public final fun getMaxRequestsPerHost ()I
+	public final fun priorityOrder ()Ljava/util/Comparator;
 	public final fun queuedCalls ()Ljava/util/List;
 	public final fun queuedCallsCount ()I
 	public final fun runningCalls ()Ljava/util/List;
@@ -482,6 +484,7 @@ public final class okhttp3/Dispatcher {
 	public final fun setIdleCallback (Ljava/lang/Runnable;)V
 	public final fun setMaxRequests (I)V
 	public final fun setMaxRequestsPerHost (I)V
+	public final fun setPriorityOrder (Ljava/util/Comparator;)V
 }
 
 public abstract interface class okhttp3/Dns {

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -470,7 +470,6 @@ public final class okhttp3/Dispatcher {
 	public final fun -deprecated_executorService ()Ljava/util/concurrent/ExecutorService;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/concurrent/ExecutorService;)V
-	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun cancelAll ()V
 	public final fun executorService ()Ljava/util/concurrent/ExecutorService;
 	public final fun getIdleCallback ()Ljava/lang/Runnable;

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
@@ -99,20 +99,17 @@ class Dispatcher() {
       return executorServiceOrNull!!
     }
 
-
+  /**
+   * Orders calls by order of execution. When two calls have equal priority order they are executed
+   * in the order that they were enqueued in.
+   */
   @get:Synchronized
   @set:Synchronized
   @get:JvmName("priorityOrder")
-    /**
-     * A comparator that determines the priority of the async calls.
-     * A call with the highest priority will be executed first.
-     *
-     * When [priorityOrder] is null or returns 0, calls that are enqueued first have priority.
-     */
   var priorityOrder: Comparator<Call>? = null
 
   /** Ready async calls in the order they'll be run. */
-  private val readyAsyncCalls = LinkedList<AsyncCall>()
+  private val readyAsyncCalls = mutableListOf<AsyncCall>()
 
   /** Running asynchronous calls. Includes canceled calls that haven't finished yet. */
   private val runningAsyncCalls = ArrayDeque<AsyncCall>()
@@ -126,26 +123,13 @@ class Dispatcher() {
 
   internal fun enqueue(call: AsyncCall) {
     synchronized(this) {
+      readyAsyncCalls.add(call)
+
       // Mutate the AsyncCall so that it shares the AtomicInteger of an existing running call to
       // the same host.
       if (!call.call.forWebSocket) {
         val existingCall = findExistingCallWithHost(call.host)
         if (existingCall != null) call.reuseCallsPerHostFrom(existingCall)
-      }
-
-      val priorityOrder = priorityOrder
-
-      if (priorityOrder == null) readyAsyncCalls.addLast(call) else {
-        val i = readyAsyncCalls.listIterator()
-
-        while (i.hasNext()) {
-          if (priorityOrder.compare(i.next().call, call.call) < 0) {
-            i.previous()
-            break
-          }
-        }
-
-        i.add(call)
       }
     }
     promoteAndExecute()
@@ -190,10 +174,8 @@ class Dispatcher() {
     val executableCalls = mutableListOf<AsyncCall>()
     val isRunning: Boolean
     synchronized(this) {
-      val priorityOrder = priorityOrder
-
-      if (priorityOrder != null) {
-        readyAsyncCalls.sortWith { a, b -> priorityOrder.compare(b.call, a.call) } // sort in descending order
+      priorityOrder?.let { comparator ->
+        readyAsyncCalls.sortWith { a, b -> comparator.compare(b.call, a.call) } // sort in descending order
       }
 
       val i = readyAsyncCalls.iterator()

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
@@ -175,7 +175,7 @@ class Dispatcher() {
     val isRunning: Boolean
     synchronized(this) {
       priorityOrder?.let { comparator ->
-        readyAsyncCalls.sortWith { a, b -> comparator.compare(b.call, a.call) } // sort in descending order
+        readyAsyncCalls.sortWith { a, b -> comparator.compare(a.call, b.call) }
       }
 
       val i = readyAsyncCalls.iterator()

--- a/okhttp/src/jvmTest/java/okhttp3/DispatcherTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/DispatcherTest.java
@@ -54,7 +54,7 @@ public final class DispatcherTest {
     float p2 = 0;
     if (t2 instanceof Priority) p2 = ((Priority) t2).priority;
 
-    return Float.compare(p1, p2);
+    return Float.compare(p2, p1);
   };
 
   @BeforeEach public void setUp() throws Exception {


### PR DESCRIPTION
Currently, `Dispatcher` executes calls First-In-First-Out.  
This PR adds a way for users to customize what calls to execute next.  
resolves #404.