### PR TITLE
Implement CONNECT tunnels for HTTP/2 prior knowledge

### DIFF
--- a/mockwebserver/api/mockwebserver3.api
+++ b/mockwebserver/api/mockwebserver3.api
@@ -28,6 +28,7 @@ public final class mockwebserver3/MockResponse : java/lang/Cloneable {
 	public final fun getHeaders ()Lokhttp3/Headers;
 	public final fun getHeadersDelay (Ljava/util/concurrent/TimeUnit;)J
 	public final fun getHttp2ErrorCode ()I
+	public final fun getInTunnel ()Z
 	public final fun getInformationalResponses ()Ljava/util/List;
 	public final fun getMessage ()Ljava/lang/String;
 	public final fun getPushPromises ()Ljava/util/List;
@@ -40,6 +41,7 @@ public final class mockwebserver3/MockResponse : java/lang/Cloneable {
 	public final fun getWebSocketListener ()Lokhttp3/WebSocketListener;
 	public final fun headers (Lokhttp3/Headers;)V
 	public final fun http2ErrorCode (I)V
+	public final fun inTunnel ()Lmockwebserver3/MockResponse;
 	public final fun isDuplex ()Z
 	public final fun removeHeader (Ljava/lang/String;)Lmockwebserver3/MockResponse;
 	public final fun setBody (Ljava/lang/String;)Lmockwebserver3/MockResponse;
@@ -181,7 +183,6 @@ public final class mockwebserver3/SocketPolicy : java/lang/Enum {
 	public static final field SHUTDOWN_OUTPUT_AT_END Lmockwebserver3/SocketPolicy;
 	public static final field SHUTDOWN_SERVER_AFTER_RESPONSE Lmockwebserver3/SocketPolicy;
 	public static final field STALL_SOCKET_AT_START Lmockwebserver3/SocketPolicy;
-	public static final field UPGRADE_TO_SSL_AT_END Lmockwebserver3/SocketPolicy;
 	public static fun valueOf (Ljava/lang/String;)Lmockwebserver3/SocketPolicy;
 	public static fun values ()[Lmockwebserver3/SocketPolicy;
 }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Route.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Route.kt
@@ -64,12 +64,16 @@ class Route(
   fun socketAddress(): InetSocketAddress = socketAddress
 
   /**
-   * Returns true if this route tunnels HTTPS through an HTTP proxy.
+   * Returns true if this route tunnels HTTPS or HTTP/2 through an HTTP proxy.
    * See [RFC 2817, Section 5.2][rfc_2817].
    *
    * [rfc_2817]: http://www.ietf.org/rfc/rfc2817.txt
    */
-  fun requiresTunnel(): Boolean = address.sslSocketFactory != null && proxy.type() == Proxy.Type.HTTP
+  fun requiresTunnel(): Boolean {
+    if (proxy.type() != Proxy.Type.HTTP) return false
+    return (address.sslSocketFactory != null) ||
+      (Protocol.H2_PRIOR_KNOWLEDGE in address.protocols)
+  }
 
   override fun equals(other: Any?): Boolean {
     return other is Route &&


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/7289