### PR TITLE
Suppress documentation on Request.tag

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/Request.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Request.kt
@@ -95,6 +95,8 @@ actual class Request internal actual constructor(builder: Builder) {
    * Prior to OkHttp 3.11, this method never returned null if no tag was attached. Instead it
    * returned either this request, or the request upon which this request was derived with
    * [newBuilder].
+   *
+   * @suppress this method breaks Dokka! https://github.com/Kotlin/dokka/issues/2473
    */
   fun tag(): Any? = tag<Any>()
 


### PR DESCRIPTION
We've got two overloads that only differ by type arguments.
We need to suppress one to prevent Dokka from crashing.

See: https://github.com/Kotlin/dokka/issues/2473