### PR TITLE
Move from git protocol due to deprecation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "okhttp-hpacktests/src/test/resources/hpack-test-case"]
 	path = okhttp-hpacktests/src/test/resources/hpack-test-case
-	url = git://github.com/http2jp/hpack-test-case.git
+	url = https://github.com/http2jp/hpack-test-case.git


### PR DESCRIPTION
Move from git to https for cloning hpack-test-case, see here https://github.blog/2021-09-01-improving-git-protocol-security-github/