### PR TITLE
Change how tunnels are configured with MockWebServer

### DIFF
--- a/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/bridge.kt
+++ b/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/bridge.kt
@@ -61,6 +61,10 @@ internal fun MockResponse.wrap(): mockwebserver3.MockResponse {
       result.add100Continue()
       mockwebserver3.SocketPolicy.KEEP_OPEN
     }
+    SocketPolicy.UPGRADE_TO_SSL_AT_END -> {
+      result.inTunnel()
+      mockwebserver3.SocketPolicy.KEEP_OPEN
+    }
     else -> socketPolicy.wrap()
   }
   result.http2ErrorCode = http2ErrorCode

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockResponse.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockResponse.kt
@@ -25,6 +25,9 @@ import okio.Buffer
 
 /** A scripted response to be replayed by the mock web server. */
 class MockResponse : Cloneable {
+  var inTunnel = false
+    private set
+
   var informationalResponses: List<MockResponse> = listOf()
     private set
 
@@ -360,6 +363,18 @@ class MockResponse : Cloneable {
     setHeader("Upgrade", "websocket")
     body = null
     webSocketListener = listener
+  }
+
+  /**
+   * Configures this response to be served as a response to an HTTP CONNECT request, either for
+   * doing HTTPS through an HTTP proxy, or HTTP/2 prior knowledge through an HTTP proxy.
+   *
+   * When a new connection is received, all in-tunnel responses are served before the connection is
+   * upgraded to HTTPS or HTTP/2.
+   */
+  fun inTunnel() = apply {
+    removeHeader("Content-Length")
+    inTunnel = true
   }
 
   /**

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -58,7 +58,6 @@ import mockwebserver3.SocketPolicy.SHUTDOWN_INPUT_AT_END
 import mockwebserver3.SocketPolicy.SHUTDOWN_OUTPUT_AT_END
 import mockwebserver3.SocketPolicy.SHUTDOWN_SERVER_AFTER_RESPONSE
 import mockwebserver3.SocketPolicy.STALL_SOCKET_AT_START
-import mockwebserver3.SocketPolicy.UPGRADE_TO_SSL_AT_END
 import mockwebserver3.internal.duplex.DuplexResponseBody
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
@@ -132,7 +131,6 @@ class MockWebServer : Closeable {
 
   private var serverSocket: ServerSocket? = null
   private var sslSocketFactory: SSLSocketFactory? = null
-  private var tunnelProxy: Boolean = false
   private var clientAuth = CLIENT_AUTH_NONE
 
   /**
@@ -283,7 +281,6 @@ class MockWebServer : Closeable {
    */
   fun useHttps(sslSocketFactory: SSLSocketFactory, tunnelProxy: Boolean) {
     this.sslSocketFactory = sslSocketFactory
-    this.tunnelProxy = tunnelProxy
   }
 
   /**
@@ -484,14 +481,13 @@ class MockWebServer : Closeable {
 
     @Throws(Exception::class)
     fun handle() {
+      if (!processTunnelRequests()) return
+
       val socketPolicy = dispatcher.peek().socketPolicy
-      var protocol = Protocol.HTTP_1_1
+      val protocol: Protocol
       val socket: Socket
       when {
         sslSocketFactory != null -> {
-          if (tunnelProxy) {
-            createTunnel()
-          }
           if (socketPolicy === FAIL_HANDSHAKE) {
             dispatchBookkeepingRequest(sequenceNumber, raw)
             processHandshakeFailure(raw)
@@ -517,17 +513,23 @@ class MockWebServer : Closeable {
 
           if (protocolNegotiationEnabled) {
             val protocolString = Platform.get().getSelectedProtocol(sslSocket)
-            protocol =
-              if (protocolString != null) Protocol.get(protocolString) else Protocol.HTTP_1_1
+            protocol = when {
+              protocolString != null -> Protocol.get(protocolString)
+              else -> Protocol.HTTP_1_1
+            }
             Platform.get().afterHandshake(sslSocket)
+          } else {
+            protocol = Protocol.HTTP_1_1
           }
           openClientSockets.remove(raw)
         }
-        Protocol.H2_PRIOR_KNOWLEDGE in protocols -> {
+        else -> {
+          protocol = when {
+            Protocol.H2_PRIOR_KNOWLEDGE in protocols -> Protocol.H2_PRIOR_KNOWLEDGE
+            else -> Protocol.HTTP_1_1
+          }
           socket = raw
-          protocol = Protocol.H2_PRIOR_KNOWLEDGE
         }
-        else -> socket = raw
       }
 
       if (socketPolicy === STALL_SOCKET_AT_START) {
@@ -566,17 +568,26 @@ class MockWebServer : Closeable {
     }
 
     /**
-     * Respond to CONNECT requests until a SWITCH_TO_SSL_AT_END response is
-     * dispatched.
+     * Respond to `CONNECT` requests until a non-tunnel response is peeked. Returns true if further
+     * calls should be attempted on the socket.
      */
     @Throws(IOException::class, InterruptedException::class)
-    private fun createTunnel() {
+    private fun processTunnelRequests(): Boolean {
+      if (!dispatcher.peek().inTunnel) return true // No tunnel requests.
+
       val source = raw.source().buffer()
       val sink = raw.sink().buffer()
       while (true) {
-        val socketPolicy = dispatcher.peek().socketPolicy
-        check(processOneRequest(raw, source, sink)) { "Tunnel without any CONNECT!" }
-        if (socketPolicy === UPGRADE_TO_SSL_AT_END) return
+        val socketStillGood = processOneRequest(raw, source, sink)
+
+        // Clean up after the last exchange on a socket.
+        if (!socketStillGood) {
+          raw.close()
+          openClientSockets.remove(raw)
+          return false
+        }
+
+        if (!dispatcher.peek().inTunnel) return true // No more tunnel requests.
       }
     }
 

--- a/mockwebserver/src/main/kotlin/mockwebserver3/SocketPolicy.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/SocketPolicy.kt
@@ -52,12 +52,6 @@ enum class SocketPolicy {
   DISCONNECT_AT_END,
 
   /**
-   * Wrap the socket with SSL at the completion of this request/response pair. Used for CONNECT
-   * messages to tunnel SSL over an HTTP proxy.
-   */
-  UPGRADE_TO_SSL_AT_END,
-
-  /**
    * Request immediate close of connection without even reading the request. Use to simulate buggy
    * SSL servers closing connections in response to unrecognized TLS extensions.
    */

--- a/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
@@ -2910,8 +2910,7 @@ open class CallTest(
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()
@@ -2980,13 +2979,13 @@ open class CallTest(
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
+        .inTunnel()
         .setResponseCode(407)
         .addHeader("Proxy-Authenticate: Basic realm=\"localhost\"")
     )
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()
@@ -3050,14 +3049,14 @@ open class CallTest(
     server.protocols = listOf<Protocol>(Protocol.HTTP_1_1)
     server.enqueue(
       MockResponse()
+        .inTunnel()
         .setResponseCode(407)
         .addHeader("Proxy-Authenticate: Basic realm=\"localhost\"")
         .addHeader("Connection: close")
     )
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()
@@ -3123,8 +3122,7 @@ open class CallTest(
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()
@@ -3155,8 +3153,7 @@ open class CallTest(
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()
@@ -3197,14 +3194,14 @@ open class CallTest(
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
+        .inTunnel()
         .setResponseCode(HttpURLConnection.HTTP_PROXY_AUTH)
         .addHeader("Proxy-Authenticate", "Basic realm=\"localhost\"")
         .setBody("proxy auth required")
     )
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(MockResponse())
     val challengeSchemes: MutableList<String?> = ArrayList()
@@ -3240,6 +3237,7 @@ open class CallTest(
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
+        .inTunnel()
         .setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST)
     )
     client = client.newBuilder()
@@ -3598,8 +3596,7 @@ open class CallTest(
     }
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     client = client.newBuilder()
       .sslSocketFactory(

--- a/okhttp/src/jvmTest/java/okhttp3/EventListenerTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/EventListenerTest.java
@@ -696,11 +696,12 @@ public final class EventListenerTest {
   @Test public void authenticatingTunnelProxyConnect() throws IOException {
     enableTlsWithTunnel(true);
     server.enqueue(new MockResponse()
+        .inTunnel()
         .setResponseCode(407)
         .addHeader("Proxy-Authenticate: Basic realm=\"localhost\"")
         .addHeader("Connection: close"));
     server.enqueue(new MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END));
+        .inTunnel());
     server.enqueue(new MockResponse());
 
     client = client.newBuilder()
@@ -768,7 +769,7 @@ public final class EventListenerTest {
   @Test public void secureConnectWithTunnel() throws IOException {
     enableTlsWithTunnel(true);
     server.enqueue(new MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END));
+        .inTunnel());
     server.enqueue(new MockResponse());
 
     client = client.newBuilder()

--- a/okhttp/src/jvmTest/java/okhttp3/URLConnectionTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/URLConnectionTest.kt
@@ -910,8 +910,7 @@ class URLConnectionTest {
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()
@@ -945,10 +944,11 @@ class URLConnectionTest {
     initResponseCache()
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     // The inclusion of a body in the response to a CONNECT is key to reproducing b/6754912.
-    val badProxyResponse = MockResponse()
-      .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-      .setBody("bogus proxy connect response content")
-    server.enqueue(badProxyResponse)
+    server.enqueue(
+      MockResponse()
+        .inTunnel()
+        .setBody("bogus proxy connect response content")
+    )
     server.enqueue(
       MockResponse()
         .setBody("response")
@@ -991,8 +991,7 @@ class URLConnectionTest {
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()
@@ -1031,13 +1030,13 @@ class URLConnectionTest {
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
+        .inTunnel()
         .setResponseCode(407)
         .addHeader("Proxy-Authenticate: Basic realm=\"localhost\"")
     )
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()
@@ -1076,8 +1075,7 @@ class URLConnectionTest {
     server.useHttps(handshakeCertificates.sslSocketFactory(), true)
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()
@@ -1106,8 +1104,7 @@ class URLConnectionTest {
     server.useHttps(socketFactory, true)
     server.enqueue(
       MockResponse()
-        .setSocketPolicy(SocketPolicy.UPGRADE_TO_SSL_AT_END)
-        .clearHeaders()
+        .inTunnel()
     )
     server.enqueue(
       MockResponse()


### PR DESCRIPTION
This is the MockWebServer side of changing how HTTP/2 prior knowledge
works with proxies.

https://github.com/square/okhttp/issues/7289