### PR TITLE
Improve runtime compatibility with kotlin 1.5.31

### DIFF
--- a/okhttp/src/commonMain/kotlin/okhttp3/internal/-CacheControlCommon.kt
+++ b/okhttp/src/commonMain/kotlin/okhttp3/internal/-CacheControlCommon.kt
@@ -18,9 +18,9 @@
 
 package okhttp3.internal
 
-import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
+import kotlin.time.toDuration
 import okhttp3.CacheControl
 import okhttp3.Headers
 
@@ -50,30 +50,23 @@ internal fun CacheControl.commonToString(): String {
 
 internal fun CacheControl.Builder.commonMaxAge(maxAge: Int, timeUnit: DurationUnit) = apply {
   require(maxAge >= 0) { "maxAge < 0: $maxAge" }
-  val maxAgeSecondsDouble = Duration.convert(maxAge.toDouble(), timeUnit, DurationUnit.SECONDS)
-  this.maxAgeSeconds = maxAgeSecondsDouble.commonClampToInt()
+  val maxAgeSecondsLong = maxAge.toDuration(timeUnit).inWholeSeconds
+  this.maxAgeSeconds = maxAgeSecondsLong.commonClampToInt()
 }
 
 internal fun CacheControl.Builder.commonMaxStale(maxStale: Int, timeUnit: DurationUnit) = apply {
   require(maxStale >= 0) { "maxStale < 0: $maxStale" }
-  val maxStaleSecondsDouble = Duration.convert(maxStale.toDouble(), timeUnit, DurationUnit.SECONDS)
-  this.maxStaleSeconds = maxStaleSecondsDouble.commonClampToInt()
+  val maxStaleSecondsLong = maxStale.toDuration(timeUnit).inWholeSeconds
+  this.maxStaleSeconds = maxStaleSecondsLong.commonClampToInt()
 }
 
 internal fun CacheControl.Builder.commonMinFresh(minFresh: Int, timeUnit: DurationUnit) = apply {
   require(minFresh >= 0) { "minFresh < 0: $minFresh" }
-  val minFreshSecondsDouble = Duration.convert(minFresh.toDouble(), timeUnit, DurationUnit.SECONDS)
-  this.minFreshSeconds = minFreshSecondsDouble.commonClampToInt()
+  val minFreshSecondsLong = minFresh.toDuration(timeUnit).inWholeSeconds
+  this.minFreshSeconds = minFreshSecondsLong.commonClampToInt()
 }
 
 internal fun Long.commonClampToInt(): Int {
-  return when {
-    this > Int.MAX_VALUE -> Int.MAX_VALUE
-    else -> toInt()
-  }
-}
-
-internal fun Double.commonClampToInt(): Int {
   return when {
     this > Int.MAX_VALUE -> Int.MAX_VALUE
     else -> toInt()

--- a/okhttp/src/jvmMain/kotlin/okhttp3/CacheControl.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/CacheControl.kt
@@ -25,9 +25,6 @@ import okhttp3.internal.commonClampToInt
 import okhttp3.internal.commonForceCache
 import okhttp3.internal.commonForceNetwork
 import okhttp3.internal.commonImmutable
-import okhttp3.internal.commonMaxAge
-import okhttp3.internal.commonMaxStale
-import okhttp3.internal.commonMinFresh
 import okhttp3.internal.commonNoCache
 import okhttp3.internal.commonNoStore
 import okhttp3.internal.commonNoTransform
@@ -153,11 +150,18 @@ actual class CacheControl internal actual constructor(
 
     actual fun immutable() = commonImmutable()
 
-    actual fun maxAge(maxAge: Int, timeUnit: DurationUnit) = commonMaxAge(maxAge, timeUnit)
+    // We are compiling with kotlin 1.6 but need to run with older versions at runtime. For
+    // maximum compat we therefore need to handle both the case where DurationUnit is typealiased
+    // to TimeUnit (as it was pre-1.6) and where it is a distinct wrapper enum (in 1.6). We also
+    // can't use durationUnit.toTimeUnit() because that doesn't exist in the typealiased case.
+    // This function should work in either case.
+    internal fun toJavaTimeUnit(durationUnit: DurationUnit) = TimeUnit.valueOf(durationUnit.name)
 
-    actual fun maxStale(maxStale: Int, timeUnit: DurationUnit) = commonMaxStale(maxStale, timeUnit)
+    actual fun maxAge(maxAge: Int, timeUnit: DurationUnit) = maxAge(maxAge, toJavaTimeUnit(timeUnit))
 
-    actual fun minFresh(minFresh: Int, timeUnit: DurationUnit) = commonMinFresh(minFresh, timeUnit)
+    actual fun maxStale(maxStale: Int, timeUnit: DurationUnit) = maxStale(maxStale, toJavaTimeUnit(timeUnit))
+
+    actual fun minFresh(minFresh: Int, timeUnit: DurationUnit) = minFresh(minFresh, toJavaTimeUnit(timeUnit))
 
     /**
      * Sets the maximum age of a cached response. If the cache response's age exceeds [maxAge], it


### PR DESCRIPTION
I tried to fix this in https://github.com/square/okhttp/pull/7329 but that didn't work. This reverts that attempt and applies a different fix that seems to work better. See individual commit messages for details.