### PR TITLE
Allow chaining the redactHeader() calls on HttpLoggingInterceptor

### DIFF
--- a/okhttp-logging-interceptor/api/logging-interceptor.api
+++ b/okhttp-logging-interceptor/api/logging-interceptor.api
@@ -6,7 +6,7 @@ public final class okhttp3/logging/HttpLoggingInterceptor : okhttp3/Interceptor 
 	public final fun getLevel ()Lokhttp3/logging/HttpLoggingInterceptor$Level;
 	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
 	public final fun level (Lokhttp3/logging/HttpLoggingInterceptor$Level;)V
-	public final fun redactHeader (Ljava/lang/String;)V
+	public final fun redactHeader (Ljava/lang/String;)Lokhttp3/logging/HttpLoggingInterceptor;
 	public final fun setLevel (Lokhttp3/logging/HttpLoggingInterceptor$Level;)Lokhttp3/logging/HttpLoggingInterceptor;
 }
 

--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -120,11 +120,11 @@ class HttpLoggingInterceptor @JvmOverloads constructor(
     }
   }
 
-  fun redactHeader(name: String) {
+  fun redactHeader(name: String) = apply {
     val newHeadersToRedact = TreeSet(String.CASE_INSENSITIVE_ORDER)
     newHeadersToRedact += headersToRedact
     newHeadersToRedact += name
-    headersToRedact = newHeadersToRedact
+    this.headersToRedact = newHeadersToRedact
   }
 
   /**


### PR DESCRIPTION
Make the following syntax possible:
```
OkHttpClient.Builder()
                .addInterceptor(
                    HttpLoggingInterceptor()
                        .setLevel(Level.BODY)
                        .redactHeader(HttpHeaders.AUTHORIZATION)
                ).build()
```

Currently one needs to introduce a local variable to hold the `HttpLoggingInterceptor` reference:

```
        val loggingInterceptor = HttpLoggingInterceptor()
            .setLevel(Level.BODY)
        loggingInterceptor.redactHeader(HttpHeaders.AUTHORIZATION)

        OkHttpClient.Builder()
            .addInterceptor(loggingInterceptor)
            .build()
```

Also, `setLevel()` already supports chaining calls, so it's logical to make `redactHeader()` support chaining as well.