### PR TITLE
Add a Kotlin dependency to work around CVE-2022-24329

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
       'junit': '4.13',
       'kotlin': '1.6.20',
       'moshi': '1.13.0',
-      'okio': '3.2.0',
+      'okio': '3.3.0',
       'ktlint': '0.38.0',
       'picocli': '4.2.0',
       'openjsse': '1.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
       'junit': '4.13',
       'kotlin': '1.6.20',
       'moshi': '1.13.0',
-      'okio': '3.3.0',
+      'okio': '3.2.0',
       'ktlint': '0.38.0',
       'picocli': '4.2.0',
       'openjsse': '1.1.0'
@@ -40,6 +40,7 @@ buildscript {
       'jsr305': "com.google.code.findbugs:jsr305:${versions.findbugs}",
       'junit': "junit:junit:${versions.junit}",
       'kotlinStdlib': "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
+      'kotlinStdlibJdk8': "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}",
       'moshi': "com.squareup.moshi:moshi:${versions.moshi}",
       'moshiKotlin': "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}",
       'okio': "com.squareup.okio:okio:${versions.okio}",

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -24,6 +24,8 @@ task copyJavaTemplates(type: Copy) {
 dependencies {
   api deps.okio
   api deps.kotlinStdlib
+  // Only imported to avoid broken vulnerability scanners for CVE-2022-24329
+  api deps.kotlinStdlibJdk8
   compileOnly deps.android
   compileOnly deps.bouncycastle
   compileOnly deps.bouncycastletls

--- a/okhttp/build.gradle
+++ b/okhttp/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   api deps.okio
   api deps.kotlinStdlib
   // Only imported to avoid broken vulnerability scanners for CVE-2022-24329
+  // https://github.com/square/okhttp/issues/7654
   api deps.kotlinStdlibJdk8
   compileOnly deps.android
   compileOnly deps.bouncycastle


### PR DESCRIPTION
fixes https://github.com/square/okhttp/issues/7654