### PR TITLE
Fix JavaHttpClientTest tests on JDK 19

### DIFF
--- a/samples/compare/src/test/kotlin/okhttp3/compare/JavaHttpClientTest.kt
+++ b/samples/compare/src/test/kotlin/okhttp3/compare/JavaHttpClientTest.kt
@@ -61,7 +61,7 @@ class JavaHttpClientTest {
       assertThat(recorded.headers["Accept"]).isEqualTo("text/plain")
       assertThat(recorded.headers["Accept-Encoding"]).isNull() // No built-in gzip.
       assertThat(recorded.headers["Connection"]).isEqualTo("Upgrade, HTTP2-Settings")
-      if (PlatformVersion.majorVersion >= 19) {
+      if (PlatformVersion.majorVersion < 19) {
         assertThat(recorded.headers["Content-Length"]).isEqualTo("0")
       }
       assertThat(recorded.headers["HTTP2-Settings"]).isNotNull()


### PR DESCRIPTION
Invert the logic for testing Content Length of JavaHttpClientTest.