### PR TITLE
Delay timeouts on response readings for duplex

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
@@ -93,7 +93,7 @@ class Http2ExchangeCodec(
 
   override fun readResponseHeaders(expectContinue: Boolean): Response.Builder? {
     val stream = stream ?: throw IOException("stream wasn't created")
-    val headers = stream.takeHeaders()
+    val headers = stream.takeHeaders(callerIsIdle = expectContinue)
     val responseBuilder = readHttp2HeadersList(headers, protocol)
     return if (expectContinue && responseBuilder.code == HTTP_CONTINUE) {
       null

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
@@ -15,6 +15,11 @@
  */
 package okhttp3.internal.http2
 
+import java.io.EOFException
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.SocketTimeoutException
+import java.util.ArrayDeque
 import okhttp3.Headers
 import okhttp3.internal.EMPTY_HEADERS
 import okhttp3.internal.assertThreadDoesntHoldLock
@@ -27,11 +32,6 @@ import okio.BufferedSource
 import okio.Sink
 import okio.Source
 import okio.Timeout
-import java.io.EOFException
-import java.io.IOException
-import java.io.InterruptedIOException
-import java.net.SocketTimeoutException
-import java.util.ArrayDeque
 
 /** A logical bidirectional stream. */
 @Suppress("NAME_SHADOWING")
@@ -131,16 +131,25 @@ class Http2Stream internal constructor(
    * Removes and returns the stream's received response headers, blocking if necessary until headers
    * have been received. If the returned list contains multiple blocks of headers the blocks will be
    * delimited by 'null'.
+   *
+   * @param callerIsIdle true if the caller isn't sending any more bytes until the peer responds.
+   *     This is true after a `Expect-Continue` request, false for duplex requests, and false for
+   *     all other requests.
    */
   @Synchronized @Throws(IOException::class)
-  fun takeHeaders(): Headers {
-    readTimeout.enter()
-    try {
-      while (headersQueue.isEmpty() && errorCode == null) {
-        waitForIo()
+  fun takeHeaders(callerIsIdle: Boolean = false): Headers {
+    while (headersQueue.isEmpty() && errorCode == null) {
+      val doReadTimeout = callerIsIdle || doReadTimeout()
+      if (doReadTimeout) {
+        readTimeout.enter()
       }
-    } finally {
-      readTimeout.exitAndThrowIfTimedOut()
+      try {
+        waitForIo()
+      } finally {
+        if (doReadTimeout) {
+          readTimeout.exitAndThrowIfTimedOut()
+        }
+      }
     }
     if (headersQueue.isNotEmpty()) {
       return headersQueue.removeFirst()
@@ -180,6 +189,7 @@ class Http2Stream internal constructor(
       this.hasResponseHeaders = true
       if (outFinished) {
         this.sink.finished = true
+        this@Http2Stream.notifyAll() // Because doReadTimeout() may have changed.
       }
     }
 
@@ -310,6 +320,16 @@ class Http2Stream internal constructor(
   }
 
   /**
+   * Returns true if read timeouts should be enforced while reading response headers or body bytes.
+   * We always do timeouts in the HTTP server role. For clients, we only do timeouts after the
+   * request is transmitted. This is only interesting for duplex calls where the request and
+   * response may be interleaved.
+   *
+   * Read this value only once for each enter/exit pair because its value can change.
+   */
+  private fun doReadTimeout() = !connection.client || sink.closed || sink.finished
+
+  /**
    * A source that reads the incoming data frames of a stream. Although this class uses
    * synchronization to safely receive incoming data frames, it is not intended for use by multiple
    * readers.
@@ -351,7 +371,10 @@ class Http2Stream internal constructor(
         // 1. Decide what to do in a synchronized block.
 
         synchronized(this@Http2Stream) {
-          readTimeout.enter()
+          val doReadTimeout = doReadTimeout()
+          if (doReadTimeout) {
+            readTimeout.enter()
+          }
           try {
             if (errorCode != null && !finished) {
               // Prepare to deliver an error.
@@ -379,7 +402,9 @@ class Http2Stream internal constructor(
               tryAgain = true
             }
           } finally {
-            readTimeout.exitAndThrowIfTimedOut()
+            if (doReadTimeout) {
+              readTimeout.exitAndThrowIfTimedOut()
+            }
           }
         }
 
@@ -623,6 +648,7 @@ class Http2Stream internal constructor(
       }
       synchronized(this@Http2Stream) {
         closed = true
+        this@Http2Stream.notifyAll() // Because doReadTimeout() may have changed.
       }
       connection.flush()
       cancelStreamIfNecessary()

--- a/okhttp/src/jvmTest/java/okhttp3/DuplexTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/DuplexTest.java
@@ -20,11 +20,12 @@ import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
-import mockwebserver3.SocketPolicy;
 import mockwebserver3.internal.duplex.MockDuplexResponseBody;
 import okhttp3.internal.RecordingOkAuthenticator;
 import okhttp3.internal.duplex.AsyncRequestBody;
@@ -35,6 +36,7 @@ import okhttp3.tls.HandshakeCertificates;
 import okio.BufferedSink;
 import okio.BufferedSource;
 import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
@@ -61,11 +63,17 @@ public final class DuplexTest {
       .eventListenerFactory(clientTestRule.wrap(listener))
       .build();
 
+  private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+
   @BeforeEach public void setUp(MockWebServer server) {
     this.server = server;
     platform.assumeNotOpenJSSE();
     platform.assumeHttp2Support();
     platform.assumeNotBouncyCastle();
+  }
+
+  @AfterEach public void tearDown() {
+    executorService.shutdown();
   }
 
   @Test public void http1DoesntSupportDuplex() throws IOException {
@@ -573,6 +581,110 @@ public final class DuplexTest {
     assertThat(log.take()).contains("StreamResetException: stream was reset: NO_ERROR");
   }
 
+  /**
+   * We delay sending the last byte of the request body 1500 ms. The 1000 ms read timeout should
+   * only elapse 1000 ms after the request body is sent.
+   */
+  @Test public void headersReadTimeoutDoesNotStartUntilLastRequestBodyByteFire() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+
+    server.enqueue(new MockResponse()
+      .setHeadersDelay(1500, TimeUnit.MILLISECONDS));
+
+    Request request = new Request.Builder()
+      .url(server.url("/"))
+      .post(new DelayedRequestBody(RequestBody.create("hello", null), 1500, TimeUnit.MILLISECONDS))
+      .build();
+
+    client = client.newBuilder()
+      .readTimeout(1000, TimeUnit.MILLISECONDS)
+      .build();
+
+    Call call = client.newCall(request);
+    try {
+      call.execute();
+      fail();
+    } catch (IOException e) {
+      assertThat(e.getMessage()).isEqualTo("timeout");
+    }
+  }
+
+  /** Same as the previous test, but the server stalls sending the response body. */
+  @Test public void bodyReadTimeoutDoesNotStartUntilLastRequestBodyByteFire() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+
+    server.enqueue(new MockResponse()
+      .setBodyDelay(1500, TimeUnit.MILLISECONDS)
+      .setBody("this should never be received"));
+
+    Request request = new Request.Builder()
+      .url(server.url("/"))
+      .post(new DelayedRequestBody(RequestBody.create("hello", null), 1500, TimeUnit.MILLISECONDS))
+      .build();
+
+    client = client.newBuilder()
+      .readTimeout(1000, TimeUnit.MILLISECONDS)
+      .build();
+
+    Call call = client.newCall(request);
+    Response response = call.execute();
+    try {
+      response.body().string();
+      fail();
+    } catch (IOException e) {
+      assertThat(e.getMessage()).isEqualTo("timeout");
+    }
+  }
+
+  /**
+   * We delay sending the last byte of the request body 1500 ms. The 1000 ms read timeout shouldn't
+   * elapse because it shouldn't start until the request body is sent.
+   */
+  @Test public void headersReadTimeoutDoesNotStartUntilLastRequestBodyByteNoFire() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+
+    server.enqueue(new MockResponse()
+      .setHeadersDelay(500, TimeUnit.MILLISECONDS));
+
+    Request request = new Request.Builder()
+      .url(server.url("/"))
+      .post(new DelayedRequestBody(RequestBody.create("hello", null), 1500, TimeUnit.MILLISECONDS))
+      .build();
+
+    client = client.newBuilder()
+      .readTimeout(1000, TimeUnit.MILLISECONDS)
+      .build();
+
+    Call call = client.newCall(request);
+    Response response = call.execute();
+    assertThat(response.isSuccessful()).isTrue();
+  }
+
+  /**
+   * We delay sending the last byte of the request body 1500 ms. The 1000 ms read timeout shouldn't
+   * elapse because it shouldn't start until the request body is sent.
+   */
+  @Test public void bodyReadTimeoutDoesNotStartUntilLastRequestBodyByteNoFire() throws Exception {
+    enableProtocol(Protocol.HTTP_2);
+
+    server.enqueue(new MockResponse()
+      .setBodyDelay(500, TimeUnit.MILLISECONDS)
+      .setBody("success"));
+
+    Request request = new Request.Builder()
+      .url(server.url("/"))
+      .post(new DelayedRequestBody(RequestBody.create("hello", null), 1500, TimeUnit.MILLISECONDS))
+      .build();
+
+    client = client.newBuilder()
+      .readTimeout(1000, TimeUnit.MILLISECONDS)
+      .build();
+
+    Call call = client.newCall(request);
+    Response response = call.execute();
+    assertThat(response.body().string()).isEqualTo("success");
+  }
+
   private MockDuplexResponseBody enqueueResponseWithBody(
       MockResponse response, MockDuplexResponseBody body) {
     MwsDuplexAccess.instance.setBody(response, body);
@@ -599,5 +711,34 @@ public final class DuplexTest {
         .hostnameVerifier(new RecordingHostnameVerifier())
         .build();
     server.useHttps(handshakeCertificates.sslSocketFactory(), false);
+  }
+
+  private class DelayedRequestBody extends RequestBody {
+    private final RequestBody delegate;
+    private final long delayMillis;
+
+    public DelayedRequestBody(RequestBody delegate, long delay, TimeUnit timeUnit) {
+      this.delegate = delegate;
+      this.delayMillis = timeUnit.toMillis(delay);
+    }
+
+    @Override public MediaType contentType() {
+      return delegate.contentType();
+    }
+
+    @Override public boolean isDuplex() {
+      return true;
+    }
+
+    @Override public void writeTo(BufferedSink sink) throws IOException {
+      executorService.schedule(() -> {
+        try {
+          delegate.writeTo(sink);
+          sink.close();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }, delayMillis, TimeUnit.MILLISECONDS);
+    }
   }
 }


### PR DESCRIPTION
Fixes #https://github.com/square/wire/issues/2174