### PR TITLE
Drop the Content-Length header from multipart parts

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/MultipartBody.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/MultipartBody.kt
@@ -39,11 +39,13 @@ class MultipartBody internal constructor(
   private val contentType: MediaType = "$type; boundary=$boundary".toMediaType()
   private var contentLength = -1L
 
-  @get:JvmName("boundary") val boundary: String
+  @get:JvmName("boundary")
+  val boundary: String
     get() = boundaryByteString.utf8()
 
   /** The number of parts in this multipart body. */
-  @get:JvmName("size") val size: Int
+  @get:JvmName("size")
+  val size: Int
     get() = parts.size
 
   fun part(index: Int): Part = parts[index]
@@ -53,30 +55,34 @@ class MultipartBody internal constructor(
 
   @JvmName("-deprecated_type")
   @Deprecated(
-      message = "moved to val",
-      replaceWith = ReplaceWith(expression = "type"),
-      level = DeprecationLevel.ERROR)
+    message = "moved to val",
+    replaceWith = ReplaceWith(expression = "type"),
+    level = DeprecationLevel.ERROR
+  )
   fun type(): MediaType = type
 
   @JvmName("-deprecated_boundary")
   @Deprecated(
-      message = "moved to val",
-      replaceWith = ReplaceWith(expression = "boundary"),
-      level = DeprecationLevel.ERROR)
+    message = "moved to val",
+    replaceWith = ReplaceWith(expression = "boundary"),
+    level = DeprecationLevel.ERROR
+  )
   fun boundary(): String = boundary
 
   @JvmName("-deprecated_size")
   @Deprecated(
-      message = "moved to val",
-      replaceWith = ReplaceWith(expression = "size"),
-      level = DeprecationLevel.ERROR)
+    message = "moved to val",
+    replaceWith = ReplaceWith(expression = "size"),
+    level = DeprecationLevel.ERROR
+  )
   fun size(): Int = size
 
   @JvmName("-deprecated_parts")
   @Deprecated(
-      message = "moved to val",
-      replaceWith = ReplaceWith(expression = "parts"),
-      level = DeprecationLevel.ERROR)
+    message = "moved to val",
+    replaceWith = ReplaceWith(expression = "parts"),
+    level = DeprecationLevel.ERROR
+  )
   fun parts(): List<Part> = parts
 
   @Throws(IOException::class)
@@ -126,26 +132,22 @@ class MultipartBody internal constructor(
       if (headers != null) {
         for (h in 0 until headers.size) {
           sink.writeUtf8(headers.name(h))
-              .write(COLONSPACE)
-              .writeUtf8(headers.value(h))
-              .write(CRLF)
+            .write(COLONSPACE)
+            .writeUtf8(headers.value(h))
+            .write(CRLF)
         }
       }
 
       val contentType = body.contentType()
       if (contentType != null) {
         sink.writeUtf8("Content-Type: ")
-            .writeUtf8(contentType.toString())
-            .write(CRLF)
+          .writeUtf8(contentType.toString())
+          .write(CRLF)
       }
 
+      // We can't measure the body's size without the sizes of its components.
       val contentLength = body.contentLength()
-      if (contentLength != -1L) {
-        sink.writeUtf8("Content-Length: ")
-            .writeDecimalLong(contentLength)
-            .write(CRLF)
-      } else if (countBytes) {
-        // We can't measure the body's size without the sizes of its components.
+      if (contentLength == -1L && countBytes) {
         byteCountBuffer!!.clear()
         return -1L
       }
@@ -181,16 +183,18 @@ class MultipartBody internal constructor(
 
     @JvmName("-deprecated_headers")
     @Deprecated(
-        message = "moved to val",
-        replaceWith = ReplaceWith(expression = "headers"),
-        level = DeprecationLevel.ERROR)
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "headers"),
+      level = DeprecationLevel.ERROR
+    )
     fun headers(): Headers? = headers
 
     @JvmName("-deprecated_body")
     @Deprecated(
-        message = "moved to val",
-        replaceWith = ReplaceWith(expression = "body"),
-        level = DeprecationLevel.ERROR)
+      message = "moved to val",
+      replaceWith = ReplaceWith(expression = "body"),
+      level = DeprecationLevel.ERROR
+    )
     fun body(): RequestBody = body
 
     companion object {
@@ -206,7 +210,7 @@ class MultipartBody internal constructor(
 
       @JvmStatic
       fun createFormData(name: String, value: String): Part =
-          createFormData(name, null, value.toRequestBody())
+        createFormData(name, null, value.toRequestBody())
 
       @JvmStatic
       fun createFormData(name: String, filename: String?, body: RequestBody): Part {
@@ -221,8 +225,8 @@ class MultipartBody internal constructor(
         }
 
         val headers = Headers.Builder()
-            .addUnsafeNonAscii("Content-Disposition", disposition)
-            .build()
+          .addUnsafeNonAscii("Content-Disposition", disposition)
+          .build()
 
         return create(headers, body)
       }

--- a/okhttp/src/jvmTest/java/okhttp3/MultipartBodyTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/MultipartBodyTest.java
@@ -37,7 +37,6 @@ public final class MultipartBodyTest {
   @Test public void singlePart() throws Exception {
     String expected = ""
         + "--123\r\n"
-        + "Content-Length: 13\r\n"
         + "\r\n"
         + "Hello, World!\r\n"
         + "--123--\r\n";
@@ -50,7 +49,7 @@ public final class MultipartBodyTest {
     assertThat(body.type()).isEqualTo(MultipartBody.MIXED);
     assertThat(body.contentType().toString()).isEqualTo("multipart/mixed; boundary=123");
     assertThat(body.parts().size()).isEqualTo(1);
-    assertThat(body.contentLength()).isEqualTo(53);
+    assertThat(body.contentLength()).isEqualTo(33L);
 
     Buffer buffer = new Buffer();
     body.writeTo(buffer);
@@ -61,15 +60,12 @@ public final class MultipartBodyTest {
   @Test public void threeParts() throws Exception {
     String expected = ""
         + "--123\r\n"
-        + "Content-Length: 5\r\n"
         + "\r\n"
         + "Quick\r\n"
         + "--123\r\n"
-        + "Content-Length: 5\r\n"
         + "\r\n"
         + "Brown\r\n"
         + "--123\r\n"
-        + "Content-Length: 3\r\n"
         + "\r\n"
         + "Fox\r\n"
         + "--123--\r\n";
@@ -84,7 +80,7 @@ public final class MultipartBodyTest {
     assertThat(body.type()).isEqualTo(MultipartBody.MIXED);
     assertThat(body.contentType().toString()).isEqualTo("multipart/mixed; boundary=123");
     assertThat(body.parts().size()).isEqualTo(3);
-    assertThat(body.contentLength()).isEqualTo(112);
+    assertThat(body.contentLength()).isEqualTo(55L);
 
     Buffer buffer = new Buffer();
     body.writeTo(buffer);
@@ -96,25 +92,21 @@ public final class MultipartBodyTest {
     String expected = ""
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"submit-name\"\r\n"
-        + "Content-Length: 5\r\n"
         + "\r\n"
         + "Larry\r\n"
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"files\"\r\n"
         + "Content-Type: multipart/mixed; boundary=BbC04y\r\n"
-        + "Content-Length: 337\r\n"
         + "\r\n"
         + "--BbC04y\r\n"
         + "Content-Disposition: file; filename=\"file1.txt\"\r\n"
         + "Content-Type: text/plain; charset=utf-8\r\n"
-        + "Content-Length: 29\r\n"
         + "\r\n"
         + "... contents of file1.txt ...\r\n"
         + "--BbC04y\r\n"
         + "Content-Disposition: file; filename=\"file2.gif\"\r\n"
         + "Content-Transfer-Encoding: binary\r\n"
         + "Content-Type: image/gif\r\n"
-        + "Content-Length: 29\r\n"
         + "\r\n"
         + "... contents of file2.gif ...\r\n"
         + "--BbC04y--\r\n"
@@ -145,7 +137,7 @@ public final class MultipartBodyTest {
     assertThat(body.contentType().toString()).isEqualTo(
         "multipart/form-data; boundary=AaB03x");
     assertThat(body.parts().size()).isEqualTo(2);
-    assertThat(body.contentLength()).isEqualTo(568);
+    assertThat(body.contentLength()).isEqualTo(488L);
 
     Buffer buffer = new Buffer();
     body.writeTo(buffer);
@@ -158,22 +150,18 @@ public final class MultipartBodyTest {
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"field with spaces\"; filename=\"filename with spaces.txt\"\r\n"
         + "Content-Type: text/plain; charset=utf-8\r\n"
-        + "Content-Length: 4\r\n"
         + "\r\n"
         + "okay\r\n"
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"field with %22\"\r\n"
-        + "Content-Length: 1\r\n"
         + "\r\n"
         + "\"\r\n"
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"field with %22\"\r\n"
-        + "Content-Length: 3\r\n"
         + "\r\n"
         + "%22\r\n"
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"field with \u007e\"\r\n"
-        + "Content-Length: 5\r\n"
         + "\r\n"
         + "Alpha\r\n"
         + "--AaB03x--\r\n";
@@ -211,14 +199,12 @@ public final class MultipartBodyTest {
 
     String expected = ""
         + "--123\r\n"
-        + "Content-Length: 5\r\n"
         + "\r\n"
         + "Quick\r\n"
         + "--123\r\n"
         + "\r\n"
         + "Brown\r\n"
         + "--123\r\n"
-        + "Content-Length: 3\r\n"
         + "\r\n"
         + "Fox\r\n"
         + "--123--\r\n";
@@ -278,7 +264,6 @@ public final class MultipartBodyTest {
         + "--AaB03x\r\n"
         + "Content-Disposition: form-data; name=\"attachment\"; filename=\"resumé.pdf\"\r\n"
         + "Content-Type: application/pdf; charset=utf-8\r\n"
-        + "Content-Length: 17\r\n"
         + "\r\n"
         + "Jesse’s Resumé\r\n"
         + "--AaB03x--\r\n";

--- a/okhttp/src/jvmTest/java/okhttp3/MultipartReaderTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/MultipartReaderTest.kt
@@ -526,7 +526,6 @@ class MultipartReaderTest {
     assertThat(quickPart.headers).isEqualTo(
       headersOf(
         "Content-Type", "text/plain; charset=utf-8",
-        "Content-Length", "5"
       )
     )
     assertThat(quickPart.body.readUtf8()).isEqualTo("Quick")
@@ -535,7 +534,6 @@ class MultipartReaderTest {
     assertThat(brownPart.headers).isEqualTo(
       headersOf(
         "Content-Disposition", "form-data; name=\"color\"",
-        "Content-Length", "5"
       )
     )
     assertThat(brownPart.body.readUtf8()).isEqualTo("Brown")
@@ -544,7 +542,6 @@ class MultipartReaderTest {
     assertThat(foxPart.headers).isEqualTo(
       headersOf(
         "Content-Disposition", "form-data; name=\"animal\"; filename=\"fox.txt\"",
-        "Content-Length", "3"
       )
     )
     assertThat(foxPart.body.readUtf8()).isEqualTo("Fox")


### PR DESCRIPTION
This causes our users grief:
https://github.com/square/okhttp/issues/2604
https://github.com/square/okhttp/issues/2138

I've resisted removing it because it seemed like it'd
break compatibility in a significant way. But with OkHttp 5
it's a good time to break compatibility.

As far as I can tell the behavior of including Content-Length
in multipart bodies is not performed by web browsers or other
HTTP clients.