### PR TITLE
The version shouldn't be const

### DIFF
--- a/okhttp/src/commonMain/kotlin/okhttp3/OkHttp.kt
+++ b/okhttp/src/commonMain/kotlin/okhttp3/OkHttp.kt
@@ -15,6 +15,8 @@
  */
 package okhttp3
 
+import okhttp3.internal.CONST_VERSION
+
 object OkHttp {
   /**
    * This is a string like "4.5.0-RC1", "4.5.0", or "4.6.0-SNAPSHOT" indicating the version of
@@ -31,5 +33,6 @@ object OkHttp {
    *
    * [semver]: https://semver.org
    */
-  const val VERSION = "$projectVersion"
+  @Suppress("MayBeConstant") // Non-const so external callers get the runtime version.
+  val VERSION = CONST_VERSION
 }

--- a/okhttp/src/commonMain/kotlin/okhttp3/OkHttp.kt
+++ b/okhttp/src/commonMain/kotlin/okhttp3/OkHttp.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3
 
+import kotlin.jvm.JvmField
 import okhttp3.internal.CONST_VERSION
 
 object OkHttp {
@@ -34,5 +35,6 @@ object OkHttp {
    * [semver]: https://semver.org
    */
   @Suppress("MayBeConstant") // Non-const so external callers get the runtime version.
+  @JvmField
   val VERSION = CONST_VERSION
 }

--- a/okhttp/src/commonMain/kotlin/okhttp3/internal/-UtilCommon.kt
+++ b/okhttp/src/commonMain/kotlin/okhttp3/internal/-UtilCommon.kt
@@ -17,7 +17,6 @@ package okhttp3.internal
 
 import kotlin.jvm.JvmField
 import okhttp3.Headers
-import okhttp3.OkHttp
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.ResponseBody
@@ -368,7 +367,7 @@ internal inline fun <T> Iterable<T>.filterList(predicate: T.() -> Boolean): List
   return result
 }
 
-internal const val userAgent: String = "okhttp/${OkHttp.VERSION}"
+internal const val userAgent: String = "okhttp/${CONST_VERSION}"
 
 internal fun checkOffsetAndCount(arrayLength: Long, offset: Long, count: Long) {
   if (offset or count < 0L || offset > arrayLength || arrayLength - offset < count) {

--- a/okhttp/src/commonMain/kotlinTemplates/okhttp3/internal/-InternalVersion.kt
+++ b/okhttp/src/commonMain/kotlinTemplates/okhttp3/internal/-InternalVersion.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal
+
+internal const val CONST_VERSION = "$projectVersion"


### PR DESCRIPTION
Downstream projects should get the current version, even if they're
not recompiled.