### PR TITLE
"java.nio.Files#delete" should be preferred

### DIFF
--- a/samples/unixdomainsockets/src/main/java/okhttp3/unixdomainsockets/ClientAndServer.java
+++ b/samples/unixdomainsockets/src/main/java/okhttp3/unixdomainsockets/ClientAndServer.java
@@ -53,7 +53,7 @@ public class ClientAndServer {
     }
 
     server.shutdown();
-    socketFile.delete();
+    File.delete(socketFile);
   }
 
   public static void main(String... args) throws Exception {


### PR DESCRIPTION
When java.io.File#delete fails, this boolean method simply returns false with no indication of the cause. On the other hand, when java.nio.file.Files#delete fails, this void method returns one of a series of exception types to better indicate the cause of the failure. And since more information is generally better in a debugging situation, java.nio.file.Files#delete is the preferred option.