### PR TITLE
Refine doc and comments about how to run android test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ org.gradle.caching=true
 Running Android Tests
 ---------------------
 
-$ ANDROID_SDK_ROOT=PATH_TO_ANDROID_HOME/sdk ./gradlew :android-test:connectedCheck
+$ ANDROID_SDK_ROOT=PATH_TO_ANDROID_HOME/sdk ./gradlew :android-test:connectedCheck -PandroidBuild=true
 
 Committer's Guides
 ------------------

--- a/android-test/README.md
+++ b/android-test/README.md
@@ -37,7 +37,7 @@ $ adb logcat '*:E' OkHttp:D Http2:D TestRunner:D TaskRunner:D OkHttpTest:D GnssH
 3. Run tests using gradle
 
 ```
-$ ANDROID_SDK_ROOT=/Users/myusername/Library/Android/sdk ./gradlew :android-test:connectedCheck
+$ ANDROID_SDK_ROOT=/Users/myusername/Library/Android/sdk ./gradlew :android-test:connectedCheck -PandroidBuild=true
 ...
 > Task :android-test:connectedDebugAndroidTest
 ...

--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -88,7 +88,7 @@ import okhttp3.Headers
 import org.junit.jupiter.api.BeforeEach
 
 /**
- * Run with "./gradlew :android-test:connectedCheck" and make sure ANDROID_SDK_ROOT is set.
+ * Run with "./gradlew :android-test:connectedCheck -PandroidBuild=true" and make sure ANDROID_SDK_ROOT is set.
  */
 @ExtendWith(MockWebServerExtension::class)
 @Tag("Slow")

--- a/docs/contribute/contributing.md
+++ b/docs/contribute/contributing.md
@@ -44,7 +44,7 @@ org.gradle.caching=true
 Running Android Tests
 ---------------------
 
-$ ANDROID_SDK_ROOT=PATH_TO_ANDROID_HOME/sdk ./gradlew :android-test:connectedCheck
+$ ANDROID_SDK_ROOT=PATH_TO_ANDROID_HOME/sdk ./gradlew :android-test:connectedCheck -PandroidBuild=true
 
 Committer's Guides
 ------------------

--- a/okhttp-android/src/androidTest/kotlin/okhttp3/android/AndroidAsyncDnsTest.kt
+++ b/okhttp-android/src/androidTest/kotlin/okhttp3/android/AndroidAsyncDnsTest.kt
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.opentest4j.TestAbortedException
 
 /**
- * Run with "./gradlew :android-test:connectedCheck" and make sure ANDROID_SDK_ROOT is set.
+ * Run with "./gradlew :android-test:connectedCheck -PandroidBuild=true" and make sure ANDROID_SDK_ROOT is set.
  */
 @ExtendWith(MockWebServerExtension::class)
 class AndroidAsyncDnsTest {


### PR DESCRIPTION
Refine doc and comments about how to run android test.
We need add an parameter `-PandroidBuild=true` so Gradle can know about `android-test ` project.
