### PR TITLE
Expand 103 handling to other non-specific 1XX messages.

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -29,13 +29,11 @@ import okhttp3.internal.checkOffsetAndCount
 import okhttp3.internal.discard
 import okhttp3.internal.headersContentLength
 import okhttp3.internal.http.ExchangeCodec
+import okhttp3.internal.http.HTTP_CONTINUE
 import okhttp3.internal.http.RequestLine
 import okhttp3.internal.http.StatusLine
 import okhttp3.internal.http.promisesBody
 import okhttp3.internal.http.receiveHeaders
-import okhttp3.internal.http.HTTP_CONTINUE
-import okhttp3.internal.http.HTTP_OK
-import okhttp3.internal.http.HTTP_PROCESSING
 import okhttp3.internal.skipAll
 import okio.Buffer
 import okio.BufferedSink
@@ -194,7 +192,7 @@ class Http1ExchangeCodec(
           state = STATE_READ_RESPONSE_HEADERS
           responseBuilder
         }
-        statusLine.code in (HTTP_PROCESSING until HTTP_OK) -> {
+        statusLine.code in (102 until 200) -> {
           // Processing and Early Hints will mean a second headers are coming.
           // Treat others the same for now
           state = STATE_READ_RESPONSE_HEADERS

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -34,7 +34,8 @@ import okhttp3.internal.http.StatusLine
 import okhttp3.internal.http.promisesBody
 import okhttp3.internal.http.receiveHeaders
 import okhttp3.internal.http.HTTP_CONTINUE
-import okhttp3.internal.http.HTTP_EARLY_HINTS
+import okhttp3.internal.http.HTTP_OK
+import okhttp3.internal.http.HTTP_PROCESSING
 import okhttp3.internal.skipAll
 import okio.Buffer
 import okio.BufferedSink
@@ -193,8 +194,9 @@ class Http1ExchangeCodec(
           state = STATE_READ_RESPONSE_HEADERS
           responseBuilder
         }
-        statusLine.code == HTTP_EARLY_HINTS -> {
-          // Early Hints will mean a second header are coming.
+        statusLine.code in (HTTP_PROCESSING until HTTP_OK) -> {
+          // Processing and Early Hints will mean a second headers are coming.
+          // Treat others the same for now
           state = STATE_READ_RESPONSE_HEADERS
           responseBuilder
         }


### PR DESCRIPTION
The basic implementation for https://github.com/square/okhttp/issues/2257

Continuation of https://github.com/square/okhttp/pull/7479

It doesn't have special handling of 102, such as resetting any timeouts.