### PR TITLE
ConnectionSpec: Fix custom specifications

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/ConnectionSpec.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/ConnectionSpec.kt
@@ -16,6 +16,7 @@
 package okhttp3
 
 import java.util.Arrays
+import java.util.Collections
 import java.util.Objects
 import javax.net.ssl.SSLSocket
 import okhttp3.ConnectionSpec.Builder
@@ -71,6 +72,15 @@ class ConnectionSpec internal constructor(
    * Returns the TLS versions to use when negotiating a connection. Returns null if all of the SSL
    * socket's enabled TLS versions should be used.
    */
+  @get:JvmName("tlsVersionsAsString") val tlsVersionsAsStringList: List<String>?
+    get() {
+      return tlsVersionsAsString?.let { Collections.unmodifiableList(it.asList()) }
+    }
+
+  /**
+   * Returns the TLS versions to use when negotiating a connection. Returns null if all of the SSL
+   * socket's enabled TLS versions should be used.
+   */
   @get:JvmName("tlsVersions") val tlsVersions: List<TlsVersion>?
     get() {
       return tlsVersionsAsString?.map { TlsVersion.forJavaName(it) }
@@ -94,7 +104,7 @@ class ConnectionSpec internal constructor(
   internal fun apply(sslSocket: SSLSocket, isFallback: Boolean) {
     val specToApply = supportedSpec(sslSocket, isFallback)
 
-    if (specToApply.tlsVersions != null) {
+    if (specToApply.tlsVersionsAsString != null) {
       sslSocket.enabledProtocols = specToApply.tlsVersionsAsString
     }
 
@@ -190,9 +200,10 @@ class ConnectionSpec internal constructor(
   override fun toString(): String {
     if (!isTls) return "ConnectionSpec()"
 
+    val tlsVersionsToUse = tlsVersionsAsString?.map { TlsVersion.parseJavaName(it)?.toString() ?: it }
     return ("ConnectionSpec(" +
         "cipherSuites=${Objects.toString(cipherSuites, "[all enabled]")}, " +
-        "tlsVersions=${Objects.toString(tlsVersions, "[all enabled]")}, " +
+        "tlsVersions=${Objects.toString(tlsVersionsToUse, "[all enabled]")}, " +
         "supportsTlsExtensions=$supportsTlsExtensions)")
   }
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/TlsVersion.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/TlsVersion.kt
@@ -37,14 +37,18 @@ actual enum class TlsVersion(
 
   companion object {
     @JvmStatic
-    fun forJavaName(javaName: String): TlsVersion  {
+    fun forJavaName(javaName: String): TlsVersion {
+      return parseJavaName(javaName) ?: throw IllegalArgumentException("Unexpected TLS version: $javaName")
+    }
+
+    internal fun parseJavaName(javaName: String): TlsVersion? {
       return when (javaName) {
         "TLSv1.3" -> TLS_1_3
         "TLSv1.2" -> TLS_1_2
         "TLSv1.1" -> TLS_1_1
         "TLSv1" -> TLS_1_0
         "SSLv3" -> SSL_3_0
-        else -> throw IllegalArgumentException("Unexpected TLS version: $javaName")
+        else -> null
       }
     }
   }


### PR DESCRIPTION
`ConnectionSpec` now support arbitrary input strings allows users to enable suites and versions that are not yet known to the library, but are supported by the platform. But this function is not implemented correctly.

This function is the key to how it works:
https://github.com/square/okhttp/blob/afcc2df23aa855220f0d532b404ec393d927520c/okhttp/src/jvmMain/kotlin/okhttp3/ConnectionSpec.kt#L94-L104

`apply()` function uses `specToApply.tlsVersions != null` to check if an arbitrary version is supported.
This is how `tlsVersions` is defined:
https://github.com/square/okhttp/blob/afcc2df23aa855220f0d532b404ec393d927520c/okhttp/src/jvmMain/kotlin/okhttp3/ConnectionSpec.kt#L74-L77

In this function, it converts TLS version string to `TlsVersion`. But an arbitrary input string cannot be converted to `TlsVersion`. It actually throws an exception. The same happens with `cipherSuites`.

And in `toStirng()`, it also uses `tlsVersions` and `cipherSuites`. This makes a `ConnectionSpec` with arbitrary input strings cannot be printed. If you create an exception described with `ConnectionSpec`, it fails again. It makes to know what happened.

I also add two string compatible getters for `tlsVersions` and `cipherSuites` to Java to help debug `ConnectionSpec`.