### PR TITLE
Fix Conscrypt NPE workaround

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/platform/android/AndroidSocketAdapter.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/platform/android/AndroidSocketAdapter.kt
@@ -79,16 +79,15 @@ open class AndroidSocketAdapter(private val sslSocketClass: Class<in SSLSocket>)
     return try {
       val alpnResult = getAlpnSelectedProtocol.invoke(sslSocket) as ByteArray?
       alpnResult?.toString(Charsets.UTF_8)
-    } catch (e: NullPointerException) {
-      // https://github.com/square/okhttp/issues/5587
-      when (e.message) {
-        "ssl == null" -> null
-        else -> throw e
-      }
     } catch (e: IllegalAccessException) {
       throw AssertionError(e)
     } catch (e: InvocationTargetException) {
-      throw AssertionError(e)
+      // https://github.com/square/okhttp/issues/5587
+      val cause = e.cause
+      when {
+        cause is NullPointerException && cause.message == "ssl == null" -> null
+        else -> throw AssertionError(e)
+      }
     }
   }
 


### PR DESCRIPTION
After turning on HTTPS with MockWebServer 4.9.2 we started seeing the transient `ssl == null` failure described in #5587 on older emulators. 

#5590 attempted to fix the problem, but I don't think the catch it introduced will ever be hit because the problematic NPE is wrapped in an `InvocationTargetException`:

```
11-05 11:53:36.557  5607 23163 E AndroidRuntime: FATAL EXCEPTION: MockWebServer
11-05 11:53:36.557  5607 23163 E AndroidRuntime: Process: com.xxx.xxx.xxx, PID: 5607
11-05 11:53:36.557  5607 23163 E AndroidRuntime: java.lang.AssertionError: java.lang.reflect.InvocationTargetException
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at okhttp3.internal.platform.android.AndroidSocketAdapter.a(SourceFile:86)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at okhttp3.internal.platform.AndroidPlatform.b(SourceFile:86)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at okhttp3.mockwebserver.MockWebServer$SocketHandler.handle(MockWebServer.kt:516)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at okhttp3.mockwebserver.MockWebServer$serveConnection$$inlined$execute$1.run(Util.kt:580)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:764)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: Caused by: java.lang.reflect.InvocationTargetException
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at okhttp3.internal.platform.android.AndroidSocketAdapter.a(SourceFile:81)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	... 6 more
11-05 11:53:36.557  5607 23163 E AndroidRuntime: Caused by: java.lang.NullPointerException: ssl == null
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at com.android.org.conscrypt.NativeCrypto.getApplicationProtocol(Native Method)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at com.android.org.conscrypt.NativeSsl.getApplicationProtocol(NativeSsl.java:568)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at com.android.org.conscrypt.ConscryptFileDescriptorSocket.getApplicationProtocol(ConscryptFileDescriptorSocket.java:1085)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	at com.android.org.conscrypt.OpenSSLSocketImpl.getAlpnSelectedProtocol(OpenSSLSocketImpl.java:134)
11-05 11:53:36.557  5607 23163 E AndroidRuntime: 	... 8 more
```