### PR TITLE
[4.10.x] Avoid incorrect cache cause IllegalArgumentException

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Cache.kt
@@ -167,6 +167,9 @@ class Cache internal constructor(
   constructor(directory: File, maxSize: Long) : this(directory, maxSize, FileSystem.SYSTEM)
 
   internal fun get(request: Request): Response? {
+    if (request.method != "GET") {
+      return null
+    }
     val key = key(request.url)
     val snapshot: DiskLruCache.Snapshot = try {
       cache[key] ?: return null


### PR DESCRIPTION
Avoid incorrect cache cause IllegalArgumentException: method POST must have a request body

```kotlin
internal fun get(request: Request): Response? {
    // ...
    val response = entry.response(snapshot) // throw IllegalArgumentException
}


fun response(snapshot: DiskLruCache.Snapshot): Response {
      val contentType = responseHeaders["Content-Type"]
      val contentLength = responseHeaders["Content-Length"]
      val cacheRequest = Request.Builder()
          .url(url)
          .method(requestMethod, null) // method POST must have a request body
          .headers(varyHeaders)
          .build()
    // ....
    }
```