### PR TITLE
Avoid failing on shutdown executor

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
@@ -181,14 +181,17 @@ class Dispatcher() {
     // particularly because RealCall handles a RejectedExecutionException
     // by executing on the same thread.
     if (executorService.isShutdown) {
-      synchronized(this) {
         for (i in 0 until executableCalls.size) {
           val asyncCall = executableCalls[i]
           asyncCall.callsPerHost.decrementAndGet()
-          runningAsyncCalls.remove(asyncCall)
+
+          synchronized(this) {
+            runningAsyncCalls.remove(asyncCall)
+          }
+
+          asyncCall.failRejected()
         }
         idleCallback?.run()
-      }
     } else {
       for (i in 0 until executableCalls.size) {
         val asyncCall = executableCalls[i]

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
@@ -179,9 +179,14 @@ class Dispatcher() {
       isRunning = runningCallsCount() > 0
     }
 
-    for (i in 0 until executableCalls.size) {
-      val asyncCall = executableCalls[i]
-      asyncCall.executeOn(executorService)
+    // Avoid resubmitting if we can't logically progress
+    // particularly because RealCall handles a RejectedExecutionException
+    // by executing on the same thread.
+    if (!executorService.isShutdown) {
+      for (i in 0 until executableCalls.size) {
+        val asyncCall = executableCalls[i]
+        asyncCall.executeOn(executorService)
+      }
     }
 
     return isRunning

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Dispatcher.kt
@@ -15,7 +15,9 @@
  */
 package okhttp3
 
-import java.util.*
+import java.util.ArrayDeque
+import java.util.Collections
+import java.util.Deque
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -27,7 +27,16 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSocketFactory
-import okhttp3.*
+import okhttp3.Address
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.CertificatePinner
+import okhttp3.EventListener
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
 import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.cache.CacheInterceptor

--- a/okhttp/src/jvmTest/java/okhttp3/DispatcherCleanupTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/DispatcherCleanupTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import java.io.IOException
+import org.junit.jupiter.api.Test
+
+class DispatcherCleanupTest {
+  @Test
+  fun testFinish() {
+    val okhttp = OkHttpClient()
+    val callback = object : Callback {
+      override fun onFailure(call: Call, e: IOException) {}
+      override fun onResponse(call: Call, response: Response) {
+        response.close()
+      }
+    }
+    repeat(10_000) {
+      okhttp.newCall(Request.Builder().url("https://example.com").build()).enqueue(callback)
+    }
+    okhttp.dispatcher.executorService.shutdown()
+  }
+}

--- a/okhttp/src/jvmTest/java/okhttp3/DispatcherCleanupTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/DispatcherCleanupTest.kt
@@ -16,11 +16,12 @@
 package okhttp3
 
 import java.io.IOException
+import mockwebserver3.MockWebServer
 import org.junit.jupiter.api.Test
 
 class DispatcherCleanupTest {
   @Test
-  fun testFinish() {
+  fun testFinish(server: MockWebServer) {
     val okhttp = OkHttpClient()
     val callback = object : Callback {
       override fun onFailure(call: Call, e: IOException) {}
@@ -29,7 +30,7 @@ class DispatcherCleanupTest {
       }
     }
     repeat(10_000) {
-      okhttp.newCall(Request.Builder().url("https://example.com").build()).enqueue(callback)
+      okhttp.newCall(Request.Builder().url(server.url("/")).build()).enqueue(callback)
     }
     okhttp.dispatcher.executorService.shutdown()
   }

--- a/okhttp/src/jvmTest/java/okhttp3/RecordingExecutor.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/RecordingExecutor.kt
@@ -60,7 +60,7 @@ internal class RecordingExecutor(
   }
 
   override fun isShutdown(): Boolean {
-    throw UnsupportedOperationException()
+    return shutdown
   }
 
   override fun isTerminated(): Boolean {


### PR DESCRIPTION
Testing of https://github.com/square/okhttp/issues/7410

Consider this fix for discussion.  Open to suggestions.

Issue happens because RealCall.executeOn has rejected execute call and falls back to recursive handling.
