### PR TITLE
Avoid incorrect cache cause IllegalArgumentException

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Cache.kt
@@ -171,6 +171,9 @@ class Cache(
   )
 
   internal fun get(request: Request): Response? {
+    if (request.method != "GET") {
+      return null
+    }
     val key = key(request.url)
     val snapshot: DiskLruCache.Snapshot = try {
       cache[key] ?: return null


### PR DESCRIPTION
Avoid incorrect cache cause IllegalArgumentException: method POST must have a request body

```kotlin
internal fun get(request: Request): Response? {
    // ...
    val response = entry.response(snapshot) // throw IllegalArgumentException
}


fun response(snapshot: DiskLruCache.Snapshot): Response {
      val contentType = responseHeaders["Content-Type"]
      val contentLength = responseHeaders["Content-Length"]
      val cacheRequest = Request.Builder()
          .url(url)
          .method(requestMethod, null) // method POST must have a request body
          .headers(varyHeaders)
          .build()
    // ....
    }
```