### PR TITLE
Make tolerant of JDK 19 quirks

### DIFF
--- a/okhttp/src/jvmTest/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
@@ -15,21 +15,8 @@
  */
 package okhttp3.internal.tls;
 
-import java.security.GeneralSecurityException;
-import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
-import java.util.Collections;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509KeyManager;
-import javax.net.ssl.X509TrustManager;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
-import mockwebserver3.SocketPolicy;
 import mockwebserver3.SocketPolicy.DisconnectAtEnd;
 import okhttp3.Call;
 import okhttp3.CertificatePinner;
@@ -40,13 +27,24 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.internal.platform.Platform;
 import okhttp3.testing.PlatformRule;
-import okhttp3.testing.PlatformVersion;
 import okhttp3.tls.HandshakeCertificates;
 import okhttp3.tls.HeldCertificate;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
 
 import static okhttp3.tls.internal.TlsUtil.newKeyManager;
 import static okhttp3.tls.internal.TlsUtil.newTrustManager;
@@ -185,9 +183,6 @@ public final class CertificatePinnerChainValidationTest {
     platform.expectFailureOnConscryptPlatform();
     platform.expectFailureOnCorrettoPlatform();
 
-    // unpredictable as to whether it passes or fails? Environmental?
-    Assumptions.assumeTrue(PlatformVersion.INSTANCE.getMajorVersion() < 19);
-
     // Start with a trusted root CA certificate.
     HeldCertificate rootCa = new HeldCertificate.Builder()
         .serialNumber(1L)
@@ -267,9 +262,6 @@ public final class CertificatePinnerChainValidationTest {
     // https://github.com/square/okhttp/issues/4729
     platform.expectFailureOnConscryptPlatform();
     platform.expectFailureOnCorrettoPlatform();
-
-    // unpredictable as to whether it passes or fails? Environmental?
-    Assumptions.assumeTrue(PlatformVersion.INSTANCE.getMajorVersion() < 19);
 
     // Start with two root CA certificates, one is good and the other is compromised.
     HeldCertificate rootCa = new HeldCertificate.Builder()

--- a/okhttp/src/jvmTest/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/tls/CertificatePinnerChainValidationTest.java
@@ -40,8 +40,10 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.internal.platform.Platform;
 import okhttp3.testing.PlatformRule;
+import okhttp3.testing.PlatformVersion;
 import okhttp3.tls.HandshakeCertificates;
 import okhttp3.tls.HeldCertificate;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -182,7 +184,9 @@ public final class CertificatePinnerChainValidationTest {
     // https://github.com/square/okhttp/issues/4729
     platform.expectFailureOnConscryptPlatform();
     platform.expectFailureOnCorrettoPlatform();
-    platform.expectFailureFromJdkVersion(19);
+
+    // unpredictable as to whether it passes or fails? Environmental?
+    Assumptions.assumeTrue(PlatformVersion.INSTANCE.getMajorVersion() < 19);
 
     // Start with a trusted root CA certificate.
     HeldCertificate rootCa = new HeldCertificate.Builder()
@@ -263,7 +267,9 @@ public final class CertificatePinnerChainValidationTest {
     // https://github.com/square/okhttp/issues/4729
     platform.expectFailureOnConscryptPlatform();
     platform.expectFailureOnCorrettoPlatform();
-    platform.expectFailureFromJdkVersion(19);
+
+    // unpredictable as to whether it passes or fails? Environmental?
+    Assumptions.assumeTrue(PlatformVersion.INSTANCE.getMajorVersion() < 19);
 
     // Start with two root CA certificates, one is good and the other is compromised.
     HeldCertificate rootCa = new HeldCertificate.Builder()


### PR DESCRIPTION
See failure https://github.com/square/okhttp/actions/runs/3834111360/jobs/6526194017

```
CertificatePinnerChainValidationTest[jvm] > unrelatedPinnedIntermediateCertificateInChain()[jvm] FAILED
    org.opentest4j.AssertionFailedError: JDK with version from 19 expected to fail with exception that ANYTHING
        at app//org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)`
```