### PR TITLE
Avoid InetAddress.getCanonicalHostName().

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -155,7 +155,7 @@ class MockWebServer : Closeable {
   val hostName: String
     get() {
       before()
-      return _inetSocketAddress!!.address.canonicalHostName
+      return _inetSocketAddress!!.address.hostName
     }
 
   private var _inetSocketAddress: InetSocketAddress? = null
@@ -206,7 +206,7 @@ class MockWebServer : Closeable {
 
   fun toProxyAddress(): Proxy {
     before()
-    val address = InetSocketAddress(_inetSocketAddress!!.address.canonicalHostName, port)
+    val address = InetSocketAddress(_inetSocketAddress!!.address.hostName, port)
     return Proxy(Proxy.Type.HTTP, address)
   }
 

--- a/okhttp-android/src/androidTest/kotlin/okhttp3/android/AndroidAsyncDnsTest.kt
+++ b/okhttp-android/src/androidTest/kotlin/okhttp3/android/AndroidAsyncDnsTest.kt
@@ -45,13 +45,11 @@ import org.opentest4j.TestAbortedException
  */
 @ExtendWith(MockWebServerExtension::class)
 class AndroidAsyncDnsTest {
-  private val localhostName: String = InetAddress.getByName("localhost").canonicalHostName
 
   private val localhost: HandshakeCertificates by lazy {
     // Generate a self-signed cert for the server to serve and the client to trust.
     val heldCertificate = HeldCertificate.Builder()
-      .commonName("localhost")
-      .addSubjectAlternativeName(localhostName)
+      .addSubjectAlternativeName("localhost")
       .build()
     return@lazy HandshakeCertificates.Builder()
       .addPlatformTrustedCertificates()
@@ -111,7 +109,7 @@ class AndroidAsyncDnsTest {
   @Test
   @Disabled("No results on CI for localhost")
   fun testDnsRequest() {
-    val (allAddresses, exception) = dnsQuery(localhostName)
+    val (allAddresses, exception) = dnsQuery("localhost")
 
     assertThat(exception).isNull()
     assertThat(allAddresses).isNotEmpty

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/testing/PlatformRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/testing/PlatformRule.kt
@@ -356,7 +356,7 @@ open class PlatformRule @JvmOverloads constructor(
     private val localhostHandshakeCertificatesWithRsa2048: HandshakeCertificates by lazy {
       val heldCertificate = HeldCertificate.Builder()
         .commonName("localhost")
-        .addSubjectAlternativeName(InetAddress.getByName("localhost").canonicalHostName)
+        .addSubjectAlternativeName("localhost")
         .rsa2048()
         .build()
       return@lazy HandshakeCertificates.Builder()

--- a/okhttp-tls/README.md
+++ b/okhttp-tls/README.md
@@ -8,9 +8,8 @@ A [`HeldCertificate`][held_certificate] is a certificate and its private key. Us
 for HTTPS:
 
 ```java
-String localhost = InetAddress.getByName("localhost").getCanonicalHostName();
 HeldCertificate localhostCertificate = new HeldCertificate.Builder()
-    .addSubjectAlternativeName(localhost)
+    .addSubjectAlternativeName("localhost")
     .build();
 ```
 
@@ -62,9 +61,8 @@ HeldCertificate intermediateCertificate = new HeldCertificate.Builder()
     .signedBy(rootCertificate)
     .build();
 
-String localhost = InetAddress.getByName("localhost").getCanonicalHostName();
 HeldCertificate serverCertificate = new HeldCertificate.Builder()
-    .addSubjectAlternativeName(localhost)
+    .addSubjectAlternativeName("localhost")
     .signedBy(intermediateCertificate)
     .build();
 ```

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/TlsUtil.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/TlsUtil.kt
@@ -37,7 +37,7 @@ object TlsUtil {
     // Generate a self-signed cert for the server to serve and the client to trust.
     val heldCertificate = HeldCertificate.Builder()
         .commonName("localhost")
-        .addSubjectAlternativeName(InetAddress.getByName("localhost").canonicalHostName)
+        .addSubjectAlternativeName("localhost")
         .build()
     return@lazy HandshakeCertificates.Builder()
         .heldCertificate(heldCertificate)

--- a/okhttp/src/jvmTest/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/OpenJSSETest.kt
@@ -99,7 +99,7 @@ class OpenJSSETest {
     // can't use TlsUtil.localhost with a non OpenJSSE trust manager
     val heldCertificate = HeldCertificate.Builder()
         .commonName("localhost")
-        .addSubjectAlternativeName(InetAddress.getByName("localhost").canonicalHostName)
+        .addSubjectAlternativeName("localhost")
         .build()
     val handshakeCertificates = HandshakeCertificates.Builder()
         .heldCertificate(heldCertificate)

--- a/samples/guide/src/main/java/okhttp3/recipes/HttpsServer.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/HttpsServer.java
@@ -30,9 +30,8 @@ import okhttp3.tls.HeldCertificate;
  */
 public class HttpsServer {
   public void run() throws Exception {
-    String localhost = InetAddress.getByName("localhost").getCanonicalHostName();
     HeldCertificate localhostCertificate = new HeldCertificate.Builder()
-        .addSubjectAlternativeName(localhost)
+        .addSubjectAlternativeName("localhost")
         .build();
 
     HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()


### PR DESCRIPTION
Just hard-coding 'localhost' is simpler and avoids problems where the host machine's IP address has additional DNS registrations.

Closes: https://github.com/square/okhttp/issues/7603