### PR TITLE
Hide the internal okhttp immutable methods

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -76,10 +76,10 @@ import okhttp3.internal.http2.ErrorCode
 import okhttp3.internal.http2.Header
 import okhttp3.internal.http2.Http2Connection
 import okhttp3.internal.http2.Http2Stream
-import okhttp3.internal.immutableListOf
+import okhttp3.internal.okImmutableListOf
 import okhttp3.internal.platform.Platform
 import okhttp3.internal.threadFactory
-import okhttp3.internal.toImmutableList
+import okhttp3.internal.okToImmutableList
 import okhttp3.internal.ws.RealWebSocket
 import okhttp3.internal.ws.WebSocketExtensions
 import okhttp3.internal.ws.WebSocketProtocol
@@ -178,9 +178,9 @@ class MockWebServer : Closeable {
    *
    * This list is ignored when [negotiation is disabled][protocolNegotiationEnabled].
    */
-  var protocols: List<Protocol> = immutableListOf(Protocol.HTTP_2, Protocol.HTTP_1_1)
+  var protocols: List<Protocol> = okImmutableListOf(Protocol.HTTP_2, Protocol.HTTP_1_1)
     set(value) {
-      val protocolList = value.toImmutableList()
+      val protocolList = value.okToImmutableList()
       require(Protocol.H2_PRIOR_KNOWLEDGE !in protocolList || protocolList.size == 1) {
         "protocols containing h2_prior_knowledge cannot use other protocols: $protocolList"
       }

--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/HandshakeCertificates.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/HandshakeCertificates.kt
@@ -27,7 +27,7 @@ import javax.net.ssl.X509KeyManager
 import javax.net.ssl.X509TrustManager
 import okhttp3.CertificatePinner
 import okhttp3.internal.platform.Platform
-import okhttp3.internal.toImmutableList
+import okhttp3.internal.okToImmutableList
 import okhttp3.tls.internal.TlsUtil.newKeyManager
 import okhttp3.tls.internal.TlsUtil.newTrustManager
 import java.security.KeyStoreException
@@ -172,7 +172,7 @@ class HandshakeCertificates private constructor(
     }
 
     fun build(): HandshakeCertificates {
-      val immutableInsecureHosts = insecureHosts.toImmutableList()
+      val immutableInsecureHosts = insecureHosts.okToImmutableList()
 
       val heldCertificate = heldCertificate
       if (heldCertificate != null && heldCertificate.keyPair.private.format == null) {

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Address.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Address.kt
@@ -21,7 +21,7 @@ import java.util.Objects
 import javax.net.SocketFactory
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSocketFactory
-import okhttp3.internal.toImmutableList
+import okhttp3.internal.okToImmutableList
 
 /**
  * A specification for a connection to an origin server. For simple connections, this is the
@@ -81,10 +81,10 @@ class Address(
    * The protocols the client supports. This method always returns a non-null list that
    * contains minimally [Protocol.HTTP_1_1].
    */
-  @get:JvmName("protocols") val protocols: List<Protocol> = protocols.toImmutableList()
+  @get:JvmName("protocols") val protocols: List<Protocol> = protocols.okToImmutableList()
 
   @get:JvmName("connectionSpecs") val connectionSpecs: List<ConnectionSpec> =
-      connectionSpecs.toImmutableList()
+      connectionSpecs.okToImmutableList()
 
   @JvmName("-deprecated_url")
   @Deprecated(

--- a/okhttp/src/jvmMain/kotlin/okhttp3/FormBody.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/FormBody.kt
@@ -21,7 +21,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.internal.CommonHttpUrl.FORM_ENCODE_SET
 import okhttp3.internal.CommonHttpUrl.percentDecode
 import okhttp3.internal.JvmHttpUrl.canonicalizeWithCharset
-import okhttp3.internal.toImmutableList
+import okhttp3.internal.okToImmutableList
 import okio.Buffer
 import okio.BufferedSink
 
@@ -29,8 +29,8 @@ class FormBody internal constructor(
   encodedNames: List<String>,
   encodedValues: List<String>
 ) : RequestBody() {
-  private val encodedNames: List<String> = encodedNames.toImmutableList()
-  private val encodedValues: List<String> = encodedValues.toImmutableList()
+  private val encodedNames: List<String> = encodedNames.okToImmutableList()
+  private val encodedValues: List<String> = encodedValues.okToImmutableList()
 
   /** The number of key-value pairs in this form-encoded body. */
   @get:JvmName("size") val size: Int

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Handshake.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Handshake.kt
@@ -21,8 +21,8 @@ import java.security.cert.Certificate
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSession
-import okhttp3.internal.immutableListOf
-import okhttp3.internal.toImmutableList
+import okhttp3.internal.okImmutableListOf
+import okhttp3.internal.okToImmutableList
 
 /**
  * A record of a TLS handshake. For HTTPS clients, the client is *local* and the remote server is
@@ -168,7 +168,7 @@ class Handshake internal constructor(
 
     private fun Array<out Certificate>?.toImmutableList(): List<Certificate> {
       return if (this != null) {
-        immutableListOf(*this)
+        okImmutableListOf(*this)
       } else {
         emptyList()
       }
@@ -189,8 +189,8 @@ class Handshake internal constructor(
       peerCertificates: List<Certificate>,
       localCertificates: List<Certificate>
     ): Handshake {
-      val peerCertificatesCopy = peerCertificates.toImmutableList()
-      return Handshake(tlsVersion, cipherSuite, localCertificates.toImmutableList()) {
+      val peerCertificatesCopy = peerCertificates.okToImmutableList()
+      return Handshake(tlsVersion, cipherSuite, localCertificates.okToImmutableList()) {
         peerCertificatesCopy
       }
     }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/MultipartBody.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/MultipartBody.kt
@@ -18,7 +18,7 @@ package okhttp3
 import java.io.IOException
 import java.util.UUID
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.internal.toImmutableList
+import okhttp3.internal.okToImmutableList
 import okio.Buffer
 import okio.BufferedSink
 import okio.ByteString
@@ -274,7 +274,7 @@ class MultipartBody internal constructor(
     /** Assemble the specified parts into a request body. */
     fun build(): MultipartBody {
       check(parts.isNotEmpty()) { "Multipart body must have at least one part." }
-      return MultipartBody(boundary, type, parts.toImmutableList())
+      return MultipartBody(boundary, type, parts.okToImmutableList())
     }
   }
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
@@ -36,12 +36,12 @@ import okhttp3.internal.checkDuration
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.connection.RealCall
 import okhttp3.internal.connection.RouteDatabase
-import okhttp3.internal.immutableListOf
+import okhttp3.internal.okImmutableListOf
 import okhttp3.internal.platform.Platform
 import okhttp3.internal.proxy.NullProxySelector
 import okhttp3.internal.tls.CertificateChainCleaner
 import okhttp3.internal.tls.OkHostnameVerifier
-import okhttp3.internal.toImmutableList
+import okhttp3.internal.okToImmutableList
 import okhttp3.internal.ws.RealWebSocket
 import okio.Sink
 import okio.Source
@@ -143,7 +143,7 @@ open class OkHttpClient internal constructor(
    * origin server, cache, or both).
    */
   @get:JvmName("interceptors") val interceptors: List<Interceptor> =
-    builder.interceptors.toImmutableList()
+    builder.interceptors.okToImmutableList()
 
   /**
    * Returns an immutable list of interceptors that observe a single network request and response.
@@ -151,7 +151,7 @@ open class OkHttpClient internal constructor(
    * a network interceptor to short-circuit or repeat a network request.
    */
   @get:JvmName("networkInterceptors") val networkInterceptors: List<Interceptor> =
-    builder.networkInterceptors.toImmutableList()
+    builder.networkInterceptors.okToImmutableList()
 
   @get:JvmName("eventListenerFactory") val eventListenerFactory: EventListener.Factory =
     builder.eventListenerFactory
@@ -883,7 +883,7 @@ open class OkHttpClient internal constructor(
         this.routeDatabase = null
       }
 
-      this.connectionSpecs = connectionSpecs.toImmutableList()
+      this.connectionSpecs = connectionSpecs.okToImmutableList()
     }
 
     /**
@@ -1141,9 +1141,9 @@ open class OkHttpClient internal constructor(
   }
 
   companion object {
-    internal val DEFAULT_PROTOCOLS = immutableListOf(HTTP_2, HTTP_1_1)
+    internal val DEFAULT_PROTOCOLS = okImmutableListOf(HTTP_2, HTTP_1_1)
 
-    internal val DEFAULT_CONNECTION_SPECS = immutableListOf(
+    internal val DEFAULT_CONNECTION_SPECS = okImmutableListOf(
       ConnectionSpec.MODERN_TLS,
       ConnectionSpec.CLEARTEXT,
     )

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/-UtilJvm.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/-UtilJvm.kt
@@ -213,13 +213,13 @@ internal fun Response.headersContentLength(): Long {
 }
 
 /** Returns an immutable copy of this. */
-fun <T> List<T>.toImmutableList(): List<T> {
+fun <T> List<T>.okToImmutableList(): List<T> {
   return Collections.unmodifiableList(toMutableList())
 }
 
 /** Returns an immutable list containing [elements]. */
 @SafeVarargs
-fun <T> immutableListOf(vararg elements: T): List<T> {
+fun <T> okImmutableListOf(vararg elements: T): List<T> {
   return Collections.unmodifiableList(listOf(*elements.clone()))
 }
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RouteSelector.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RouteSelector.kt
@@ -28,8 +28,8 @@ import okhttp3.EventListener
 import okhttp3.HttpUrl
 import okhttp3.Route
 import okhttp3.internal.canParseAsIpAddress
-import okhttp3.internal.immutableListOf
-import okhttp3.internal.toImmutableList
+import okhttp3.internal.okImmutableListOf
+import okhttp3.internal.okToImmutableList
 
 /**
  * Selects routes to connect to an origin server. Each connection requires a choice of proxy server,
@@ -103,13 +103,13 @@ class RouteSelector(
 
       // If the URI lacks a host (as in "http://</"), don't call the ProxySelector.
       val uri = url.toUri()
-      if (uri.host == null) return immutableListOf(Proxy.NO_PROXY)
+      if (uri.host == null) return okImmutableListOf(Proxy.NO_PROXY)
 
       // Try each of the ProxySelector choices until one connection succeeds.
       val proxiesOrNull = address.proxySelector.select(uri)
-      if (proxiesOrNull.isNullOrEmpty()) return immutableListOf(Proxy.NO_PROXY)
+      if (proxiesOrNull.isNullOrEmpty()) return okImmutableListOf(Proxy.NO_PROXY)
 
-      return proxiesOrNull.toImmutableList()
+      return proxiesOrNull.okToImmutableList()
     }
 
     eventListener.proxySelectStart(call, url)

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
@@ -41,7 +41,7 @@ import okhttp3.internal.http2.Header.Companion.TARGET_PATH
 import okhttp3.internal.http2.Header.Companion.TARGET_PATH_UTF8
 import okhttp3.internal.http2.Header.Companion.TARGET_SCHEME
 import okhttp3.internal.http2.Header.Companion.TARGET_SCHEME_UTF8
-import okhttp3.internal.immutableListOf
+import okhttp3.internal.okImmutableListOf
 import okio.Sink
 import okio.Source
 
@@ -133,7 +133,7 @@ class Http2ExchangeCodec(
     private const val UPGRADE = "upgrade"
 
     /** See http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-8.1.3. */
-    private val HTTP_2_SKIPPED_REQUEST_HEADERS = immutableListOf(
+    private val HTTP_2_SKIPPED_REQUEST_HEADERS = okImmutableListOf(
         CONNECTION,
         HOST,
         KEEP_ALIVE,
@@ -146,7 +146,7 @@ class Http2ExchangeCodec(
         TARGET_PATH_UTF8,
         TARGET_SCHEME_UTF8,
         TARGET_AUTHORITY_UTF8)
-    private val HTTP_2_SKIPPED_RESPONSE_HEADERS = immutableListOf(
+    private val HTTP_2_SKIPPED_RESPONSE_HEADERS = okImmutableListOf(
         CONNECTION,
         HOST,
         KEEP_ALIVE,


### PR DESCRIPTION
In Android Studio/IntelliJ, if you are looking to convert a list to an immutable list, you start to type `toImmu` and then it shows:

<img width="1161" alt="Screenshot 2023-02-22 at 2 51 51 PM" src="https://user-images.githubusercontent.com/1459320/220761872-f393cadf-abf1-4142-b558-07af8f7ed753.png">

Many times, I find myself accidentally selecting the okhttp3 internal implementation. 

My first assumption is that you all are using an internal implementation instead of kotlinx so as to not add another dependency within okhttp. My second assumption, which I found to be true through testing, is that these functions cannot actually use the `internal` modifier. 

So, the solution to me would be to have some prefix that others are unlikely to type, such as `okToImmutableList`. I'll admit though that when actually calling this function within these OkHttp libraries does look a bit ugly. 

I am open to suggestions on other prefixes, or other ways to solve this! Just a pretty annoying thing that I am sure a lot of folks run in to with trying to create an immutable list in their Kotlin projects that use OkHttp.