### PR TITLE
Run all the tests in CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -275,6 +275,13 @@ subprojects {
       ignoredPackages += "okhttp3.tls.internal"
     }
   }
+
+  plugins.withId("org.jetbrains.kotlin.jvm") {
+    val jvmTest by tasks.creating {
+      description = "Get 'gradlew jvmTest' to run the tests of JVM-only modules"
+      dependsOn("test")
+    }
+  }
 }
 
 tasks.wrapper {

--- a/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
+++ b/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.java
@@ -574,8 +574,8 @@ public final class MockWebServerTest {
   @Test public void testMockWebServerH2PriorKnowledgeProtocol() {
     server.setProtocols(asList(Protocol.H2_PRIOR_KNOWLEDGE));
 
-    assertThat(server.protocols().size()).isEqualTo(1);
-    assertThat(server.protocols().get(0)).isEqualTo(Protocol.H2_PRIOR_KNOWLEDGE);
+    assertThat(server.getProtocols().size()).isEqualTo(1);
+    assertThat(server.getProtocols().get(0)).isEqualTo(Protocol.H2_PRIOR_KNOWLEDGE);
   }
 
   @Test public void https() throws Exception {


### PR DESCRIPTION
When we split jvmTest and jsTest, we lost the tests of JVM-only modules.