### PR TITLE
Restore AnimalSniffer support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,8 +111,19 @@ subprojects {
 
   val signature: Configuration by configurations.getting
   dependencies {
-    signature(rootProject.libs.signature.android.apilevel21)
-    signature(rootProject.libs.codehaus.signature.java18)
+    // No dependency requirements for testing-support.
+    if (project.name == "okhttp-testing-support") return@dependencies
+
+    if (project.name == "mockwebserver3-junit5") {
+      // JUnit 5's APIs need java.util.function.Function and java.util.Optional from API 24.
+      signature(rootProject.libs.signature.android.apilevel24) { artifact { type = "signature" } }
+    } else {
+      // Everything else requires Android API 21+.
+      signature(rootProject.libs.signature.android.apilevel21) { artifact { type = "signature" } }
+    }
+
+    // OkHttp requires Java 8+.
+    signature(rootProject.libs.codehaus.signature.java18) { artifact { type = "signature" } }
   }
 
   tasks.withType<KotlinCompile> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ openjsse = "org.openjsse:openjsse:1.1.10"
 playservices-safetynet = "com.google.android.gms:play-services-safetynet:18.0.1"
 robolectric-android = "org.robolectric:android-all:13-robolectric-9030017"
 signature-android-apilevel21 = "net.sf.androidscents.signature:android-api-level-21:5.0.1_r2"
+signature-android-apilevel24 = "net.sf.androidscents.signature:android-api-level-24:7.0_r2"
 squareup-moshi = { module = "com.squareup.moshi:moshi", version.ref = "com-squareup-moshi" }
 squareup-moshi-compiler = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "com-squareup-moshi" }
 squareup-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "com-squareup-moshi" }

--- a/mockwebserver-junit5/README.md
+++ b/mockwebserver-junit5/README.md
@@ -50,3 +50,10 @@ class MyTest(
   }
 }
 ```
+
+Requirements
+------------
+
+MockWebServer's JUnit 5 integration works on Android 7.0+ (API level 24+) and Java 8+. Note that
+this is above OkHttp's core requirements.
+

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Headers.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Headers.kt
@@ -18,7 +18,6 @@
 package okhttp3
 
 import java.time.Instant
-import java.util.ArrayList
 import java.util.Collections
 import java.util.Date
 import java.util.Locale
@@ -45,6 +44,7 @@ import okhttp3.internal.commonValues
 import okhttp3.internal.headersCheckName
 import okhttp3.internal.http.toHttpDateOrNull
 import okhttp3.internal.http.toHttpDateString
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 @Suppress("NAME_SHADOWING")
 actual class Headers internal actual constructor(
@@ -62,6 +62,7 @@ actual class Headers internal actual constructor(
    * Returns the last value corresponding to the specified field parsed as an HTTP date, or null if
    * either the field is absent or cannot be parsed as a date.
    */
+  @IgnoreJRERequirement // Only programs that already have Instant will use this.
   fun getInstant(name: String): Instant? {
     return getDate(name)?.toInstant()
   }
@@ -186,6 +187,7 @@ actual class Headers internal actual constructor(
      * Add a header with the specified name and formatted instant. Does validation of header names
      * and value.
      */
+    @IgnoreJRERequirement // Only programs that already have Instant will use this.
     fun add(name: String, value: Instant) = add(name, Date.from(value))
 
     /**
@@ -198,6 +200,7 @@ actual class Headers internal actual constructor(
      * Set a field with the specified instant. If the field is not found, it is added. If the field
      * is found, the existing values are replaced.
      */
+    @IgnoreJRERequirement // Only programs that already have Instant will use this.
     operator fun set(name: String, value: Instant) = set(name, Date.from(value))
 
     /**

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/platform/Platform.kt
@@ -42,6 +42,7 @@ import okhttp3.internal.tls.BasicTrustRootIndex
 import okhttp3.internal.tls.CertificateChainCleaner
 import okhttp3.internal.tls.TrustRootIndex
 import okio.Buffer
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 /**
  * Access to platform-specific features.
@@ -128,6 +129,7 @@ open class Platform {
 
   /** For MockWebServer. This returns the inbound SNI names. */
   @SuppressLint("NewApi")
+  @IgnoreJRERequirement // This function is overridden to require API >= 24.
   open fun getHandshakeServerNames(sslSocket: SSLSocket): List<String> {
     val session = sslSocket.session as? ExtendedSSLSession ?: return listOf()
     return session.requestedServerNames.mapNotNull { (it as? SNIHostName)?.asciiName }

--- a/samples/tlssurvey/src/main/kotlin/okhttp3/survey/ssllabs/UserAgentCapabilities.kt
+++ b/samples/tlssurvey/src/main/kotlin/okhttp3/survey/ssllabs/UserAgentCapabilities.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.JsonClass
 
 
 @JsonClass(generateAdapter = true)
-data class UserAgentCapabilities(
+class UserAgentCapabilities(
     val abortsOnUnrecognizedName: Boolean,
     val alpnProtocols: List<String>,
     val ellipticCurves: List<Int>,


### PR DESCRIPTION
It wasn't working because we weren't configuring the dependency type correctly.

https://github.com/xvik/gradle-animalsniffer-plugin/issues/64

Closes: https://github.com/square/okhttp/issues/7652