### PR TITLE
Create MockResponseBody

### DIFF
--- a/mockwebserver/api/mockwebserver3.api
+++ b/mockwebserver/api/mockwebserver3.api
@@ -16,7 +16,7 @@ public final class mockwebserver3/MockResponse {
 	public fun <init> (ILokhttp3/Headers;Ljava/lang/String;ZLmockwebserver3/SocketPolicy;I)V
 	public synthetic fun <init> (ILokhttp3/Headers;Ljava/lang/String;ZLmockwebserver3/SocketPolicy;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lmockwebserver3/MockResponse$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getBody ()Lokio/Buffer;
+	public final fun getBody ()Lmockwebserver3/MockResponseBody;
 	public final fun getBodyDelayNanos ()J
 	public final fun getCode ()I
 	public final fun getDuplexResponseBody ()Lmockwebserver3/internal/duplex/DuplexResponseBody;
@@ -58,6 +58,7 @@ public final class mockwebserver3/MockResponse$Builder : java/lang/Cloneable {
 	public synthetic fun clone ()Ljava/lang/Object;
 	public fun clone ()Lmockwebserver3/MockResponse$Builder;
 	public final fun code (I)Lmockwebserver3/MockResponse$Builder;
+	public final fun getBody ()Lmockwebserver3/MockResponseBody;
 	public final fun getCode ()I
 	public final fun getDuplexResponseBody ()Lmockwebserver3/internal/duplex/DuplexResponseBody;
 	public final fun getHttp2ErrorCode ()I
@@ -74,6 +75,7 @@ public final class mockwebserver3/MockResponse$Builder : java/lang/Cloneable {
 	public final fun http2ErrorCode (I)Lmockwebserver3/MockResponse$Builder;
 	public final fun inTunnel ()Lmockwebserver3/MockResponse$Builder;
 	public final fun removeHeader (Ljava/lang/String;)Lmockwebserver3/MockResponse$Builder;
+	public final fun setBody (Lmockwebserver3/MockResponseBody;)V
 	public final fun setCode (I)V
 	public final fun setHeader (Ljava/lang/String;Ljava/lang/Object;)Lmockwebserver3/MockResponse$Builder;
 	public final fun setHttp2ErrorCode (I)V
@@ -88,6 +90,11 @@ public final class mockwebserver3/MockResponse$Builder : java/lang/Cloneable {
 }
 
 public final class mockwebserver3/MockResponse$Companion {
+}
+
+public abstract interface class mockwebserver3/MockResponseBody {
+	public abstract fun getContentLength ()J
+	public abstract fun writeTo (Lokio/BufferedSink;)V
 }
 
 public final class mockwebserver3/MockWebServer : java/io/Closeable {

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockResponse.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockResponse.kt
@@ -17,6 +17,7 @@ package mockwebserver3
 
 import java.util.concurrent.TimeUnit
 import mockwebserver3.internal.duplex.DuplexResponseBody
+import mockwebserver3.internal.toMockResponseBody
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.WebSocketListener
@@ -47,8 +48,7 @@ class MockResponse {
   val headers: Headers
   val trailers: Headers
 
-  val body: Buffer?
-    get() { return field?.clone() }
+  val body: MockResponseBody?
 
   val inTunnel: Boolean
   val informationalResponses: List<MockResponse>
@@ -101,7 +101,7 @@ class MockResponse {
     this.status = builder.status
     this.headers = builder.headers.build()
     this.trailers = builder.trailers.build()
-    this.body = builder.body?.clone()
+    this.body = builder.body
     this.inTunnel = builder.inTunnel
     this.informationalResponses = builder.informationalResponses.toList()
     this.throttleBytesPerPeriod = builder.throttleBytesPerPeriod
@@ -152,7 +152,7 @@ class MockResponse {
 
     internal var trailers: Headers.Builder
 
-    internal var body: Buffer?
+    var body: MockResponseBody?
 
     var throttleBytesPerPeriod: Long
       private set
@@ -271,7 +271,7 @@ class MockResponse {
 
     fun body(body: Buffer) = apply {
       setHeader("Content-Length", body.size)
-      this.body = body.clone() // Defensive copy.
+      this.body = body.toMockResponseBody()
     }
 
     /** Sets the response body to the UTF-8 encoded bytes of [body]. */
@@ -297,7 +297,7 @@ class MockResponse {
         bytesOut.writeUtf8("\r\n")
       }
       bytesOut.writeUtf8("0\r\n") // Last chunk. Trailers follow!
-      this.body = bytesOut
+      this.body = bytesOut.toMockResponseBody()
     }
 
     /**

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockResponseBody.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockResponseBody.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package mockwebserver3
+
+import java.io.IOException
+import okio.BufferedSink
+
+/**
+ * The body of a [MockResponse].
+ *
+ * Unlike [okhttp3.ResponseBody], this interface is designed to be implemented by writers and not
+ * called by readers.
+ */
+interface MockResponseBody {
+  /** The length of this response in bytes, or -1 if unknown. */
+  val contentLength: Long
+
+  @Throws(IOException::class)
+  fun writeTo(sink: BufferedSink)
+}

--- a/mockwebserver/src/main/kotlin/mockwebserver3/internal/ThrottledSink.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/internal/ThrottledSink.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package mockwebserver3.internal
+
+import okio.Buffer
+import okio.Sink
+
+/**
+ * A sink that sleeps [periodDelayNanos] every [bytesPerPeriod] bytes. Unlike [okio.Throttler],
+ * this permits any interval to be used.
+ */
+internal class ThrottledSink(
+  private val delegate: Sink,
+  private val bytesPerPeriod: Long,
+  private val periodDelayNanos: Long,
+) : Sink by delegate {
+  private var bytesWrittenSinceLastDelay = 0L
+  override fun write(source: Buffer, byteCount: Long) {
+    var bytesLeft = byteCount
+
+    while (bytesLeft > 0) {
+      if (bytesWrittenSinceLastDelay == bytesPerPeriod) {
+        flush()
+        sleepNanos(periodDelayNanos)
+        bytesWrittenSinceLastDelay = 0
+      }
+
+      val toWrite = minOf(bytesLeft, bytesPerPeriod - bytesWrittenSinceLastDelay)
+      bytesWrittenSinceLastDelay += toWrite
+      bytesLeft -= toWrite
+      delegate.write(source, toWrite)
+    }
+  }
+}

--- a/mockwebserver/src/main/kotlin/mockwebserver3/internal/TriggerSink.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/internal/TriggerSink.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package mockwebserver3.internal
+
+import okio.Buffer
+import okio.Sink
+
+/**
+ * A sink that executes [trigger] after [triggerByteCount] bytes are written, and then skips all
+ * subsequent bytes.
+ */
+internal class TriggerSink(
+  private val delegate: Sink,
+  private val triggerByteCount: Long,
+  private val trigger: () -> Unit,
+) : Sink by delegate {
+  private var bytesWritten = 0L
+
+  override fun write(source: Buffer, byteCount: Long) {
+    if (byteCount == 0L) return // Avoid double-triggering.
+
+    if (bytesWritten == triggerByteCount) {
+      source.skip(byteCount)
+      return
+    }
+
+    val toWrite = minOf(byteCount, triggerByteCount - bytesWritten)
+    bytesWritten += toWrite
+
+    delegate.write(source, toWrite)
+
+    if (bytesWritten == triggerByteCount) {
+      trigger()
+    }
+
+    source.skip(byteCount - toWrite)
+  }
+}

--- a/mockwebserver/src/main/kotlin/mockwebserver3/internal/mockResponseBodies.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/internal/mockResponseBodies.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+@file:JvmName("MockResponseBodiesKt")
+
+package mockwebserver3.internal
+
+import mockwebserver3.MockResponseBody
+import okio.Buffer
+import okio.BufferedSink
+
+internal fun Buffer.toMockResponseBody(): MockResponseBody {
+  val defensiveCopy = clone()
+  return BufferMockResponseBody(defensiveCopy)
+}
+
+internal class BufferMockResponseBody(
+  val buffer: Buffer,
+) : MockResponseBody {
+  override val contentLength = buffer.size
+
+  override fun writeTo(sink: BufferedSink) {
+    buffer.copyTo(sink.buffer)
+    sink.emitCompleteSegments()
+  }
+}

--- a/mockwebserver/src/main/kotlin/mockwebserver3/internal/sleep.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/internal/sleep.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package mockwebserver3.internal
+
+internal fun sleepNanos(nanos: Long) {
+  val ms = nanos / 1_000_000L
+  val ns = nanos - (ms * 1_000_000L)
+  if (ms > 0L || nanos > 0) {
+    Thread.sleep(ms, ns.toInt())
+  }
+}

--- a/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
@@ -44,6 +44,7 @@ import okhttp3.TestUtil;
 import okhttp3.testing.PlatformRule;
 import okhttp3.tls.HandshakeCertificates;
 import okhttp3.tls.HeldCertificate;
+import okio.Buffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -115,7 +116,9 @@ public final class MockWebServerTest {
     MockResponse.Builder builder = new MockResponse.Builder().body("ABC");
     assertThat(headersToList(builder)).containsExactly("Content-Length: 3");
     MockResponse response = builder.build();
-    assertThat(response.getBody().readUtf8()).isEqualTo("ABC");
+    Buffer body = new Buffer();
+    response.getBody().writeTo(body);
+    assertThat(body.readUtf8()).isEqualTo("ABC");
   }
 
   @Test public void mockResponseAddHeader() {
@@ -574,8 +577,8 @@ public final class MockWebServerTest {
   @Test public void testMockWebServerH2PriorKnowledgeProtocol() {
     server.setProtocols(asList(Protocol.H2_PRIOR_KNOWLEDGE));
 
-    assertThat(server.protocols().size()).isEqualTo(1);
-    assertThat(server.protocols().get(0)).isEqualTo(Protocol.H2_PRIOR_KNOWLEDGE);
+    assertThat(server.getProtocols().size()).isEqualTo(1);
+    assertThat(server.getProtocols().get(0)).isEqualTo(Protocol.H2_PRIOR_KNOWLEDGE);
   }
 
   @Test public void https() throws Exception {

--- a/okhttp/src/jvmTest/java/okhttp3/CacheTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/CacheTest.java
@@ -2889,12 +2889,14 @@ public final class CacheTest {
    * Shortens the body of {@code response} but not the corresponding headers. Only useful to test
    * how clients respond to the premature conclusion of the HTTP body.
    */
-  private MockResponse.Builder truncateViolently(MockResponse.Builder builder, int numBytesToKeep) {
+  private MockResponse.Builder truncateViolently(MockResponse.Builder builder, int numBytesToKeep) throws IOException {
     MockResponse response = builder.build();
     builder.socketPolicy(DISCONNECT_AT_END);
     Headers headers = response.getHeaders();
+    Buffer fullBody = new Buffer();
+    response.getBody().writeTo(fullBody);
     Buffer truncatedBody = new Buffer();
-    truncatedBody.write(response.getBody(), numBytesToKeep);
+    truncatedBody.write(fullBody, numBytesToKeep);
     builder.body(truncatedBody);
     builder.headers(headers);
     return builder;

--- a/okhttp/src/jvmTest/java/okhttp3/URLConnectionTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/URLConnectionTest.kt
@@ -803,7 +803,8 @@ class URLConnectionTest {
   fun contentDisagreesWithChunkedHeaderBodyTooLong() {
     val builder = MockResponse.Builder()
       .chunkedBody("abc", 3)
-    val buffer = builder.build().body!!
+    val buffer = Buffer()
+    builder.body!!.writeTo(buffer)
     buffer.writeUtf8("\r\nYOU SHOULD NOT SEE THIS")
     builder.body(buffer)
     builder.clearHeaders()
@@ -816,8 +817,9 @@ class URLConnectionTest {
   fun contentDisagreesWithChunkedHeaderBodyTooShort() {
     val builder = MockResponse.Builder()
       .chunkedBody("abcdefg", 5)
+    val fullBody = Buffer()
+    builder.body!!.writeTo(fullBody)
     val truncatedBody = Buffer()
-    val fullBody = builder.build().body!!
     truncatedBody.write(fullBody, 4)
     builder.body(truncatedBody)
     builder.clearHeaders()

--- a/okhttp/src/jvmTest/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -1416,8 +1416,8 @@ class HttpOverHttp2Test {
     // doesn't wait to read the client's DATA frame and may send a DATA frame before the client
     // does. So we can't assume the client's empty DATA will be logged first.
     assertThat(countFrames(logs, "FINE: >> 0x00000003     0 DATA          END_STREAM"))
-      .isEqualTo(2L)
-    assertThat(countFrames(logs, "FINE: >> 0x00000003     3 DATA          "))
+      .isEqualTo(1L)
+    assertThat(countFrames(logs, "FINE: >> 0x00000003     3 DATA          END_STREAM"))
       .isEqualTo(1L)
   }
 


### PR DESCRIPTION
We'd previously only ever used Buffer to model the type of the MockResponse body. This has proven inadequate, particularly for features like duplex responses.

Most of the complexity in this PR is changing how throttling and disconnect-during-body work when we don't necessarily have a Buffer for the response body.

This is a first step, more capability to follow.