### PR TITLE
4.10: Version bump of kotlin, okio.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,6 +302,12 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
+      - name: Configure JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
       - name: Run Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/android-test/build.gradle
+++ b/android-test/build.gradle
@@ -2,12 +2,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 repositories {
-  jcenter {
-    // Required for a dependency of Android lint.
-    content {
-      includeGroup 'org.jetbrains.trove4j'
-    }
-  }
+  mavenCentral()
+  gradlePluginPortal()
+  google()
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,7 @@ subprojects { project ->
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
       jvmTarget = "1.8"
+      freeCompilerArgs += "-Xjvm-default=compatibility"
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,9 @@ buildscript {
   ]
 
   dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
-    classpath "com.android.tools.build:gradle:4.0.1"
+    classpath "com.android.tools.build:gradle:4.0.2"
   }
 
   repositories {
@@ -93,9 +93,6 @@ allprojects {
 
   repositories {
     mavenCentral()
-    maven {
-      url 'https://dl.bintray.com/kotlin/dokka'
-    }
     google()
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
       'jsoup': '1.13.1',
       'junit': '4.13',
       'kotlin': '1.6.20',
-      'moshi': '1.9.2',
+      'moshi': '1.13.0',
       'okio': '3.0.0',
       'ktlint': '0.38.0',
       'picocli': '4.2.0',

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
 
   ext.deps = [
       'picocli': "info.picocli:picocli:${versions.picocli}",
-      'android': "org.robolectric:android-all:10-robolectric-5803371",
+      'android': "org.robolectric:android-all:12.1-robolectric-8229987",
       'animalSniffer': "org.codehaus.mojo:animal-sniffer-annotations:${versions.animalSniffer}",
       'assertj': "org.assertj:assertj-core:${versions.assertj}",
       'bouncycastle': "org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}",
@@ -49,7 +49,7 @@ buildscript {
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
-    classpath "com.android.tools.build:gradle:4.0.2"
+    classpath "com.android.tools.build:gradle:7.1.3"
   }
 
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -7,17 +7,17 @@ buildscript {
       'bouncycastle': '1.65',
       'brotli': '0.1.2',
       'checkstyle': '8.28',
-      'conscrypt': '2.5.1',
+      'conscrypt': '2.5.2',
       'corretto': '1.3.1',
       'findbugs': '3.0.2',
-      'guava': '28.2-jre',
+      'guava': '31.1-jre',
       'java': '1.8',
       'jnrUnixsocket': '0.28',
       'jsoup': '1.13.1',
       'junit': '4.13',
-      'kotlin': '1.4.10',
+      'kotlin': '1.6.20',
       'moshi': '1.9.2',
-      'okio': '2.8.0',
+      'okio': '3.0.0',
       'ktlint': '0.38.0',
       'picocli': '4.2.0',
       'openjsse': '1.1.0'
@@ -47,7 +47,7 @@ buildscript {
   ]
 
   dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
     classpath "com.android.tools.build:gradle:4.0.1"
   }

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ buildscript {
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
-    classpath "com.android.tools.build:gradle:7.1.3"
+    classpath "com.android.tools.build:gradle:7.0.4"
   }
 
   repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bump Kotlin to both fix a CVE (without any clear attack), and also to provide a 4.x version of OkHttp with the major upgrade hit taken early.

This should be a 4.10 build not 4.9.4