### PR TITLE
Avoid assuming RealCall

### DIFF
--- a/okhttp-sse/api/okhttp-sse.api
+++ b/okhttp-sse/api/okhttp-sse.api
@@ -21,3 +21,14 @@ public final class okhttp3/sse/EventSources {
 	public static final fun processResponse (Lokhttp3/Response;Lokhttp3/sse/EventSourceListener;)V
 }
 
+public final class okhttp3/sse/EventSources$EventSourceRequest {
+	public fun <init> (Lokhttp3/sse/EventSourceListener;)V
+	public final fun component1 ()Lokhttp3/sse/EventSourceListener;
+	public final fun copy (Lokhttp3/sse/EventSourceListener;)Lokhttp3/sse/EventSources$EventSourceRequest;
+	public static synthetic fun copy$default (Lokhttp3/sse/EventSources$EventSourceRequest;Lokhttp3/sse/EventSourceListener;ILjava/lang/Object;)Lokhttp3/sse/EventSources$EventSourceRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getListener ()Lokhttp3/sse/EventSourceListener;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSources.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSources.kt
@@ -42,6 +42,10 @@ object EventSources {
     eventSource.processResponse(response)
   }
 
+  /**
+   * Request tag that indicates the request is a SSE request,
+   * including carrying the EventSourceListener through the chain.
+   */
   data class EventSourceRequest(
     val listener: EventSourceListener
   )

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSources.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSources.kt
@@ -41,4 +41,8 @@ object EventSources {
     val eventSource = RealEventSource(response.request, listener)
     eventSource.processResponse(response)
   }
+
+  data class EventSourceRequest(
+    val listener: EventSourceListener
+  )
 }

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
@@ -19,6 +19,7 @@ import java.io.IOException
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.EventListener
+import okhttp3.EventListener.Companion.DisableEventListener
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -27,21 +28,31 @@ import okhttp3.internal.connection.RealCall
 import okhttp3.internal.stripBody
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
+import okhttp3.sse.EventSources
 
 internal class RealEventSource(
   private val request: Request,
   private val listener: EventSourceListener
 ) : EventSource, ServerSentEventReader.Callback, Callback {
-  private var call: RealCall? = null
-  @Volatile private var canceled = false
+  private lateinit var call: Call
+  @Volatile
+  private var canceled = false
+
+  fun connect(client: Call.Factory) {
+    val taggedRequest = request.newBuilder()
+      .tag(EventSources.EventSourceRequest(listener))
+      .tag(DisableEventListener)
+      .build()
+
+    client.newCall(taggedRequest)
+      .also {
+        call = it
+      }
+      .enqueue(this)
+  }
 
   fun connect(client: OkHttpClient) {
-    val client = client.newBuilder()
-        .eventListener(EventListener.NONE)
-        .build()
-    val realCall = client.newCall(request) as RealCall
-    call = realCall
-    realCall.enqueue(this)
+    connect(client as Call.Factory)
   }
 
   override fun onResponse(call: Call, response: Response) {
@@ -59,12 +70,12 @@ internal class RealEventSource(
 
       if (!body.isEventStream()) {
         listener.onFailure(this,
-            IllegalStateException("Invalid content-type: ${body.contentType()}"), response)
+          IllegalStateException("Invalid content-type: ${body.contentType()}"), response)
         return
       }
 
       // This is a long-lived response. Cancel full-call timeouts.
-      call?.timeoutEarlyExit()
+      (call as? RealCall)?.timeoutEarlyExit()
 
       // Replace the body with a stripped one so the callbacks can't see real data.
       val response = response.stripBody()
@@ -105,7 +116,7 @@ internal class RealEventSource(
 
   override fun cancel() {
     canceled = true
-    call?.cancel()
+    call.cancel()
   }
 
   override fun onEvent(id: String?, type: String?, data: String) {

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
@@ -25,6 +25,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
 import okhttp3.internal.connection.RealCall
+import okhttp3.internal.connection.RealCall.Companion.asRealCall
 import okhttp3.internal.stripBody
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
@@ -75,7 +76,7 @@ internal class RealEventSource(
       }
 
       // This is a long-lived response. Cancel full-call timeouts.
-      (call as? RealCall)?.timeoutEarlyExit()
+      call.asRealCall()?.timeoutEarlyExit()
 
       // Replace the body with a stripped one so the callbacks can't see real data.
       val response = response.stripBody()

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
@@ -16,8 +16,13 @@
 package okhttp3.sse.internal
 
 import java.io.IOException
-import okhttp3.*
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.EventListener.Companion.DisableEventListener
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
 import okhttp3.internal.connection.RealCall.Companion.asRealCall
 import okhttp3.internal.stripBody
 import okhttp3.sse.EventSource

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/internal/RealEventSource.kt
@@ -16,15 +16,8 @@
 package okhttp3.sse.internal
 
 import java.io.IOException
-import okhttp3.Call
-import okhttp3.Callback
-import okhttp3.EventListener
+import okhttp3.*
 import okhttp3.EventListener.Companion.DisableEventListener
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
-import okhttp3.ResponseBody
-import okhttp3.internal.connection.RealCall
 import okhttp3.internal.connection.RealCall.Companion.asRealCall
 import okhttp3.internal.stripBody
 import okhttp3.sse.EventSource
@@ -35,7 +28,7 @@ internal class RealEventSource(
   private val request: Request,
   private val listener: EventSourceListener
 ) : EventSource, ServerSentEventReader.Callback, Callback {
-  private lateinit var call: Call
+  private var call: Call? = null
   @Volatile
   private var canceled = false
 
@@ -76,7 +69,7 @@ internal class RealEventSource(
       }
 
       // This is a long-lived response. Cancel full-call timeouts.
-      call.asRealCall()?.timeoutEarlyExit()
+      call?.asRealCall()?.timeoutEarlyExit()
 
       // Replace the body with a stripped one so the callbacks can't see real data.
       val response = response.stripBody()
@@ -117,7 +110,7 @@ internal class RealEventSource(
 
   override fun cancel() {
     canceled = true
-    call.cancel()
+    call?.cancel()
   }
 
   override fun onEvent(id: String?, type: String?, data: String) {

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
@@ -176,7 +176,7 @@ class TestValueFactory : Closeable {
     client: OkHttpClient,
     address: Address = newAddress(),
   ): RealRoutePlanner {
-    val call = RealCall(client, Request(address.url), forWebSocket = false)
+    val call = RealCall(client, Request(address.url))
     return RealRoutePlanner(client, address, call, newChain(call), ConnectionListener.NONE)
   }
 

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -145,6 +145,7 @@ public final class okhttp3/CacheControl$Companion {
 }
 
 public abstract interface class okhttp3/Call : java/lang/Cloneable {
+	public fun asOkHttpClient (Lokhttp3/Call$Factory;)Lokhttp3/OkHttpClient;
 	public abstract fun cancel ()V
 	public abstract fun clone ()Lokhttp3/Call;
 	public abstract fun enqueue (Lokhttp3/Callback;)V
@@ -484,6 +485,10 @@ public final class okhttp3/Credentials {
 	public static synthetic fun basic$default (Ljava/lang/String;Ljava/lang/String;Ljava/nio/charset/Charset;ILjava/lang/Object;)Ljava/lang/String;
 }
 
+public abstract interface class okhttp3/Decorator {
+	public abstract fun getDecorated ()Ljava/lang/Object;
+}
+
 public final class okhttp3/Dispatcher {
 	public final fun -deprecated_executorService ()Ljava/util/concurrent/ExecutorService;
 	public fun <init> ()V
@@ -547,6 +552,10 @@ public abstract class okhttp3/EventListener {
 }
 
 public final class okhttp3/EventListener$Companion {
+}
+
+public final class okhttp3/EventListener$Companion$DisableEventListener {
+	public static final field INSTANCE Lokhttp3/EventListener$Companion$DisableEventListener;
 }
 
 public abstract interface class okhttp3/EventListener$Factory {
@@ -1247,7 +1256,16 @@ public abstract interface class okhttp3/WebSocket {
 }
 
 public abstract interface class okhttp3/WebSocket$Factory {
+	public static final field Companion Lokhttp3/WebSocket$Factory$Companion;
 	public abstract fun newWebSocket (Lokhttp3/Request;Lokhttp3/WebSocketListener;)Lokhttp3/WebSocket;
+}
+
+public final class okhttp3/WebSocket$Factory$Companion {
+	public final fun asOkHttpClient (Lokhttp3/WebSocket$Factory;)Lokhttp3/OkHttpClient;
+}
+
+public final class okhttp3/WebSocket$WebSocketRequest {
+	public static final field INSTANCE Lokhttp3/WebSocket$WebSocketRequest;
 }
 
 public abstract class okhttp3/WebSocketListener {

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Call.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Call.kt
@@ -72,4 +72,8 @@ actual interface Call : Cloneable {
   actual fun interface Factory {
     actual fun newCall(request: Request): Call
   }
+
+  fun Factory.asOkHttpClient(): OkHttpClient? {
+    return (this as? OkHttpClient) ?: ((this as? Decorator<*>)?.decorated as? Factory)?.asOkHttpClient()
+  }
 }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Decorator.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Decorator.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+/**
+ * Interface establishing that this implementation of an OkHttp interface
+ * is a decorator, and can be unwrapped.
+ *
+ * Libraries that wrap instances of Call, Call.Factory, WebSocket.Factory
+ * should implement this interface to allow the RealCall or OkHttpClient
+ * to be accessed.
+ */
+interface Decorator<T> {
+  val decorated: T?
+}

--- a/okhttp/src/jvmMain/kotlin/okhttp3/EventListener.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/EventListener.kt
@@ -474,5 +474,10 @@ abstract class EventListener {
     @JvmField
     val NONE: EventListener = object : EventListener() {
     }
+
+    /**
+     * Tag to disable the EventListener for a request.
+     */
+    object DisableEventListener
   }
 }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
@@ -279,7 +279,7 @@ open class OkHttpClient internal constructor(
   }
 
   /** Prepares the [request] to be executed at some point in the future. */
-  override fun newCall(request: Request): Call = RealCall(this, request, forWebSocket = false)
+  override fun newCall(request: Request): Call = RealCall(this, request)
 
   /** Uses [request] to connect a new web socket. */
   override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {

--- a/okhttp/src/jvmMain/kotlin/okhttp3/WebSocket.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/WebSocket.kt
@@ -118,4 +118,6 @@ interface WebSocket {
      */
     fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket
   }
+
+  object WebSocketRequest
 }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/WebSocket.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/WebSocket.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3
 
+import okhttp3.internal.connection.RealCall
 import okio.ByteString
 
 /**
@@ -117,6 +118,13 @@ interface WebSocket {
      * in use.
      */
     fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket
+
+    companion object {
+
+      fun Factory.asOkHttpClient(): OkHttpClient? {
+        return (this as? OkHttpClient) ?: ((this as? Decorator<*>)?.decorated as? Factory)?.asOkHttpClient()
+      }
+    }
   }
 
   object WebSocketRequest

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -574,4 +574,10 @@ class RealCall(
      */
     val callStackTrace: Any?
   ) : WeakReference<RealCall>(referent)
+
+  companion object {
+    fun Call.asRealCall(): RealCall? {
+      return (this as? RealCall) ?: ((this as? Decorator<*>)?.decorated as? Call)?.asRealCall()
+    }
+  }
 }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -27,8 +27,19 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLSocketFactory
-import okhttp3.*
+import okhttp3.Address
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.CertificatePinner
+import okhttp3.Decorator
+import okhttp3.EventListener
 import okhttp3.EventListener.Companion.DisableEventListener
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket.WebSocketRequest
 import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.cache.CacheInterceptor
@@ -56,7 +67,7 @@ class RealCall(
   /** The application's original request unadulterated by redirects or auth headers. */
   val originalRequest: Request
 ) : Call, Cloneable {
-  internal val forWebSocket = originalRequest.tag<WebSocket.WebSocketRequest>() != null
+  internal val forWebSocket = originalRequest.tag<WebSocketRequest>() != null
 
   private val connectionPool: RealConnectionPool = client.connectionPool.delegate
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/RealWebSocket.kt
@@ -25,12 +25,13 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import okhttp3.Call
 import okhttp3.Callback
-import okhttp3.EventListener
+import okhttp3.EventListener.Companion.DisableEventListener
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
+import okhttp3.WebSocket.WebSocketRequest
 import okhttp3.WebSocketListener
 import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.closeQuietly
@@ -151,7 +152,6 @@ class RealWebSocket(
     }
 
     val webSocketClient = client.newBuilder()
-        .eventListener(EventListener.NONE)
         .protocols(ONLY_HTTP1)
         .build()
     val request = originalRequest.newBuilder()
@@ -160,7 +160,8 @@ class RealWebSocket(
         .header("Sec-WebSocket-Key", key)
         .header("Sec-WebSocket-Version", "13")
         .header("Sec-WebSocket-Extensions", "permessage-deflate")
-        .tag(WebSocket.WebSocketRequest)
+        .tag<WebSocketRequest>(WebSocketRequest)
+        .tag<DisableEventListener>(DisableEventListener)
         .build()
     call = RealCall(webSocketClient, request)
     call!!.enqueue(object : Callback {

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/RealWebSocket.kt
@@ -160,8 +160,9 @@ class RealWebSocket(
         .header("Sec-WebSocket-Key", key)
         .header("Sec-WebSocket-Version", "13")
         .header("Sec-WebSocket-Extensions", "permessage-deflate")
+        .tag(WebSocket.WebSocketRequest)
         .build()
-    call = RealCall(webSocketClient, request, forWebSocket = true)
+    call = RealCall(webSocketClient, request)
     call!!.enqueue(object : Callback {
       override fun onResponse(call: Call, response: Response) {
         val exchange = response.exchange

--- a/okhttp/src/jvmTest/java/okhttp3/DecoratorTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/DecoratorTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import org.assertj.core.api.Assertions.assertThat
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.internal.connection.RealCall
+import okhttp3.internal.connection.RealCall.Companion.asRealCall
+import org.junit.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class DecoratorTest {
+  @JvmField @RegisterExtension
+  val clientTestRule = OkHttpClientTestRule()
+
+  val client = clientTestRule.newClient()
+  val request = Request("https://example.org".toHttpUrl())
+
+  @Test
+  fun testDirectRealCall() {
+    val call = client.newCall(request)
+
+    assertThat(call.asRealCall()).isInstanceOf(RealCall::class.java)
+  }
+
+  @Test
+  fun testWrappedRealCall() {
+    val call = SimpleWrappedCall(client.newCall(request))
+
+    assertThat(call.asRealCall()).isNull()
+  }
+
+  @Test
+  fun testDecoratedRealCall() {
+    val call = DecoratedCall(client.newCall(request))
+
+    assertThat(call.asRealCall()).isInstanceOf(RealCall::class.java)
+  }
+
+  @Test
+  fun testDoubleDecoratedRealCall() {
+    val call = DecoratedCall(DecoratedCall(client.newCall(request)))
+
+    assertThat(call.asRealCall()).isInstanceOf(RealCall::class.java)
+  }
+
+  class SimpleWrappedCall(call: Call): Call by call
+
+  class DecoratedCall(override val decorated: Call): Call by decorated, Decorator<Call>
+}

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -30,7 +30,6 @@ import mockwebserver3.Dispatcher;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
-import mockwebserver3.SocketPolicy;
 import mockwebserver3.SocketPolicy.KeepOpen;
 import mockwebserver3.SocketPolicy.NoResponse;
 import okhttp3.OkHttpClient;
@@ -43,6 +42,7 @@ import okhttp3.Response;
 import okhttp3.TestLogHandler;
 import okhttp3.TestUtil;
 import okhttp3.WebSocket;
+import okhttp3.WebSocket.WebSocketRequest;
 import okhttp3.WebSocketListener;
 import okhttp3.internal.UnreadableResponseBody;
 import okhttp3.internal.concurrent.TaskRunner;
@@ -1000,7 +1000,8 @@ public final class WebSocketHttpTest {
   }
 
   private RealWebSocket newWebSocket(Request request) {
-    RealWebSocket webSocket = new RealWebSocket(TaskRunner.INSTANCE, request, clientListener,
+    Request taggedRequest = request.newBuilder().tag(WebSocketRequest.class, WebSocketRequest.INSTANCE).build();
+    RealWebSocket webSocket = new RealWebSocket(TaskRunner.INSTANCE, taggedRequest, clientListener,
         random, client.pingIntervalMillis(), null, 0L);
     webSocket.connect(client);
     return webSocket;


### PR DESCRIPTION
Two aims

- 1 avoid needing to cast to RealCall within OkHttp
- Support a clean decorator mechanism for libraries that decorate Call.Factory of WebSocket.Factory