### PR TITLE
bugfix(fix_docs_code_blocks): Upgrade Dokka to fix bug with KDocs code blocks

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ gradlePlugin-androidJunit5 = "de.mannodermaus.gradle.plugins:android-junit5:1.8.
 gradlePlugin-animalsniffer = "ru.vyarus:gradle-animalsniffer-plugin:1.5.4"
 gradlePlugin-binaryCompatibilityValidator = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin:0.11.0"
 gradlePlugin-bnd = { module = "biz.aQute.bnd:biz.aQute.bnd.gradle", version.ref = "biz-aQute-bnd" }
-gradlePlugin-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.6.21"
+gradlePlugin-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.7.10"
 gradlePlugin-errorprone = "net.ltgt.gradle:gradle-errorprone-plugin:2.0.2"
 gradlePlugin-graal = "com.palantir.graal:gradle-graal:0.12.0"
 gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "org-jetbrains-kotlin" }


### PR DESCRIPTION
Addressing issue #7105 

Code blocks were not being rendered properly using KDocs inline markdown in Kotlin classes. I tried to change syntax and still saw formatting issues. This appears to be a bug with Dokka version 1.6.21 for which I raised this issue: https://github.com/Kotlin/dokka/issues/2624

Upgrading Dokka plugin to 1.7.10 seems to fix the issue and code blocks are now rendering, along with syntax highlighting.

## Screenshots:
Before:
<img width="791" alt="Screen Shot 2022-08-12 at 2 48 50 PM" src="https://user-images.githubusercontent.com/36639521/184424202-875aee05-2256-424f-88b8-27d847f76522.png">

After:
<img width="810" alt="Screen Shot 2022-08-12 at 2 49 05 PM" src="https://user-images.githubusercontent.com/36639521/184424236-28162b6a-0ea6-41dc-8ffd-a843820dbd81.png">

