### PR TITLE
jvm-default=all

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ subprojects {
       jvmTarget = JavaVersion.VERSION_1_8.toString()
 
       freeCompilerArgs = listOf(
-        "-Xjvm-default=compatibility",
+        "-Xjvm-default=all",
         "-opt-in=kotlin.RequiresOptIn"
       )
     }


### PR DESCRIPTION
Warning from build

```
w: '-Xjvm-default=compatibility' is deprecated, please use '-Xjvm-default=all|all-compatibility'
```