### PR TITLE
Proguard exclusion for SLF4J dependencies in 5.x

### DIFF
--- a/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro
+++ b/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro
@@ -12,3 +12,6 @@
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
+
+# Transitively required by biz.aQute
+-dontwarn org.slf4j.**


### PR DESCRIPTION
To fix https://github.com/square/okhttp/issues/7777

https://issuetracker.google.com/issues/278765639

Seemingly required because of the biz.aQute build.