### PR TITLE
Testing refused requests

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -998,7 +998,11 @@ class MockWebServer : Closeable {
 
       val socketPolicy = response.socketPolicy
       if (socketPolicy === DISCONNECT_AFTER_REQUEST) {
-        socket.close()
+        if (response.http2ErrorCode != -1) {
+          stream.close(ErrorCode.fromHttp2(response.http2ErrorCode)!!, null)
+        } else {
+          socket.close()
+        }
         return
       }
       writeResponse(stream, request, response)

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
@@ -124,18 +124,23 @@ class RetryAndFollowUpInterceptor(private val client: OkHttpClient) : Intercepto
     userRequest: Request,
     requestSendStarted: Boolean
   ): Boolean {
+    println("1")
     // The application layer has forbidden retries.
     if (!client.retryOnConnectionFailure) return false
 
+    println("2")
     // We can't send the request body again.
     if (requestSendStarted && requestIsOneShot(e, userRequest)) return false
 
+    println("3")
     // This exception is fatal.
     if (!isRecoverable(e, requestSendStarted)) return false
 
+    println("4")
     // No more routes to attempt.
     if (!call.retryAfterFailure()) return false
 
+    println("5")
     // For failure recovery, use the same route selector with a new connection.
     return true
   }

--- a/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/CallTest.kt
@@ -904,6 +904,7 @@ open class CallTest {
   @Flaky
   @Test fun refusedStreamDoesntRetryIndefinitely() {
     enableProtocol(Protocol.HTTP_2)
+    clientTestRule.recordFrames = true
 
     server.enqueue(
       MockResponse()


### PR DESCRIPTION
Related to https://github.com/square/okhttp/issues/7530

I can't seem to test HTTP/2 + proxies + mockwebserver.  That would be closest to the Charles case.

But trying to follow along via just HTTP/2 + mockwebserver.  Can't reproduce the failure at the moment on 5.x