### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
@@ -42,6 +45,8 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
 
   checkjdk11:
+    permissions:
+      checks: write # for mikepenz/action-junit-report
     runs-on: ubuntu-latest
 
     steps:
@@ -68,6 +73,8 @@ jobs:
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
   testopenjdk11:
+    permissions:
+      checks: write # for mikepenz/action-junit-report
     runs-on: ubuntu-latest
 
     steps:
@@ -94,6 +101,8 @@ jobs:
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
   testjs:
+    permissions:
+      checks: write # for mikepenz/action-junit-report
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.