### PR TITLE
Straightforward implementation of IDNA mapping, for tests only

### DIFF
--- a/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTable.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTable.kt
@@ -22,5 +22,5 @@ interface IdnaMappingTable {
   /**
    * Returns true if the [codePoint] was applied successfully. Returns false if it was disallowed.
    */
-  fun apply(codePoint: Int, sink: BufferedSink): Boolean
+  fun map(codePoint: Int, sink: BufferedSink): Boolean
 }

--- a/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTable.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTable.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.idn
+
+import okio.BufferedSink
+
+interface IdnaMappingTable {
+
+  /**
+   * Returns true if the [codePoint] was applied successfully. Returns false if it was disallowed.
+   */
+  fun apply(codePoint: Int, sink: BufferedSink): Boolean
+}

--- a/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTableTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTableTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.idn
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import okio.Buffer
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IdnaMappingTableTest {
+  private lateinit var table: IdnaMappingTable
+
+  @BeforeEach
+  fun setUp() {
+    table = FileSystem.RESOURCES.read("/okhttp3/internal/idna/IdnaMappingTable.txt".toPath()) {
+      readPlainTextIdnaMappingTable()
+    }
+  }
+
+  @Test fun regularMappings() {
+    assertThat("hello".map()).isEqualTo("hello")
+    assertThat("hello-world".map()).isEqualTo("hello-world")
+    assertThat("HELLO".map()).isEqualTo("hello")
+    assertThat("Hello".map()).isEqualTo("hello")
+    assertThat("¼".map()).isEqualTo("1⁄4")
+  }
+
+  @Test fun deviations() {
+    assertThat("ß".map()).isEqualTo("ss")
+    assertThat("ς".map()).isEqualTo("σ")
+    assertThat("\u200c".map()).isEqualTo("")
+    assertThat("\u200d".map()).isEqualTo("")
+  }
+
+  @Test fun ignored() {
+    assertThat("\u200b".map()).isEqualTo("")
+    assertThat("\ufeff".map()).isEqualTo("")
+  }
+
+  @Test fun disallowed() {
+    assertThat("\u0080".mapExpectingErrors()).isEqualTo("")
+  }
+
+  @Test fun disallowedStd3Valid() {
+    assertThat("/".map()).isEqualTo("/")
+  }
+
+  @Test fun disallowedStd3Mapped() {
+    assertThat("\u00b8".map()).isEqualTo("\u0020\u0327")
+  }
+
+  private fun String.map(): String {
+    val result = Buffer()
+    for (codePoint in codePoints()) {
+      require(table.apply(codePoint, result))
+    }
+    return result.readUtf8()
+  }
+
+  private fun String.mapExpectingErrors(): String {
+    val result = Buffer()
+    var errorCount = 0
+    for (codePoint in codePoints()) {
+      if (!table.apply(codePoint, result)) errorCount++
+    }
+    assertThat(errorCount).isGreaterThan(0)
+    return result.readUtf8()
+  }
+}

--- a/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTableTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTableTest.kt
@@ -43,7 +43,7 @@ class IdnaMappingTableTest {
 
     // These compound characters map their its components.
     assertThat("¼".map()).isEqualTo("1⁄4")
-    assertThat("™".map()).isEqualTo("TM")
+    assertThat("™".map()).isEqualTo("tm")
   }
 
   @Test fun deviations() {

--- a/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTableTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/idn/IdnaMappingTableTest.kt
@@ -40,7 +40,10 @@ class IdnaMappingTableTest {
     assertThat("hello-world".map()).isEqualTo("hello-world")
     assertThat("HELLO".map()).isEqualTo("hello")
     assertThat("Hello".map()).isEqualTo("hello")
+
+    // These compound characters map their its components.
     assertThat("¼".map()).isEqualTo("1⁄4")
+    assertThat("™".map()).isEqualTo("TM")
   }
 
   @Test fun deviations() {

--- a/okhttp/src/jvmTest/java/okhttp3/internal/idn/PlainTextIdnaMappingTable.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/idn/PlainTextIdnaMappingTable.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.idn
+
+import okio.Buffer
+import okio.BufferedSink
+import okio.BufferedSource
+import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
+import okio.IOException
+import okio.Options
+
+/**
+ * A decoded [mapping table] that can perform the [mapping step] of IDNA processing.
+ *
+ * This implementation is optimized for readability over efficiency.
+ *
+ * [mapping table]: https://www.unicode.org/reports/tr46/#IDNA_Mapping_Table
+ * [mapping step]: https://www.unicode.org/reports/tr46/#ProcessingStepMap
+ */
+class PlainTextIdnaMappingTable internal constructor(
+  private val mappings: List<Mapping>,
+) : IdnaMappingTable {
+  override fun apply(codePoint: Int, sink: BufferedSink): Boolean {
+    val index = mappings.binarySearch {
+      when {
+        it.sourceCodePoint1 < codePoint -> -1
+        it.sourceCodePoint0 > codePoint -> 1
+        else -> 0
+      }
+    }
+
+    val mapping = mappings[index]
+    var result = true
+
+    when (mapping.type) {
+      TYPE_IGNORED -> Unit
+      TYPE_DEVIATION, TYPE_MAPPED, TYPE_DISALLOWED_STD3_MAPPED -> {
+        sink.write(mapping.mappedTo)
+      }
+      TYPE_DISALLOWED_STD3_VALID, TYPE_VALID -> {
+        sink.writeUtf8CodePoint(codePoint)
+      }
+      TYPE_DISALLOWED -> result = false
+    }
+
+    return result
+  }
+}
+
+
+private val optionsDelimeter = Options.of(
+  ".".encodeUtf8(),  // 0.
+  " ".encodeUtf8(),  // 1.
+  ";".encodeUtf8(),  // 2.
+  "#".encodeUtf8(),  // 3.
+  "\n".encodeUtf8(), // 4.
+)
+
+private val optionsDot = Options.of(
+  ".".encodeUtf8(),  // 0.
+)
+
+private const val DELIMITER_DOT = 0
+private const val DELIMITER_SPACE = 1
+private const val DELIMITER_SEMICOLON = 2
+private const val DELIMITER_HASH = 3
+private const val DELIMITER_NEWLINE = 4
+
+private val optionsType = Options.of(
+  "deviation ".encodeUtf8(),              // 0.
+  "disallowed ".encodeUtf8(),             // 1.
+  "disallowed_STD3_mapped ".encodeUtf8(), // 2.
+  "disallowed_STD3_valid ".encodeUtf8(),  // 3.
+  "ignored ".encodeUtf8(),                // 4.
+  "mapped ".encodeUtf8(),                 // 5.
+  "valid ".encodeUtf8(),                  // 6.
+)
+
+private const val TYPE_DEVIATION = 0
+private const val TYPE_DISALLOWED = 1
+private const val TYPE_DISALLOWED_STD3_MAPPED = 2
+private const val TYPE_DISALLOWED_STD3_VALID = 3
+private const val TYPE_IGNORED = 4
+private const val TYPE_MAPPED = 5
+private const val TYPE_VALID = 6
+
+private fun BufferedSource.skipWhitespace() {
+  while (!exhausted()) {
+    if (buffer[0] != ' '.code.toByte()) return
+    skip(1L)
+  }
+}
+
+private fun BufferedSource.skipRestOfLine() {
+  when (val newline = indexOf('\n'.code.toByte())) {
+    -1L -> skip(buffer.size) // Exhaust this source.
+    else -> skip(newline + 1)
+  }
+}
+
+/**
+ * Reads lines from `IdnaMappingTable.txt`.
+ *
+ * Comment lines are either blank or start with a `#` character. Lines may also end with a comment.
+ * All comments are ignored.
+ *
+ * Regular lines contain fields separated by semicolons.
+ *
+ * The first element on each line is a single hex code point (like 0041) or a hex code point range
+ * (like 0030..0039).
+ *
+ * The second element on each line is a mapping type, like `valid` or `mapped`.
+ *
+ * For lines that contain a mapping target, the next thing is a sequence of hex code points (like
+ * 0031 2044 0034).
+ *
+ * All other data is ignored.
+ */
+fun BufferedSource.readPlainTextIdnaMappingTable(): PlainTextIdnaMappingTable {
+  val mappedTo = Buffer()
+  val result = mutableListOf<Mapping>()
+
+  while (!exhausted()) {
+    // Skip comment and empty lines.
+    when (select(optionsDelimeter)) {
+      DELIMITER_HASH -> {
+        skipRestOfLine()
+        continue
+      }
+      DELIMITER_NEWLINE -> {
+        continue
+      }
+      DELIMITER_DOT, DELIMITER_SPACE, DELIMITER_SEMICOLON -> {
+        throw IOException("unexpected delimiter")
+      }
+    }
+
+    // "002F" or "0000..002C"
+    val sourceCodePoint0 = readHexadecimalUnsignedLong()
+    val sourceCodePoint1 = when (select(optionsDot)) {
+      DELIMITER_DOT -> {
+        if (readByte() != '.'.code.toByte()) throw IOException("expected '..'")
+        readHexadecimalUnsignedLong()
+      }
+      else -> sourceCodePoint0
+    }
+
+    skipWhitespace()
+    if (readByte() != ';'.code.toByte()) throw IOException("expected ';'")
+
+    // "valid" or "mapped"
+    skipWhitespace()
+    val type = select(optionsType)
+
+    when (type) {
+      TYPE_DEVIATION, TYPE_MAPPED, TYPE_DISALLOWED_STD3_MAPPED -> {
+        skipWhitespace()
+        if (readByte() != ';'.code.toByte()) throw IOException("expected ';'")
+
+        // Like "0061" or "0031 2044 0034".
+        while (true) {
+          skipWhitespace()
+
+          when (select(optionsDelimeter)) {
+            DELIMITER_HASH -> {
+              break
+            }
+            DELIMITER_DOT, DELIMITER_SEMICOLON, DELIMITER_NEWLINE -> {
+              throw IOException("unexpected delimiter")
+            }
+          }
+
+          mappedTo.writeUtf8CodePoint(readHexadecimalUnsignedLong().toInt())
+        }
+      }
+
+      TYPE_DISALLOWED, TYPE_DISALLOWED_STD3_VALID, TYPE_IGNORED, TYPE_VALID -> Unit
+
+      else -> throw IOException("unexpected type")
+    }
+
+    skipRestOfLine()
+
+    result += Mapping(
+      sourceCodePoint0.toInt(),
+      sourceCodePoint1.toInt(),
+      type,
+      mappedTo.readByteString(),
+    )
+  }
+
+  return PlainTextIdnaMappingTable(result)
+}
+
+internal data class Mapping(
+  val sourceCodePoint0: Int,
+  val sourceCodePoint1: Int,
+  val type: Int,
+  val mappedTo: ByteString,
+)

--- a/okhttp/src/jvmTest/resources/okhttp3/internal/idna/IdnaMappingTable.txt
+++ b/okhttp/src/jvmTest/resources/okhttp3/internal/idna/IdnaMappingTable.txt
@@ -1,0 +1,9027 @@
+# IdnaMappingTable.txt
+# Date: 2022-05-02, 19:29:26 GMT
+# © 2022 Unicode®, Inc.
+# Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+# For terms of use, see https://www.unicode.org/terms_of_use.html
+#
+# Unicode IDNA Compatible Preprocessing for UTS #46
+# Version: 15.0.0
+#
+# For documentation and usage, see https://www.unicode.org/reports/tr46
+#
+0000..002C    ; disallowed_STD3_valid                  # 1.1  <control-0000>..COMMA
+002D..002E    ; valid                                  # 1.1  HYPHEN-MINUS..FULL STOP
+002F          ; disallowed_STD3_valid                  # 1.1  SOLIDUS
+0030..0039    ; valid                                  # 1.1  DIGIT ZERO..DIGIT NINE
+003A..0040    ; disallowed_STD3_valid                  # 1.1  COLON..COMMERCIAL AT
+0041          ; mapped                 ; 0061          # 1.1  LATIN CAPITAL LETTER A
+0042          ; mapped                 ; 0062          # 1.1  LATIN CAPITAL LETTER B
+0043          ; mapped                 ; 0063          # 1.1  LATIN CAPITAL LETTER C
+0044          ; mapped                 ; 0064          # 1.1  LATIN CAPITAL LETTER D
+0045          ; mapped                 ; 0065          # 1.1  LATIN CAPITAL LETTER E
+0046          ; mapped                 ; 0066          # 1.1  LATIN CAPITAL LETTER F
+0047          ; mapped                 ; 0067          # 1.1  LATIN CAPITAL LETTER G
+0048          ; mapped                 ; 0068          # 1.1  LATIN CAPITAL LETTER H
+0049          ; mapped                 ; 0069          # 1.1  LATIN CAPITAL LETTER I
+004A          ; mapped                 ; 006A          # 1.1  LATIN CAPITAL LETTER J
+004B          ; mapped                 ; 006B          # 1.1  LATIN CAPITAL LETTER K
+004C          ; mapped                 ; 006C          # 1.1  LATIN CAPITAL LETTER L
+004D          ; mapped                 ; 006D          # 1.1  LATIN CAPITAL LETTER M
+004E          ; mapped                 ; 006E          # 1.1  LATIN CAPITAL LETTER N
+004F          ; mapped                 ; 006F          # 1.1  LATIN CAPITAL LETTER O
+0050          ; mapped                 ; 0070          # 1.1  LATIN CAPITAL LETTER P
+0051          ; mapped                 ; 0071          # 1.1  LATIN CAPITAL LETTER Q
+0052          ; mapped                 ; 0072          # 1.1  LATIN CAPITAL LETTER R
+0053          ; mapped                 ; 0073          # 1.1  LATIN CAPITAL LETTER S
+0054          ; mapped                 ; 0074          # 1.1  LATIN CAPITAL LETTER T
+0055          ; mapped                 ; 0075          # 1.1  LATIN CAPITAL LETTER U
+0056          ; mapped                 ; 0076          # 1.1  LATIN CAPITAL LETTER V
+0057          ; mapped                 ; 0077          # 1.1  LATIN CAPITAL LETTER W
+0058          ; mapped                 ; 0078          # 1.1  LATIN CAPITAL LETTER X
+0059          ; mapped                 ; 0079          # 1.1  LATIN CAPITAL LETTER Y
+005A          ; mapped                 ; 007A          # 1.1  LATIN CAPITAL LETTER Z
+005B..0060    ; disallowed_STD3_valid                  # 1.1  LEFT SQUARE BRACKET..GRAVE ACCENT
+0061..007A    ; valid                                  # 1.1  LATIN SMALL LETTER A..LATIN SMALL LETTER Z
+007B..007F    ; disallowed_STD3_valid                  # 1.1  LEFT CURLY BRACKET..<control-007F>
+0080..009F    ; disallowed                             # 1.1  <control-0080>..<control-009F>
+00A0          ; disallowed_STD3_mapped ; 0020          # 1.1  NO-BREAK SPACE
+00A1..00A7    ; valid                  ;      ; NV8    # 1.1  INVERTED EXCLAMATION MARK..SECTION SIGN
+00A8          ; disallowed_STD3_mapped ; 0020 0308     # 1.1  DIAERESIS
+00A9          ; valid                  ;      ; NV8    # 1.1  COPYRIGHT SIGN
+00AA          ; mapped                 ; 0061          # 1.1  FEMININE ORDINAL INDICATOR
+00AB..00AC    ; valid                  ;      ; NV8    # 1.1  LEFT-POINTING DOUBLE ANGLE QUOTATION MARK..NOT SIGN
+00AD          ; ignored                                # 1.1  SOFT HYPHEN
+00AE          ; valid                  ;      ; NV8    # 1.1  REGISTERED SIGN
+00AF          ; disallowed_STD3_mapped ; 0020 0304     # 1.1  MACRON
+00B0..00B1    ; valid                  ;      ; NV8    # 1.1  DEGREE SIGN..PLUS-MINUS SIGN
+00B2          ; mapped                 ; 0032          # 1.1  SUPERSCRIPT TWO
+00B3          ; mapped                 ; 0033          # 1.1  SUPERSCRIPT THREE
+00B4          ; disallowed_STD3_mapped ; 0020 0301     # 1.1  ACUTE ACCENT
+00B5          ; mapped                 ; 03BC          # 1.1  MICRO SIGN
+00B6          ; valid                  ;      ; NV8    # 1.1  PILCROW SIGN
+00B7          ; valid                                  # 1.1  MIDDLE DOT
+00B8          ; disallowed_STD3_mapped ; 0020 0327     # 1.1  CEDILLA
+00B9          ; mapped                 ; 0031          # 1.1  SUPERSCRIPT ONE
+00BA          ; mapped                 ; 006F          # 1.1  MASCULINE ORDINAL INDICATOR
+00BB          ; valid                  ;      ; NV8    # 1.1  RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+00BC          ; mapped                 ; 0031 2044 0034 #1.1  VULGAR FRACTION ONE QUARTER
+00BD          ; mapped                 ; 0031 2044 0032 #1.1  VULGAR FRACTION ONE HALF
+00BE          ; mapped                 ; 0033 2044 0034 #1.1  VULGAR FRACTION THREE QUARTERS
+00BF          ; valid                  ;      ; NV8    # 1.1  INVERTED QUESTION MARK
+00C0          ; mapped                 ; 00E0          # 1.1  LATIN CAPITAL LETTER A WITH GRAVE
+00C1          ; mapped                 ; 00E1          # 1.1  LATIN CAPITAL LETTER A WITH ACUTE
+00C2          ; mapped                 ; 00E2          # 1.1  LATIN CAPITAL LETTER A WITH CIRCUMFLEX
+00C3          ; mapped                 ; 00E3          # 1.1  LATIN CAPITAL LETTER A WITH TILDE
+00C4          ; mapped                 ; 00E4          # 1.1  LATIN CAPITAL LETTER A WITH DIAERESIS
+00C5          ; mapped                 ; 00E5          # 1.1  LATIN CAPITAL LETTER A WITH RING ABOVE
+00C6          ; mapped                 ; 00E6          # 1.1  LATIN CAPITAL LETTER AE
+00C7          ; mapped                 ; 00E7          # 1.1  LATIN CAPITAL LETTER C WITH CEDILLA
+00C8          ; mapped                 ; 00E8          # 1.1  LATIN CAPITAL LETTER E WITH GRAVE
+00C9          ; mapped                 ; 00E9          # 1.1  LATIN CAPITAL LETTER E WITH ACUTE
+00CA          ; mapped                 ; 00EA          # 1.1  LATIN CAPITAL LETTER E WITH CIRCUMFLEX
+00CB          ; mapped                 ; 00EB          # 1.1  LATIN CAPITAL LETTER E WITH DIAERESIS
+00CC          ; mapped                 ; 00EC          # 1.1  LATIN CAPITAL LETTER I WITH GRAVE
+00CD          ; mapped                 ; 00ED          # 1.1  LATIN CAPITAL LETTER I WITH ACUTE
+00CE          ; mapped                 ; 00EE          # 1.1  LATIN CAPITAL LETTER I WITH CIRCUMFLEX
+00CF          ; mapped                 ; 00EF          # 1.1  LATIN CAPITAL LETTER I WITH DIAERESIS
+00D0          ; mapped                 ; 00F0          # 1.1  LATIN CAPITAL LETTER ETH
+00D1          ; mapped                 ; 00F1          # 1.1  LATIN CAPITAL LETTER N WITH TILDE
+00D2          ; mapped                 ; 00F2          # 1.1  LATIN CAPITAL LETTER O WITH GRAVE
+00D3          ; mapped                 ; 00F3          # 1.1  LATIN CAPITAL LETTER O WITH ACUTE
+00D4          ; mapped                 ; 00F4          # 1.1  LATIN CAPITAL LETTER O WITH CIRCUMFLEX
+00D5          ; mapped                 ; 00F5          # 1.1  LATIN CAPITAL LETTER O WITH TILDE
+00D6          ; mapped                 ; 00F6          # 1.1  LATIN CAPITAL LETTER O WITH DIAERESIS
+00D7          ; valid                  ;      ; NV8    # 1.1  MULTIPLICATION SIGN
+00D8          ; mapped                 ; 00F8          # 1.1  LATIN CAPITAL LETTER O WITH STROKE
+00D9          ; mapped                 ; 00F9          # 1.1  LATIN CAPITAL LETTER U WITH GRAVE
+00DA          ; mapped                 ; 00FA          # 1.1  LATIN CAPITAL LETTER U WITH ACUTE
+00DB          ; mapped                 ; 00FB          # 1.1  LATIN CAPITAL LETTER U WITH CIRCUMFLEX
+00DC          ; mapped                 ; 00FC          # 1.1  LATIN CAPITAL LETTER U WITH DIAERESIS
+00DD          ; mapped                 ; 00FD          # 1.1  LATIN CAPITAL LETTER Y WITH ACUTE
+00DE          ; mapped                 ; 00FE          # 1.1  LATIN CAPITAL LETTER THORN
+00DF          ; deviation              ; 0073 0073     # 1.1  LATIN SMALL LETTER SHARP S
+00E0..00F6    ; valid                                  # 1.1  LATIN SMALL LETTER A WITH GRAVE..LATIN SMALL LETTER O WITH DIAERESIS
+00F7          ; valid                  ;      ; NV8    # 1.1  DIVISION SIGN
+00F8..00FF    ; valid                                  # 1.1  LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER Y WITH DIAERESIS
+0100          ; mapped                 ; 0101          # 1.1  LATIN CAPITAL LETTER A WITH MACRON
+0101          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH MACRON
+0102          ; mapped                 ; 0103          # 1.1  LATIN CAPITAL LETTER A WITH BREVE
+0103          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH BREVE
+0104          ; mapped                 ; 0105          # 1.1  LATIN CAPITAL LETTER A WITH OGONEK
+0105          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH OGONEK
+0106          ; mapped                 ; 0107          # 1.1  LATIN CAPITAL LETTER C WITH ACUTE
+0107          ; valid                                  # 1.1  LATIN SMALL LETTER C WITH ACUTE
+0108          ; mapped                 ; 0109          # 1.1  LATIN CAPITAL LETTER C WITH CIRCUMFLEX
+0109          ; valid                                  # 1.1  LATIN SMALL LETTER C WITH CIRCUMFLEX
+010A          ; mapped                 ; 010B          # 1.1  LATIN CAPITAL LETTER C WITH DOT ABOVE
+010B          ; valid                                  # 1.1  LATIN SMALL LETTER C WITH DOT ABOVE
+010C          ; mapped                 ; 010D          # 1.1  LATIN CAPITAL LETTER C WITH CARON
+010D          ; valid                                  # 1.1  LATIN SMALL LETTER C WITH CARON
+010E          ; mapped                 ; 010F          # 1.1  LATIN CAPITAL LETTER D WITH CARON
+010F          ; valid                                  # 1.1  LATIN SMALL LETTER D WITH CARON
+0110          ; mapped                 ; 0111          # 1.1  LATIN CAPITAL LETTER D WITH STROKE
+0111          ; valid                                  # 1.1  LATIN SMALL LETTER D WITH STROKE
+0112          ; mapped                 ; 0113          # 1.1  LATIN CAPITAL LETTER E WITH MACRON
+0113          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH MACRON
+0114          ; mapped                 ; 0115          # 1.1  LATIN CAPITAL LETTER E WITH BREVE
+0115          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH BREVE
+0116          ; mapped                 ; 0117          # 1.1  LATIN CAPITAL LETTER E WITH DOT ABOVE
+0117          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH DOT ABOVE
+0118          ; mapped                 ; 0119          # 1.1  LATIN CAPITAL LETTER E WITH OGONEK
+0119          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH OGONEK
+011A          ; mapped                 ; 011B          # 1.1  LATIN CAPITAL LETTER E WITH CARON
+011B          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH CARON
+011C          ; mapped                 ; 011D          # 1.1  LATIN CAPITAL LETTER G WITH CIRCUMFLEX
+011D          ; valid                                  # 1.1  LATIN SMALL LETTER G WITH CIRCUMFLEX
+011E          ; mapped                 ; 011F          # 1.1  LATIN CAPITAL LETTER G WITH BREVE
+011F          ; valid                                  # 1.1  LATIN SMALL LETTER G WITH BREVE
+0120          ; mapped                 ; 0121          # 1.1  LATIN CAPITAL LETTER G WITH DOT ABOVE
+0121          ; valid                                  # 1.1  LATIN SMALL LETTER G WITH DOT ABOVE
+0122          ; mapped                 ; 0123          # 1.1  LATIN CAPITAL LETTER G WITH CEDILLA
+0123          ; valid                                  # 1.1  LATIN SMALL LETTER G WITH CEDILLA
+0124          ; mapped                 ; 0125          # 1.1  LATIN CAPITAL LETTER H WITH CIRCUMFLEX
+0125          ; valid                                  # 1.1  LATIN SMALL LETTER H WITH CIRCUMFLEX
+0126          ; mapped                 ; 0127          # 1.1  LATIN CAPITAL LETTER H WITH STROKE
+0127          ; valid                                  # 1.1  LATIN SMALL LETTER H WITH STROKE
+0128          ; mapped                 ; 0129          # 1.1  LATIN CAPITAL LETTER I WITH TILDE
+0129          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH TILDE
+012A          ; mapped                 ; 012B          # 1.1  LATIN CAPITAL LETTER I WITH MACRON
+012B          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH MACRON
+012C          ; mapped                 ; 012D          # 1.1  LATIN CAPITAL LETTER I WITH BREVE
+012D          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH BREVE
+012E          ; mapped                 ; 012F          # 1.1  LATIN CAPITAL LETTER I WITH OGONEK
+012F          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH OGONEK
+0130          ; mapped                 ; 0069 0307     # 1.1  LATIN CAPITAL LETTER I WITH DOT ABOVE
+0131          ; valid                                  # 1.1  LATIN SMALL LETTER DOTLESS I
+0132..0133    ; mapped                 ; 0069 006A     # 1.1  LATIN CAPITAL LIGATURE IJ..LATIN SMALL LIGATURE IJ
+0134          ; mapped                 ; 0135          # 1.1  LATIN CAPITAL LETTER J WITH CIRCUMFLEX
+0135          ; valid                                  # 1.1  LATIN SMALL LETTER J WITH CIRCUMFLEX
+0136          ; mapped                 ; 0137          # 1.1  LATIN CAPITAL LETTER K WITH CEDILLA
+0137..0138    ; valid                                  # 1.1  LATIN SMALL LETTER K WITH CEDILLA..LATIN SMALL LETTER KRA
+0139          ; mapped                 ; 013A          # 1.1  LATIN CAPITAL LETTER L WITH ACUTE
+013A          ; valid                                  # 1.1  LATIN SMALL LETTER L WITH ACUTE
+013B          ; mapped                 ; 013C          # 1.1  LATIN CAPITAL LETTER L WITH CEDILLA
+013C          ; valid                                  # 1.1  LATIN SMALL LETTER L WITH CEDILLA
+013D          ; mapped                 ; 013E          # 1.1  LATIN CAPITAL LETTER L WITH CARON
+013E          ; valid                                  # 1.1  LATIN SMALL LETTER L WITH CARON
+013F..0140    ; mapped                 ; 006C 00B7     # 1.1  LATIN CAPITAL LETTER L WITH MIDDLE DOT..LATIN SMALL LETTER L WITH MIDDLE DOT
+0141          ; mapped                 ; 0142          # 1.1  LATIN CAPITAL LETTER L WITH STROKE
+0142          ; valid                                  # 1.1  LATIN SMALL LETTER L WITH STROKE
+0143          ; mapped                 ; 0144          # 1.1  LATIN CAPITAL LETTER N WITH ACUTE
+0144          ; valid                                  # 1.1  LATIN SMALL LETTER N WITH ACUTE
+0145          ; mapped                 ; 0146          # 1.1  LATIN CAPITAL LETTER N WITH CEDILLA
+0146          ; valid                                  # 1.1  LATIN SMALL LETTER N WITH CEDILLA
+0147          ; mapped                 ; 0148          # 1.1  LATIN CAPITAL LETTER N WITH CARON
+0148          ; valid                                  # 1.1  LATIN SMALL LETTER N WITH CARON
+0149          ; mapped                 ; 02BC 006E     # 1.1  LATIN SMALL LETTER N PRECEDED BY APOSTROPHE
+014A          ; mapped                 ; 014B          # 1.1  LATIN CAPITAL LETTER ENG
+014B          ; valid                                  # 1.1  LATIN SMALL LETTER ENG
+014C          ; mapped                 ; 014D          # 1.1  LATIN CAPITAL LETTER O WITH MACRON
+014D          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH MACRON
+014E          ; mapped                 ; 014F          # 1.1  LATIN CAPITAL LETTER O WITH BREVE
+014F          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH BREVE
+0150          ; mapped                 ; 0151          # 1.1  LATIN CAPITAL LETTER O WITH DOUBLE ACUTE
+0151          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH DOUBLE ACUTE
+0152          ; mapped                 ; 0153          # 1.1  LATIN CAPITAL LIGATURE OE
+0153          ; valid                                  # 1.1  LATIN SMALL LIGATURE OE
+0154          ; mapped                 ; 0155          # 1.1  LATIN CAPITAL LETTER R WITH ACUTE
+0155          ; valid                                  # 1.1  LATIN SMALL LETTER R WITH ACUTE
+0156          ; mapped                 ; 0157          # 1.1  LATIN CAPITAL LETTER R WITH CEDILLA
+0157          ; valid                                  # 1.1  LATIN SMALL LETTER R WITH CEDILLA
+0158          ; mapped                 ; 0159          # 1.1  LATIN CAPITAL LETTER R WITH CARON
+0159          ; valid                                  # 1.1  LATIN SMALL LETTER R WITH CARON
+015A          ; mapped                 ; 015B          # 1.1  LATIN CAPITAL LETTER S WITH ACUTE
+015B          ; valid                                  # 1.1  LATIN SMALL LETTER S WITH ACUTE
+015C          ; mapped                 ; 015D          # 1.1  LATIN CAPITAL LETTER S WITH CIRCUMFLEX
+015D          ; valid                                  # 1.1  LATIN SMALL LETTER S WITH CIRCUMFLEX
+015E          ; mapped                 ; 015F          # 1.1  LATIN CAPITAL LETTER S WITH CEDILLA
+015F          ; valid                                  # 1.1  LATIN SMALL LETTER S WITH CEDILLA
+0160          ; mapped                 ; 0161          # 1.1  LATIN CAPITAL LETTER S WITH CARON
+0161          ; valid                                  # 1.1  LATIN SMALL LETTER S WITH CARON
+0162          ; mapped                 ; 0163          # 1.1  LATIN CAPITAL LETTER T WITH CEDILLA
+0163          ; valid                                  # 1.1  LATIN SMALL LETTER T WITH CEDILLA
+0164          ; mapped                 ; 0165          # 1.1  LATIN CAPITAL LETTER T WITH CARON
+0165          ; valid                                  # 1.1  LATIN SMALL LETTER T WITH CARON
+0166          ; mapped                 ; 0167          # 1.1  LATIN CAPITAL LETTER T WITH STROKE
+0167          ; valid                                  # 1.1  LATIN SMALL LETTER T WITH STROKE
+0168          ; mapped                 ; 0169          # 1.1  LATIN CAPITAL LETTER U WITH TILDE
+0169          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH TILDE
+016A          ; mapped                 ; 016B          # 1.1  LATIN CAPITAL LETTER U WITH MACRON
+016B          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH MACRON
+016C          ; mapped                 ; 016D          # 1.1  LATIN CAPITAL LETTER U WITH BREVE
+016D          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH BREVE
+016E          ; mapped                 ; 016F          # 1.1  LATIN CAPITAL LETTER U WITH RING ABOVE
+016F          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH RING ABOVE
+0170          ; mapped                 ; 0171          # 1.1  LATIN CAPITAL LETTER U WITH DOUBLE ACUTE
+0171          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH DOUBLE ACUTE
+0172          ; mapped                 ; 0173          # 1.1  LATIN CAPITAL LETTER U WITH OGONEK
+0173          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH OGONEK
+0174          ; mapped                 ; 0175          # 1.1  LATIN CAPITAL LETTER W WITH CIRCUMFLEX
+0175          ; valid                                  # 1.1  LATIN SMALL LETTER W WITH CIRCUMFLEX
+0176          ; mapped                 ; 0177          # 1.1  LATIN CAPITAL LETTER Y WITH CIRCUMFLEX
+0177          ; valid                                  # 1.1  LATIN SMALL LETTER Y WITH CIRCUMFLEX
+0178          ; mapped                 ; 00FF          # 1.1  LATIN CAPITAL LETTER Y WITH DIAERESIS
+0179          ; mapped                 ; 017A          # 1.1  LATIN CAPITAL LETTER Z WITH ACUTE
+017A          ; valid                                  # 1.1  LATIN SMALL LETTER Z WITH ACUTE
+017B          ; mapped                 ; 017C          # 1.1  LATIN CAPITAL LETTER Z WITH DOT ABOVE
+017C          ; valid                                  # 1.1  LATIN SMALL LETTER Z WITH DOT ABOVE
+017D          ; mapped                 ; 017E          # 1.1  LATIN CAPITAL LETTER Z WITH CARON
+017E          ; valid                                  # 1.1  LATIN SMALL LETTER Z WITH CARON
+017F          ; mapped                 ; 0073          # 1.1  LATIN SMALL LETTER LONG S
+0180          ; valid                                  # 1.1  LATIN SMALL LETTER B WITH STROKE
+0181          ; mapped                 ; 0253          # 1.1  LATIN CAPITAL LETTER B WITH HOOK
+0182          ; mapped                 ; 0183          # 1.1  LATIN CAPITAL LETTER B WITH TOPBAR
+0183          ; valid                                  # 1.1  LATIN SMALL LETTER B WITH TOPBAR
+0184          ; mapped                 ; 0185          # 1.1  LATIN CAPITAL LETTER TONE SIX
+0185          ; valid                                  # 1.1  LATIN SMALL LETTER TONE SIX
+0186          ; mapped                 ; 0254          # 1.1  LATIN CAPITAL LETTER OPEN O
+0187          ; mapped                 ; 0188          # 1.1  LATIN CAPITAL LETTER C WITH HOOK
+0188          ; valid                                  # 1.1  LATIN SMALL LETTER C WITH HOOK
+0189          ; mapped                 ; 0256          # 1.1  LATIN CAPITAL LETTER AFRICAN D
+018A          ; mapped                 ; 0257          # 1.1  LATIN CAPITAL LETTER D WITH HOOK
+018B          ; mapped                 ; 018C          # 1.1  LATIN CAPITAL LETTER D WITH TOPBAR
+018C..018D    ; valid                                  # 1.1  LATIN SMALL LETTER D WITH TOPBAR..LATIN SMALL LETTER TURNED DELTA
+018E          ; mapped                 ; 01DD          # 1.1  LATIN CAPITAL LETTER REVERSED E
+018F          ; mapped                 ; 0259          # 1.1  LATIN CAPITAL LETTER SCHWA
+0190          ; mapped                 ; 025B          # 1.1  LATIN CAPITAL LETTER OPEN E
+0191          ; mapped                 ; 0192          # 1.1  LATIN CAPITAL LETTER F WITH HOOK
+0192          ; valid                                  # 1.1  LATIN SMALL LETTER F WITH HOOK
+0193          ; mapped                 ; 0260          # 1.1  LATIN CAPITAL LETTER G WITH HOOK
+0194          ; mapped                 ; 0263          # 1.1  LATIN CAPITAL LETTER GAMMA
+0195          ; valid                                  # 1.1  LATIN SMALL LETTER HV
+0196          ; mapped                 ; 0269          # 1.1  LATIN CAPITAL LETTER IOTA
+0197          ; mapped                 ; 0268          # 1.1  LATIN CAPITAL LETTER I WITH STROKE
+0198          ; mapped                 ; 0199          # 1.1  LATIN CAPITAL LETTER K WITH HOOK
+0199..019B    ; valid                                  # 1.1  LATIN SMALL LETTER K WITH HOOK..LATIN SMALL LETTER LAMBDA WITH STROKE
+019C          ; mapped                 ; 026F          # 1.1  LATIN CAPITAL LETTER TURNED M
+019D          ; mapped                 ; 0272          # 1.1  LATIN CAPITAL LETTER N WITH LEFT HOOK
+019E          ; valid                                  # 1.1  LATIN SMALL LETTER N WITH LONG RIGHT LEG
+019F          ; mapped                 ; 0275          # 1.1  LATIN CAPITAL LETTER O WITH MIDDLE TILDE
+01A0          ; mapped                 ; 01A1          # 1.1  LATIN CAPITAL LETTER O WITH HORN
+01A1          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH HORN
+01A2          ; mapped                 ; 01A3          # 1.1  LATIN CAPITAL LETTER OI
+01A3          ; valid                                  # 1.1  LATIN SMALL LETTER OI
+01A4          ; mapped                 ; 01A5          # 1.1  LATIN CAPITAL LETTER P WITH HOOK
+01A5          ; valid                                  # 1.1  LATIN SMALL LETTER P WITH HOOK
+01A6          ; mapped                 ; 0280          # 1.1  LATIN LETTER YR
+01A7          ; mapped                 ; 01A8          # 1.1  LATIN CAPITAL LETTER TONE TWO
+01A8          ; valid                                  # 1.1  LATIN SMALL LETTER TONE TWO
+01A9          ; mapped                 ; 0283          # 1.1  LATIN CAPITAL LETTER ESH
+01AA..01AB    ; valid                                  # 1.1  LATIN LETTER REVERSED ESH LOOP..LATIN SMALL LETTER T WITH PALATAL HOOK
+01AC          ; mapped                 ; 01AD          # 1.1  LATIN CAPITAL LETTER T WITH HOOK
+01AD          ; valid                                  # 1.1  LATIN SMALL LETTER T WITH HOOK
+01AE          ; mapped                 ; 0288          # 1.1  LATIN CAPITAL LETTER T WITH RETROFLEX HOOK
+01AF          ; mapped                 ; 01B0          # 1.1  LATIN CAPITAL LETTER U WITH HORN
+01B0          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH HORN
+01B1          ; mapped                 ; 028A          # 1.1  LATIN CAPITAL LETTER UPSILON
+01B2          ; mapped                 ; 028B          # 1.1  LATIN CAPITAL LETTER V WITH HOOK
+01B3          ; mapped                 ; 01B4          # 1.1  LATIN CAPITAL LETTER Y WITH HOOK
+01B4          ; valid                                  # 1.1  LATIN SMALL LETTER Y WITH HOOK
+01B5          ; mapped                 ; 01B6          # 1.1  LATIN CAPITAL LETTER Z WITH STROKE
+01B6          ; valid                                  # 1.1  LATIN SMALL LETTER Z WITH STROKE
+01B7          ; mapped                 ; 0292          # 1.1  LATIN CAPITAL LETTER EZH
+01B8          ; mapped                 ; 01B9          # 1.1  LATIN CAPITAL LETTER EZH REVERSED
+01B9..01BB    ; valid                                  # 1.1  LATIN SMALL LETTER EZH REVERSED..LATIN LETTER TWO WITH STROKE
+01BC          ; mapped                 ; 01BD          # 1.1  LATIN CAPITAL LETTER TONE FIVE
+01BD..01C3    ; valid                                  # 1.1  LATIN SMALL LETTER TONE FIVE..LATIN LETTER RETROFLEX CLICK
+01C4..01C6    ; mapped                 ; 0064 017E     # 1.1  LATIN CAPITAL LETTER DZ WITH CARON..LATIN SMALL LETTER DZ WITH CARON
+01C7..01C9    ; mapped                 ; 006C 006A     # 1.1  LATIN CAPITAL LETTER LJ..LATIN SMALL LETTER LJ
+01CA..01CC    ; mapped                 ; 006E 006A     # 1.1  LATIN CAPITAL LETTER NJ..LATIN SMALL LETTER NJ
+01CD          ; mapped                 ; 01CE          # 1.1  LATIN CAPITAL LETTER A WITH CARON
+01CE          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH CARON
+01CF          ; mapped                 ; 01D0          # 1.1  LATIN CAPITAL LETTER I WITH CARON
+01D0          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH CARON
+01D1          ; mapped                 ; 01D2          # 1.1  LATIN CAPITAL LETTER O WITH CARON
+01D2          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH CARON
+01D3          ; mapped                 ; 01D4          # 1.1  LATIN CAPITAL LETTER U WITH CARON
+01D4          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH CARON
+01D5          ; mapped                 ; 01D6          # 1.1  LATIN CAPITAL LETTER U WITH DIAERESIS AND MACRON
+01D6          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH DIAERESIS AND MACRON
+01D7          ; mapped                 ; 01D8          # 1.1  LATIN CAPITAL LETTER U WITH DIAERESIS AND ACUTE
+01D8          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH DIAERESIS AND ACUTE
+01D9          ; mapped                 ; 01DA          # 1.1  LATIN CAPITAL LETTER U WITH DIAERESIS AND CARON
+01DA          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH DIAERESIS AND CARON
+01DB          ; mapped                 ; 01DC          # 1.1  LATIN CAPITAL LETTER U WITH DIAERESIS AND GRAVE
+01DC..01DD    ; valid                                  # 1.1  LATIN SMALL LETTER U WITH DIAERESIS AND GRAVE..LATIN SMALL LETTER TURNED E
+01DE          ; mapped                 ; 01DF          # 1.1  LATIN CAPITAL LETTER A WITH DIAERESIS AND MACRON
+01DF          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH DIAERESIS AND MACRON
+01E0          ; mapped                 ; 01E1          # 1.1  LATIN CAPITAL LETTER A WITH DOT ABOVE AND MACRON
+01E1          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH DOT ABOVE AND MACRON
+01E2          ; mapped                 ; 01E3          # 1.1  LATIN CAPITAL LETTER AE WITH MACRON
+01E3          ; valid                                  # 1.1  LATIN SMALL LETTER AE WITH MACRON
+01E4          ; mapped                 ; 01E5          # 1.1  LATIN CAPITAL LETTER G WITH STROKE
+01E5          ; valid                                  # 1.1  LATIN SMALL LETTER G WITH STROKE
+01E6          ; mapped                 ; 01E7          # 1.1  LATIN CAPITAL LETTER G WITH CARON
+01E7          ; valid                                  # 1.1  LATIN SMALL LETTER G WITH CARON
+01E8          ; mapped                 ; 01E9          # 1.1  LATIN CAPITAL LETTER K WITH CARON
+01E9          ; valid                                  # 1.1  LATIN SMALL LETTER K WITH CARON
+01EA          ; mapped                 ; 01EB          # 1.1  LATIN CAPITAL LETTER O WITH OGONEK
+01EB          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH OGONEK
+01EC          ; mapped                 ; 01ED          # 1.1  LATIN CAPITAL LETTER O WITH OGONEK AND MACRON
+01ED          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH OGONEK AND MACRON
+01EE          ; mapped                 ; 01EF          # 1.1  LATIN CAPITAL LETTER EZH WITH CARON
+01EF..01F0    ; valid                                  # 1.1  LATIN SMALL LETTER EZH WITH CARON..LATIN SMALL LETTER J WITH CARON
+01F1..01F3    ; mapped                 ; 0064 007A     # 1.1  LATIN CAPITAL LETTER DZ..LATIN SMALL LETTER DZ
+01F4          ; mapped                 ; 01F5          # 1.1  LATIN CAPITAL LETTER G WITH ACUTE
+01F5          ; valid                                  # 1.1  LATIN SMALL LETTER G WITH ACUTE
+01F6          ; mapped                 ; 0195          # 3.0  LATIN CAPITAL LETTER HWAIR
+01F7          ; mapped                 ; 01BF          # 3.0  LATIN CAPITAL LETTER WYNN
+01F8          ; mapped                 ; 01F9          # 3.0  LATIN CAPITAL LETTER N WITH GRAVE
+01F9          ; valid                                  # 3.0  LATIN SMALL LETTER N WITH GRAVE
+01FA          ; mapped                 ; 01FB          # 1.1  LATIN CAPITAL LETTER A WITH RING ABOVE AND ACUTE
+01FB          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH RING ABOVE AND ACUTE
+01FC          ; mapped                 ; 01FD          # 1.1  LATIN CAPITAL LETTER AE WITH ACUTE
+01FD          ; valid                                  # 1.1  LATIN SMALL LETTER AE WITH ACUTE
+01FE          ; mapped                 ; 01FF          # 1.1  LATIN CAPITAL LETTER O WITH STROKE AND ACUTE
+01FF          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH STROKE AND ACUTE
+0200          ; mapped                 ; 0201          # 1.1  LATIN CAPITAL LETTER A WITH DOUBLE GRAVE
+0201          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH DOUBLE GRAVE
+0202          ; mapped                 ; 0203          # 1.1  LATIN CAPITAL LETTER A WITH INVERTED BREVE
+0203          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH INVERTED BREVE
+0204          ; mapped                 ; 0205          # 1.1  LATIN CAPITAL LETTER E WITH DOUBLE GRAVE
+0205          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH DOUBLE GRAVE
+0206          ; mapped                 ; 0207          # 1.1  LATIN CAPITAL LETTER E WITH INVERTED BREVE
+0207          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH INVERTED BREVE
+0208          ; mapped                 ; 0209          # 1.1  LATIN CAPITAL LETTER I WITH DOUBLE GRAVE
+0209          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH DOUBLE GRAVE
+020A          ; mapped                 ; 020B          # 1.1  LATIN CAPITAL LETTER I WITH INVERTED BREVE
+020B          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH INVERTED BREVE
+020C          ; mapped                 ; 020D          # 1.1  LATIN CAPITAL LETTER O WITH DOUBLE GRAVE
+020D          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH DOUBLE GRAVE
+020E          ; mapped                 ; 020F          # 1.1  LATIN CAPITAL LETTER O WITH INVERTED BREVE
+020F          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH INVERTED BREVE
+0210          ; mapped                 ; 0211          # 1.1  LATIN CAPITAL LETTER R WITH DOUBLE GRAVE
+0211          ; valid                                  # 1.1  LATIN SMALL LETTER R WITH DOUBLE GRAVE
+0212          ; mapped                 ; 0213          # 1.1  LATIN CAPITAL LETTER R WITH INVERTED BREVE
+0213          ; valid                                  # 1.1  LATIN SMALL LETTER R WITH INVERTED BREVE
+0214          ; mapped                 ; 0215          # 1.1  LATIN CAPITAL LETTER U WITH DOUBLE GRAVE
+0215          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH DOUBLE GRAVE
+0216          ; mapped                 ; 0217          # 1.1  LATIN CAPITAL LETTER U WITH INVERTED BREVE
+0217          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH INVERTED BREVE
+0218          ; mapped                 ; 0219          # 3.0  LATIN CAPITAL LETTER S WITH COMMA BELOW
+0219          ; valid                                  # 3.0  LATIN SMALL LETTER S WITH COMMA BELOW
+021A          ; mapped                 ; 021B          # 3.0  LATIN CAPITAL LETTER T WITH COMMA BELOW
+021B          ; valid                                  # 3.0  LATIN SMALL LETTER T WITH COMMA BELOW
+021C          ; mapped                 ; 021D          # 3.0  LATIN CAPITAL LETTER YOGH
+021D          ; valid                                  # 3.0  LATIN SMALL LETTER YOGH
+021E          ; mapped                 ; 021F          # 3.0  LATIN CAPITAL LETTER H WITH CARON
+021F          ; valid                                  # 3.0  LATIN SMALL LETTER H WITH CARON
+0220          ; mapped                 ; 019E          # 3.2  LATIN CAPITAL LETTER N WITH LONG RIGHT LEG
+0221          ; valid                                  # 4.0  LATIN SMALL LETTER D WITH CURL
+0222          ; mapped                 ; 0223          # 3.0  LATIN CAPITAL LETTER OU
+0223          ; valid                                  # 3.0  LATIN SMALL LETTER OU
+0224          ; mapped                 ; 0225          # 3.0  LATIN CAPITAL LETTER Z WITH HOOK
+0225          ; valid                                  # 3.0  LATIN SMALL LETTER Z WITH HOOK
+0226          ; mapped                 ; 0227          # 3.0  LATIN CAPITAL LETTER A WITH DOT ABOVE
+0227          ; valid                                  # 3.0  LATIN SMALL LETTER A WITH DOT ABOVE
+0228          ; mapped                 ; 0229          # 3.0  LATIN CAPITAL LETTER E WITH CEDILLA
+0229          ; valid                                  # 3.0  LATIN SMALL LETTER E WITH CEDILLA
+022A          ; mapped                 ; 022B          # 3.0  LATIN CAPITAL LETTER O WITH DIAERESIS AND MACRON
+022B          ; valid                                  # 3.0  LATIN SMALL LETTER O WITH DIAERESIS AND MACRON
+022C          ; mapped                 ; 022D          # 3.0  LATIN CAPITAL LETTER O WITH TILDE AND MACRON
+022D          ; valid                                  # 3.0  LATIN SMALL LETTER O WITH TILDE AND MACRON
+022E          ; mapped                 ; 022F          # 3.0  LATIN CAPITAL LETTER O WITH DOT ABOVE
+022F          ; valid                                  # 3.0  LATIN SMALL LETTER O WITH DOT ABOVE
+0230          ; mapped                 ; 0231          # 3.0  LATIN CAPITAL LETTER O WITH DOT ABOVE AND MACRON
+0231          ; valid                                  # 3.0  LATIN SMALL LETTER O WITH DOT ABOVE AND MACRON
+0232          ; mapped                 ; 0233          # 3.0  LATIN CAPITAL LETTER Y WITH MACRON
+0233          ; valid                                  # 3.0  LATIN SMALL LETTER Y WITH MACRON
+0234..0236    ; valid                                  # 4.0  LATIN SMALL LETTER L WITH CURL..LATIN SMALL LETTER T WITH CURL
+0237..0239    ; valid                                  # 4.1  LATIN SMALL LETTER DOTLESS J..LATIN SMALL LETTER QP DIGRAPH
+023A          ; mapped                 ; 2C65          # 4.1  LATIN CAPITAL LETTER A WITH STROKE
+023B          ; mapped                 ; 023C          # 4.1  LATIN CAPITAL LETTER C WITH STROKE
+023C          ; valid                                  # 4.1  LATIN SMALL LETTER C WITH STROKE
+023D          ; mapped                 ; 019A          # 4.1  LATIN CAPITAL LETTER L WITH BAR
+023E          ; mapped                 ; 2C66          # 4.1  LATIN CAPITAL LETTER T WITH DIAGONAL STROKE
+023F..0240    ; valid                                  # 4.1  LATIN SMALL LETTER S WITH SWASH TAIL..LATIN SMALL LETTER Z WITH SWASH TAIL
+0241          ; mapped                 ; 0242          # 4.1  LATIN CAPITAL LETTER GLOTTAL STOP
+0242          ; valid                                  # 5.0  LATIN SMALL LETTER GLOTTAL STOP
+0243          ; mapped                 ; 0180          # 5.0  LATIN CAPITAL LETTER B WITH STROKE
+0244          ; mapped                 ; 0289          # 5.0  LATIN CAPITAL LETTER U BAR
+0245          ; mapped                 ; 028C          # 5.0  LATIN CAPITAL LETTER TURNED V
+0246          ; mapped                 ; 0247          # 5.0  LATIN CAPITAL LETTER E WITH STROKE
+0247          ; valid                                  # 5.0  LATIN SMALL LETTER E WITH STROKE
+0248          ; mapped                 ; 0249          # 5.0  LATIN CAPITAL LETTER J WITH STROKE
+0249          ; valid                                  # 5.0  LATIN SMALL LETTER J WITH STROKE
+024A          ; mapped                 ; 024B          # 5.0  LATIN CAPITAL LETTER SMALL Q WITH HOOK TAIL
+024B          ; valid                                  # 5.0  LATIN SMALL LETTER Q WITH HOOK TAIL
+024C          ; mapped                 ; 024D          # 5.0  LATIN CAPITAL LETTER R WITH STROKE
+024D          ; valid                                  # 5.0  LATIN SMALL LETTER R WITH STROKE
+024E          ; mapped                 ; 024F          # 5.0  LATIN CAPITAL LETTER Y WITH STROKE
+024F          ; valid                                  # 5.0  LATIN SMALL LETTER Y WITH STROKE
+0250..02A8    ; valid                                  # 1.1  LATIN SMALL LETTER TURNED A..LATIN SMALL LETTER TC DIGRAPH WITH CURL
+02A9..02AD    ; valid                                  # 3.0  LATIN SMALL LETTER FENG DIGRAPH..LATIN LETTER BIDENTAL PERCUSSIVE
+02AE..02AF    ; valid                                  # 4.0  LATIN SMALL LETTER TURNED H WITH FISHHOOK..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
+02B0          ; mapped                 ; 0068          # 1.1  MODIFIER LETTER SMALL H
+02B1          ; mapped                 ; 0266          # 1.1  MODIFIER LETTER SMALL H WITH HOOK
+02B2          ; mapped                 ; 006A          # 1.1  MODIFIER LETTER SMALL J
+02B3          ; mapped                 ; 0072          # 1.1  MODIFIER LETTER SMALL R
+02B4          ; mapped                 ; 0279          # 1.1  MODIFIER LETTER SMALL TURNED R
+02B5          ; mapped                 ; 027B          # 1.1  MODIFIER LETTER SMALL TURNED R WITH HOOK
+02B6          ; mapped                 ; 0281          # 1.1  MODIFIER LETTER SMALL CAPITAL INVERTED R
+02B7          ; mapped                 ; 0077          # 1.1  MODIFIER LETTER SMALL W
+02B8          ; mapped                 ; 0079          # 1.1  MODIFIER LETTER SMALL Y
+02B9..02C1    ; valid                                  # 1.1  MODIFIER LETTER PRIME..MODIFIER LETTER REVERSED GLOTTAL STOP
+02C2..02C5    ; valid                  ;      ; NV8    # 1.1  MODIFIER LETTER LEFT ARROWHEAD..MODIFIER LETTER DOWN ARROWHEAD
+02C6..02D1    ; valid                                  # 1.1  MODIFIER LETTER CIRCUMFLEX ACCENT..MODIFIER LETTER HALF TRIANGULAR COLON
+02D2..02D7    ; valid                  ;      ; NV8    # 1.1  MODIFIER LETTER CENTRED RIGHT HALF RING..MODIFIER LETTER MINUS SIGN
+02D8          ; disallowed_STD3_mapped ; 0020 0306     # 1.1  BREVE
+02D9          ; disallowed_STD3_mapped ; 0020 0307     # 1.1  DOT ABOVE
+02DA          ; disallowed_STD3_mapped ; 0020 030A     # 1.1  RING ABOVE
+02DB          ; disallowed_STD3_mapped ; 0020 0328     # 1.1  OGONEK
+02DC          ; disallowed_STD3_mapped ; 0020 0303     # 1.1  SMALL TILDE
+02DD          ; disallowed_STD3_mapped ; 0020 030B     # 1.1  DOUBLE ACUTE ACCENT
+02DE          ; valid                  ;      ; NV8    # 1.1  MODIFIER LETTER RHOTIC HOOK
+02DF          ; valid                  ;      ; NV8    # 3.0  MODIFIER LETTER CROSS ACCENT
+02E0          ; mapped                 ; 0263          # 1.1  MODIFIER LETTER SMALL GAMMA
+02E1          ; mapped                 ; 006C          # 1.1  MODIFIER LETTER SMALL L
+02E2          ; mapped                 ; 0073          # 1.1  MODIFIER LETTER SMALL S
+02E3          ; mapped                 ; 0078          # 1.1  MODIFIER LETTER SMALL X
+02E4          ; mapped                 ; 0295          # 1.1  MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
+02E5..02E9    ; valid                  ;      ; NV8    # 1.1  MODIFIER LETTER EXTRA-HIGH TONE BAR..MODIFIER LETTER EXTRA-LOW TONE BAR
+02EA..02EB    ; valid                  ;      ; NV8    # 3.0  MODIFIER LETTER YIN DEPARTING TONE MARK..MODIFIER LETTER YANG DEPARTING TONE MARK
+02EC          ; valid                                  # 3.0  MODIFIER LETTER VOICING
+02ED          ; valid                  ;      ; NV8    # 3.0  MODIFIER LETTER UNASPIRATED
+02EE          ; valid                                  # 3.0  MODIFIER LETTER DOUBLE APOSTROPHE
+02EF..02FF    ; valid                  ;      ; NV8    # 4.0  MODIFIER LETTER LOW DOWN ARROWHEAD..MODIFIER LETTER LOW LEFT ARROW
+0300..033F    ; valid                                  # 1.1  COMBINING GRAVE ACCENT..COMBINING DOUBLE OVERLINE
+0340          ; mapped                 ; 0300          # 1.1  COMBINING GRAVE TONE MARK
+0341          ; mapped                 ; 0301          # 1.1  COMBINING ACUTE TONE MARK
+0342          ; valid                                  # 1.1  COMBINING GREEK PERISPOMENI
+0343          ; mapped                 ; 0313          # 1.1  COMBINING GREEK KORONIS
+0344          ; mapped                 ; 0308 0301     # 1.1  COMBINING GREEK DIALYTIKA TONOS
+0345          ; mapped                 ; 03B9          # 1.1  COMBINING GREEK YPOGEGRAMMENI
+0346..034E    ; valid                                  # 3.0  COMBINING BRIDGE ABOVE..COMBINING UPWARDS ARROW BELOW
+034F          ; ignored                                # 3.2  COMBINING GRAPHEME JOINER
+0350..0357    ; valid                                  # 4.0  COMBINING RIGHT ARROWHEAD ABOVE..COMBINING RIGHT HALF RING ABOVE
+0358..035C    ; valid                                  # 4.1  COMBINING DOT ABOVE RIGHT..COMBINING DOUBLE BREVE BELOW
+035D..035F    ; valid                                  # 4.0  COMBINING DOUBLE BREVE..COMBINING DOUBLE MACRON BELOW
+0360..0361    ; valid                                  # 1.1  COMBINING DOUBLE TILDE..COMBINING DOUBLE INVERTED BREVE
+0362          ; valid                                  # 3.0  COMBINING DOUBLE RIGHTWARDS ARROW BELOW
+0363..036F    ; valid                                  # 3.2  COMBINING LATIN SMALL LETTER A..COMBINING LATIN SMALL LETTER X
+0370          ; mapped                 ; 0371          # 5.1  GREEK CAPITAL LETTER HETA
+0371          ; valid                                  # 5.1  GREEK SMALL LETTER HETA
+0372          ; mapped                 ; 0373          # 5.1  GREEK CAPITAL LETTER ARCHAIC SAMPI
+0373          ; valid                                  # 5.1  GREEK SMALL LETTER ARCHAIC SAMPI
+0374          ; mapped                 ; 02B9          # 1.1  GREEK NUMERAL SIGN
+0375          ; valid                                  # 1.1  GREEK LOWER NUMERAL SIGN
+0376          ; mapped                 ; 0377          # 5.1  GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA
+0377          ; valid                                  # 5.1  GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
+0378..0379    ; disallowed                             # NA   <reserved-0378>..<reserved-0379>
+037A          ; disallowed_STD3_mapped ; 0020 03B9     # 1.1  GREEK YPOGEGRAMMENI
+037B..037D    ; valid                                  # 5.0  GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
+037E          ; disallowed_STD3_mapped ; 003B          # 1.1  GREEK QUESTION MARK
+037F          ; mapped                 ; 03F3          # 7.0  GREEK CAPITAL LETTER YOT
+0380..0383    ; disallowed                             # NA   <reserved-0380>..<reserved-0383>
+0384          ; disallowed_STD3_mapped ; 0020 0301     # 1.1  GREEK TONOS
+0385          ; disallowed_STD3_mapped ; 0020 0308 0301 #1.1  GREEK DIALYTIKA TONOS
+0386          ; mapped                 ; 03AC          # 1.1  GREEK CAPITAL LETTER ALPHA WITH TONOS
+0387          ; mapped                 ; 00B7          # 1.1  GREEK ANO TELEIA
+0388          ; mapped                 ; 03AD          # 1.1  GREEK CAPITAL LETTER EPSILON WITH TONOS
+0389          ; mapped                 ; 03AE          # 1.1  GREEK CAPITAL LETTER ETA WITH TONOS
+038A          ; mapped                 ; 03AF          # 1.1  GREEK CAPITAL LETTER IOTA WITH TONOS
+038B          ; disallowed                             # NA   <reserved-038B>
+038C          ; mapped                 ; 03CC          # 1.1  GREEK CAPITAL LETTER OMICRON WITH TONOS
+038D          ; disallowed                             # NA   <reserved-038D>
+038E          ; mapped                 ; 03CD          # 1.1  GREEK CAPITAL LETTER UPSILON WITH TONOS
+038F          ; mapped                 ; 03CE          # 1.1  GREEK CAPITAL LETTER OMEGA WITH TONOS
+0390          ; valid                                  # 1.1  GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
+0391          ; mapped                 ; 03B1          # 1.1  GREEK CAPITAL LETTER ALPHA
+0392          ; mapped                 ; 03B2          # 1.1  GREEK CAPITAL LETTER BETA
+0393          ; mapped                 ; 03B3          # 1.1  GREEK CAPITAL LETTER GAMMA
+0394          ; mapped                 ; 03B4          # 1.1  GREEK CAPITAL LETTER DELTA
+0395          ; mapped                 ; 03B5          # 1.1  GREEK CAPITAL LETTER EPSILON
+0396          ; mapped                 ; 03B6          # 1.1  GREEK CAPITAL LETTER ZETA
+0397          ; mapped                 ; 03B7          # 1.1  GREEK CAPITAL LETTER ETA
+0398          ; mapped                 ; 03B8          # 1.1  GREEK CAPITAL LETTER THETA
+0399          ; mapped                 ; 03B9          # 1.1  GREEK CAPITAL LETTER IOTA
+039A          ; mapped                 ; 03BA          # 1.1  GREEK CAPITAL LETTER KAPPA
+039B          ; mapped                 ; 03BB          # 1.1  GREEK CAPITAL LETTER LAMDA
+039C          ; mapped                 ; 03BC          # 1.1  GREEK CAPITAL LETTER MU
+039D          ; mapped                 ; 03BD          # 1.1  GREEK CAPITAL LETTER NU
+039E          ; mapped                 ; 03BE          # 1.1  GREEK CAPITAL LETTER XI
+039F          ; mapped                 ; 03BF          # 1.1  GREEK CAPITAL LETTER OMICRON
+03A0          ; mapped                 ; 03C0          # 1.1  GREEK CAPITAL LETTER PI
+03A1          ; mapped                 ; 03C1          # 1.1  GREEK CAPITAL LETTER RHO
+03A2          ; disallowed                             # NA   <reserved-03A2>
+03A3          ; mapped                 ; 03C3          # 1.1  GREEK CAPITAL LETTER SIGMA
+03A4          ; mapped                 ; 03C4          # 1.1  GREEK CAPITAL LETTER TAU
+03A5          ; mapped                 ; 03C5          # 1.1  GREEK CAPITAL LETTER UPSILON
+03A6          ; mapped                 ; 03C6          # 1.1  GREEK CAPITAL LETTER PHI
+03A7          ; mapped                 ; 03C7          # 1.1  GREEK CAPITAL LETTER CHI
+03A8          ; mapped                 ; 03C8          # 1.1  GREEK CAPITAL LETTER PSI
+03A9          ; mapped                 ; 03C9          # 1.1  GREEK CAPITAL LETTER OMEGA
+03AA          ; mapped                 ; 03CA          # 1.1  GREEK CAPITAL LETTER IOTA WITH DIALYTIKA
+03AB          ; mapped                 ; 03CB          # 1.1  GREEK CAPITAL LETTER UPSILON WITH DIALYTIKA
+03AC..03C1    ; valid                                  # 1.1  GREEK SMALL LETTER ALPHA WITH TONOS..GREEK SMALL LETTER RHO
+03C2          ; deviation              ; 03C3          # 1.1  GREEK SMALL LETTER FINAL SIGMA
+03C3..03CE    ; valid                                  # 1.1  GREEK SMALL LETTER SIGMA..GREEK SMALL LETTER OMEGA WITH TONOS
+03CF          ; mapped                 ; 03D7          # 5.1  GREEK CAPITAL KAI SYMBOL
+03D0          ; mapped                 ; 03B2          # 1.1  GREEK BETA SYMBOL
+03D1          ; mapped                 ; 03B8          # 1.1  GREEK THETA SYMBOL
+03D2          ; mapped                 ; 03C5          # 1.1  GREEK UPSILON WITH HOOK SYMBOL
+03D3          ; mapped                 ; 03CD          # 1.1  GREEK UPSILON WITH ACUTE AND HOOK SYMBOL
+03D4          ; mapped                 ; 03CB          # 1.1  GREEK UPSILON WITH DIAERESIS AND HOOK SYMBOL
+03D5          ; mapped                 ; 03C6          # 1.1  GREEK PHI SYMBOL
+03D6          ; mapped                 ; 03C0          # 1.1  GREEK PI SYMBOL
+03D7          ; valid                                  # 3.0  GREEK KAI SYMBOL
+03D8          ; mapped                 ; 03D9          # 3.2  GREEK LETTER ARCHAIC KOPPA
+03D9          ; valid                                  # 3.2  GREEK SMALL LETTER ARCHAIC KOPPA
+03DA          ; mapped                 ; 03DB          # 1.1  GREEK LETTER STIGMA
+03DB          ; valid                                  # 3.0  GREEK SMALL LETTER STIGMA
+03DC          ; mapped                 ; 03DD          # 1.1  GREEK LETTER DIGAMMA
+03DD          ; valid                                  # 3.0  GREEK SMALL LETTER DIGAMMA
+03DE          ; mapped                 ; 03DF          # 1.1  GREEK LETTER KOPPA
+03DF          ; valid                                  # 3.0  GREEK SMALL LETTER KOPPA
+03E0          ; mapped                 ; 03E1          # 1.1  GREEK LETTER SAMPI
+03E1          ; valid                                  # 3.0  GREEK SMALL LETTER SAMPI
+03E2          ; mapped                 ; 03E3          # 1.1  COPTIC CAPITAL LETTER SHEI
+03E3          ; valid                                  # 1.1  COPTIC SMALL LETTER SHEI
+03E4          ; mapped                 ; 03E5          # 1.1  COPTIC CAPITAL LETTER FEI
+03E5          ; valid                                  # 1.1  COPTIC SMALL LETTER FEI
+03E6          ; mapped                 ; 03E7          # 1.1  COPTIC CAPITAL LETTER KHEI
+03E7          ; valid                                  # 1.1  COPTIC SMALL LETTER KHEI
+03E8          ; mapped                 ; 03E9          # 1.1  COPTIC CAPITAL LETTER HORI
+03E9          ; valid                                  # 1.1  COPTIC SMALL LETTER HORI
+03EA          ; mapped                 ; 03EB          # 1.1  COPTIC CAPITAL LETTER GANGIA
+03EB          ; valid                                  # 1.1  COPTIC SMALL LETTER GANGIA
+03EC          ; mapped                 ; 03ED          # 1.1  COPTIC CAPITAL LETTER SHIMA
+03ED          ; valid                                  # 1.1  COPTIC SMALL LETTER SHIMA
+03EE          ; mapped                 ; 03EF          # 1.1  COPTIC CAPITAL LETTER DEI
+03EF          ; valid                                  # 1.1  COPTIC SMALL LETTER DEI
+03F0          ; mapped                 ; 03BA          # 1.1  GREEK KAPPA SYMBOL
+03F1          ; mapped                 ; 03C1          # 1.1  GREEK RHO SYMBOL
+03F2          ; mapped                 ; 03C3          # 1.1  GREEK LUNATE SIGMA SYMBOL
+03F3          ; valid                                  # 1.1  GREEK LETTER YOT
+03F4          ; mapped                 ; 03B8          # 3.1  GREEK CAPITAL THETA SYMBOL
+03F5          ; mapped                 ; 03B5          # 3.1  GREEK LUNATE EPSILON SYMBOL
+03F6          ; valid                  ;      ; NV8    # 3.2  GREEK REVERSED LUNATE EPSILON SYMBOL
+03F7          ; mapped                 ; 03F8          # 4.0  GREEK CAPITAL LETTER SHO
+03F8          ; valid                                  # 4.0  GREEK SMALL LETTER SHO
+03F9          ; mapped                 ; 03C3          # 4.0  GREEK CAPITAL LUNATE SIGMA SYMBOL
+03FA          ; mapped                 ; 03FB          # 4.0  GREEK CAPITAL LETTER SAN
+03FB          ; valid                                  # 4.0  GREEK SMALL LETTER SAN
+03FC          ; valid                                  # 4.1  GREEK RHO WITH STROKE SYMBOL
+03FD          ; mapped                 ; 037B          # 4.1  GREEK CAPITAL REVERSED LUNATE SIGMA SYMBOL
+03FE          ; mapped                 ; 037C          # 4.1  GREEK CAPITAL DOTTED LUNATE SIGMA SYMBOL
+03FF          ; mapped                 ; 037D          # 4.1  GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL
+0400          ; mapped                 ; 0450          # 3.0  CYRILLIC CAPITAL LETTER IE WITH GRAVE
+0401          ; mapped                 ; 0451          # 1.1  CYRILLIC CAPITAL LETTER IO
+0402          ; mapped                 ; 0452          # 1.1  CYRILLIC CAPITAL LETTER DJE
+0403          ; mapped                 ; 0453          # 1.1  CYRILLIC CAPITAL LETTER GJE
+0404          ; mapped                 ; 0454          # 1.1  CYRILLIC CAPITAL LETTER UKRAINIAN IE
+0405          ; mapped                 ; 0455          # 1.1  CYRILLIC CAPITAL LETTER DZE
+0406          ; mapped                 ; 0456          # 1.1  CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I
+0407          ; mapped                 ; 0457          # 1.1  CYRILLIC CAPITAL LETTER YI
+0408          ; mapped                 ; 0458          # 1.1  CYRILLIC CAPITAL LETTER JE
+0409          ; mapped                 ; 0459          # 1.1  CYRILLIC CAPITAL LETTER LJE
+040A          ; mapped                 ; 045A          # 1.1  CYRILLIC CAPITAL LETTER NJE
+040B          ; mapped                 ; 045B          # 1.1  CYRILLIC CAPITAL LETTER TSHE
+040C          ; mapped                 ; 045C          # 1.1  CYRILLIC CAPITAL LETTER KJE
+040D          ; mapped                 ; 045D          # 3.0  CYRILLIC CAPITAL LETTER I WITH GRAVE
+040E          ; mapped                 ; 045E          # 1.1  CYRILLIC CAPITAL LETTER SHORT U
+040F          ; mapped                 ; 045F          # 1.1  CYRILLIC CAPITAL LETTER DZHE
+0410          ; mapped                 ; 0430          # 1.1  CYRILLIC CAPITAL LETTER A
+0411          ; mapped                 ; 0431          # 1.1  CYRILLIC CAPITAL LETTER BE
+0412          ; mapped                 ; 0432          # 1.1  CYRILLIC CAPITAL LETTER VE
+0413          ; mapped                 ; 0433          # 1.1  CYRILLIC CAPITAL LETTER GHE
+0414          ; mapped                 ; 0434          # 1.1  CYRILLIC CAPITAL LETTER DE
+0415          ; mapped                 ; 0435          # 1.1  CYRILLIC CAPITAL LETTER IE
+0416          ; mapped                 ; 0436          # 1.1  CYRILLIC CAPITAL LETTER ZHE
+0417          ; mapped                 ; 0437          # 1.1  CYRILLIC CAPITAL LETTER ZE
+0418          ; mapped                 ; 0438          # 1.1  CYRILLIC CAPITAL LETTER I
+0419          ; mapped                 ; 0439          # 1.1  CYRILLIC CAPITAL LETTER SHORT I
+041A          ; mapped                 ; 043A          # 1.1  CYRILLIC CAPITAL LETTER KA
+041B          ; mapped                 ; 043B          # 1.1  CYRILLIC CAPITAL LETTER EL
+041C          ; mapped                 ; 043C          # 1.1  CYRILLIC CAPITAL LETTER EM
+041D          ; mapped                 ; 043D          # 1.1  CYRILLIC CAPITAL LETTER EN
+041E          ; mapped                 ; 043E          # 1.1  CYRILLIC CAPITAL LETTER O
+041F          ; mapped                 ; 043F          # 1.1  CYRILLIC CAPITAL LETTER PE
+0420          ; mapped                 ; 0440          # 1.1  CYRILLIC CAPITAL LETTER ER
+0421          ; mapped                 ; 0441          # 1.1  CYRILLIC CAPITAL LETTER ES
+0422          ; mapped                 ; 0442          # 1.1  CYRILLIC CAPITAL LETTER TE
+0423          ; mapped                 ; 0443          # 1.1  CYRILLIC CAPITAL LETTER U
+0424          ; mapped                 ; 0444          # 1.1  CYRILLIC CAPITAL LETTER EF
+0425          ; mapped                 ; 0445          # 1.1  CYRILLIC CAPITAL LETTER HA
+0426          ; mapped                 ; 0446          # 1.1  CYRILLIC CAPITAL LETTER TSE
+0427          ; mapped                 ; 0447          # 1.1  CYRILLIC CAPITAL LETTER CHE
+0428          ; mapped                 ; 0448          # 1.1  CYRILLIC CAPITAL LETTER SHA
+0429          ; mapped                 ; 0449          # 1.1  CYRILLIC CAPITAL LETTER SHCHA
+042A          ; mapped                 ; 044A          # 1.1  CYRILLIC CAPITAL LETTER HARD SIGN
+042B          ; mapped                 ; 044B          # 1.1  CYRILLIC CAPITAL LETTER YERU
+042C          ; mapped                 ; 044C          # 1.1  CYRILLIC CAPITAL LETTER SOFT SIGN
+042D          ; mapped                 ; 044D          # 1.1  CYRILLIC CAPITAL LETTER E
+042E          ; mapped                 ; 044E          # 1.1  CYRILLIC CAPITAL LETTER YU
+042F          ; mapped                 ; 044F          # 1.1  CYRILLIC CAPITAL LETTER YA
+0430..044F    ; valid                                  # 1.1  CYRILLIC SMALL LETTER A..CYRILLIC SMALL LETTER YA
+0450          ; valid                                  # 3.0  CYRILLIC SMALL LETTER IE WITH GRAVE
+0451..045C    ; valid                                  # 1.1  CYRILLIC SMALL LETTER IO..CYRILLIC SMALL LETTER KJE
+045D          ; valid                                  # 3.0  CYRILLIC SMALL LETTER I WITH GRAVE
+045E..045F    ; valid                                  # 1.1  CYRILLIC SMALL LETTER SHORT U..CYRILLIC SMALL LETTER DZHE
+0460          ; mapped                 ; 0461          # 1.1  CYRILLIC CAPITAL LETTER OMEGA
+0461          ; valid                                  # 1.1  CYRILLIC SMALL LETTER OMEGA
+0462          ; mapped                 ; 0463          # 1.1  CYRILLIC CAPITAL LETTER YAT
+0463          ; valid                                  # 1.1  CYRILLIC SMALL LETTER YAT
+0464          ; mapped                 ; 0465          # 1.1  CYRILLIC CAPITAL LETTER IOTIFIED E
+0465          ; valid                                  # 1.1  CYRILLIC SMALL LETTER IOTIFIED E
+0466          ; mapped                 ; 0467          # 1.1  CYRILLIC CAPITAL LETTER LITTLE YUS
+0467          ; valid                                  # 1.1  CYRILLIC SMALL LETTER LITTLE YUS
+0468          ; mapped                 ; 0469          # 1.1  CYRILLIC CAPITAL LETTER IOTIFIED LITTLE YUS
+0469          ; valid                                  # 1.1  CYRILLIC SMALL LETTER IOTIFIED LITTLE YUS
+046A          ; mapped                 ; 046B          # 1.1  CYRILLIC CAPITAL LETTER BIG YUS
+046B          ; valid                                  # 1.1  CYRILLIC SMALL LETTER BIG YUS
+046C          ; mapped                 ; 046D          # 1.1  CYRILLIC CAPITAL LETTER IOTIFIED BIG YUS
+046D          ; valid                                  # 1.1  CYRILLIC SMALL LETTER IOTIFIED BIG YUS
+046E          ; mapped                 ; 046F          # 1.1  CYRILLIC CAPITAL LETTER KSI
+046F          ; valid                                  # 1.1  CYRILLIC SMALL LETTER KSI
+0470          ; mapped                 ; 0471          # 1.1  CYRILLIC CAPITAL LETTER PSI
+0471          ; valid                                  # 1.1  CYRILLIC SMALL LETTER PSI
+0472          ; mapped                 ; 0473          # 1.1  CYRILLIC CAPITAL LETTER FITA
+0473          ; valid                                  # 1.1  CYRILLIC SMALL LETTER FITA
+0474          ; mapped                 ; 0475          # 1.1  CYRILLIC CAPITAL LETTER IZHITSA
+0475          ; valid                                  # 1.1  CYRILLIC SMALL LETTER IZHITSA
+0476          ; mapped                 ; 0477          # 1.1  CYRILLIC CAPITAL LETTER IZHITSA WITH DOUBLE GRAVE ACCENT
+0477          ; valid                                  # 1.1  CYRILLIC SMALL LETTER IZHITSA WITH DOUBLE GRAVE ACCENT
+0478          ; mapped                 ; 0479          # 1.1  CYRILLIC CAPITAL LETTER UK
+0479          ; valid                                  # 1.1  CYRILLIC SMALL LETTER UK
+047A          ; mapped                 ; 047B          # 1.1  CYRILLIC CAPITAL LETTER ROUND OMEGA
+047B          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ROUND OMEGA
+047C          ; mapped                 ; 047D          # 1.1  CYRILLIC CAPITAL LETTER OMEGA WITH TITLO
+047D          ; valid                                  # 1.1  CYRILLIC SMALL LETTER OMEGA WITH TITLO
+047E          ; mapped                 ; 047F          # 1.1  CYRILLIC CAPITAL LETTER OT
+047F          ; valid                                  # 1.1  CYRILLIC SMALL LETTER OT
+0480          ; mapped                 ; 0481          # 1.1  CYRILLIC CAPITAL LETTER KOPPA
+0481          ; valid                                  # 1.1  CYRILLIC SMALL LETTER KOPPA
+0482          ; valid                  ;      ; NV8    # 1.1  CYRILLIC THOUSANDS SIGN
+0483..0486    ; valid                                  # 1.1  COMBINING CYRILLIC TITLO..COMBINING CYRILLIC PSILI PNEUMATA
+0487          ; valid                                  # 5.1  COMBINING CYRILLIC POKRYTIE
+0488..0489    ; valid                  ;      ; NV8    # 3.0  COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
+048A          ; mapped                 ; 048B          # 3.2  CYRILLIC CAPITAL LETTER SHORT I WITH TAIL
+048B          ; valid                                  # 3.2  CYRILLIC SMALL LETTER SHORT I WITH TAIL
+048C          ; mapped                 ; 048D          # 3.0  CYRILLIC CAPITAL LETTER SEMISOFT SIGN
+048D          ; valid                                  # 3.0  CYRILLIC SMALL LETTER SEMISOFT SIGN
+048E          ; mapped                 ; 048F          # 3.0  CYRILLIC CAPITAL LETTER ER WITH TICK
+048F          ; valid                                  # 3.0  CYRILLIC SMALL LETTER ER WITH TICK
+0490          ; mapped                 ; 0491          # 1.1  CYRILLIC CAPITAL LETTER GHE WITH UPTURN
+0491          ; valid                                  # 1.1  CYRILLIC SMALL LETTER GHE WITH UPTURN
+0492          ; mapped                 ; 0493          # 1.1  CYRILLIC CAPITAL LETTER GHE WITH STROKE
+0493          ; valid                                  # 1.1  CYRILLIC SMALL LETTER GHE WITH STROKE
+0494          ; mapped                 ; 0495          # 1.1  CYRILLIC CAPITAL LETTER GHE WITH MIDDLE HOOK
+0495          ; valid                                  # 1.1  CYRILLIC SMALL LETTER GHE WITH MIDDLE HOOK
+0496          ; mapped                 ; 0497          # 1.1  CYRILLIC CAPITAL LETTER ZHE WITH DESCENDER
+0497          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ZHE WITH DESCENDER
+0498          ; mapped                 ; 0499          # 1.1  CYRILLIC CAPITAL LETTER ZE WITH DESCENDER
+0499          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ZE WITH DESCENDER
+049A          ; mapped                 ; 049B          # 1.1  CYRILLIC CAPITAL LETTER KA WITH DESCENDER
+049B          ; valid                                  # 1.1  CYRILLIC SMALL LETTER KA WITH DESCENDER
+049C          ; mapped                 ; 049D          # 1.1  CYRILLIC CAPITAL LETTER KA WITH VERTICAL STROKE
+049D          ; valid                                  # 1.1  CYRILLIC SMALL LETTER KA WITH VERTICAL STROKE
+049E          ; mapped                 ; 049F          # 1.1  CYRILLIC CAPITAL LETTER KA WITH STROKE
+049F          ; valid                                  # 1.1  CYRILLIC SMALL LETTER KA WITH STROKE
+04A0          ; mapped                 ; 04A1          # 1.1  CYRILLIC CAPITAL LETTER BASHKIR KA
+04A1          ; valid                                  # 1.1  CYRILLIC SMALL LETTER BASHKIR KA
+04A2          ; mapped                 ; 04A3          # 1.1  CYRILLIC CAPITAL LETTER EN WITH DESCENDER
+04A3          ; valid                                  # 1.1  CYRILLIC SMALL LETTER EN WITH DESCENDER
+04A4          ; mapped                 ; 04A5          # 1.1  CYRILLIC CAPITAL LIGATURE EN GHE
+04A5          ; valid                                  # 1.1  CYRILLIC SMALL LIGATURE EN GHE
+04A6          ; mapped                 ; 04A7          # 1.1  CYRILLIC CAPITAL LETTER PE WITH MIDDLE HOOK
+04A7          ; valid                                  # 1.1  CYRILLIC SMALL LETTER PE WITH MIDDLE HOOK
+04A8          ; mapped                 ; 04A9          # 1.1  CYRILLIC CAPITAL LETTER ABKHASIAN HA
+04A9          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ABKHASIAN HA
+04AA          ; mapped                 ; 04AB          # 1.1  CYRILLIC CAPITAL LETTER ES WITH DESCENDER
+04AB          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ES WITH DESCENDER
+04AC          ; mapped                 ; 04AD          # 1.1  CYRILLIC CAPITAL LETTER TE WITH DESCENDER
+04AD          ; valid                                  # 1.1  CYRILLIC SMALL LETTER TE WITH DESCENDER
+04AE          ; mapped                 ; 04AF          # 1.1  CYRILLIC CAPITAL LETTER STRAIGHT U
+04AF          ; valid                                  # 1.1  CYRILLIC SMALL LETTER STRAIGHT U
+04B0          ; mapped                 ; 04B1          # 1.1  CYRILLIC CAPITAL LETTER STRAIGHT U WITH STROKE
+04B1          ; valid                                  # 1.1  CYRILLIC SMALL LETTER STRAIGHT U WITH STROKE
+04B2          ; mapped                 ; 04B3          # 1.1  CYRILLIC CAPITAL LETTER HA WITH DESCENDER
+04B3          ; valid                                  # 1.1  CYRILLIC SMALL LETTER HA WITH DESCENDER
+04B4          ; mapped                 ; 04B5          # 1.1  CYRILLIC CAPITAL LIGATURE TE TSE
+04B5          ; valid                                  # 1.1  CYRILLIC SMALL LIGATURE TE TSE
+04B6          ; mapped                 ; 04B7          # 1.1  CYRILLIC CAPITAL LETTER CHE WITH DESCENDER
+04B7          ; valid                                  # 1.1  CYRILLIC SMALL LETTER CHE WITH DESCENDER
+04B8          ; mapped                 ; 04B9          # 1.1  CYRILLIC CAPITAL LETTER CHE WITH VERTICAL STROKE
+04B9          ; valid                                  # 1.1  CYRILLIC SMALL LETTER CHE WITH VERTICAL STROKE
+04BA          ; mapped                 ; 04BB          # 1.1  CYRILLIC CAPITAL LETTER SHHA
+04BB          ; valid                                  # 1.1  CYRILLIC SMALL LETTER SHHA
+04BC          ; mapped                 ; 04BD          # 1.1  CYRILLIC CAPITAL LETTER ABKHASIAN CHE
+04BD          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ABKHASIAN CHE
+04BE          ; mapped                 ; 04BF          # 1.1  CYRILLIC CAPITAL LETTER ABKHASIAN CHE WITH DESCENDER
+04BF          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ABKHASIAN CHE WITH DESCENDER
+04C0          ; disallowed                             # 1.1  CYRILLIC LETTER PALOCHKA
+04C1          ; mapped                 ; 04C2          # 1.1  CYRILLIC CAPITAL LETTER ZHE WITH BREVE
+04C2          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ZHE WITH BREVE
+04C3          ; mapped                 ; 04C4          # 1.1  CYRILLIC CAPITAL LETTER KA WITH HOOK
+04C4          ; valid                                  # 1.1  CYRILLIC SMALL LETTER KA WITH HOOK
+04C5          ; mapped                 ; 04C6          # 3.2  CYRILLIC CAPITAL LETTER EL WITH TAIL
+04C6          ; valid                                  # 3.2  CYRILLIC SMALL LETTER EL WITH TAIL
+04C7          ; mapped                 ; 04C8          # 1.1  CYRILLIC CAPITAL LETTER EN WITH HOOK
+04C8          ; valid                                  # 1.1  CYRILLIC SMALL LETTER EN WITH HOOK
+04C9          ; mapped                 ; 04CA          # 3.2  CYRILLIC CAPITAL LETTER EN WITH TAIL
+04CA          ; valid                                  # 3.2  CYRILLIC SMALL LETTER EN WITH TAIL
+04CB          ; mapped                 ; 04CC          # 1.1  CYRILLIC CAPITAL LETTER KHAKASSIAN CHE
+04CC          ; valid                                  # 1.1  CYRILLIC SMALL LETTER KHAKASSIAN CHE
+04CD          ; mapped                 ; 04CE          # 3.2  CYRILLIC CAPITAL LETTER EM WITH TAIL
+04CE          ; valid                                  # 3.2  CYRILLIC SMALL LETTER EM WITH TAIL
+04CF          ; valid                                  # 5.0  CYRILLIC SMALL LETTER PALOCHKA
+04D0          ; mapped                 ; 04D1          # 1.1  CYRILLIC CAPITAL LETTER A WITH BREVE
+04D1          ; valid                                  # 1.1  CYRILLIC SMALL LETTER A WITH BREVE
+04D2          ; mapped                 ; 04D3          # 1.1  CYRILLIC CAPITAL LETTER A WITH DIAERESIS
+04D3          ; valid                                  # 1.1  CYRILLIC SMALL LETTER A WITH DIAERESIS
+04D4          ; mapped                 ; 04D5          # 1.1  CYRILLIC CAPITAL LIGATURE A IE
+04D5          ; valid                                  # 1.1  CYRILLIC SMALL LIGATURE A IE
+04D6          ; mapped                 ; 04D7          # 1.1  CYRILLIC CAPITAL LETTER IE WITH BREVE
+04D7          ; valid                                  # 1.1  CYRILLIC SMALL LETTER IE WITH BREVE
+04D8          ; mapped                 ; 04D9          # 1.1  CYRILLIC CAPITAL LETTER SCHWA
+04D9          ; valid                                  # 1.1  CYRILLIC SMALL LETTER SCHWA
+04DA          ; mapped                 ; 04DB          # 1.1  CYRILLIC CAPITAL LETTER SCHWA WITH DIAERESIS
+04DB          ; valid                                  # 1.1  CYRILLIC SMALL LETTER SCHWA WITH DIAERESIS
+04DC          ; mapped                 ; 04DD          # 1.1  CYRILLIC CAPITAL LETTER ZHE WITH DIAERESIS
+04DD          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ZHE WITH DIAERESIS
+04DE          ; mapped                 ; 04DF          # 1.1  CYRILLIC CAPITAL LETTER ZE WITH DIAERESIS
+04DF          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ZE WITH DIAERESIS
+04E0          ; mapped                 ; 04E1          # 1.1  CYRILLIC CAPITAL LETTER ABKHASIAN DZE
+04E1          ; valid                                  # 1.1  CYRILLIC SMALL LETTER ABKHASIAN DZE
+04E2          ; mapped                 ; 04E3          # 1.1  CYRILLIC CAPITAL LETTER I WITH MACRON
+04E3          ; valid                                  # 1.1  CYRILLIC SMALL LETTER I WITH MACRON
+04E4          ; mapped                 ; 04E5          # 1.1  CYRILLIC CAPITAL LETTER I WITH DIAERESIS
+04E5          ; valid                                  # 1.1  CYRILLIC SMALL LETTER I WITH DIAERESIS
+04E6          ; mapped                 ; 04E7          # 1.1  CYRILLIC CAPITAL LETTER O WITH DIAERESIS
+04E7          ; valid                                  # 1.1  CYRILLIC SMALL LETTER O WITH DIAERESIS
+04E8          ; mapped                 ; 04E9          # 1.1  CYRILLIC CAPITAL LETTER BARRED O
+04E9          ; valid                                  # 1.1  CYRILLIC SMALL LETTER BARRED O
+04EA          ; mapped                 ; 04EB          # 1.1  CYRILLIC CAPITAL LETTER BARRED O WITH DIAERESIS
+04EB          ; valid                                  # 1.1  CYRILLIC SMALL LETTER BARRED O WITH DIAERESIS
+04EC          ; mapped                 ; 04ED          # 3.0  CYRILLIC CAPITAL LETTER E WITH DIAERESIS
+04ED          ; valid                                  # 3.0  CYRILLIC SMALL LETTER E WITH DIAERESIS
+04EE          ; mapped                 ; 04EF          # 1.1  CYRILLIC CAPITAL LETTER U WITH MACRON
+04EF          ; valid                                  # 1.1  CYRILLIC SMALL LETTER U WITH MACRON
+04F0          ; mapped                 ; 04F1          # 1.1  CYRILLIC CAPITAL LETTER U WITH DIAERESIS
+04F1          ; valid                                  # 1.1  CYRILLIC SMALL LETTER U WITH DIAERESIS
+04F2          ; mapped                 ; 04F3          # 1.1  CYRILLIC CAPITAL LETTER U WITH DOUBLE ACUTE
+04F3          ; valid                                  # 1.1  CYRILLIC SMALL LETTER U WITH DOUBLE ACUTE
+04F4          ; mapped                 ; 04F5          # 1.1  CYRILLIC CAPITAL LETTER CHE WITH DIAERESIS
+04F5          ; valid                                  # 1.1  CYRILLIC SMALL LETTER CHE WITH DIAERESIS
+04F6          ; mapped                 ; 04F7          # 4.1  CYRILLIC CAPITAL LETTER GHE WITH DESCENDER
+04F7          ; valid                                  # 4.1  CYRILLIC SMALL LETTER GHE WITH DESCENDER
+04F8          ; mapped                 ; 04F9          # 1.1  CYRILLIC CAPITAL LETTER YERU WITH DIAERESIS
+04F9          ; valid                                  # 1.1  CYRILLIC SMALL LETTER YERU WITH DIAERESIS
+04FA          ; mapped                 ; 04FB          # 5.0  CYRILLIC CAPITAL LETTER GHE WITH STROKE AND HOOK
+04FB          ; valid                                  # 5.0  CYRILLIC SMALL LETTER GHE WITH STROKE AND HOOK
+04FC          ; mapped                 ; 04FD          # 5.0  CYRILLIC CAPITAL LETTER HA WITH HOOK
+04FD          ; valid                                  # 5.0  CYRILLIC SMALL LETTER HA WITH HOOK
+04FE          ; mapped                 ; 04FF          # 5.0  CYRILLIC CAPITAL LETTER HA WITH STROKE
+04FF          ; valid                                  # 5.0  CYRILLIC SMALL LETTER HA WITH STROKE
+0500          ; mapped                 ; 0501          # 3.2  CYRILLIC CAPITAL LETTER KOMI DE
+0501          ; valid                                  # 3.2  CYRILLIC SMALL LETTER KOMI DE
+0502          ; mapped                 ; 0503          # 3.2  CYRILLIC CAPITAL LETTER KOMI DJE
+0503          ; valid                                  # 3.2  CYRILLIC SMALL LETTER KOMI DJE
+0504          ; mapped                 ; 0505          # 3.2  CYRILLIC CAPITAL LETTER KOMI ZJE
+0505          ; valid                                  # 3.2  CYRILLIC SMALL LETTER KOMI ZJE
+0506          ; mapped                 ; 0507          # 3.2  CYRILLIC CAPITAL LETTER KOMI DZJE
+0507          ; valid                                  # 3.2  CYRILLIC SMALL LETTER KOMI DZJE
+0508          ; mapped                 ; 0509          # 3.2  CYRILLIC CAPITAL LETTER KOMI LJE
+0509          ; valid                                  # 3.2  CYRILLIC SMALL LETTER KOMI LJE
+050A          ; mapped                 ; 050B          # 3.2  CYRILLIC CAPITAL LETTER KOMI NJE
+050B          ; valid                                  # 3.2  CYRILLIC SMALL LETTER KOMI NJE
+050C          ; mapped                 ; 050D          # 3.2  CYRILLIC CAPITAL LETTER KOMI SJE
+050D          ; valid                                  # 3.2  CYRILLIC SMALL LETTER KOMI SJE
+050E          ; mapped                 ; 050F          # 3.2  CYRILLIC CAPITAL LETTER KOMI TJE
+050F          ; valid                                  # 3.2  CYRILLIC SMALL LETTER KOMI TJE
+0510          ; mapped                 ; 0511          # 5.0  CYRILLIC CAPITAL LETTER REVERSED ZE
+0511          ; valid                                  # 5.0  CYRILLIC SMALL LETTER REVERSED ZE
+0512          ; mapped                 ; 0513          # 5.0  CYRILLIC CAPITAL LETTER EL WITH HOOK
+0513          ; valid                                  # 5.0  CYRILLIC SMALL LETTER EL WITH HOOK
+0514          ; mapped                 ; 0515          # 5.1  CYRILLIC CAPITAL LETTER LHA
+0515          ; valid                                  # 5.1  CYRILLIC SMALL LETTER LHA
+0516          ; mapped                 ; 0517          # 5.1  CYRILLIC CAPITAL LETTER RHA
+0517          ; valid                                  # 5.1  CYRILLIC SMALL LETTER RHA
+0518          ; mapped                 ; 0519          # 5.1  CYRILLIC CAPITAL LETTER YAE
+0519          ; valid                                  # 5.1  CYRILLIC SMALL LETTER YAE
+051A          ; mapped                 ; 051B          # 5.1  CYRILLIC CAPITAL LETTER QA
+051B          ; valid                                  # 5.1  CYRILLIC SMALL LETTER QA
+051C          ; mapped                 ; 051D          # 5.1  CYRILLIC CAPITAL LETTER WE
+051D          ; valid                                  # 5.1  CYRILLIC SMALL LETTER WE
+051E          ; mapped                 ; 051F          # 5.1  CYRILLIC CAPITAL LETTER ALEUT KA
+051F          ; valid                                  # 5.1  CYRILLIC SMALL LETTER ALEUT KA
+0520          ; mapped                 ; 0521          # 5.1  CYRILLIC CAPITAL LETTER EL WITH MIDDLE HOOK
+0521          ; valid                                  # 5.1  CYRILLIC SMALL LETTER EL WITH MIDDLE HOOK
+0522          ; mapped                 ; 0523          # 5.1  CYRILLIC CAPITAL LETTER EN WITH MIDDLE HOOK
+0523          ; valid                                  # 5.1  CYRILLIC SMALL LETTER EN WITH MIDDLE HOOK
+0524          ; mapped                 ; 0525          # 5.2  CYRILLIC CAPITAL LETTER PE WITH DESCENDER
+0525          ; valid                                  # 5.2  CYRILLIC SMALL LETTER PE WITH DESCENDER
+0526          ; mapped                 ; 0527          # 6.0  CYRILLIC CAPITAL LETTER SHHA WITH DESCENDER
+0527          ; valid                                  # 6.0  CYRILLIC SMALL LETTER SHHA WITH DESCENDER
+0528          ; mapped                 ; 0529          # 7.0  CYRILLIC CAPITAL LETTER EN WITH LEFT HOOK
+0529          ; valid                                  # 7.0  CYRILLIC SMALL LETTER EN WITH LEFT HOOK
+052A          ; mapped                 ; 052B          # 7.0  CYRILLIC CAPITAL LETTER DZZHE
+052B          ; valid                                  # 7.0  CYRILLIC SMALL LETTER DZZHE
+052C          ; mapped                 ; 052D          # 7.0  CYRILLIC CAPITAL LETTER DCHE
+052D          ; valid                                  # 7.0  CYRILLIC SMALL LETTER DCHE
+052E          ; mapped                 ; 052F          # 7.0  CYRILLIC CAPITAL LETTER EL WITH DESCENDER
+052F          ; valid                                  # 7.0  CYRILLIC SMALL LETTER EL WITH DESCENDER
+0530          ; disallowed                             # NA   <reserved-0530>
+0531          ; mapped                 ; 0561          # 1.1  ARMENIAN CAPITAL LETTER AYB
+0532          ; mapped                 ; 0562          # 1.1  ARMENIAN CAPITAL LETTER BEN
+0533          ; mapped                 ; 0563          # 1.1  ARMENIAN CAPITAL LETTER GIM
+0534          ; mapped                 ; 0564          # 1.1  ARMENIAN CAPITAL LETTER DA
+0535          ; mapped                 ; 0565          # 1.1  ARMENIAN CAPITAL LETTER ECH
+0536          ; mapped                 ; 0566          # 1.1  ARMENIAN CAPITAL LETTER ZA
+0537          ; mapped                 ; 0567          # 1.1  ARMENIAN CAPITAL LETTER EH
+0538          ; mapped                 ; 0568          # 1.1  ARMENIAN CAPITAL LETTER ET
+0539          ; mapped                 ; 0569          # 1.1  ARMENIAN CAPITAL LETTER TO
+053A          ; mapped                 ; 056A          # 1.1  ARMENIAN CAPITAL LETTER ZHE
+053B          ; mapped                 ; 056B          # 1.1  ARMENIAN CAPITAL LETTER INI
+053C          ; mapped                 ; 056C          # 1.1  ARMENIAN CAPITAL LETTER LIWN
+053D          ; mapped                 ; 056D          # 1.1  ARMENIAN CAPITAL LETTER XEH
+053E          ; mapped                 ; 056E          # 1.1  ARMENIAN CAPITAL LETTER CA
+053F          ; mapped                 ; 056F          # 1.1  ARMENIAN CAPITAL LETTER KEN
+0540          ; mapped                 ; 0570          # 1.1  ARMENIAN CAPITAL LETTER HO
+0541          ; mapped                 ; 0571          # 1.1  ARMENIAN CAPITAL LETTER JA
+0542          ; mapped                 ; 0572          # 1.1  ARMENIAN CAPITAL LETTER GHAD
+0543          ; mapped                 ; 0573          # 1.1  ARMENIAN CAPITAL LETTER CHEH
+0544          ; mapped                 ; 0574          # 1.1  ARMENIAN CAPITAL LETTER MEN
+0545          ; mapped                 ; 0575          # 1.1  ARMENIAN CAPITAL LETTER YI
+0546          ; mapped                 ; 0576          # 1.1  ARMENIAN CAPITAL LETTER NOW
+0547          ; mapped                 ; 0577          # 1.1  ARMENIAN CAPITAL LETTER SHA
+0548          ; mapped                 ; 0578          # 1.1  ARMENIAN CAPITAL LETTER VO
+0549          ; mapped                 ; 0579          # 1.1  ARMENIAN CAPITAL LETTER CHA
+054A          ; mapped                 ; 057A          # 1.1  ARMENIAN CAPITAL LETTER PEH
+054B          ; mapped                 ; 057B          # 1.1  ARMENIAN CAPITAL LETTER JHEH
+054C          ; mapped                 ; 057C          # 1.1  ARMENIAN CAPITAL LETTER RA
+054D          ; mapped                 ; 057D          # 1.1  ARMENIAN CAPITAL LETTER SEH
+054E          ; mapped                 ; 057E          # 1.1  ARMENIAN CAPITAL LETTER VEW
+054F          ; mapped                 ; 057F          # 1.1  ARMENIAN CAPITAL LETTER TIWN
+0550          ; mapped                 ; 0580          # 1.1  ARMENIAN CAPITAL LETTER REH
+0551          ; mapped                 ; 0581          # 1.1  ARMENIAN CAPITAL LETTER CO
+0552          ; mapped                 ; 0582          # 1.1  ARMENIAN CAPITAL LETTER YIWN
+0553          ; mapped                 ; 0583          # 1.1  ARMENIAN CAPITAL LETTER PIWR
+0554          ; mapped                 ; 0584          # 1.1  ARMENIAN CAPITAL LETTER KEH
+0555          ; mapped                 ; 0585          # 1.1  ARMENIAN CAPITAL LETTER OH
+0556          ; mapped                 ; 0586          # 1.1  ARMENIAN CAPITAL LETTER FEH
+0557..0558    ; disallowed                             # NA   <reserved-0557>..<reserved-0558>
+0559          ; valid                                  # 1.1  ARMENIAN MODIFIER LETTER LEFT HALF RING
+055A..055F    ; valid                  ;      ; NV8    # 1.1  ARMENIAN APOSTROPHE..ARMENIAN ABBREVIATION MARK
+0560          ; valid                                  # 11.0 ARMENIAN SMALL LETTER TURNED AYB
+0561..0586    ; valid                                  # 1.1  ARMENIAN SMALL LETTER AYB..ARMENIAN SMALL LETTER FEH
+0587          ; mapped                 ; 0565 0582     # 1.1  ARMENIAN SMALL LIGATURE ECH YIWN
+0588          ; valid                                  # 11.0 ARMENIAN SMALL LETTER YI WITH STROKE
+0589          ; valid                  ;      ; NV8    # 1.1  ARMENIAN FULL STOP
+058A          ; valid                  ;      ; NV8    # 3.0  ARMENIAN HYPHEN
+058B..058C    ; disallowed                             # NA   <reserved-058B>..<reserved-058C>
+058D..058E    ; valid                  ;      ; NV8    # 7.0  RIGHT-FACING ARMENIAN ETERNITY SIGN..LEFT-FACING ARMENIAN ETERNITY SIGN
+058F          ; valid                  ;      ; NV8    # 6.1  ARMENIAN DRAM SIGN
+0590          ; disallowed                             # NA   <reserved-0590>
+0591..05A1    ; valid                                  # 2.0  HEBREW ACCENT ETNAHTA..HEBREW ACCENT PAZER
+05A2          ; valid                                  # 4.1  HEBREW ACCENT ATNAH HAFUKH
+05A3..05AF    ; valid                                  # 2.0  HEBREW ACCENT MUNAH..HEBREW MARK MASORA CIRCLE
+05B0..05B9    ; valid                                  # 1.1  HEBREW POINT SHEVA..HEBREW POINT HOLAM
+05BA          ; valid                                  # 5.0  HEBREW POINT HOLAM HASER FOR VAV
+05BB..05BD    ; valid                                  # 1.1  HEBREW POINT QUBUTS..HEBREW POINT METEG
+05BE          ; valid                  ;      ; NV8    # 1.1  HEBREW PUNCTUATION MAQAF
+05BF          ; valid                                  # 1.1  HEBREW POINT RAFE
+05C0          ; valid                  ;      ; NV8    # 1.1  HEBREW PUNCTUATION PASEQ
+05C1..05C2    ; valid                                  # 1.1  HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
+05C3          ; valid                  ;      ; NV8    # 1.1  HEBREW PUNCTUATION SOF PASUQ
+05C4          ; valid                                  # 2.0  HEBREW MARK UPPER DOT
+05C5          ; valid                                  # 4.1  HEBREW MARK LOWER DOT
+05C6          ; valid                  ;      ; NV8    # 4.1  HEBREW PUNCTUATION NUN HAFUKHA
+05C7          ; valid                                  # 4.1  HEBREW POINT QAMATS QATAN
+05C8..05CF    ; disallowed                             # NA   <reserved-05C8>..<reserved-05CF>
+05D0..05EA    ; valid                                  # 1.1  HEBREW LETTER ALEF..HEBREW LETTER TAV
+05EB..05EE    ; disallowed                             # NA   <reserved-05EB>..<reserved-05EE>
+05EF          ; valid                                  # 11.0 HEBREW YOD TRIANGLE
+05F0..05F4    ; valid                                  # 1.1  HEBREW LIGATURE YIDDISH DOUBLE VAV..HEBREW PUNCTUATION GERSHAYIM
+05F5..05FF    ; disallowed                             # NA   <reserved-05F5>..<reserved-05FF>
+0600..0603    ; disallowed                             # 4.0  ARABIC NUMBER SIGN..ARABIC SIGN SAFHA
+0604          ; disallowed                             # 6.1  ARABIC SIGN SAMVAT
+0605          ; disallowed                             # 7.0  ARABIC NUMBER MARK ABOVE
+0606..060A    ; valid                  ;      ; NV8    # 5.1  ARABIC-INDIC CUBE ROOT..ARABIC-INDIC PER TEN THOUSAND SIGN
+060B          ; valid                  ;      ; NV8    # 4.1  AFGHANI SIGN
+060C          ; valid                  ;      ; NV8    # 1.1  ARABIC COMMA
+060D..060F    ; valid                  ;      ; NV8    # 4.0  ARABIC DATE SEPARATOR..ARABIC SIGN MISRA
+0610..0615    ; valid                                  # 4.0  ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL HIGH TAH
+0616..061A    ; valid                                  # 5.1  ARABIC SMALL HIGH LIGATURE ALEF WITH LAM WITH YEH..ARABIC SMALL KASRA
+061B          ; valid                  ;      ; NV8    # 1.1  ARABIC SEMICOLON
+061C          ; disallowed                             # 6.3  ARABIC LETTER MARK
+061D          ; valid                  ;      ; NV8    # 14.0 ARABIC END OF TEXT MARK
+061E          ; valid                  ;      ; NV8    # 4.1  ARABIC TRIPLE DOT PUNCTUATION MARK
+061F          ; valid                  ;      ; NV8    # 1.1  ARABIC QUESTION MARK
+0620          ; valid                                  # 6.0  ARABIC LETTER KASHMIRI YEH
+0621..063A    ; valid                                  # 1.1  ARABIC LETTER HAMZA..ARABIC LETTER GHAIN
+063B..063F    ; valid                                  # 5.1  ARABIC LETTER KEHEH WITH TWO DOTS ABOVE..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
+0640          ; valid                  ;      ; NV8    # 1.1  ARABIC TATWEEL
+0641..0652    ; valid                                  # 1.1  ARABIC LETTER FEH..ARABIC SUKUN
+0653..0655    ; valid                                  # 3.0  ARABIC MADDAH ABOVE..ARABIC HAMZA BELOW
+0656..0658    ; valid                                  # 4.0  ARABIC SUBSCRIPT ALEF..ARABIC MARK NOON GHUNNA
+0659..065E    ; valid                                  # 4.1  ARABIC ZWARAKAY..ARABIC FATHA WITH TWO DOTS
+065F          ; valid                                  # 6.0  ARABIC WAVY HAMZA BELOW
+0660..0669    ; valid                                  # 1.1  ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
+066A..066D    ; valid                  ;      ; NV8    # 1.1  ARABIC PERCENT SIGN..ARABIC FIVE POINTED STAR
+066E..066F    ; valid                                  # 3.2  ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
+0670..0674    ; valid                                  # 1.1  ARABIC LETTER SUPERSCRIPT ALEF..ARABIC LETTER HIGH HAMZA
+0675          ; mapped                 ; 0627 0674     # 1.1  ARABIC LETTER HIGH HAMZA ALEF
+0676          ; mapped                 ; 0648 0674     # 1.1  ARABIC LETTER HIGH HAMZA WAW
+0677          ; mapped                 ; 06C7 0674     # 1.1  ARABIC LETTER U WITH HAMZA ABOVE
+0678          ; mapped                 ; 064A 0674     # 1.1  ARABIC LETTER HIGH HAMZA YEH
+0679..06B7    ; valid                                  # 1.1  ARABIC LETTER TTEH..ARABIC LETTER LAM WITH THREE DOTS ABOVE
+06B8..06B9    ; valid                                  # 3.0  ARABIC LETTER LAM WITH THREE DOTS BELOW..ARABIC LETTER NOON WITH DOT BELOW
+06BA..06BE    ; valid                                  # 1.1  ARABIC LETTER NOON GHUNNA..ARABIC LETTER HEH DOACHASHMEE
+06BF          ; valid                                  # 3.0  ARABIC LETTER TCHEH WITH DOT ABOVE
+06C0..06CE    ; valid                                  # 1.1  ARABIC LETTER HEH WITH YEH ABOVE..ARABIC LETTER YEH WITH SMALL V
+06CF          ; valid                                  # 3.0  ARABIC LETTER WAW WITH DOT ABOVE
+06D0..06D3    ; valid                                  # 1.1  ARABIC LETTER E..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
+06D4          ; valid                  ;      ; NV8    # 1.1  ARABIC FULL STOP
+06D5..06DC    ; valid                                  # 1.1  ARABIC LETTER AE..ARABIC SMALL HIGH SEEN
+06DD          ; disallowed                             # 1.1  ARABIC END OF AYAH
+06DE          ; valid                  ;      ; NV8    # 1.1  ARABIC START OF RUB EL HIZB
+06DF..06E8    ; valid                                  # 1.1  ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH NOON
+06E9          ; valid                  ;      ; NV8    # 1.1  ARABIC PLACE OF SAJDAH
+06EA..06ED    ; valid                                  # 1.1  ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
+06EE..06EF    ; valid                                  # 4.0  ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
+06F0..06F9    ; valid                                  # 1.1  EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
+06FA..06FE    ; valid                                  # 3.0  ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC SIGN SINDHI POSTPOSITION MEN
+06FF          ; valid                                  # 4.0  ARABIC LETTER HEH WITH INVERTED V
+0700..070D    ; valid                  ;      ; NV8    # 3.0  SYRIAC END OF PARAGRAPH..SYRIAC HARKLEAN ASTERISCUS
+070E          ; disallowed                             # NA   <reserved-070E>
+070F          ; disallowed                             # 3.0  SYRIAC ABBREVIATION MARK
+0710..072C    ; valid                                  # 3.0  SYRIAC LETTER ALAPH..SYRIAC LETTER TAW
+072D..072F    ; valid                                  # 4.0  SYRIAC LETTER PERSIAN BHETH..SYRIAC LETTER PERSIAN DHALATH
+0730..074A    ; valid                                  # 3.0  SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
+074B..074C    ; disallowed                             # NA   <reserved-074B>..<reserved-074C>
+074D..074F    ; valid                                  # 4.0  SYRIAC LETTER SOGDIAN ZHAIN..SYRIAC LETTER SOGDIAN FE
+0750..076D    ; valid                                  # 4.1  ARABIC LETTER BEH WITH THREE DOTS HORIZONTALLY BELOW..ARABIC LETTER SEEN WITH TWO DOTS VERTICALLY ABOVE
+076E..077F    ; valid                                  # 5.1  ARABIC LETTER HAH WITH SMALL ARABIC LETTER TAH BELOW..ARABIC LETTER KAF WITH TWO DOTS ABOVE
+0780..07B0    ; valid                                  # 3.0  THAANA LETTER HAA..THAANA SUKUN
+07B1          ; valid                                  # 3.2  THAANA LETTER NAA
+07B2..07BF    ; disallowed                             # NA   <reserved-07B2>..<reserved-07BF>
+07C0..07F5    ; valid                                  # 5.0  NKO DIGIT ZERO..NKO LOW TONE APOSTROPHE
+07F6..07FA    ; valid                  ;      ; NV8    # 5.0  NKO SYMBOL OO DENNEN..NKO LAJANYALAN
+07FB..07FC    ; disallowed                             # NA   <reserved-07FB>..<reserved-07FC>
+07FD          ; valid                                  # 11.0 NKO DANTAYALAN
+07FE..07FF    ; valid                  ;      ; NV8    # 11.0 NKO DOROME SIGN..NKO TAMAN SIGN
+0800..082D    ; valid                                  # 5.2  SAMARITAN LETTER ALAF..SAMARITAN MARK NEQUDAA
+082E..082F    ; disallowed                             # NA   <reserved-082E>..<reserved-082F>
+0830..083E    ; valid                  ;      ; NV8    # 5.2  SAMARITAN PUNCTUATION NEQUDAA..SAMARITAN PUNCTUATION ANNAAU
+083F          ; disallowed                             # NA   <reserved-083F>
+0840..085B    ; valid                                  # 6.0  MANDAIC LETTER HALQA..MANDAIC GEMINATION MARK
+085C..085D    ; disallowed                             # NA   <reserved-085C>..<reserved-085D>
+085E          ; valid                  ;      ; NV8    # 6.0  MANDAIC PUNCTUATION
+085F          ; disallowed                             # NA   <reserved-085F>
+0860..086A    ; valid                                  # 10.0 SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
+086B..086F    ; disallowed                             # NA   <reserved-086B>..<reserved-086F>
+0870..0887    ; valid                                  # 14.0 ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
+0888          ; valid                  ;      ; NV8    # 14.0 ARABIC RAISED ROUND DOT
+0889..088E    ; valid                                  # 14.0 ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
+088F          ; disallowed                             # NA   <reserved-088F>
+0890..0891    ; disallowed                             # 14.0 ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
+0892..0897    ; disallowed                             # NA   <reserved-0892>..<reserved-0897>
+0898..089F    ; valid                                  # 14.0 ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
+08A0          ; valid                                  # 6.1  ARABIC LETTER BEH WITH SMALL V BELOW
+08A1          ; valid                                  # 7.0  ARABIC LETTER BEH WITH HAMZA ABOVE
+08A2..08AC    ; valid                                  # 6.1  ARABIC LETTER JEEM WITH TWO DOTS ABOVE..ARABIC LETTER ROHINGYA YEH
+08AD..08B2    ; valid                                  # 7.0  ARABIC LETTER LOW ALEF..ARABIC LETTER ZAIN WITH INVERTED V ABOVE
+08B3..08B4    ; valid                                  # 8.0  ARABIC LETTER AIN WITH THREE DOTS BELOW..ARABIC LETTER KAF WITH DOT BELOW
+08B5          ; valid                                  # 14.0 ARABIC LETTER QAF WITH DOT BELOW AND NO DOTS ABOVE
+08B6..08BD    ; valid                                  # 9.0  ARABIC LETTER BEH WITH SMALL MEEM ABOVE..ARABIC LETTER AFRICAN NOON
+08BE..08C7    ; valid                                  # 13.0 ARABIC LETTER PEH WITH SMALL V..ARABIC LETTER LAM WITH SMALL ARABIC LETTER TAH ABOVE
+08C8..08D2    ; valid                                  # 14.0 ARABIC LETTER GRAF..ARABIC LARGE ROUND DOT INSIDE CIRCLE BELOW
+08D3          ; valid                                  # 11.0 ARABIC SMALL LOW WAW
+08D4..08E1    ; valid                                  # 9.0  ARABIC SMALL HIGH WORD AR-RUB..ARABIC SMALL HIGH SIGN SAFHA
+08E2          ; disallowed                             # 9.0  ARABIC DISPUTED END OF AYAH
+08E3          ; valid                                  # 8.0  ARABIC TURNED DAMMA BELOW
+08E4..08FE    ; valid                                  # 6.1  ARABIC CURLY FATHA..ARABIC DAMMA WITH DOT
+08FF          ; valid                                  # 7.0  ARABIC MARK SIDEWAYS NOON GHUNNA
+0900          ; valid                                  # 5.2  DEVANAGARI SIGN INVERTED CANDRABINDU
+0901..0903    ; valid                                  # 1.1  DEVANAGARI SIGN CANDRABINDU..DEVANAGARI SIGN VISARGA
+0904          ; valid                                  # 4.0  DEVANAGARI LETTER SHORT A
+0905..0939    ; valid                                  # 1.1  DEVANAGARI LETTER A..DEVANAGARI LETTER HA
+093A..093B    ; valid                                  # 6.0  DEVANAGARI VOWEL SIGN OE..DEVANAGARI VOWEL SIGN OOE
+093C..094D    ; valid                                  # 1.1  DEVANAGARI SIGN NUKTA..DEVANAGARI SIGN VIRAMA
+094E          ; valid                                  # 5.2  DEVANAGARI VOWEL SIGN PRISHTHAMATRA E
+094F          ; valid                                  # 6.0  DEVANAGARI VOWEL SIGN AW
+0950..0954    ; valid                                  # 1.1  DEVANAGARI OM..DEVANAGARI ACUTE ACCENT
+0955          ; valid                                  # 5.2  DEVANAGARI VOWEL SIGN CANDRA LONG E
+0956..0957    ; valid                                  # 6.0  DEVANAGARI VOWEL SIGN UE..DEVANAGARI VOWEL SIGN UUE
+0958          ; mapped                 ; 0915 093C     # 1.1  DEVANAGARI LETTER QA
+0959          ; mapped                 ; 0916 093C     # 1.1  DEVANAGARI LETTER KHHA
+095A          ; mapped                 ; 0917 093C     # 1.1  DEVANAGARI LETTER GHHA
+095B          ; mapped                 ; 091C 093C     # 1.1  DEVANAGARI LETTER ZA
+095C          ; mapped                 ; 0921 093C     # 1.1  DEVANAGARI LETTER DDDHA
+095D          ; mapped                 ; 0922 093C     # 1.1  DEVANAGARI LETTER RHA
+095E          ; mapped                 ; 092B 093C     # 1.1  DEVANAGARI LETTER FA
+095F          ; mapped                 ; 092F 093C     # 1.1  DEVANAGARI LETTER YYA
+0960..0963    ; valid                                  # 1.1  DEVANAGARI LETTER VOCALIC RR..DEVANAGARI VOWEL SIGN VOCALIC LL
+0964..0965    ; valid                  ;      ; NV8    # 1.1  DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
+0966..096F    ; valid                                  # 1.1  DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
+0970          ; valid                  ;      ; NV8    # 1.1  DEVANAGARI ABBREVIATION SIGN
+0971..0972    ; valid                                  # 5.1  DEVANAGARI SIGN HIGH SPACING DOT..DEVANAGARI LETTER CANDRA A
+0973..0977    ; valid                                  # 6.0  DEVANAGARI LETTER OE..DEVANAGARI LETTER UUE
+0978          ; valid                                  # 7.0  DEVANAGARI LETTER MARWARI DDA
+0979..097A    ; valid                                  # 5.2  DEVANAGARI LETTER ZHA..DEVANAGARI LETTER HEAVY YA
+097B..097C    ; valid                                  # 5.0  DEVANAGARI LETTER GGA..DEVANAGARI LETTER JJA
+097D          ; valid                                  # 4.1  DEVANAGARI LETTER GLOTTAL STOP
+097E..097F    ; valid                                  # 5.0  DEVANAGARI LETTER DDDA..DEVANAGARI LETTER BBA
+0980          ; valid                                  # 7.0  BENGALI ANJI
+0981..0983    ; valid                                  # 1.1  BENGALI SIGN CANDRABINDU..BENGALI SIGN VISARGA
+0984          ; disallowed                             # NA   <reserved-0984>
+0985..098C    ; valid                                  # 1.1  BENGALI LETTER A..BENGALI LETTER VOCALIC L
+098D..098E    ; disallowed                             # NA   <reserved-098D>..<reserved-098E>
+098F..0990    ; valid                                  # 1.1  BENGALI LETTER E..BENGALI LETTER AI
+0991..0992    ; disallowed                             # NA   <reserved-0991>..<reserved-0992>
+0993..09A8    ; valid                                  # 1.1  BENGALI LETTER O..BENGALI LETTER NA
+09A9          ; disallowed                             # NA   <reserved-09A9>
+09AA..09B0    ; valid                                  # 1.1  BENGALI LETTER PA..BENGALI LETTER RA
+09B1          ; disallowed                             # NA   <reserved-09B1>
+09B2          ; valid                                  # 1.1  BENGALI LETTER LA
+09B3..09B5    ; disallowed                             # NA   <reserved-09B3>..<reserved-09B5>
+09B6..09B9    ; valid                                  # 1.1  BENGALI LETTER SHA..BENGALI LETTER HA
+09BA..09BB    ; disallowed                             # NA   <reserved-09BA>..<reserved-09BB>
+09BC          ; valid                                  # 1.1  BENGALI SIGN NUKTA
+09BD          ; valid                                  # 4.0  BENGALI SIGN AVAGRAHA
+09BE..09C4    ; valid                                  # 1.1  BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN VOCALIC RR
+09C5..09C6    ; disallowed                             # NA   <reserved-09C5>..<reserved-09C6>
+09C7..09C8    ; valid                                  # 1.1  BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
+09C9..09CA    ; disallowed                             # NA   <reserved-09C9>..<reserved-09CA>
+09CB..09CD    ; valid                                  # 1.1  BENGALI VOWEL SIGN O..BENGALI SIGN VIRAMA
+09CE          ; valid                                  # 4.1  BENGALI LETTER KHANDA TA
+09CF..09D6    ; disallowed                             # NA   <reserved-09CF>..<reserved-09D6>
+09D7          ; valid                                  # 1.1  BENGALI AU LENGTH MARK
+09D8..09DB    ; disallowed                             # NA   <reserved-09D8>..<reserved-09DB>
+09DC          ; mapped                 ; 09A1 09BC     # 1.1  BENGALI LETTER RRA
+09DD          ; mapped                 ; 09A2 09BC     # 1.1  BENGALI LETTER RHA
+09DE          ; disallowed                             # NA   <reserved-09DE>
+09DF          ; mapped                 ; 09AF 09BC     # 1.1  BENGALI LETTER YYA
+09E0..09E3    ; valid                                  # 1.1  BENGALI LETTER VOCALIC RR..BENGALI VOWEL SIGN VOCALIC LL
+09E4..09E5    ; disallowed                             # NA   <reserved-09E4>..<reserved-09E5>
+09E6..09F1    ; valid                                  # 1.1  BENGALI DIGIT ZERO..BENGALI LETTER RA WITH LOWER DIAGONAL
+09F2..09FA    ; valid                  ;      ; NV8    # 1.1  BENGALI RUPEE MARK..BENGALI ISSHAR
+09FB          ; valid                  ;      ; NV8    # 5.2  BENGALI GANDA MARK
+09FC          ; valid                                  # 10.0 BENGALI LETTER VEDIC ANUSVARA
+09FD          ; valid                  ;      ; NV8    # 10.0 BENGALI ABBREVIATION SIGN
+09FE          ; valid                                  # 11.0 BENGALI SANDHI MARK
+09FF..0A00    ; disallowed                             # NA   <reserved-09FF>..<reserved-0A00>
+0A01          ; valid                                  # 4.0  GURMUKHI SIGN ADAK BINDI
+0A02          ; valid                                  # 1.1  GURMUKHI SIGN BINDI
+0A03          ; valid                                  # 4.0  GURMUKHI SIGN VISARGA
+0A04          ; disallowed                             # NA   <reserved-0A04>
+0A05..0A0A    ; valid                                  # 1.1  GURMUKHI LETTER A..GURMUKHI LETTER UU
+0A0B..0A0E    ; disallowed                             # NA   <reserved-0A0B>..<reserved-0A0E>
+0A0F..0A10    ; valid                                  # 1.1  GURMUKHI LETTER EE..GURMUKHI LETTER AI
+0A11..0A12    ; disallowed                             # NA   <reserved-0A11>..<reserved-0A12>
+0A13..0A28    ; valid                                  # 1.1  GURMUKHI LETTER OO..GURMUKHI LETTER NA
+0A29          ; disallowed                             # NA   <reserved-0A29>
+0A2A..0A30    ; valid                                  # 1.1  GURMUKHI LETTER PA..GURMUKHI LETTER RA
+0A31          ; disallowed                             # NA   <reserved-0A31>
+0A32          ; valid                                  # 1.1  GURMUKHI LETTER LA
+0A33          ; mapped                 ; 0A32 0A3C     # 1.1  GURMUKHI LETTER LLA
+0A34          ; disallowed                             # NA   <reserved-0A34>
+0A35          ; valid                                  # 1.1  GURMUKHI LETTER VA
+0A36          ; mapped                 ; 0A38 0A3C     # 1.1  GURMUKHI LETTER SHA
+0A37          ; disallowed                             # NA   <reserved-0A37>
+0A38..0A39    ; valid                                  # 1.1  GURMUKHI LETTER SA..GURMUKHI LETTER HA
+0A3A..0A3B    ; disallowed                             # NA   <reserved-0A3A>..<reserved-0A3B>
+0A3C          ; valid                                  # 1.1  GURMUKHI SIGN NUKTA
+0A3D          ; disallowed                             # NA   <reserved-0A3D>
+0A3E..0A42    ; valid                                  # 1.1  GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN UU
+0A43..0A46    ; disallowed                             # NA   <reserved-0A43>..<reserved-0A46>
+0A47..0A48    ; valid                                  # 1.1  GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
+0A49..0A4A    ; disallowed                             # NA   <reserved-0A49>..<reserved-0A4A>
+0A4B..0A4D    ; valid                                  # 1.1  GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
+0A4E..0A50    ; disallowed                             # NA   <reserved-0A4E>..<reserved-0A50>
+0A51          ; valid                                  # 5.1  GURMUKHI SIGN UDAAT
+0A52..0A58    ; disallowed                             # NA   <reserved-0A52>..<reserved-0A58>
+0A59          ; mapped                 ; 0A16 0A3C     # 1.1  GURMUKHI LETTER KHHA
+0A5A          ; mapped                 ; 0A17 0A3C     # 1.1  GURMUKHI LETTER GHHA
+0A5B          ; mapped                 ; 0A1C 0A3C     # 1.1  GURMUKHI LETTER ZA
+0A5C          ; valid                                  # 1.1  GURMUKHI LETTER RRA
+0A5D          ; disallowed                             # NA   <reserved-0A5D>
+0A5E          ; mapped                 ; 0A2B 0A3C     # 1.1  GURMUKHI LETTER FA
+0A5F..0A65    ; disallowed                             # NA   <reserved-0A5F>..<reserved-0A65>
+0A66..0A74    ; valid                                  # 1.1  GURMUKHI DIGIT ZERO..GURMUKHI EK ONKAR
+0A75          ; valid                                  # 5.1  GURMUKHI SIGN YAKASH
+0A76          ; valid                  ;      ; NV8    # 11.0 GURMUKHI ABBREVIATION SIGN
+0A77..0A80    ; disallowed                             # NA   <reserved-0A77>..<reserved-0A80>
+0A81..0A83    ; valid                                  # 1.1  GUJARATI SIGN CANDRABINDU..GUJARATI SIGN VISARGA
+0A84          ; disallowed                             # NA   <reserved-0A84>
+0A85..0A8B    ; valid                                  # 1.1  GUJARATI LETTER A..GUJARATI LETTER VOCALIC R
+0A8C          ; valid                                  # 4.0  GUJARATI LETTER VOCALIC L
+0A8D          ; valid                                  # 1.1  GUJARATI VOWEL CANDRA E
+0A8E          ; disallowed                             # NA   <reserved-0A8E>
+0A8F..0A91    ; valid                                  # 1.1  GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
+0A92          ; disallowed                             # NA   <reserved-0A92>
+0A93..0AA8    ; valid                                  # 1.1  GUJARATI LETTER O..GUJARATI LETTER NA
+0AA9          ; disallowed                             # NA   <reserved-0AA9>
+0AAA..0AB0    ; valid                                  # 1.1  GUJARATI LETTER PA..GUJARATI LETTER RA
+0AB1          ; disallowed                             # NA   <reserved-0AB1>
+0AB2..0AB3    ; valid                                  # 1.1  GUJARATI LETTER LA..GUJARATI LETTER LLA
+0AB4          ; disallowed                             # NA   <reserved-0AB4>
+0AB5..0AB9    ; valid                                  # 1.1  GUJARATI LETTER VA..GUJARATI LETTER HA
+0ABA..0ABB    ; disallowed                             # NA   <reserved-0ABA>..<reserved-0ABB>
+0ABC..0AC5    ; valid                                  # 1.1  GUJARATI SIGN NUKTA..GUJARATI VOWEL SIGN CANDRA E
+0AC6          ; disallowed                             # NA   <reserved-0AC6>
+0AC7..0AC9    ; valid                                  # 1.1  GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN CANDRA O
+0ACA          ; disallowed                             # NA   <reserved-0ACA>
+0ACB..0ACD    ; valid                                  # 1.1  GUJARATI VOWEL SIGN O..GUJARATI SIGN VIRAMA
+0ACE..0ACF    ; disallowed                             # NA   <reserved-0ACE>..<reserved-0ACF>
+0AD0          ; valid                                  # 1.1  GUJARATI OM
+0AD1..0ADF    ; disallowed                             # NA   <reserved-0AD1>..<reserved-0ADF>
+0AE0          ; valid                                  # 1.1  GUJARATI LETTER VOCALIC RR
+0AE1..0AE3    ; valid                                  # 4.0  GUJARATI LETTER VOCALIC LL..GUJARATI VOWEL SIGN VOCALIC LL
+0AE4..0AE5    ; disallowed                             # NA   <reserved-0AE4>..<reserved-0AE5>
+0AE6..0AEF    ; valid                                  # 1.1  GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
+0AF0          ; valid                  ;      ; NV8    # 6.1  GUJARATI ABBREVIATION SIGN
+0AF1          ; valid                  ;      ; NV8    # 4.0  GUJARATI RUPEE SIGN
+0AF2..0AF8    ; disallowed                             # NA   <reserved-0AF2>..<reserved-0AF8>
+0AF9          ; valid                                  # 8.0  GUJARATI LETTER ZHA
+0AFA..0AFF    ; valid                                  # 10.0 GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
+0B00          ; disallowed                             # NA   <reserved-0B00>
+0B01..0B03    ; valid                                  # 1.1  ORIYA SIGN CANDRABINDU..ORIYA SIGN VISARGA
+0B04          ; disallowed                             # NA   <reserved-0B04>
+0B05..0B0C    ; valid                                  # 1.1  ORIYA LETTER A..ORIYA LETTER VOCALIC L
+0B0D..0B0E    ; disallowed                             # NA   <reserved-0B0D>..<reserved-0B0E>
+0B0F..0B10    ; valid                                  # 1.1  ORIYA LETTER E..ORIYA LETTER AI
+0B11..0B12    ; disallowed                             # NA   <reserved-0B11>..<reserved-0B12>
+0B13..0B28    ; valid                                  # 1.1  ORIYA LETTER O..ORIYA LETTER NA
+0B29          ; disallowed                             # NA   <reserved-0B29>
+0B2A..0B30    ; valid                                  # 1.1  ORIYA LETTER PA..ORIYA LETTER RA
+0B31          ; disallowed                             # NA   <reserved-0B31>
+0B32..0B33    ; valid                                  # 1.1  ORIYA LETTER LA..ORIYA LETTER LLA
+0B34          ; disallowed                             # NA   <reserved-0B34>
+0B35          ; valid                                  # 4.0  ORIYA LETTER VA
+0B36..0B39    ; valid                                  # 1.1  ORIYA LETTER SHA..ORIYA LETTER HA
+0B3A..0B3B    ; disallowed                             # NA   <reserved-0B3A>..<reserved-0B3B>
+0B3C..0B43    ; valid                                  # 1.1  ORIYA SIGN NUKTA..ORIYA VOWEL SIGN VOCALIC R
+0B44          ; valid                                  # 5.1  ORIYA VOWEL SIGN VOCALIC RR
+0B45..0B46    ; disallowed                             # NA   <reserved-0B45>..<reserved-0B46>
+0B47..0B48    ; valid                                  # 1.1  ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
+0B49..0B4A    ; disallowed                             # NA   <reserved-0B49>..<reserved-0B4A>
+0B4B..0B4D    ; valid                                  # 1.1  ORIYA VOWEL SIGN O..ORIYA SIGN VIRAMA
+0B4E..0B54    ; disallowed                             # NA   <reserved-0B4E>..<reserved-0B54>
+0B55          ; valid                                  # 13.0 ORIYA SIGN OVERLINE
+0B56..0B57    ; valid                                  # 1.1  ORIYA AI LENGTH MARK..ORIYA AU LENGTH MARK
+0B58..0B5B    ; disallowed                             # NA   <reserved-0B58>..<reserved-0B5B>
+0B5C          ; mapped                 ; 0B21 0B3C     # 1.1  ORIYA LETTER RRA
+0B5D          ; mapped                 ; 0B22 0B3C     # 1.1  ORIYA LETTER RHA
+0B5E          ; disallowed                             # NA   <reserved-0B5E>
+0B5F..0B61    ; valid                                  # 1.1  ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
+0B62..0B63    ; valid                                  # 5.1  ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
+0B64..0B65    ; disallowed                             # NA   <reserved-0B64>..<reserved-0B65>
+0B66..0B6F    ; valid                                  # 1.1  ORIYA DIGIT ZERO..ORIYA DIGIT NINE
+0B70          ; valid                  ;      ; NV8    # 1.1  ORIYA ISSHAR
+0B71          ; valid                                  # 4.0  ORIYA LETTER WA
+0B72..0B77    ; valid                  ;      ; NV8    # 6.0  ORIYA FRACTION ONE QUARTER..ORIYA FRACTION THREE SIXTEENTHS
+0B78..0B81    ; disallowed                             # NA   <reserved-0B78>..<reserved-0B81>
+0B82..0B83    ; valid                                  # 1.1  TAMIL SIGN ANUSVARA..TAMIL SIGN VISARGA
+0B84          ; disallowed                             # NA   <reserved-0B84>
+0B85..0B8A    ; valid                                  # 1.1  TAMIL LETTER A..TAMIL LETTER UU
+0B8B..0B8D    ; disallowed                             # NA   <reserved-0B8B>..<reserved-0B8D>
+0B8E..0B90    ; valid                                  # 1.1  TAMIL LETTER E..TAMIL LETTER AI
+0B91          ; disallowed                             # NA   <reserved-0B91>
+0B92..0B95    ; valid                                  # 1.1  TAMIL LETTER O..TAMIL LETTER KA
+0B96..0B98    ; disallowed                             # NA   <reserved-0B96>..<reserved-0B98>
+0B99..0B9A    ; valid                                  # 1.1  TAMIL LETTER NGA..TAMIL LETTER CA
+0B9B          ; disallowed                             # NA   <reserved-0B9B>
+0B9C          ; valid                                  # 1.1  TAMIL LETTER JA
+0B9D          ; disallowed                             # NA   <reserved-0B9D>
+0B9E..0B9F    ; valid                                  # 1.1  TAMIL LETTER NYA..TAMIL LETTER TTA
+0BA0..0BA2    ; disallowed                             # NA   <reserved-0BA0>..<reserved-0BA2>
+0BA3..0BA4    ; valid                                  # 1.1  TAMIL LETTER NNA..TAMIL LETTER TA
+0BA5..0BA7    ; disallowed                             # NA   <reserved-0BA5>..<reserved-0BA7>
+0BA8..0BAA    ; valid                                  # 1.1  TAMIL LETTER NA..TAMIL LETTER PA
+0BAB..0BAD    ; disallowed                             # NA   <reserved-0BAB>..<reserved-0BAD>
+0BAE..0BB5    ; valid                                  # 1.1  TAMIL LETTER MA..TAMIL LETTER VA
+0BB6          ; valid                                  # 4.1  TAMIL LETTER SHA
+0BB7..0BB9    ; valid                                  # 1.1  TAMIL LETTER SSA..TAMIL LETTER HA
+0BBA..0BBD    ; disallowed                             # NA   <reserved-0BBA>..<reserved-0BBD>
+0BBE..0BC2    ; valid                                  # 1.1  TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN UU
+0BC3..0BC5    ; disallowed                             # NA   <reserved-0BC3>..<reserved-0BC5>
+0BC6..0BC8    ; valid                                  # 1.1  TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
+0BC9          ; disallowed                             # NA   <reserved-0BC9>
+0BCA..0BCD    ; valid                                  # 1.1  TAMIL VOWEL SIGN O..TAMIL SIGN VIRAMA
+0BCE..0BCF    ; disallowed                             # NA   <reserved-0BCE>..<reserved-0BCF>
+0BD0          ; valid                                  # 5.1  TAMIL OM
+0BD1..0BD6    ; disallowed                             # NA   <reserved-0BD1>..<reserved-0BD6>
+0BD7          ; valid                                  # 1.1  TAMIL AU LENGTH MARK
+0BD8..0BE5    ; disallowed                             # NA   <reserved-0BD8>..<reserved-0BE5>
+0BE6          ; valid                                  # 4.1  TAMIL DIGIT ZERO
+0BE7..0BEF    ; valid                                  # 1.1  TAMIL DIGIT ONE..TAMIL DIGIT NINE
+0BF0..0BF2    ; valid                  ;      ; NV8    # 1.1  TAMIL NUMBER TEN..TAMIL NUMBER ONE THOUSAND
+0BF3..0BFA    ; valid                  ;      ; NV8    # 4.0  TAMIL DAY SIGN..TAMIL NUMBER SIGN
+0BFB..0BFF    ; disallowed                             # NA   <reserved-0BFB>..<reserved-0BFF>
+0C00          ; valid                                  # 7.0  TELUGU SIGN COMBINING CANDRABINDU ABOVE
+0C01..0C03    ; valid                                  # 1.1  TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
+0C04          ; valid                                  # 11.0 TELUGU SIGN COMBINING ANUSVARA ABOVE
+0C05..0C0C    ; valid                                  # 1.1  TELUGU LETTER A..TELUGU LETTER VOCALIC L
+0C0D          ; disallowed                             # NA   <reserved-0C0D>
+0C0E..0C10    ; valid                                  # 1.1  TELUGU LETTER E..TELUGU LETTER AI
+0C11          ; disallowed                             # NA   <reserved-0C11>
+0C12..0C28    ; valid                                  # 1.1  TELUGU LETTER O..TELUGU LETTER NA
+0C29          ; disallowed                             # NA   <reserved-0C29>
+0C2A..0C33    ; valid                                  # 1.1  TELUGU LETTER PA..TELUGU LETTER LLA
+0C34          ; valid                                  # 7.0  TELUGU LETTER LLLA
+0C35..0C39    ; valid                                  # 1.1  TELUGU LETTER VA..TELUGU LETTER HA
+0C3A..0C3B    ; disallowed                             # NA   <reserved-0C3A>..<reserved-0C3B>
+0C3C          ; valid                                  # 14.0 TELUGU SIGN NUKTA
+0C3D          ; valid                                  # 5.1  TELUGU SIGN AVAGRAHA
+0C3E..0C44    ; valid                                  # 1.1  TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN VOCALIC RR
+0C45          ; disallowed                             # NA   <reserved-0C45>
+0C46..0C48    ; valid                                  # 1.1  TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
+0C49          ; disallowed                             # NA   <reserved-0C49>
+0C4A..0C4D    ; valid                                  # 1.1  TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
+0C4E..0C54    ; disallowed                             # NA   <reserved-0C4E>..<reserved-0C54>
+0C55..0C56    ; valid                                  # 1.1  TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
+0C57          ; disallowed                             # NA   <reserved-0C57>
+0C58..0C59    ; valid                                  # 5.1  TELUGU LETTER TSA..TELUGU LETTER DZA
+0C5A          ; valid                                  # 8.0  TELUGU LETTER RRRA
+0C5B..0C5C    ; disallowed                             # NA   <reserved-0C5B>..<reserved-0C5C>
+0C5D          ; valid                                  # 14.0 TELUGU LETTER NAKAARA POLLU
+0C5E..0C5F    ; disallowed                             # NA   <reserved-0C5E>..<reserved-0C5F>
+0C60..0C61    ; valid                                  # 1.1  TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
+0C62..0C63    ; valid                                  # 5.1  TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
+0C64..0C65    ; disallowed                             # NA   <reserved-0C64>..<reserved-0C65>
+0C66..0C6F    ; valid                                  # 1.1  TELUGU DIGIT ZERO..TELUGU DIGIT NINE
+0C70..0C76    ; disallowed                             # NA   <reserved-0C70>..<reserved-0C76>
+0C77          ; valid                  ;      ; NV8    # 12.0 TELUGU SIGN SIDDHAM
+0C78..0C7F    ; valid                  ;      ; NV8    # 5.1  TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR..TELUGU SIGN TUUMU
+0C80          ; valid                                  # 9.0  KANNADA SIGN SPACING CANDRABINDU
+0C81          ; valid                                  # 7.0  KANNADA SIGN CANDRABINDU
+0C82..0C83    ; valid                                  # 1.1  KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
+0C84          ; valid                  ;      ; NV8    # 11.0 KANNADA SIGN SIDDHAM
+0C85..0C8C    ; valid                                  # 1.1  KANNADA LETTER A..KANNADA LETTER VOCALIC L
+0C8D          ; disallowed                             # NA   <reserved-0C8D>
+0C8E..0C90    ; valid                                  # 1.1  KANNADA LETTER E..KANNADA LETTER AI
+0C91          ; disallowed                             # NA   <reserved-0C91>
+0C92..0CA8    ; valid                                  # 1.1  KANNADA LETTER O..KANNADA LETTER NA
+0CA9          ; disallowed                             # NA   <reserved-0CA9>
+0CAA..0CB3    ; valid                                  # 1.1  KANNADA LETTER PA..KANNADA LETTER LLA
+0CB4          ; disallowed                             # NA   <reserved-0CB4>
+0CB5..0CB9    ; valid                                  # 1.1  KANNADA LETTER VA..KANNADA LETTER HA
+0CBA..0CBB    ; disallowed                             # NA   <reserved-0CBA>..<reserved-0CBB>
+0CBC..0CBD    ; valid                                  # 4.0  KANNADA SIGN NUKTA..KANNADA SIGN AVAGRAHA
+0CBE..0CC4    ; valid                                  # 1.1  KANNADA VOWEL SIGN AA..KANNADA VOWEL SIGN VOCALIC RR
+0CC5          ; disallowed                             # NA   <reserved-0CC5>
+0CC6..0CC8    ; valid                                  # 1.1  KANNADA VOWEL SIGN E..KANNADA VOWEL SIGN AI
+0CC9          ; disallowed                             # NA   <reserved-0CC9>
+0CCA..0CCD    ; valid                                  # 1.1  KANNADA VOWEL SIGN O..KANNADA SIGN VIRAMA
+0CCE..0CD4    ; disallowed                             # NA   <reserved-0CCE>..<reserved-0CD4>
+0CD5..0CD6    ; valid                                  # 1.1  KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
+0CD7..0CDC    ; disallowed                             # NA   <reserved-0CD7>..<reserved-0CDC>
+0CDD          ; valid                                  # 14.0 KANNADA LETTER NAKAARA POLLU
+0CDE          ; valid                                  # 1.1  KANNADA LETTER FA
+0CDF          ; disallowed                             # NA   <reserved-0CDF>
+0CE0..0CE1    ; valid                                  # 1.1  KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
+0CE2..0CE3    ; valid                                  # 5.0  KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
+0CE4..0CE5    ; disallowed                             # NA   <reserved-0CE4>..<reserved-0CE5>
+0CE6..0CEF    ; valid                                  # 1.1  KANNADA DIGIT ZERO..KANNADA DIGIT NINE
+0CF0          ; disallowed                             # NA   <reserved-0CF0>
+0CF1..0CF2    ; valid                                  # 5.0  KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
+0CF3          ; valid                                  # 15.0 KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
+0CF4..0CFF    ; disallowed                             # NA   <reserved-0CF4>..<reserved-0CFF>
+0D00          ; valid                                  # 10.0 MALAYALAM SIGN COMBINING ANUSVARA ABOVE
+0D01          ; valid                                  # 7.0  MALAYALAM SIGN CANDRABINDU
+0D02..0D03    ; valid                                  # 1.1  MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
+0D04          ; valid                                  # 13.0 MALAYALAM LETTER VEDIC ANUSVARA
+0D05..0D0C    ; valid                                  # 1.1  MALAYALAM LETTER A..MALAYALAM LETTER VOCALIC L
+0D0D          ; disallowed                             # NA   <reserved-0D0D>
+0D0E..0D10    ; valid                                  # 1.1  MALAYALAM LETTER E..MALAYALAM LETTER AI
+0D11          ; disallowed                             # NA   <reserved-0D11>
+0D12..0D28    ; valid                                  # 1.1  MALAYALAM LETTER O..MALAYALAM LETTER NA
+0D29          ; valid                                  # 6.0  MALAYALAM LETTER NNNA
+0D2A..0D39    ; valid                                  # 1.1  MALAYALAM LETTER PA..MALAYALAM LETTER HA
+0D3A          ; valid                                  # 6.0  MALAYALAM LETTER TTTA
+0D3B..0D3C    ; valid                                  # 10.0 MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
+0D3D          ; valid                                  # 5.1  MALAYALAM SIGN AVAGRAHA
+0D3E..0D43    ; valid                                  # 1.1  MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN VOCALIC R
+0D44          ; valid                                  # 5.1  MALAYALAM VOWEL SIGN VOCALIC RR
+0D45          ; disallowed                             # NA   <reserved-0D45>
+0D46..0D48    ; valid                                  # 1.1  MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
+0D49          ; disallowed                             # NA   <reserved-0D49>
+0D4A..0D4D    ; valid                                  # 1.1  MALAYALAM VOWEL SIGN O..MALAYALAM SIGN VIRAMA
+0D4E          ; valid                                  # 6.0  MALAYALAM LETTER DOT REPH
+0D4F          ; valid                  ;      ; NV8    # 9.0  MALAYALAM SIGN PARA
+0D50..0D53    ; disallowed                             # NA   <reserved-0D50>..<reserved-0D53>
+0D54..0D56    ; valid                                  # 9.0  MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
+0D57          ; valid                                  # 1.1  MALAYALAM AU LENGTH MARK
+0D58..0D5E    ; valid                  ;      ; NV8    # 9.0  MALAYALAM FRACTION ONE ONE-HUNDRED-AND-SIXTIETH..MALAYALAM FRACTION ONE FIFTH
+0D5F          ; valid                                  # 8.0  MALAYALAM LETTER ARCHAIC II
+0D60..0D61    ; valid                                  # 1.1  MALAYALAM LETTER VOCALIC RR..MALAYALAM LETTER VOCALIC LL
+0D62..0D63    ; valid                                  # 5.1  MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
+0D64..0D65    ; disallowed                             # NA   <reserved-0D64>..<reserved-0D65>
+0D66..0D6F    ; valid                                  # 1.1  MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
+0D70..0D75    ; valid                  ;      ; NV8    # 5.1  MALAYALAM NUMBER TEN..MALAYALAM FRACTION THREE QUARTERS
+0D76..0D78    ; valid                  ;      ; NV8    # 9.0  MALAYALAM FRACTION ONE SIXTEENTH..MALAYALAM FRACTION THREE SIXTEENTHS
+0D79          ; valid                  ;      ; NV8    # 5.1  MALAYALAM DATE MARK
+0D7A..0D7F    ; valid                                  # 5.1  MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
+0D80          ; disallowed                             # NA   <reserved-0D80>
+0D81          ; valid                                  # 13.0 SINHALA SIGN CANDRABINDU
+0D82..0D83    ; valid                                  # 3.0  SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
+0D84          ; disallowed                             # NA   <reserved-0D84>
+0D85..0D96    ; valid                                  # 3.0  SINHALA LETTER AYANNA..SINHALA LETTER AUYANNA
+0D97..0D99    ; disallowed                             # NA   <reserved-0D97>..<reserved-0D99>
+0D9A..0DB1    ; valid                                  # 3.0  SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER DANTAJA NAYANNA
+0DB2          ; disallowed                             # NA   <reserved-0DB2>
+0DB3..0DBB    ; valid                                  # 3.0  SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
+0DBC          ; disallowed                             # NA   <reserved-0DBC>
+0DBD          ; valid                                  # 3.0  SINHALA LETTER DANTAJA LAYANNA
+0DBE..0DBF    ; disallowed                             # NA   <reserved-0DBE>..<reserved-0DBF>
+0DC0..0DC6    ; valid                                  # 3.0  SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
+0DC7..0DC9    ; disallowed                             # NA   <reserved-0DC7>..<reserved-0DC9>
+0DCA          ; valid                                  # 3.0  SINHALA SIGN AL-LAKUNA
+0DCB..0DCE    ; disallowed                             # NA   <reserved-0DCB>..<reserved-0DCE>
+0DCF..0DD4    ; valid                                  # 3.0  SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
+0DD5          ; disallowed                             # NA   <reserved-0DD5>
+0DD6          ; valid                                  # 3.0  SINHALA VOWEL SIGN DIGA PAA-PILLA
+0DD7          ; disallowed                             # NA   <reserved-0DD7>
+0DD8..0DDF    ; valid                                  # 3.0  SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN GAYANUKITTA
+0DE0..0DE5    ; disallowed                             # NA   <reserved-0DE0>..<reserved-0DE5>
+0DE6..0DEF    ; valid                                  # 7.0  SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
+0DF0..0DF1    ; disallowed                             # NA   <reserved-0DF0>..<reserved-0DF1>
+0DF2..0DF3    ; valid                                  # 3.0  SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
+0DF4          ; valid                  ;      ; NV8    # 3.0  SINHALA PUNCTUATION KUNDDALIYA
+0DF5..0E00    ; disallowed                             # NA   <reserved-0DF5>..<reserved-0E00>
+0E01..0E32    ; valid                                  # 1.1  THAI CHARACTER KO KAI..THAI CHARACTER SARA AA
+0E33          ; mapped                 ; 0E4D 0E32     # 1.1  THAI CHARACTER SARA AM
+0E34..0E3A    ; valid                                  # 1.1  THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
+0E3B..0E3E    ; disallowed                             # NA   <reserved-0E3B>..<reserved-0E3E>
+0E3F          ; valid                  ;      ; NV8    # 1.1  THAI CURRENCY SYMBOL BAHT
+0E40..0E4E    ; valid                                  # 1.1  THAI CHARACTER SARA E..THAI CHARACTER YAMAKKAN
+0E4F          ; valid                  ;      ; NV8    # 1.1  THAI CHARACTER FONGMAN
+0E50..0E59    ; valid                                  # 1.1  THAI DIGIT ZERO..THAI DIGIT NINE
+0E5A..0E5B    ; valid                  ;      ; NV8    # 1.1  THAI CHARACTER ANGKHANKHU..THAI CHARACTER KHOMUT
+0E5C..0E80    ; disallowed                             # NA   <reserved-0E5C>..<reserved-0E80>
+0E81..0E82    ; valid                                  # 1.1  LAO LETTER KO..LAO LETTER KHO SUNG
+0E83          ; disallowed                             # NA   <reserved-0E83>
+0E84          ; valid                                  # 1.1  LAO LETTER KHO TAM
+0E85          ; disallowed                             # NA   <reserved-0E85>
+0E86          ; valid                                  # 12.0 LAO LETTER PALI GHA
+0E87..0E88    ; valid                                  # 1.1  LAO LETTER NGO..LAO LETTER CO
+0E89          ; valid                                  # 12.0 LAO LETTER PALI CHA
+0E8A          ; valid                                  # 1.1  LAO LETTER SO TAM
+0E8B          ; disallowed                             # NA   <reserved-0E8B>
+0E8C          ; valid                                  # 12.0 LAO LETTER PALI JHA
+0E8D          ; valid                                  # 1.1  LAO LETTER NYO
+0E8E..0E93    ; valid                                  # 12.0 LAO LETTER PALI NYA..LAO LETTER PALI NNA
+0E94..0E97    ; valid                                  # 1.1  LAO LETTER DO..LAO LETTER THO TAM
+0E98          ; valid                                  # 12.0 LAO LETTER PALI DHA
+0E99..0E9F    ; valid                                  # 1.1  LAO LETTER NO..LAO LETTER FO SUNG
+0EA0          ; valid                                  # 12.0 LAO LETTER PALI BHA
+0EA1..0EA3    ; valid                                  # 1.1  LAO LETTER MO..LAO LETTER LO LING
+0EA4          ; disallowed                             # NA   <reserved-0EA4>
+0EA5          ; valid                                  # 1.1  LAO LETTER LO LOOT
+0EA6          ; disallowed                             # NA   <reserved-0EA6>
+0EA7          ; valid                                  # 1.1  LAO LETTER WO
+0EA8..0EA9    ; valid                                  # 12.0 LAO LETTER SANSKRIT SHA..LAO LETTER SANSKRIT SSA
+0EAA..0EAB    ; valid                                  # 1.1  LAO LETTER SO SUNG..LAO LETTER HO SUNG
+0EAC          ; valid                                  # 12.0 LAO LETTER PALI LLA
+0EAD..0EB2    ; valid                                  # 1.1  LAO LETTER O..LAO VOWEL SIGN AA
+0EB3          ; mapped                 ; 0ECD 0EB2     # 1.1  LAO VOWEL SIGN AM
+0EB4..0EB9    ; valid                                  # 1.1  LAO VOWEL SIGN I..LAO VOWEL SIGN UU
+0EBA          ; valid                                  # 12.0 LAO SIGN PALI VIRAMA
+0EBB..0EBD    ; valid                                  # 1.1  LAO VOWEL SIGN MAI KON..LAO SEMIVOWEL SIGN NYO
+0EBE..0EBF    ; disallowed                             # NA   <reserved-0EBE>..<reserved-0EBF>
+0EC0..0EC4    ; valid                                  # 1.1  LAO VOWEL SIGN E..LAO VOWEL SIGN AI
+0EC5          ; disallowed                             # NA   <reserved-0EC5>
+0EC6          ; valid                                  # 1.1  LAO KO LA
+0EC7          ; disallowed                             # NA   <reserved-0EC7>
+0EC8..0ECD    ; valid                                  # 1.1  LAO TONE MAI EK..LAO NIGGAHITA
+0ECE          ; valid                                  # 15.0 LAO YAMAKKAN
+0ECF          ; disallowed                             # NA   <reserved-0ECF>
+0ED0..0ED9    ; valid                                  # 1.1  LAO DIGIT ZERO..LAO DIGIT NINE
+0EDA..0EDB    ; disallowed                             # NA   <reserved-0EDA>..<reserved-0EDB>
+0EDC          ; mapped                 ; 0EAB 0E99     # 1.1  LAO HO NO
+0EDD          ; mapped                 ; 0EAB 0EA1     # 1.1  LAO HO MO
+0EDE..0EDF    ; valid                                  # 6.1  LAO LETTER KHMU GO..LAO LETTER KHMU NYO
+0EE0..0EFF    ; disallowed                             # NA   <reserved-0EE0>..<reserved-0EFF>
+0F00          ; valid                                  # 2.0  TIBETAN SYLLABLE OM
+0F01..0F0A    ; valid                  ;      ; NV8    # 2.0  TIBETAN MARK GTER YIG MGO TRUNCATED A..TIBETAN MARK BKA- SHOG YIG MGO
+0F0B          ; valid                                  # 2.0  TIBETAN MARK INTERSYLLABIC TSHEG
+0F0C          ; mapped                 ; 0F0B          # 2.0  TIBETAN MARK DELIMITER TSHEG BSTAR
+0F0D..0F17    ; valid                  ;      ; NV8    # 2.0  TIBETAN MARK SHAD..TIBETAN ASTROLOGICAL SIGN SGRA GCAN -CHAR RTAGS
+0F18..0F19    ; valid                                  # 2.0  TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
+0F1A..0F1F    ; valid                  ;      ; NV8    # 2.0  TIBETAN SIGN RDEL DKAR GCIG..TIBETAN SIGN RDEL DKAR RDEL NAG
+0F20..0F29    ; valid                                  # 2.0  TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
+0F2A..0F34    ; valid                  ;      ; NV8    # 2.0  TIBETAN DIGIT HALF ONE..TIBETAN MARK BSDUS RTAGS
+0F35          ; valid                                  # 2.0  TIBETAN MARK NGAS BZUNG NYI ZLA
+0F36          ; valid                  ;      ; NV8    # 2.0  TIBETAN MARK CARET -DZUD RTAGS BZHI MIG CAN
+0F37          ; valid                                  # 2.0  TIBETAN MARK NGAS BZUNG SGOR RTAGS
+0F38          ; valid                  ;      ; NV8    # 2.0  TIBETAN MARK CHE MGO
+0F39          ; valid                                  # 2.0  TIBETAN MARK TSA -PHRU
+0F3A..0F3D    ; valid                  ;      ; NV8    # 2.0  TIBETAN MARK GUG RTAGS GYON..TIBETAN MARK ANG KHANG GYAS
+0F3E..0F42    ; valid                                  # 2.0  TIBETAN SIGN YAR TSHES..TIBETAN LETTER GA
+0F43          ; mapped                 ; 0F42 0FB7     # 2.0  TIBETAN LETTER GHA
+0F44..0F47    ; valid                                  # 2.0  TIBETAN LETTER NGA..TIBETAN LETTER JA
+0F48          ; disallowed                             # NA   <reserved-0F48>
+0F49..0F4C    ; valid                                  # 2.0  TIBETAN LETTER NYA..TIBETAN LETTER DDA
+0F4D          ; mapped                 ; 0F4C 0FB7     # 2.0  TIBETAN LETTER DDHA
+0F4E..0F51    ; valid                                  # 2.0  TIBETAN LETTER NNA..TIBETAN LETTER DA
+0F52          ; mapped                 ; 0F51 0FB7     # 2.0  TIBETAN LETTER DHA
+0F53..0F56    ; valid                                  # 2.0  TIBETAN LETTER NA..TIBETAN LETTER BA
+0F57          ; mapped                 ; 0F56 0FB7     # 2.0  TIBETAN LETTER BHA
+0F58..0F5B    ; valid                                  # 2.0  TIBETAN LETTER MA..TIBETAN LETTER DZA
+0F5C          ; mapped                 ; 0F5B 0FB7     # 2.0  TIBETAN LETTER DZHA
+0F5D..0F68    ; valid                                  # 2.0  TIBETAN LETTER WA..TIBETAN LETTER A
+0F69          ; mapped                 ; 0F40 0FB5     # 2.0  TIBETAN LETTER KSSA
+0F6A          ; valid                                  # 3.0  TIBETAN LETTER FIXED-FORM RA
+0F6B..0F6C    ; valid                                  # 5.1  TIBETAN LETTER KKA..TIBETAN LETTER RRA
+0F6D..0F70    ; disallowed                             # NA   <reserved-0F6D>..<reserved-0F70>
+0F71..0F72    ; valid                                  # 2.0  TIBETAN VOWEL SIGN AA..TIBETAN VOWEL SIGN I
+0F73          ; mapped                 ; 0F71 0F72     # 2.0  TIBETAN VOWEL SIGN II
+0F74          ; valid                                  # 2.0  TIBETAN VOWEL SIGN U
+0F75          ; mapped                 ; 0F71 0F74     # 2.0  TIBETAN VOWEL SIGN UU
+0F76          ; mapped                 ; 0FB2 0F80     # 2.0  TIBETAN VOWEL SIGN VOCALIC R
+0F77          ; mapped                 ; 0FB2 0F71 0F80 #2.0  TIBETAN VOWEL SIGN VOCALIC RR
+0F78          ; mapped                 ; 0FB3 0F80     # 2.0  TIBETAN VOWEL SIGN VOCALIC L
+0F79          ; mapped                 ; 0FB3 0F71 0F80 #2.0  TIBETAN VOWEL SIGN VOCALIC LL
+0F7A..0F80    ; valid                                  # 2.0  TIBETAN VOWEL SIGN E..TIBETAN VOWEL SIGN REVERSED I
+0F81          ; mapped                 ; 0F71 0F80     # 2.0  TIBETAN VOWEL SIGN REVERSED II
+0F82..0F84    ; valid                                  # 2.0  TIBETAN SIGN NYI ZLA NAA DA..TIBETAN MARK HALANTA
+0F85          ; valid                  ;      ; NV8    # 2.0  TIBETAN MARK PALUTA
+0F86..0F8B    ; valid                                  # 2.0  TIBETAN SIGN LCI RTAGS..TIBETAN SIGN GRU MED RGYINGS
+0F8C..0F8F    ; valid                                  # 6.0  TIBETAN SIGN INVERTED MCHU CAN..TIBETAN SUBJOINED SIGN INVERTED MCHU CAN
+0F90..0F92    ; valid                                  # 2.0  TIBETAN SUBJOINED LETTER KA..TIBETAN SUBJOINED LETTER GA
+0F93          ; mapped                 ; 0F92 0FB7     # 2.0  TIBETAN SUBJOINED LETTER GHA
+0F94..0F95    ; valid                                  # 2.0  TIBETAN SUBJOINED LETTER NGA..TIBETAN SUBJOINED LETTER CA
+0F96          ; valid                                  # 3.0  TIBETAN SUBJOINED LETTER CHA
+0F97          ; valid                                  # 2.0  TIBETAN SUBJOINED LETTER JA
+0F98          ; disallowed                             # NA   <reserved-0F98>
+0F99..0F9C    ; valid                                  # 2.0  TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER DDA
+0F9D          ; mapped                 ; 0F9C 0FB7     # 2.0  TIBETAN SUBJOINED LETTER DDHA
+0F9E..0FA1    ; valid                                  # 2.0  TIBETAN SUBJOINED LETTER NNA..TIBETAN SUBJOINED LETTER DA
+0FA2          ; mapped                 ; 0FA1 0FB7     # 2.0  TIBETAN SUBJOINED LETTER DHA
+0FA3..0FA6    ; valid                                  # 2.0  TIBETAN SUBJOINED LETTER NA..TIBETAN SUBJOINED LETTER BA
+0FA7          ; mapped                 ; 0FA6 0FB7     # 2.0  TIBETAN SUBJOINED LETTER BHA
+0FA8..0FAB    ; valid                                  # 2.0  TIBETAN SUBJOINED LETTER MA..TIBETAN SUBJOINED LETTER DZA
+0FAC          ; mapped                 ; 0FAB 0FB7     # 2.0  TIBETAN SUBJOINED LETTER DZHA
+0FAD          ; valid                                  # 2.0  TIBETAN SUBJOINED LETTER WA
+0FAE..0FB0    ; valid                                  # 3.0  TIBETAN SUBJOINED LETTER ZHA..TIBETAN SUBJOINED LETTER -A
+0FB1..0FB7    ; valid                                  # 2.0  TIBETAN SUBJOINED LETTER YA..TIBETAN SUBJOINED LETTER HA
+0FB8          ; valid                                  # 3.0  TIBETAN SUBJOINED LETTER A
+0FB9          ; mapped                 ; 0F90 0FB5     # 2.0  TIBETAN SUBJOINED LETTER KSSA
+0FBA..0FBC    ; valid                                  # 3.0  TIBETAN SUBJOINED LETTER FIXED-FORM WA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
+0FBD          ; disallowed                             # NA   <reserved-0FBD>
+0FBE..0FC5    ; valid                  ;      ; NV8    # 3.0  TIBETAN KU RU KHA..TIBETAN SYMBOL RDO RJE
+0FC6          ; valid                                  # 3.0  TIBETAN SYMBOL PADMA GDAN
+0FC7..0FCC    ; valid                  ;      ; NV8    # 3.0  TIBETAN SYMBOL RDO RJE RGYA GRAM..TIBETAN SYMBOL NOR BU BZHI -KHYIL
+0FCD          ; disallowed                             # NA   <reserved-0FCD>
+0FCE          ; valid                  ;      ; NV8    # 5.1  TIBETAN SIGN RDEL NAG RDEL DKAR
+0FCF          ; valid                  ;      ; NV8    # 3.0  TIBETAN SIGN RDEL NAG GSUM
+0FD0..0FD1    ; valid                  ;      ; NV8    # 4.1  TIBETAN MARK BSKA- SHOG GI MGO RGYAN..TIBETAN MARK MNYAM YIG GI MGO RGYAN
+0FD2..0FD4    ; valid                  ;      ; NV8    # 5.1  TIBETAN MARK NYIS TSHEG..TIBETAN MARK CLOSING BRDA RNYING YIG MGO SGAB MA
+0FD5..0FD8    ; valid                  ;      ; NV8    # 5.2  RIGHT-FACING SVASTI SIGN..LEFT-FACING SVASTI SIGN WITH DOTS
+0FD9..0FDA    ; valid                  ;      ; NV8    # 6.0  TIBETAN MARK LEADING MCHAN RTAGS..TIBETAN MARK TRAILING MCHAN RTAGS
+0FDB..0FFF    ; disallowed                             # NA   <reserved-0FDB>..<reserved-0FFF>
+1000..1021    ; valid                                  # 3.0  MYANMAR LETTER KA..MYANMAR LETTER A
+1022          ; valid                                  # 5.1  MYANMAR LETTER SHAN A
+1023..1027    ; valid                                  # 3.0  MYANMAR LETTER I..MYANMAR LETTER E
+1028          ; valid                                  # 5.1  MYANMAR LETTER MON E
+1029..102A    ; valid                                  # 3.0  MYANMAR LETTER O..MYANMAR LETTER AU
+102B          ; valid                                  # 5.1  MYANMAR VOWEL SIGN TALL AA
+102C..1032    ; valid                                  # 3.0  MYANMAR VOWEL SIGN AA..MYANMAR VOWEL SIGN AI
+1033..1035    ; valid                                  # 5.1  MYANMAR VOWEL SIGN MON II..MYANMAR VOWEL SIGN E ABOVE
+1036..1039    ; valid                                  # 3.0  MYANMAR SIGN ANUSVARA..MYANMAR SIGN VIRAMA
+103A..103F    ; valid                                  # 5.1  MYANMAR SIGN ASAT..MYANMAR LETTER GREAT SA
+1040..1049    ; valid                                  # 3.0  MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
+104A..104F    ; valid                  ;      ; NV8    # 3.0  MYANMAR SIGN LITTLE SECTION..MYANMAR SYMBOL GENITIVE
+1050..1059    ; valid                                  # 3.0  MYANMAR LETTER SHA..MYANMAR VOWEL SIGN VOCALIC LL
+105A..1099    ; valid                                  # 5.1  MYANMAR LETTER MON NGA..MYANMAR SHAN DIGIT NINE
+109A..109D    ; valid                                  # 5.2  MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON AI
+109E..109F    ; valid                  ;      ; NV8    # 5.1  MYANMAR SYMBOL SHAN ONE..MYANMAR SYMBOL SHAN EXCLAMATION
+10A0..10C5    ; disallowed                             # 1.1  GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
+10C6          ; disallowed                             # NA   <reserved-10C6>
+10C7          ; mapped                 ; 2D27          # 6.1  GEORGIAN CAPITAL LETTER YN
+10C8..10CC    ; disallowed                             # NA   <reserved-10C8>..<reserved-10CC>
+10CD          ; mapped                 ; 2D2D          # 6.1  GEORGIAN CAPITAL LETTER AEN
+10CE..10CF    ; disallowed                             # NA   <reserved-10CE>..<reserved-10CF>
+10D0..10F6    ; valid                                  # 1.1  GEORGIAN LETTER AN..GEORGIAN LETTER FI
+10F7..10F8    ; valid                                  # 3.2  GEORGIAN LETTER YN..GEORGIAN LETTER ELIFI
+10F9..10FA    ; valid                                  # 4.1  GEORGIAN LETTER TURNED GAN..GEORGIAN LETTER AIN
+10FB          ; valid                  ;      ; NV8    # 1.1  GEORGIAN PARAGRAPH SEPARATOR
+10FC          ; mapped                 ; 10DC          # 4.1  MODIFIER LETTER GEORGIAN NAR
+10FD..10FF    ; valid                                  # 6.1  GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
+1100..1159    ; valid                  ;      ; NV8    # 1.1  HANGUL CHOSEONG KIYEOK..HANGUL CHOSEONG YEORINHIEUH
+115A..115E    ; valid                  ;      ; NV8    # 5.2  HANGUL CHOSEONG KIYEOK-TIKEUT..HANGUL CHOSEONG TIKEUT-RIEUL
+115F..1160    ; disallowed                             # 1.1  HANGUL CHOSEONG FILLER..HANGUL JUNGSEONG FILLER
+1161..11A2    ; valid                  ;      ; NV8    # 1.1  HANGUL JUNGSEONG A..HANGUL JUNGSEONG SSANGARAEA
+11A3..11A7    ; valid                  ;      ; NV8    # 5.2  HANGUL JUNGSEONG A-EU..HANGUL JUNGSEONG O-YAE
+11A8..11F9    ; valid                  ;      ; NV8    # 1.1  HANGUL JONGSEONG KIYEOK..HANGUL JONGSEONG YEORINHIEUH
+11FA..11FF    ; valid                  ;      ; NV8    # 5.2  HANGUL JONGSEONG KIYEOK-NIEUN..HANGUL JONGSEONG SSANGNIEUN
+1200..1206    ; valid                                  # 3.0  ETHIOPIC SYLLABLE HA..ETHIOPIC SYLLABLE HO
+1207          ; valid                                  # 4.1  ETHIOPIC SYLLABLE HOA
+1208..1246    ; valid                                  # 3.0  ETHIOPIC SYLLABLE LA..ETHIOPIC SYLLABLE QO
+1247          ; valid                                  # 4.1  ETHIOPIC SYLLABLE QOA
+1248          ; valid                                  # 3.0  ETHIOPIC SYLLABLE QWA
+1249          ; disallowed                             # NA   <reserved-1249>
+124A..124D    ; valid                                  # 3.0  ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
+124E..124F    ; disallowed                             # NA   <reserved-124E>..<reserved-124F>
+1250..1256    ; valid                                  # 3.0  ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
+1257          ; disallowed                             # NA   <reserved-1257>
+1258          ; valid                                  # 3.0  ETHIOPIC SYLLABLE QHWA
+1259          ; disallowed                             # NA   <reserved-1259>
+125A..125D    ; valid                                  # 3.0  ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
+125E..125F    ; disallowed                             # NA   <reserved-125E>..<reserved-125F>
+1260..1286    ; valid                                  # 3.0  ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XO
+1287          ; valid                                  # 4.1  ETHIOPIC SYLLABLE XOA
+1288          ; valid                                  # 3.0  ETHIOPIC SYLLABLE XWA
+1289          ; disallowed                             # NA   <reserved-1289>
+128A..128D    ; valid                                  # 3.0  ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
+128E..128F    ; disallowed                             # NA   <reserved-128E>..<reserved-128F>
+1290..12AE    ; valid                                  # 3.0  ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KO
+12AF          ; valid                                  # 4.1  ETHIOPIC SYLLABLE KOA
+12B0          ; valid                                  # 3.0  ETHIOPIC SYLLABLE KWA
+12B1          ; disallowed                             # NA   <reserved-12B1>
+12B2..12B5    ; valid                                  # 3.0  ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
+12B6..12B7    ; disallowed                             # NA   <reserved-12B6>..<reserved-12B7>
+12B8..12BE    ; valid                                  # 3.0  ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
+12BF          ; disallowed                             # NA   <reserved-12BF>
+12C0          ; valid                                  # 3.0  ETHIOPIC SYLLABLE KXWA
+12C1          ; disallowed                             # NA   <reserved-12C1>
+12C2..12C5    ; valid                                  # 3.0  ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
+12C6..12C7    ; disallowed                             # NA   <reserved-12C6>..<reserved-12C7>
+12C8..12CE    ; valid                                  # 3.0  ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE WO
+12CF          ; valid                                  # 4.1  ETHIOPIC SYLLABLE WOA
+12D0..12D6    ; valid                                  # 3.0  ETHIOPIC SYLLABLE PHARYNGEAL A..ETHIOPIC SYLLABLE PHARYNGEAL O
+12D7          ; disallowed                             # NA   <reserved-12D7>
+12D8..12EE    ; valid                                  # 3.0  ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE YO
+12EF          ; valid                                  # 4.1  ETHIOPIC SYLLABLE YOA
+12F0..130E    ; valid                                  # 3.0  ETHIOPIC SYLLABLE DA..ETHIOPIC SYLLABLE GO
+130F          ; valid                                  # 4.1  ETHIOPIC SYLLABLE GOA
+1310          ; valid                                  # 3.0  ETHIOPIC SYLLABLE GWA
+1311          ; disallowed                             # NA   <reserved-1311>
+1312..1315    ; valid                                  # 3.0  ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
+1316..1317    ; disallowed                             # NA   <reserved-1316>..<reserved-1317>
+1318..131E    ; valid                                  # 3.0  ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE GGO
+131F          ; valid                                  # 4.1  ETHIOPIC SYLLABLE GGWAA
+1320..1346    ; valid                                  # 3.0  ETHIOPIC SYLLABLE THA..ETHIOPIC SYLLABLE TZO
+1347          ; valid                                  # 4.1  ETHIOPIC SYLLABLE TZOA
+1348..135A    ; valid                                  # 3.0  ETHIOPIC SYLLABLE FA..ETHIOPIC SYLLABLE FYA
+135B..135C    ; disallowed                             # NA   <reserved-135B>..<reserved-135C>
+135D..135E    ; valid                                  # 6.0  ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING VOWEL LENGTH MARK
+135F          ; valid                                  # 4.1  ETHIOPIC COMBINING GEMINATION MARK
+1360          ; valid                  ;      ; NV8    # 4.1  ETHIOPIC SECTION MARK
+1361..137C    ; valid                  ;      ; NV8    # 3.0  ETHIOPIC WORDSPACE..ETHIOPIC NUMBER TEN THOUSAND
+137D..137F    ; disallowed                             # NA   <reserved-137D>..<reserved-137F>
+1380..138F    ; valid                                  # 4.1  ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
+1390..1399    ; valid                  ;      ; NV8    # 4.1  ETHIOPIC TONAL MARK YIZET..ETHIOPIC TONAL MARK KURT
+139A..139F    ; disallowed                             # NA   <reserved-139A>..<reserved-139F>
+13A0..13F4    ; valid                                  # 3.0  CHEROKEE LETTER A..CHEROKEE LETTER YV
+13F5          ; valid                                  # 8.0  CHEROKEE LETTER MV
+13F6..13F7    ; disallowed                             # NA   <reserved-13F6>..<reserved-13F7>
+13F8          ; mapped                 ; 13F0          # 8.0  CHEROKEE SMALL LETTER YE
+13F9          ; mapped                 ; 13F1          # 8.0  CHEROKEE SMALL LETTER YI
+13FA          ; mapped                 ; 13F2          # 8.0  CHEROKEE SMALL LETTER YO
+13FB          ; mapped                 ; 13F3          # 8.0  CHEROKEE SMALL LETTER YU
+13FC          ; mapped                 ; 13F4          # 8.0  CHEROKEE SMALL LETTER YV
+13FD          ; mapped                 ; 13F5          # 8.0  CHEROKEE SMALL LETTER MV
+13FE..13FF    ; disallowed                             # NA   <reserved-13FE>..<reserved-13FF>
+1400          ; valid                  ;      ; NV8    # 5.2  CANADIAN SYLLABICS HYPHEN
+1401..166C    ; valid                                  # 3.0  CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
+166D..166E    ; valid                  ;      ; NV8    # 3.0  CANADIAN SYLLABICS CHI SIGN..CANADIAN SYLLABICS FULL STOP
+166F..1676    ; valid                                  # 3.0  CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS NNGAA
+1677..167F    ; valid                                  # 5.2  CANADIAN SYLLABICS WOODS-CREE THWEE..CANADIAN SYLLABICS BLACKFOOT W
+1680          ; disallowed                             # 3.0  OGHAM SPACE MARK
+1681..169A    ; valid                                  # 3.0  OGHAM LETTER BEITH..OGHAM LETTER PEITH
+169B..169C    ; valid                  ;      ; NV8    # 3.0  OGHAM FEATHER MARK..OGHAM REVERSED FEATHER MARK
+169D..169F    ; disallowed                             # NA   <reserved-169D>..<reserved-169F>
+16A0..16EA    ; valid                                  # 3.0  RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
+16EB..16F0    ; valid                  ;      ; NV8    # 3.0  RUNIC SINGLE PUNCTUATION..RUNIC BELGTHOR SYMBOL
+16F1..16F8    ; valid                                  # 7.0  RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
+16F9..16FF    ; disallowed                             # NA   <reserved-16F9>..<reserved-16FF>
+1700..170C    ; valid                                  # 3.2  TAGALOG LETTER A..TAGALOG LETTER YA
+170D          ; valid                                  # 14.0 TAGALOG LETTER RA
+170E..1714    ; valid                                  # 3.2  TAGALOG LETTER LA..TAGALOG SIGN VIRAMA
+1715          ; valid                                  # 14.0 TAGALOG SIGN PAMUDPOD
+1716..171E    ; disallowed                             # NA   <reserved-1716>..<reserved-171E>
+171F          ; valid                                  # 14.0 TAGALOG LETTER ARCHAIC RA
+1720..1734    ; valid                                  # 3.2  HANUNOO LETTER A..HANUNOO SIGN PAMUDPOD
+1735..1736    ; valid                  ;      ; NV8    # 3.2  PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
+1737..173F    ; disallowed                             # NA   <reserved-1737>..<reserved-173F>
+1740..1753    ; valid                                  # 3.2  BUHID LETTER A..BUHID VOWEL SIGN U
+1754..175F    ; disallowed                             # NA   <reserved-1754>..<reserved-175F>
+1760..176C    ; valid                                  # 3.2  TAGBANWA LETTER A..TAGBANWA LETTER YA
+176D          ; disallowed                             # NA   <reserved-176D>
+176E..1770    ; valid                                  # 3.2  TAGBANWA LETTER LA..TAGBANWA LETTER SA
+1771          ; disallowed                             # NA   <reserved-1771>
+1772..1773    ; valid                                  # 3.2  TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
+1774..177F    ; disallowed                             # NA   <reserved-1774>..<reserved-177F>
+1780..17B3    ; valid                                  # 3.0  KHMER LETTER KA..KHMER INDEPENDENT VOWEL QAU
+17B4..17B5    ; disallowed                             # 3.0  KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
+17B6..17D3    ; valid                                  # 3.0  KHMER VOWEL SIGN AA..KHMER SIGN BATHAMASAT
+17D4..17D6    ; valid                  ;      ; NV8    # 3.0  KHMER SIGN KHAN..KHMER SIGN CAMNUC PII KUUH
+17D7          ; valid                                  # 3.0  KHMER SIGN LEK TOO
+17D8..17DB    ; valid                  ;      ; NV8    # 3.0  KHMER SIGN BEYYAL..KHMER CURRENCY SYMBOL RIEL
+17DC          ; valid                                  # 3.0  KHMER SIGN AVAKRAHASANYA
+17DD          ; valid                                  # 4.0  KHMER SIGN ATTHACAN
+17DE..17DF    ; disallowed                             # NA   <reserved-17DE>..<reserved-17DF>
+17E0..17E9    ; valid                                  # 3.0  KHMER DIGIT ZERO..KHMER DIGIT NINE
+17EA..17EF    ; disallowed                             # NA   <reserved-17EA>..<reserved-17EF>
+17F0..17F9    ; valid                  ;      ; NV8    # 4.0  KHMER SYMBOL LEK ATTAK SON..KHMER SYMBOL LEK ATTAK PRAM-BUON
+17FA..17FF    ; disallowed                             # NA   <reserved-17FA>..<reserved-17FF>
+1800..1805    ; valid                  ;      ; NV8    # 3.0  MONGOLIAN BIRGA..MONGOLIAN FOUR DOTS
+1806          ; disallowed                             # 3.0  MONGOLIAN TODO SOFT HYPHEN
+1807..180A    ; valid                  ;      ; NV8    # 3.0  MONGOLIAN SIBE SYLLABLE BOUNDARY MARKER..MONGOLIAN NIRUGU
+180B..180D    ; ignored                                # 3.0  MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
+180E          ; disallowed                             # 3.0  MONGOLIAN VOWEL SEPARATOR
+180F          ; ignored                                # 14.0 MONGOLIAN FREE VARIATION SELECTOR FOUR
+1810..1819    ; valid                                  # 3.0  MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
+181A..181F    ; disallowed                             # NA   <reserved-181A>..<reserved-181F>
+1820..1877    ; valid                                  # 3.0  MONGOLIAN LETTER A..MONGOLIAN LETTER MANCHU ZHA
+1878          ; valid                                  # 11.0 MONGOLIAN LETTER CHA WITH TWO DOTS
+1879..187F    ; disallowed                             # NA   <reserved-1879>..<reserved-187F>
+1880..18A9    ; valid                                  # 3.0  MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER ALI GALI DAGALGA
+18AA          ; valid                                  # 5.1  MONGOLIAN LETTER MANCHU ALI GALI LHA
+18AB..18AF    ; disallowed                             # NA   <reserved-18AB>..<reserved-18AF>
+18B0..18F5    ; valid                                  # 5.2  CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
+18F6..18FF    ; disallowed                             # NA   <reserved-18F6>..<reserved-18FF>
+1900..191C    ; valid                                  # 4.0  LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER HA
+191D..191E    ; valid                                  # 7.0  LIMBU LETTER GYAN..LIMBU LETTER TRA
+191F          ; disallowed                             # NA   <reserved-191F>
+1920..192B    ; valid                                  # 4.0  LIMBU VOWEL SIGN A..LIMBU SUBJOINED LETTER WA
+192C..192F    ; disallowed                             # NA   <reserved-192C>..<reserved-192F>
+1930..193B    ; valid                                  # 4.0  LIMBU SMALL LETTER KA..LIMBU SIGN SA-I
+193C..193F    ; disallowed                             # NA   <reserved-193C>..<reserved-193F>
+1940          ; valid                  ;      ; NV8    # 4.0  LIMBU SIGN LOO
+1941..1943    ; disallowed                             # NA   <reserved-1941>..<reserved-1943>
+1944..1945    ; valid                  ;      ; NV8    # 4.0  LIMBU EXCLAMATION MARK..LIMBU QUESTION MARK
+1946..196D    ; valid                                  # 4.0  LIMBU DIGIT ZERO..TAI LE LETTER AI
+196E..196F    ; disallowed                             # NA   <reserved-196E>..<reserved-196F>
+1970..1974    ; valid                                  # 4.0  TAI LE LETTER TONE-2..TAI LE LETTER TONE-6
+1975..197F    ; disallowed                             # NA   <reserved-1975>..<reserved-197F>
+1980..19A9    ; valid                                  # 4.1  NEW TAI LUE LETTER HIGH QA..NEW TAI LUE LETTER LOW XVA
+19AA..19AB    ; valid                                  # 5.2  NEW TAI LUE LETTER HIGH SUA..NEW TAI LUE LETTER LOW SUA
+19AC..19AF    ; disallowed                             # NA   <reserved-19AC>..<reserved-19AF>
+19B0..19C9    ; valid                                  # 4.1  NEW TAI LUE VOWEL SIGN VOWEL SHORTENER..NEW TAI LUE TONE MARK-2
+19CA..19CF    ; disallowed                             # NA   <reserved-19CA>..<reserved-19CF>
+19D0..19D9    ; valid                                  # 4.1  NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
+19DA          ; valid                  ;      ; XV8    # 5.2  NEW TAI LUE THAM DIGIT ONE
+19DB..19DD    ; disallowed                             # NA   <reserved-19DB>..<reserved-19DD>
+19DE..19DF    ; valid                  ;      ; NV8    # 4.1  NEW TAI LUE SIGN LAE..NEW TAI LUE SIGN LAEV
+19E0..19FF    ; valid                  ;      ; NV8    # 4.0  KHMER SYMBOL PATHAMASAT..KHMER SYMBOL DAP-PRAM ROC
+1A00..1A1B    ; valid                                  # 4.1  BUGINESE LETTER KA..BUGINESE VOWEL SIGN AE
+1A1C..1A1D    ; disallowed                             # NA   <reserved-1A1C>..<reserved-1A1D>
+1A1E..1A1F    ; valid                  ;      ; NV8    # 4.1  BUGINESE PALLAWA..BUGINESE END OF SECTION
+1A20..1A5E    ; valid                                  # 5.2  TAI THAM LETTER HIGH KA..TAI THAM CONSONANT SIGN SA
+1A5F          ; disallowed                             # NA   <reserved-1A5F>
+1A60..1A7C    ; valid                                  # 5.2  TAI THAM SIGN SAKOT..TAI THAM SIGN KHUEN-LUE KARAN
+1A7D..1A7E    ; disallowed                             # NA   <reserved-1A7D>..<reserved-1A7E>
+1A7F..1A89    ; valid                                  # 5.2  TAI THAM COMBINING CRYPTOGRAMMIC DOT..TAI THAM HORA DIGIT NINE
+1A8A..1A8F    ; disallowed                             # NA   <reserved-1A8A>..<reserved-1A8F>
+1A90..1A99    ; valid                                  # 5.2  TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
+1A9A..1A9F    ; disallowed                             # NA   <reserved-1A9A>..<reserved-1A9F>
+1AA0..1AA6    ; valid                  ;      ; NV8    # 5.2  TAI THAM SIGN WIANG..TAI THAM SIGN REVERSED ROTATED RANA
+1AA7          ; valid                                  # 5.2  TAI THAM SIGN MAI YAMOK
+1AA8..1AAD    ; valid                  ;      ; NV8    # 5.2  TAI THAM SIGN KAAN..TAI THAM SIGN CAANG
+1AAE..1AAF    ; disallowed                             # NA   <reserved-1AAE>..<reserved-1AAF>
+1AB0..1ABD    ; valid                                  # 7.0  COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
+1ABE          ; valid                  ;      ; NV8    # 7.0  COMBINING PARENTHESES OVERLAY
+1ABF..1AC0    ; valid                                  # 13.0 COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER TURNED W BELOW
+1AC1..1ACE    ; valid                                  # 14.0 COMBINING LEFT PARENTHESIS ABOVE LEFT..COMBINING LATIN SMALL LETTER INSULAR T
+1ACF..1AFF    ; disallowed                             # NA   <reserved-1ACF>..<reserved-1AFF>
+1B00..1B4B    ; valid                                  # 5.0  BALINESE SIGN ULU RICEM..BALINESE LETTER ASYURA SASAK
+1B4C          ; valid                                  # 14.0 BALINESE LETTER ARCHAIC JNYA
+1B4D..1B4F    ; disallowed                             # NA   <reserved-1B4D>..<reserved-1B4F>
+1B50..1B59    ; valid                                  # 5.0  BALINESE DIGIT ZERO..BALINESE DIGIT NINE
+1B5A..1B6A    ; valid                  ;      ; NV8    # 5.0  BALINESE PANTI..BALINESE MUSICAL SYMBOL DANG GEDE
+1B6B..1B73    ; valid                                  # 5.0  BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
+1B74..1B7C    ; valid                  ;      ; NV8    # 5.0  BALINESE MUSICAL SYMBOL RIGHT-HAND OPEN DUG..BALINESE MUSICAL SYMBOL LEFT-HAND OPEN PING
+1B7D..1B7E    ; valid                  ;      ; NV8    # 14.0 BALINESE PANTI LANTANG..BALINESE PAMADA LANTANG
+1B7F          ; disallowed                             # NA   <reserved-1B7F>
+1B80..1BAA    ; valid                                  # 5.1  SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PAMAAEH
+1BAB..1BAD    ; valid                                  # 6.1  SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
+1BAE..1BB9    ; valid                                  # 5.1  SUNDANESE LETTER KHA..SUNDANESE DIGIT NINE
+1BBA..1BBF    ; valid                                  # 6.1  SUNDANESE AVAGRAHA..SUNDANESE LETTER FINAL M
+1BC0..1BF3    ; valid                                  # 6.0  BATAK LETTER A..BATAK PANONGONAN
+1BF4..1BFB    ; disallowed                             # NA   <reserved-1BF4>..<reserved-1BFB>
+1BFC..1BFF    ; valid                  ;      ; NV8    # 6.0  BATAK SYMBOL BINDU NA METEK..BATAK SYMBOL BINDU PANGOLAT
+1C00..1C37    ; valid                                  # 5.1  LEPCHA LETTER KA..LEPCHA SIGN NUKTA
+1C38..1C3A    ; disallowed                             # NA   <reserved-1C38>..<reserved-1C3A>
+1C3B..1C3F    ; valid                  ;      ; NV8    # 5.1  LEPCHA PUNCTUATION TA-ROL..LEPCHA PUNCTUATION TSHOOK
+1C40..1C49    ; valid                                  # 5.1  LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
+1C4A..1C4C    ; disallowed                             # NA   <reserved-1C4A>..<reserved-1C4C>
+1C4D..1C7D    ; valid                                  # 5.1  LEPCHA LETTER TTA..OL CHIKI AHAD
+1C7E..1C7F    ; valid                  ;      ; NV8    # 5.1  OL CHIKI PUNCTUATION MUCAAD..OL CHIKI PUNCTUATION DOUBLE MUCAAD
+1C80          ; mapped                 ; 0432          # 9.0  CYRILLIC SMALL LETTER ROUNDED VE
+1C81          ; mapped                 ; 0434          # 9.0  CYRILLIC SMALL LETTER LONG-LEGGED DE
+1C82          ; mapped                 ; 043E          # 9.0  CYRILLIC SMALL LETTER NARROW O
+1C83          ; mapped                 ; 0441          # 9.0  CYRILLIC SMALL LETTER WIDE ES
+1C84..1C85    ; mapped                 ; 0442          # 9.0  CYRILLIC SMALL LETTER TALL TE..CYRILLIC SMALL LETTER THREE-LEGGED TE
+1C86          ; mapped                 ; 044A          # 9.0  CYRILLIC SMALL LETTER TALL HARD SIGN
+1C87          ; mapped                 ; 0463          # 9.0  CYRILLIC SMALL LETTER TALL YAT
+1C88          ; mapped                 ; A64B          # 9.0  CYRILLIC SMALL LETTER UNBLENDED UK
+1C89..1C8F    ; disallowed                             # NA   <reserved-1C89>..<reserved-1C8F>
+1C90          ; mapped                 ; 10D0          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER AN
+1C91          ; mapped                 ; 10D1          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER BAN
+1C92          ; mapped                 ; 10D2          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER GAN
+1C93          ; mapped                 ; 10D3          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER DON
+1C94          ; mapped                 ; 10D4          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER EN
+1C95          ; mapped                 ; 10D5          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER VIN
+1C96          ; mapped                 ; 10D6          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER ZEN
+1C97          ; mapped                 ; 10D7          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER TAN
+1C98          ; mapped                 ; 10D8          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER IN
+1C99          ; mapped                 ; 10D9          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER KAN
+1C9A          ; mapped                 ; 10DA          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER LAS
+1C9B          ; mapped                 ; 10DB          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER MAN
+1C9C          ; mapped                 ; 10DC          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER NAR
+1C9D          ; mapped                 ; 10DD          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER ON
+1C9E          ; mapped                 ; 10DE          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER PAR
+1C9F          ; mapped                 ; 10DF          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER ZHAR
+1CA0          ; mapped                 ; 10E0          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER RAE
+1CA1          ; mapped                 ; 10E1          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER SAN
+1CA2          ; mapped                 ; 10E2          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER TAR
+1CA3          ; mapped                 ; 10E3          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER UN
+1CA4          ; mapped                 ; 10E4          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER PHAR
+1CA5          ; mapped                 ; 10E5          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER KHAR
+1CA6          ; mapped                 ; 10E6          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER GHAN
+1CA7          ; mapped                 ; 10E7          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER QAR
+1CA8          ; mapped                 ; 10E8          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER SHIN
+1CA9          ; mapped                 ; 10E9          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER CHIN
+1CAA          ; mapped                 ; 10EA          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER CAN
+1CAB          ; mapped                 ; 10EB          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER JIL
+1CAC          ; mapped                 ; 10EC          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER CIL
+1CAD          ; mapped                 ; 10ED          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER CHAR
+1CAE          ; mapped                 ; 10EE          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER XAN
+1CAF          ; mapped                 ; 10EF          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER JHAN
+1CB0          ; mapped                 ; 10F0          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER HAE
+1CB1          ; mapped                 ; 10F1          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER HE
+1CB2          ; mapped                 ; 10F2          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER HIE
+1CB3          ; mapped                 ; 10F3          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER WE
+1CB4          ; mapped                 ; 10F4          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER HAR
+1CB5          ; mapped                 ; 10F5          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER HOE
+1CB6          ; mapped                 ; 10F6          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER FI
+1CB7          ; mapped                 ; 10F7          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER YN
+1CB8          ; mapped                 ; 10F8          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER ELIFI
+1CB9          ; mapped                 ; 10F9          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER TURNED GAN
+1CBA          ; mapped                 ; 10FA          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER AIN
+1CBB..1CBC    ; disallowed                             # NA   <reserved-1CBB>..<reserved-1CBC>
+1CBD          ; mapped                 ; 10FD          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER AEN
+1CBE          ; mapped                 ; 10FE          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER HARD SIGN
+1CBF          ; mapped                 ; 10FF          # 11.0 GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
+1CC0..1CC7    ; valid                  ;      ; NV8    # 6.1  SUNDANESE PUNCTUATION BINDU SURYA..SUNDANESE PUNCTUATION BINDU BA SATANGA
+1CC8..1CCF    ; disallowed                             # NA   <reserved-1CC8>..<reserved-1CCF>
+1CD0..1CD2    ; valid                                  # 5.2  VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
+1CD3          ; valid                  ;      ; NV8    # 5.2  VEDIC SIGN NIHSHVASA
+1CD4..1CF2    ; valid                                  # 5.2  VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC SIGN ARDHAVISARGA
+1CF3..1CF6    ; valid                                  # 6.1  VEDIC SIGN ROTATED ARDHAVISARGA..VEDIC SIGN UPADHMANIYA
+1CF7          ; valid                                  # 10.0 VEDIC SIGN ATIKRAMA
+1CF8..1CF9    ; valid                                  # 7.0  VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
+1CFA          ; valid                                  # 12.0 VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
+1CFB..1CFF    ; disallowed                             # NA   <reserved-1CFB>..<reserved-1CFF>
+1D00..1D2B    ; valid                                  # 4.0  LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
+1D2C          ; mapped                 ; 0061          # 4.0  MODIFIER LETTER CAPITAL A
+1D2D          ; mapped                 ; 00E6          # 4.0  MODIFIER LETTER CAPITAL AE
+1D2E          ; mapped                 ; 0062          # 4.0  MODIFIER LETTER CAPITAL B
+1D2F          ; valid                                  # 4.0  MODIFIER LETTER CAPITAL BARRED B
+1D30          ; mapped                 ; 0064          # 4.0  MODIFIER LETTER CAPITAL D
+1D31          ; mapped                 ; 0065          # 4.0  MODIFIER LETTER CAPITAL E
+1D32          ; mapped                 ; 01DD          # 4.0  MODIFIER LETTER CAPITAL REVERSED E
+1D33          ; mapped                 ; 0067          # 4.0  MODIFIER LETTER CAPITAL G
+1D34          ; mapped                 ; 0068          # 4.0  MODIFIER LETTER CAPITAL H
+1D35          ; mapped                 ; 0069          # 4.0  MODIFIER LETTER CAPITAL I
+1D36          ; mapped                 ; 006A          # 4.0  MODIFIER LETTER CAPITAL J
+1D37          ; mapped                 ; 006B          # 4.0  MODIFIER LETTER CAPITAL K
+1D38          ; mapped                 ; 006C          # 4.0  MODIFIER LETTER CAPITAL L
+1D39          ; mapped                 ; 006D          # 4.0  MODIFIER LETTER CAPITAL M
+1D3A          ; mapped                 ; 006E          # 4.0  MODIFIER LETTER CAPITAL N
+1D3B          ; valid                                  # 4.0  MODIFIER LETTER CAPITAL REVERSED N
+1D3C          ; mapped                 ; 006F          # 4.0  MODIFIER LETTER CAPITAL O
+1D3D          ; mapped                 ; 0223          # 4.0  MODIFIER LETTER CAPITAL OU
+1D3E          ; mapped                 ; 0070          # 4.0  MODIFIER LETTER CAPITAL P
+1D3F          ; mapped                 ; 0072          # 4.0  MODIFIER LETTER CAPITAL R
+1D40          ; mapped                 ; 0074          # 4.0  MODIFIER LETTER CAPITAL T
+1D41          ; mapped                 ; 0075          # 4.0  MODIFIER LETTER CAPITAL U
+1D42          ; mapped                 ; 0077          # 4.0  MODIFIER LETTER CAPITAL W
+1D43          ; mapped                 ; 0061          # 4.0  MODIFIER LETTER SMALL A
+1D44          ; mapped                 ; 0250          # 4.0  MODIFIER LETTER SMALL TURNED A
+1D45          ; mapped                 ; 0251          # 4.0  MODIFIER LETTER SMALL ALPHA
+1D46          ; mapped                 ; 1D02          # 4.0  MODIFIER LETTER SMALL TURNED AE
+1D47          ; mapped                 ; 0062          # 4.0  MODIFIER LETTER SMALL B
+1D48          ; mapped                 ; 0064          # 4.0  MODIFIER LETTER SMALL D
+1D49          ; mapped                 ; 0065          # 4.0  MODIFIER LETTER SMALL E
+1D4A          ; mapped                 ; 0259          # 4.0  MODIFIER LETTER SMALL SCHWA
+1D4B          ; mapped                 ; 025B          # 4.0  MODIFIER LETTER SMALL OPEN E
+1D4C          ; mapped                 ; 025C          # 4.0  MODIFIER LETTER SMALL TURNED OPEN E
+1D4D          ; mapped                 ; 0067          # 4.0  MODIFIER LETTER SMALL G
+1D4E          ; valid                                  # 4.0  MODIFIER LETTER SMALL TURNED I
+1D4F          ; mapped                 ; 006B          # 4.0  MODIFIER LETTER SMALL K
+1D50          ; mapped                 ; 006D          # 4.0  MODIFIER LETTER SMALL M
+1D51          ; mapped                 ; 014B          # 4.0  MODIFIER LETTER SMALL ENG
+1D52          ; mapped                 ; 006F          # 4.0  MODIFIER LETTER SMALL O
+1D53          ; mapped                 ; 0254          # 4.0  MODIFIER LETTER SMALL OPEN O
+1D54          ; mapped                 ; 1D16          # 4.0  MODIFIER LETTER SMALL TOP HALF O
+1D55          ; mapped                 ; 1D17          # 4.0  MODIFIER LETTER SMALL BOTTOM HALF O
+1D56          ; mapped                 ; 0070          # 4.0  MODIFIER LETTER SMALL P
+1D57          ; mapped                 ; 0074          # 4.0  MODIFIER LETTER SMALL T
+1D58          ; mapped                 ; 0075          # 4.0  MODIFIER LETTER SMALL U
+1D59          ; mapped                 ; 1D1D          # 4.0  MODIFIER LETTER SMALL SIDEWAYS U
+1D5A          ; mapped                 ; 026F          # 4.0  MODIFIER LETTER SMALL TURNED M
+1D5B          ; mapped                 ; 0076          # 4.0  MODIFIER LETTER SMALL V
+1D5C          ; mapped                 ; 1D25          # 4.0  MODIFIER LETTER SMALL AIN
+1D5D          ; mapped                 ; 03B2          # 4.0  MODIFIER LETTER SMALL BETA
+1D5E          ; mapped                 ; 03B3          # 4.0  MODIFIER LETTER SMALL GREEK GAMMA
+1D5F          ; mapped                 ; 03B4          # 4.0  MODIFIER LETTER SMALL DELTA
+1D60          ; mapped                 ; 03C6          # 4.0  MODIFIER LETTER SMALL GREEK PHI
+1D61          ; mapped                 ; 03C7          # 4.0  MODIFIER LETTER SMALL CHI
+1D62          ; mapped                 ; 0069          # 4.0  LATIN SUBSCRIPT SMALL LETTER I
+1D63          ; mapped                 ; 0072          # 4.0  LATIN SUBSCRIPT SMALL LETTER R
+1D64          ; mapped                 ; 0075          # 4.0  LATIN SUBSCRIPT SMALL LETTER U
+1D65          ; mapped                 ; 0076          # 4.0  LATIN SUBSCRIPT SMALL LETTER V
+1D66          ; mapped                 ; 03B2          # 4.0  GREEK SUBSCRIPT SMALL LETTER BETA
+1D67          ; mapped                 ; 03B3          # 4.0  GREEK SUBSCRIPT SMALL LETTER GAMMA
+1D68          ; mapped                 ; 03C1          # 4.0  GREEK SUBSCRIPT SMALL LETTER RHO
+1D69          ; mapped                 ; 03C6          # 4.0  GREEK SUBSCRIPT SMALL LETTER PHI
+1D6A          ; mapped                 ; 03C7          # 4.0  GREEK SUBSCRIPT SMALL LETTER CHI
+1D6B          ; valid                                  # 4.0  LATIN SMALL LETTER UE
+1D6C..1D77    ; valid                                  # 4.1  LATIN SMALL LETTER B WITH MIDDLE TILDE..LATIN SMALL LETTER TURNED G
+1D78          ; mapped                 ; 043D          # 4.1  MODIFIER LETTER CYRILLIC EN
+1D79..1D9A    ; valid                                  # 4.1  LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
+1D9B          ; mapped                 ; 0252          # 4.1  MODIFIER LETTER SMALL TURNED ALPHA
+1D9C          ; mapped                 ; 0063          # 4.1  MODIFIER LETTER SMALL C
+1D9D          ; mapped                 ; 0255          # 4.1  MODIFIER LETTER SMALL C WITH CURL
+1D9E          ; mapped                 ; 00F0          # 4.1  MODIFIER LETTER SMALL ETH
+1D9F          ; mapped                 ; 025C          # 4.1  MODIFIER LETTER SMALL REVERSED OPEN E
+1DA0          ; mapped                 ; 0066          # 4.1  MODIFIER LETTER SMALL F
+1DA1          ; mapped                 ; 025F          # 4.1  MODIFIER LETTER SMALL DOTLESS J WITH STROKE
+1DA2          ; mapped                 ; 0261          # 4.1  MODIFIER LETTER SMALL SCRIPT G
+1DA3          ; mapped                 ; 0265          # 4.1  MODIFIER LETTER SMALL TURNED H
+1DA4          ; mapped                 ; 0268          # 4.1  MODIFIER LETTER SMALL I WITH STROKE
+1DA5          ; mapped                 ; 0269          # 4.1  MODIFIER LETTER SMALL IOTA
+1DA6          ; mapped                 ; 026A          # 4.1  MODIFIER LETTER SMALL CAPITAL I
+1DA7          ; mapped                 ; 1D7B          # 4.1  MODIFIER LETTER SMALL CAPITAL I WITH STROKE
+1DA8          ; mapped                 ; 029D          # 4.1  MODIFIER LETTER SMALL J WITH CROSSED-TAIL
+1DA9          ; mapped                 ; 026D          # 4.1  MODIFIER LETTER SMALL L WITH RETROFLEX HOOK
+1DAA          ; mapped                 ; 1D85          # 4.1  MODIFIER LETTER SMALL L WITH PALATAL HOOK
+1DAB          ; mapped                 ; 029F          # 4.1  MODIFIER LETTER SMALL CAPITAL L
+1DAC          ; mapped                 ; 0271          # 4.1  MODIFIER LETTER SMALL M WITH HOOK
+1DAD          ; mapped                 ; 0270          # 4.1  MODIFIER LETTER SMALL TURNED M WITH LONG LEG
+1DAE          ; mapped                 ; 0272          # 4.1  MODIFIER LETTER SMALL N WITH LEFT HOOK
+1DAF          ; mapped                 ; 0273          # 4.1  MODIFIER LETTER SMALL N WITH RETROFLEX HOOK
+1DB0          ; mapped                 ; 0274          # 4.1  MODIFIER LETTER SMALL CAPITAL N
+1DB1          ; mapped                 ; 0275          # 4.1  MODIFIER LETTER SMALL BARRED O
+1DB2          ; mapped                 ; 0278          # 4.1  MODIFIER LETTER SMALL PHI
+1DB3          ; mapped                 ; 0282          # 4.1  MODIFIER LETTER SMALL S WITH HOOK
+1DB4          ; mapped                 ; 0283          # 4.1  MODIFIER LETTER SMALL ESH
+1DB5          ; mapped                 ; 01AB          # 4.1  MODIFIER LETTER SMALL T WITH PALATAL HOOK
+1DB6          ; mapped                 ; 0289          # 4.1  MODIFIER LETTER SMALL U BAR
+1DB7          ; mapped                 ; 028A          # 4.1  MODIFIER LETTER SMALL UPSILON
+1DB8          ; mapped                 ; 1D1C          # 4.1  MODIFIER LETTER SMALL CAPITAL U
+1DB9          ; mapped                 ; 028B          # 4.1  MODIFIER LETTER SMALL V WITH HOOK
+1DBA          ; mapped                 ; 028C          # 4.1  MODIFIER LETTER SMALL TURNED V
+1DBB          ; mapped                 ; 007A          # 4.1  MODIFIER LETTER SMALL Z
+1DBC          ; mapped                 ; 0290          # 4.1  MODIFIER LETTER SMALL Z WITH RETROFLEX HOOK
+1DBD          ; mapped                 ; 0291          # 4.1  MODIFIER LETTER SMALL Z WITH CURL
+1DBE          ; mapped                 ; 0292          # 4.1  MODIFIER LETTER SMALL EZH
+1DBF          ; mapped                 ; 03B8          # 4.1  MODIFIER LETTER SMALL THETA
+1DC0..1DC3    ; valid                                  # 4.1  COMBINING DOTTED GRAVE ACCENT..COMBINING SUSPENSION MARK
+1DC4..1DCA    ; valid                                  # 5.0  COMBINING MACRON-ACUTE..COMBINING LATIN SMALL LETTER R BELOW
+1DCB..1DE6    ; valid                                  # 5.1  COMBINING BREVE-MACRON..COMBINING LATIN SMALL LETTER Z
+1DE7..1DF5    ; valid                                  # 7.0  COMBINING LATIN SMALL LETTER ALPHA..COMBINING UP TACK ABOVE
+1DF6..1DF9    ; valid                                  # 10.0 COMBINING KAVYKA ABOVE RIGHT..COMBINING WIDE INVERTED BRIDGE BELOW
+1DFA          ; valid                                  # 14.0 COMBINING DOT BELOW LEFT
+1DFB          ; valid                                  # 9.0  COMBINING DELETION MARK
+1DFC          ; valid                                  # 6.0  COMBINING DOUBLE INVERTED BREVE BELOW
+1DFD          ; valid                                  # 5.2  COMBINING ALMOST EQUAL TO BELOW
+1DFE..1DFF    ; valid                                  # 5.0  COMBINING LEFT ARROWHEAD ABOVE..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
+1E00          ; mapped                 ; 1E01          # 1.1  LATIN CAPITAL LETTER A WITH RING BELOW
+1E01          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH RING BELOW
+1E02          ; mapped                 ; 1E03          # 1.1  LATIN CAPITAL LETTER B WITH DOT ABOVE
+1E03          ; valid                                  # 1.1  LATIN SMALL LETTER B WITH DOT ABOVE
+1E04          ; mapped                 ; 1E05          # 1.1  LATIN CAPITAL LETTER B WITH DOT BELOW
+1E05          ; valid                                  # 1.1  LATIN SMALL LETTER B WITH DOT BELOW
+1E06          ; mapped                 ; 1E07          # 1.1  LATIN CAPITAL LETTER B WITH LINE BELOW
+1E07          ; valid                                  # 1.1  LATIN SMALL LETTER B WITH LINE BELOW
+1E08          ; mapped                 ; 1E09          # 1.1  LATIN CAPITAL LETTER C WITH CEDILLA AND ACUTE
+1E09          ; valid                                  # 1.1  LATIN SMALL LETTER C WITH CEDILLA AND ACUTE
+1E0A          ; mapped                 ; 1E0B          # 1.1  LATIN CAPITAL LETTER D WITH DOT ABOVE
+1E0B          ; valid                                  # 1.1  LATIN SMALL LETTER D WITH DOT ABOVE
+1E0C          ; mapped                 ; 1E0D          # 1.1  LATIN CAPITAL LETTER D WITH DOT BELOW
+1E0D          ; valid                                  # 1.1  LATIN SMALL LETTER D WITH DOT BELOW
+1E0E          ; mapped                 ; 1E0F          # 1.1  LATIN CAPITAL LETTER D WITH LINE BELOW
+1E0F          ; valid                                  # 1.1  LATIN SMALL LETTER D WITH LINE BELOW
+1E10          ; mapped                 ; 1E11          # 1.1  LATIN CAPITAL LETTER D WITH CEDILLA
+1E11          ; valid                                  # 1.1  LATIN SMALL LETTER D WITH CEDILLA
+1E12          ; mapped                 ; 1E13          # 1.1  LATIN CAPITAL LETTER D WITH CIRCUMFLEX BELOW
+1E13          ; valid                                  # 1.1  LATIN SMALL LETTER D WITH CIRCUMFLEX BELOW
+1E14          ; mapped                 ; 1E15          # 1.1  LATIN CAPITAL LETTER E WITH MACRON AND GRAVE
+1E15          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH MACRON AND GRAVE
+1E16          ; mapped                 ; 1E17          # 1.1  LATIN CAPITAL LETTER E WITH MACRON AND ACUTE
+1E17          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH MACRON AND ACUTE
+1E18          ; mapped                 ; 1E19          # 1.1  LATIN CAPITAL LETTER E WITH CIRCUMFLEX BELOW
+1E19          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH CIRCUMFLEX BELOW
+1E1A          ; mapped                 ; 1E1B          # 1.1  LATIN CAPITAL LETTER E WITH TILDE BELOW
+1E1B          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH TILDE BELOW
+1E1C          ; mapped                 ; 1E1D          # 1.1  LATIN CAPITAL LETTER E WITH CEDILLA AND BREVE
+1E1D          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH CEDILLA AND BREVE
+1E1E          ; mapped                 ; 1E1F          # 1.1  LATIN CAPITAL LETTER F WITH DOT ABOVE
+1E1F          ; valid                                  # 1.1  LATIN SMALL LETTER F WITH DOT ABOVE
+1E20          ; mapped                 ; 1E21          # 1.1  LATIN CAPITAL LETTER G WITH MACRON
+1E21          ; valid                                  # 1.1  LATIN SMALL LETTER G WITH MACRON
+1E22          ; mapped                 ; 1E23          # 1.1  LATIN CAPITAL LETTER H WITH DOT ABOVE
+1E23          ; valid                                  # 1.1  LATIN SMALL LETTER H WITH DOT ABOVE
+1E24          ; mapped                 ; 1E25          # 1.1  LATIN CAPITAL LETTER H WITH DOT BELOW
+1E25          ; valid                                  # 1.1  LATIN SMALL LETTER H WITH DOT BELOW
+1E26          ; mapped                 ; 1E27          # 1.1  LATIN CAPITAL LETTER H WITH DIAERESIS
+1E27          ; valid                                  # 1.1  LATIN SMALL LETTER H WITH DIAERESIS
+1E28          ; mapped                 ; 1E29          # 1.1  LATIN CAPITAL LETTER H WITH CEDILLA
+1E29          ; valid                                  # 1.1  LATIN SMALL LETTER H WITH CEDILLA
+1E2A          ; mapped                 ; 1E2B          # 1.1  LATIN CAPITAL LETTER H WITH BREVE BELOW
+1E2B          ; valid                                  # 1.1  LATIN SMALL LETTER H WITH BREVE BELOW
+1E2C          ; mapped                 ; 1E2D          # 1.1  LATIN CAPITAL LETTER I WITH TILDE BELOW
+1E2D          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH TILDE BELOW
+1E2E          ; mapped                 ; 1E2F          # 1.1  LATIN CAPITAL LETTER I WITH DIAERESIS AND ACUTE
+1E2F          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH DIAERESIS AND ACUTE
+1E30          ; mapped                 ; 1E31          # 1.1  LATIN CAPITAL LETTER K WITH ACUTE
+1E31          ; valid                                  # 1.1  LATIN SMALL LETTER K WITH ACUTE
+1E32          ; mapped                 ; 1E33          # 1.1  LATIN CAPITAL LETTER K WITH DOT BELOW
+1E33          ; valid                                  # 1.1  LATIN SMALL LETTER K WITH DOT BELOW
+1E34          ; mapped                 ; 1E35          # 1.1  LATIN CAPITAL LETTER K WITH LINE BELOW
+1E35          ; valid                                  # 1.1  LATIN SMALL LETTER K WITH LINE BELOW
+1E36          ; mapped                 ; 1E37          # 1.1  LATIN CAPITAL LETTER L WITH DOT BELOW
+1E37          ; valid                                  # 1.1  LATIN SMALL LETTER L WITH DOT BELOW
+1E38          ; mapped                 ; 1E39          # 1.1  LATIN CAPITAL LETTER L WITH DOT BELOW AND MACRON
+1E39          ; valid                                  # 1.1  LATIN SMALL LETTER L WITH DOT BELOW AND MACRON
+1E3A          ; mapped                 ; 1E3B          # 1.1  LATIN CAPITAL LETTER L WITH LINE BELOW
+1E3B          ; valid                                  # 1.1  LATIN SMALL LETTER L WITH LINE BELOW
+1E3C          ; mapped                 ; 1E3D          # 1.1  LATIN CAPITAL LETTER L WITH CIRCUMFLEX BELOW
+1E3D          ; valid                                  # 1.1  LATIN SMALL LETTER L WITH CIRCUMFLEX BELOW
+1E3E          ; mapped                 ; 1E3F          # 1.1  LATIN CAPITAL LETTER M WITH ACUTE
+1E3F          ; valid                                  # 1.1  LATIN SMALL LETTER M WITH ACUTE
+1E40          ; mapped                 ; 1E41          # 1.1  LATIN CAPITAL LETTER M WITH DOT ABOVE
+1E41          ; valid                                  # 1.1  LATIN SMALL LETTER M WITH DOT ABOVE
+1E42          ; mapped                 ; 1E43          # 1.1  LATIN CAPITAL LETTER M WITH DOT BELOW
+1E43          ; valid                                  # 1.1  LATIN SMALL LETTER M WITH DOT BELOW
+1E44          ; mapped                 ; 1E45          # 1.1  LATIN CAPITAL LETTER N WITH DOT ABOVE
+1E45          ; valid                                  # 1.1  LATIN SMALL LETTER N WITH DOT ABOVE
+1E46          ; mapped                 ; 1E47          # 1.1  LATIN CAPITAL LETTER N WITH DOT BELOW
+1E47          ; valid                                  # 1.1  LATIN SMALL LETTER N WITH DOT BELOW
+1E48          ; mapped                 ; 1E49          # 1.1  LATIN CAPITAL LETTER N WITH LINE BELOW
+1E49          ; valid                                  # 1.1  LATIN SMALL LETTER N WITH LINE BELOW
+1E4A          ; mapped                 ; 1E4B          # 1.1  LATIN CAPITAL LETTER N WITH CIRCUMFLEX BELOW
+1E4B          ; valid                                  # 1.1  LATIN SMALL LETTER N WITH CIRCUMFLEX BELOW
+1E4C          ; mapped                 ; 1E4D          # 1.1  LATIN CAPITAL LETTER O WITH TILDE AND ACUTE
+1E4D          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH TILDE AND ACUTE
+1E4E          ; mapped                 ; 1E4F          # 1.1  LATIN CAPITAL LETTER O WITH TILDE AND DIAERESIS
+1E4F          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH TILDE AND DIAERESIS
+1E50          ; mapped                 ; 1E51          # 1.1  LATIN CAPITAL LETTER O WITH MACRON AND GRAVE
+1E51          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH MACRON AND GRAVE
+1E52          ; mapped                 ; 1E53          # 1.1  LATIN CAPITAL LETTER O WITH MACRON AND ACUTE
+1E53          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH MACRON AND ACUTE
+1E54          ; mapped                 ; 1E55          # 1.1  LATIN CAPITAL LETTER P WITH ACUTE
+1E55          ; valid                                  # 1.1  LATIN SMALL LETTER P WITH ACUTE
+1E56          ; mapped                 ; 1E57          # 1.1  LATIN CAPITAL LETTER P WITH DOT ABOVE
+1E57          ; valid                                  # 1.1  LATIN SMALL LETTER P WITH DOT ABOVE
+1E58          ; mapped                 ; 1E59          # 1.1  LATIN CAPITAL LETTER R WITH DOT ABOVE
+1E59          ; valid                                  # 1.1  LATIN SMALL LETTER R WITH DOT ABOVE
+1E5A          ; mapped                 ; 1E5B          # 1.1  LATIN CAPITAL LETTER R WITH DOT BELOW
+1E5B          ; valid                                  # 1.1  LATIN SMALL LETTER R WITH DOT BELOW
+1E5C          ; mapped                 ; 1E5D          # 1.1  LATIN CAPITAL LETTER R WITH DOT BELOW AND MACRON
+1E5D          ; valid                                  # 1.1  LATIN SMALL LETTER R WITH DOT BELOW AND MACRON
+1E5E          ; mapped                 ; 1E5F          # 1.1  LATIN CAPITAL LETTER R WITH LINE BELOW
+1E5F          ; valid                                  # 1.1  LATIN SMALL LETTER R WITH LINE BELOW
+1E60          ; mapped                 ; 1E61          # 1.1  LATIN CAPITAL LETTER S WITH DOT ABOVE
+1E61          ; valid                                  # 1.1  LATIN SMALL LETTER S WITH DOT ABOVE
+1E62          ; mapped                 ; 1E63          # 1.1  LATIN CAPITAL LETTER S WITH DOT BELOW
+1E63          ; valid                                  # 1.1  LATIN SMALL LETTER S WITH DOT BELOW
+1E64          ; mapped                 ; 1E65          # 1.1  LATIN CAPITAL LETTER S WITH ACUTE AND DOT ABOVE
+1E65          ; valid                                  # 1.1  LATIN SMALL LETTER S WITH ACUTE AND DOT ABOVE
+1E66          ; mapped                 ; 1E67          # 1.1  LATIN CAPITAL LETTER S WITH CARON AND DOT ABOVE
+1E67          ; valid                                  # 1.1  LATIN SMALL LETTER S WITH CARON AND DOT ABOVE
+1E68          ; mapped                 ; 1E69          # 1.1  LATIN CAPITAL LETTER S WITH DOT BELOW AND DOT ABOVE
+1E69          ; valid                                  # 1.1  LATIN SMALL LETTER S WITH DOT BELOW AND DOT ABOVE
+1E6A          ; mapped                 ; 1E6B          # 1.1  LATIN CAPITAL LETTER T WITH DOT ABOVE
+1E6B          ; valid                                  # 1.1  LATIN SMALL LETTER T WITH DOT ABOVE
+1E6C          ; mapped                 ; 1E6D          # 1.1  LATIN CAPITAL LETTER T WITH DOT BELOW
+1E6D          ; valid                                  # 1.1  LATIN SMALL LETTER T WITH DOT BELOW
+1E6E          ; mapped                 ; 1E6F          # 1.1  LATIN CAPITAL LETTER T WITH LINE BELOW
+1E6F          ; valid                                  # 1.1  LATIN SMALL LETTER T WITH LINE BELOW
+1E70          ; mapped                 ; 1E71          # 1.1  LATIN CAPITAL LETTER T WITH CIRCUMFLEX BELOW
+1E71          ; valid                                  # 1.1  LATIN SMALL LETTER T WITH CIRCUMFLEX BELOW
+1E72          ; mapped                 ; 1E73          # 1.1  LATIN CAPITAL LETTER U WITH DIAERESIS BELOW
+1E73          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH DIAERESIS BELOW
+1E74          ; mapped                 ; 1E75          # 1.1  LATIN CAPITAL LETTER U WITH TILDE BELOW
+1E75          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH TILDE BELOW
+1E76          ; mapped                 ; 1E77          # 1.1  LATIN CAPITAL LETTER U WITH CIRCUMFLEX BELOW
+1E77          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH CIRCUMFLEX BELOW
+1E78          ; mapped                 ; 1E79          # 1.1  LATIN CAPITAL LETTER U WITH TILDE AND ACUTE
+1E79          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH TILDE AND ACUTE
+1E7A          ; mapped                 ; 1E7B          # 1.1  LATIN CAPITAL LETTER U WITH MACRON AND DIAERESIS
+1E7B          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH MACRON AND DIAERESIS
+1E7C          ; mapped                 ; 1E7D          # 1.1  LATIN CAPITAL LETTER V WITH TILDE
+1E7D          ; valid                                  # 1.1  LATIN SMALL LETTER V WITH TILDE
+1E7E          ; mapped                 ; 1E7F          # 1.1  LATIN CAPITAL LETTER V WITH DOT BELOW
+1E7F          ; valid                                  # 1.1  LATIN SMALL LETTER V WITH DOT BELOW
+1E80          ; mapped                 ; 1E81          # 1.1  LATIN CAPITAL LETTER W WITH GRAVE
+1E81          ; valid                                  # 1.1  LATIN SMALL LETTER W WITH GRAVE
+1E82          ; mapped                 ; 1E83          # 1.1  LATIN CAPITAL LETTER W WITH ACUTE
+1E83          ; valid                                  # 1.1  LATIN SMALL LETTER W WITH ACUTE
+1E84          ; mapped                 ; 1E85          # 1.1  LATIN CAPITAL LETTER W WITH DIAERESIS
+1E85          ; valid                                  # 1.1  LATIN SMALL LETTER W WITH DIAERESIS
+1E86          ; mapped                 ; 1E87          # 1.1  LATIN CAPITAL LETTER W WITH DOT ABOVE
+1E87          ; valid                                  # 1.1  LATIN SMALL LETTER W WITH DOT ABOVE
+1E88          ; mapped                 ; 1E89          # 1.1  LATIN CAPITAL LETTER W WITH DOT BELOW
+1E89          ; valid                                  # 1.1  LATIN SMALL LETTER W WITH DOT BELOW
+1E8A          ; mapped                 ; 1E8B          # 1.1  LATIN CAPITAL LETTER X WITH DOT ABOVE
+1E8B          ; valid                                  # 1.1  LATIN SMALL LETTER X WITH DOT ABOVE
+1E8C          ; mapped                 ; 1E8D          # 1.1  LATIN CAPITAL LETTER X WITH DIAERESIS
+1E8D          ; valid                                  # 1.1  LATIN SMALL LETTER X WITH DIAERESIS
+1E8E          ; mapped                 ; 1E8F          # 1.1  LATIN CAPITAL LETTER Y WITH DOT ABOVE
+1E8F          ; valid                                  # 1.1  LATIN SMALL LETTER Y WITH DOT ABOVE
+1E90          ; mapped                 ; 1E91          # 1.1  LATIN CAPITAL LETTER Z WITH CIRCUMFLEX
+1E91          ; valid                                  # 1.1  LATIN SMALL LETTER Z WITH CIRCUMFLEX
+1E92          ; mapped                 ; 1E93          # 1.1  LATIN CAPITAL LETTER Z WITH DOT BELOW
+1E93          ; valid                                  # 1.1  LATIN SMALL LETTER Z WITH DOT BELOW
+1E94          ; mapped                 ; 1E95          # 1.1  LATIN CAPITAL LETTER Z WITH LINE BELOW
+1E95..1E99    ; valid                                  # 1.1  LATIN SMALL LETTER Z WITH LINE BELOW..LATIN SMALL LETTER Y WITH RING ABOVE
+1E9A          ; mapped                 ; 0061 02BE     # 1.1  LATIN SMALL LETTER A WITH RIGHT HALF RING
+1E9B          ; mapped                 ; 1E61          # 2.0  LATIN SMALL LETTER LONG S WITH DOT ABOVE
+1E9C..1E9D    ; valid                                  # 5.1  LATIN SMALL LETTER LONG S WITH DIAGONAL STROKE..LATIN SMALL LETTER LONG S WITH HIGH STROKE
+1E9E          ; mapped                 ; 0073 0073     # 5.1  LATIN CAPITAL LETTER SHARP S
+1E9F          ; valid                                  # 5.1  LATIN SMALL LETTER DELTA
+1EA0          ; mapped                 ; 1EA1          # 1.1  LATIN CAPITAL LETTER A WITH DOT BELOW
+1EA1          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH DOT BELOW
+1EA2          ; mapped                 ; 1EA3          # 1.1  LATIN CAPITAL LETTER A WITH HOOK ABOVE
+1EA3          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH HOOK ABOVE
+1EA4          ; mapped                 ; 1EA5          # 1.1  LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND ACUTE
+1EA5          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH CIRCUMFLEX AND ACUTE
+1EA6          ; mapped                 ; 1EA7          # 1.1  LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND GRAVE
+1EA7          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH CIRCUMFLEX AND GRAVE
+1EA8          ; mapped                 ; 1EA9          # 1.1  LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND HOOK ABOVE
+1EA9          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH CIRCUMFLEX AND HOOK ABOVE
+1EAA          ; mapped                 ; 1EAB          # 1.1  LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND TILDE
+1EAB          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH CIRCUMFLEX AND TILDE
+1EAC          ; mapped                 ; 1EAD          # 1.1  LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND DOT BELOW
+1EAD          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH CIRCUMFLEX AND DOT BELOW
+1EAE          ; mapped                 ; 1EAF          # 1.1  LATIN CAPITAL LETTER A WITH BREVE AND ACUTE
+1EAF          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH BREVE AND ACUTE
+1EB0          ; mapped                 ; 1EB1          # 1.1  LATIN CAPITAL LETTER A WITH BREVE AND GRAVE
+1EB1          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH BREVE AND GRAVE
+1EB2          ; mapped                 ; 1EB3          # 1.1  LATIN CAPITAL LETTER A WITH BREVE AND HOOK ABOVE
+1EB3          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH BREVE AND HOOK ABOVE
+1EB4          ; mapped                 ; 1EB5          # 1.1  LATIN CAPITAL LETTER A WITH BREVE AND TILDE
+1EB5          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH BREVE AND TILDE
+1EB6          ; mapped                 ; 1EB7          # 1.1  LATIN CAPITAL LETTER A WITH BREVE AND DOT BELOW
+1EB7          ; valid                                  # 1.1  LATIN SMALL LETTER A WITH BREVE AND DOT BELOW
+1EB8          ; mapped                 ; 1EB9          # 1.1  LATIN CAPITAL LETTER E WITH DOT BELOW
+1EB9          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH DOT BELOW
+1EBA          ; mapped                 ; 1EBB          # 1.1  LATIN CAPITAL LETTER E WITH HOOK ABOVE
+1EBB          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH HOOK ABOVE
+1EBC          ; mapped                 ; 1EBD          # 1.1  LATIN CAPITAL LETTER E WITH TILDE
+1EBD          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH TILDE
+1EBE          ; mapped                 ; 1EBF          # 1.1  LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND ACUTE
+1EBF          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH CIRCUMFLEX AND ACUTE
+1EC0          ; mapped                 ; 1EC1          # 1.1  LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND GRAVE
+1EC1          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH CIRCUMFLEX AND GRAVE
+1EC2          ; mapped                 ; 1EC3          # 1.1  LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND HOOK ABOVE
+1EC3          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH CIRCUMFLEX AND HOOK ABOVE
+1EC4          ; mapped                 ; 1EC5          # 1.1  LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND TILDE
+1EC5          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH CIRCUMFLEX AND TILDE
+1EC6          ; mapped                 ; 1EC7          # 1.1  LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND DOT BELOW
+1EC7          ; valid                                  # 1.1  LATIN SMALL LETTER E WITH CIRCUMFLEX AND DOT BELOW
+1EC8          ; mapped                 ; 1EC9          # 1.1  LATIN CAPITAL LETTER I WITH HOOK ABOVE
+1EC9          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH HOOK ABOVE
+1ECA          ; mapped                 ; 1ECB          # 1.1  LATIN CAPITAL LETTER I WITH DOT BELOW
+1ECB          ; valid                                  # 1.1  LATIN SMALL LETTER I WITH DOT BELOW
+1ECC          ; mapped                 ; 1ECD          # 1.1  LATIN CAPITAL LETTER O WITH DOT BELOW
+1ECD          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH DOT BELOW
+1ECE          ; mapped                 ; 1ECF          # 1.1  LATIN CAPITAL LETTER O WITH HOOK ABOVE
+1ECF          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH HOOK ABOVE
+1ED0          ; mapped                 ; 1ED1          # 1.1  LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND ACUTE
+1ED1          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH CIRCUMFLEX AND ACUTE
+1ED2          ; mapped                 ; 1ED3          # 1.1  LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND GRAVE
+1ED3          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH CIRCUMFLEX AND GRAVE
+1ED4          ; mapped                 ; 1ED5          # 1.1  LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND HOOK ABOVE
+1ED5          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH CIRCUMFLEX AND HOOK ABOVE
+1ED6          ; mapped                 ; 1ED7          # 1.1  LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND TILDE
+1ED7          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH CIRCUMFLEX AND TILDE
+1ED8          ; mapped                 ; 1ED9          # 1.1  LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND DOT BELOW
+1ED9          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH CIRCUMFLEX AND DOT BELOW
+1EDA          ; mapped                 ; 1EDB          # 1.1  LATIN CAPITAL LETTER O WITH HORN AND ACUTE
+1EDB          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH HORN AND ACUTE
+1EDC          ; mapped                 ; 1EDD          # 1.1  LATIN CAPITAL LETTER O WITH HORN AND GRAVE
+1EDD          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH HORN AND GRAVE
+1EDE          ; mapped                 ; 1EDF          # 1.1  LATIN CAPITAL LETTER O WITH HORN AND HOOK ABOVE
+1EDF          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH HORN AND HOOK ABOVE
+1EE0          ; mapped                 ; 1EE1          # 1.1  LATIN CAPITAL LETTER O WITH HORN AND TILDE
+1EE1          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH HORN AND TILDE
+1EE2          ; mapped                 ; 1EE3          # 1.1  LATIN CAPITAL LETTER O WITH HORN AND DOT BELOW
+1EE3          ; valid                                  # 1.1  LATIN SMALL LETTER O WITH HORN AND DOT BELOW
+1EE4          ; mapped                 ; 1EE5          # 1.1  LATIN CAPITAL LETTER U WITH DOT BELOW
+1EE5          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH DOT BELOW
+1EE6          ; mapped                 ; 1EE7          # 1.1  LATIN CAPITAL LETTER U WITH HOOK ABOVE
+1EE7          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH HOOK ABOVE
+1EE8          ; mapped                 ; 1EE9          # 1.1  LATIN CAPITAL LETTER U WITH HORN AND ACUTE
+1EE9          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH HORN AND ACUTE
+1EEA          ; mapped                 ; 1EEB          # 1.1  LATIN CAPITAL LETTER U WITH HORN AND GRAVE
+1EEB          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH HORN AND GRAVE
+1EEC          ; mapped                 ; 1EED          # 1.1  LATIN CAPITAL LETTER U WITH HORN AND HOOK ABOVE
+1EED          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH HORN AND HOOK ABOVE
+1EEE          ; mapped                 ; 1EEF          # 1.1  LATIN CAPITAL LETTER U WITH HORN AND TILDE
+1EEF          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH HORN AND TILDE
+1EF0          ; mapped                 ; 1EF1          # 1.1  LATIN CAPITAL LETTER U WITH HORN AND DOT BELOW
+1EF1          ; valid                                  # 1.1  LATIN SMALL LETTER U WITH HORN AND DOT BELOW
+1EF2          ; mapped                 ; 1EF3          # 1.1  LATIN CAPITAL LETTER Y WITH GRAVE
+1EF3          ; valid                                  # 1.1  LATIN SMALL LETTER Y WITH GRAVE
+1EF4          ; mapped                 ; 1EF5          # 1.1  LATIN CAPITAL LETTER Y WITH DOT BELOW
+1EF5          ; valid                                  # 1.1  LATIN SMALL LETTER Y WITH DOT BELOW
+1EF6          ; mapped                 ; 1EF7          # 1.1  LATIN CAPITAL LETTER Y WITH HOOK ABOVE
+1EF7          ; valid                                  # 1.1  LATIN SMALL LETTER Y WITH HOOK ABOVE
+1EF8          ; mapped                 ; 1EF9          # 1.1  LATIN CAPITAL LETTER Y WITH TILDE
+1EF9          ; valid                                  # 1.1  LATIN SMALL LETTER Y WITH TILDE
+1EFA          ; mapped                 ; 1EFB          # 5.1  LATIN CAPITAL LETTER MIDDLE-WELSH LL
+1EFB          ; valid                                  # 5.1  LATIN SMALL LETTER MIDDLE-WELSH LL
+1EFC          ; mapped                 ; 1EFD          # 5.1  LATIN CAPITAL LETTER MIDDLE-WELSH V
+1EFD          ; valid                                  # 5.1  LATIN SMALL LETTER MIDDLE-WELSH V
+1EFE          ; mapped                 ; 1EFF          # 5.1  LATIN CAPITAL LETTER Y WITH LOOP
+1EFF          ; valid                                  # 5.1  LATIN SMALL LETTER Y WITH LOOP
+1F00..1F07    ; valid                                  # 1.1  GREEK SMALL LETTER ALPHA WITH PSILI..GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI
+1F08          ; mapped                 ; 1F00          # 1.1  GREEK CAPITAL LETTER ALPHA WITH PSILI
+1F09          ; mapped                 ; 1F01          # 1.1  GREEK CAPITAL LETTER ALPHA WITH DASIA
+1F0A          ; mapped                 ; 1F02          # 1.1  GREEK CAPITAL LETTER ALPHA WITH PSILI AND VARIA
+1F0B          ; mapped                 ; 1F03          # 1.1  GREEK CAPITAL LETTER ALPHA WITH DASIA AND VARIA
+1F0C          ; mapped                 ; 1F04          # 1.1  GREEK CAPITAL LETTER ALPHA WITH PSILI AND OXIA
+1F0D          ; mapped                 ; 1F05          # 1.1  GREEK CAPITAL LETTER ALPHA WITH DASIA AND OXIA
+1F0E          ; mapped                 ; 1F06          # 1.1  GREEK CAPITAL LETTER ALPHA WITH PSILI AND PERISPOMENI
+1F0F          ; mapped                 ; 1F07          # 1.1  GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI
+1F10..1F15    ; valid                                  # 1.1  GREEK SMALL LETTER EPSILON WITH PSILI..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
+1F16..1F17    ; disallowed                             # NA   <reserved-1F16>..<reserved-1F17>
+1F18          ; mapped                 ; 1F10          # 1.1  GREEK CAPITAL LETTER EPSILON WITH PSILI
+1F19          ; mapped                 ; 1F11          # 1.1  GREEK CAPITAL LETTER EPSILON WITH DASIA
+1F1A          ; mapped                 ; 1F12          # 1.1  GREEK CAPITAL LETTER EPSILON WITH PSILI AND VARIA
+1F1B          ; mapped                 ; 1F13          # 1.1  GREEK CAPITAL LETTER EPSILON WITH DASIA AND VARIA
+1F1C          ; mapped                 ; 1F14          # 1.1  GREEK CAPITAL LETTER EPSILON WITH PSILI AND OXIA
+1F1D          ; mapped                 ; 1F15          # 1.1  GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
+1F1E..1F1F    ; disallowed                             # NA   <reserved-1F1E>..<reserved-1F1F>
+1F20..1F27    ; valid                                  # 1.1  GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI
+1F28          ; mapped                 ; 1F20          # 1.1  GREEK CAPITAL LETTER ETA WITH PSILI
+1F29          ; mapped                 ; 1F21          # 1.1  GREEK CAPITAL LETTER ETA WITH DASIA
+1F2A          ; mapped                 ; 1F22          # 1.1  GREEK CAPITAL LETTER ETA WITH PSILI AND VARIA
+1F2B          ; mapped                 ; 1F23          # 1.1  GREEK CAPITAL LETTER ETA WITH DASIA AND VARIA
+1F2C          ; mapped                 ; 1F24          # 1.1  GREEK CAPITAL LETTER ETA WITH PSILI AND OXIA
+1F2D          ; mapped                 ; 1F25          # 1.1  GREEK CAPITAL LETTER ETA WITH DASIA AND OXIA
+1F2E          ; mapped                 ; 1F26          # 1.1  GREEK CAPITAL LETTER ETA WITH PSILI AND PERISPOMENI
+1F2F          ; mapped                 ; 1F27          # 1.1  GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI
+1F30..1F37    ; valid                                  # 1.1  GREEK SMALL LETTER IOTA WITH PSILI..GREEK SMALL LETTER IOTA WITH DASIA AND PERISPOMENI
+1F38          ; mapped                 ; 1F30          # 1.1  GREEK CAPITAL LETTER IOTA WITH PSILI
+1F39          ; mapped                 ; 1F31          # 1.1  GREEK CAPITAL LETTER IOTA WITH DASIA
+1F3A          ; mapped                 ; 1F32          # 1.1  GREEK CAPITAL LETTER IOTA WITH PSILI AND VARIA
+1F3B          ; mapped                 ; 1F33          # 1.1  GREEK CAPITAL LETTER IOTA WITH DASIA AND VARIA
+1F3C          ; mapped                 ; 1F34          # 1.1  GREEK CAPITAL LETTER IOTA WITH PSILI AND OXIA
+1F3D          ; mapped                 ; 1F35          # 1.1  GREEK CAPITAL LETTER IOTA WITH DASIA AND OXIA
+1F3E          ; mapped                 ; 1F36          # 1.1  GREEK CAPITAL LETTER IOTA WITH PSILI AND PERISPOMENI
+1F3F          ; mapped                 ; 1F37          # 1.1  GREEK CAPITAL LETTER IOTA WITH DASIA AND PERISPOMENI
+1F40..1F45    ; valid                                  # 1.1  GREEK SMALL LETTER OMICRON WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
+1F46..1F47    ; disallowed                             # NA   <reserved-1F46>..<reserved-1F47>
+1F48          ; mapped                 ; 1F40          # 1.1  GREEK CAPITAL LETTER OMICRON WITH PSILI
+1F49          ; mapped                 ; 1F41          # 1.1  GREEK CAPITAL LETTER OMICRON WITH DASIA
+1F4A          ; mapped                 ; 1F42          # 1.1  GREEK CAPITAL LETTER OMICRON WITH PSILI AND VARIA
+1F4B          ; mapped                 ; 1F43          # 1.1  GREEK CAPITAL LETTER OMICRON WITH DASIA AND VARIA
+1F4C          ; mapped                 ; 1F44          # 1.1  GREEK CAPITAL LETTER OMICRON WITH PSILI AND OXIA
+1F4D          ; mapped                 ; 1F45          # 1.1  GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
+1F4E..1F4F    ; disallowed                             # NA   <reserved-1F4E>..<reserved-1F4F>
+1F50..1F57    ; valid                                  # 1.1  GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
+1F58          ; disallowed                             # NA   <reserved-1F58>
+1F59          ; mapped                 ; 1F51          # 1.1  GREEK CAPITAL LETTER UPSILON WITH DASIA
+1F5A          ; disallowed                             # NA   <reserved-1F5A>
+1F5B          ; mapped                 ; 1F53          # 1.1  GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
+1F5C          ; disallowed                             # NA   <reserved-1F5C>
+1F5D          ; mapped                 ; 1F55          # 1.1  GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
+1F5E          ; disallowed                             # NA   <reserved-1F5E>
+1F5F          ; mapped                 ; 1F57          # 1.1  GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI
+1F60..1F67    ; valid                                  # 1.1  GREEK SMALL LETTER OMEGA WITH PSILI..GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI
+1F68          ; mapped                 ; 1F60          # 1.1  GREEK CAPITAL LETTER OMEGA WITH PSILI
+1F69          ; mapped                 ; 1F61          # 1.1  GREEK CAPITAL LETTER OMEGA WITH DASIA
+1F6A          ; mapped                 ; 1F62          # 1.1  GREEK CAPITAL LETTER OMEGA WITH PSILI AND VARIA
+1F6B          ; mapped                 ; 1F63          # 1.1  GREEK CAPITAL LETTER OMEGA WITH DASIA AND VARIA
+1F6C          ; mapped                 ; 1F64          # 1.1  GREEK CAPITAL LETTER OMEGA WITH PSILI AND OXIA
+1F6D          ; mapped                 ; 1F65          # 1.1  GREEK CAPITAL LETTER OMEGA WITH DASIA AND OXIA
+1F6E          ; mapped                 ; 1F66          # 1.1  GREEK CAPITAL LETTER OMEGA WITH PSILI AND PERISPOMENI
+1F6F          ; mapped                 ; 1F67          # 1.1  GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI
+1F70          ; valid                                  # 1.1  GREEK SMALL LETTER ALPHA WITH VARIA
+1F71          ; mapped                 ; 03AC          # 1.1  GREEK SMALL LETTER ALPHA WITH OXIA
+1F72          ; valid                                  # 1.1  GREEK SMALL LETTER EPSILON WITH VARIA
+1F73          ; mapped                 ; 03AD          # 1.1  GREEK SMALL LETTER EPSILON WITH OXIA
+1F74          ; valid                                  # 1.1  GREEK SMALL LETTER ETA WITH VARIA
+1F75          ; mapped                 ; 03AE          # 1.1  GREEK SMALL LETTER ETA WITH OXIA
+1F76          ; valid                                  # 1.1  GREEK SMALL LETTER IOTA WITH VARIA
+1F77          ; mapped                 ; 03AF          # 1.1  GREEK SMALL LETTER IOTA WITH OXIA
+1F78          ; valid                                  # 1.1  GREEK SMALL LETTER OMICRON WITH VARIA
+1F79          ; mapped                 ; 03CC          # 1.1  GREEK SMALL LETTER OMICRON WITH OXIA
+1F7A          ; valid                                  # 1.1  GREEK SMALL LETTER UPSILON WITH VARIA
+1F7B          ; mapped                 ; 03CD          # 1.1  GREEK SMALL LETTER UPSILON WITH OXIA
+1F7C          ; valid                                  # 1.1  GREEK SMALL LETTER OMEGA WITH VARIA
+1F7D          ; mapped                 ; 03CE          # 1.1  GREEK SMALL LETTER OMEGA WITH OXIA
+1F7E..1F7F    ; disallowed                             # NA   <reserved-1F7E>..<reserved-1F7F>
+1F80          ; mapped                 ; 1F00 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI
+1F81          ; mapped                 ; 1F01 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH DASIA AND YPOGEGRAMMENI
+1F82          ; mapped                 ; 1F02 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH PSILI AND VARIA AND YPOGEGRAMMENI
+1F83          ; mapped                 ; 1F03 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH DASIA AND VARIA AND YPOGEGRAMMENI
+1F84          ; mapped                 ; 1F04 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH PSILI AND OXIA AND YPOGEGRAMMENI
+1F85          ; mapped                 ; 1F05 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH DASIA AND OXIA AND YPOGEGRAMMENI
+1F86          ; mapped                 ; 1F06 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI
+1F87          ; mapped                 ; 1F07 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI
+1F88          ; mapped                 ; 1F00 03B9     # 1.1  GREEK CAPITAL LETTER ALPHA WITH PSILI AND PROSGEGRAMMENI
+1F89          ; mapped                 ; 1F01 03B9     # 1.1  GREEK CAPITAL LETTER ALPHA WITH DASIA AND PROSGEGRAMMENI
+1F8A          ; mapped                 ; 1F02 03B9     # 1.1  GREEK CAPITAL LETTER ALPHA WITH PSILI AND VARIA AND PROSGEGRAMMENI
+1F8B          ; mapped                 ; 1F03 03B9     # 1.1  GREEK CAPITAL LETTER ALPHA WITH DASIA AND VARIA AND PROSGEGRAMMENI
+1F8C          ; mapped                 ; 1F04 03B9     # 1.1  GREEK CAPITAL LETTER ALPHA WITH PSILI AND OXIA AND PROSGEGRAMMENI
+1F8D          ; mapped                 ; 1F05 03B9     # 1.1  GREEK CAPITAL LETTER ALPHA WITH DASIA AND OXIA AND PROSGEGRAMMENI
+1F8E          ; mapped                 ; 1F06 03B9     # 1.1  GREEK CAPITAL LETTER ALPHA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI
+1F8F          ; mapped                 ; 1F07 03B9     # 1.1  GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
+1F90          ; mapped                 ; 1F20 03B9     # 1.1  GREEK SMALL LETTER ETA WITH PSILI AND YPOGEGRAMMENI
+1F91          ; mapped                 ; 1F21 03B9     # 1.1  GREEK SMALL LETTER ETA WITH DASIA AND YPOGEGRAMMENI
+1F92          ; mapped                 ; 1F22 03B9     # 1.1  GREEK SMALL LETTER ETA WITH PSILI AND VARIA AND YPOGEGRAMMENI
+1F93          ; mapped                 ; 1F23 03B9     # 1.1  GREEK SMALL LETTER ETA WITH DASIA AND VARIA AND YPOGEGRAMMENI
+1F94          ; mapped                 ; 1F24 03B9     # 1.1  GREEK SMALL LETTER ETA WITH PSILI AND OXIA AND YPOGEGRAMMENI
+1F95          ; mapped                 ; 1F25 03B9     # 1.1  GREEK SMALL LETTER ETA WITH DASIA AND OXIA AND YPOGEGRAMMENI
+1F96          ; mapped                 ; 1F26 03B9     # 1.1  GREEK SMALL LETTER ETA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI
+1F97          ; mapped                 ; 1F27 03B9     # 1.1  GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI
+1F98          ; mapped                 ; 1F20 03B9     # 1.1  GREEK CAPITAL LETTER ETA WITH PSILI AND PROSGEGRAMMENI
+1F99          ; mapped                 ; 1F21 03B9     # 1.1  GREEK CAPITAL LETTER ETA WITH DASIA AND PROSGEGRAMMENI
+1F9A          ; mapped                 ; 1F22 03B9     # 1.1  GREEK CAPITAL LETTER ETA WITH PSILI AND VARIA AND PROSGEGRAMMENI
+1F9B          ; mapped                 ; 1F23 03B9     # 1.1  GREEK CAPITAL LETTER ETA WITH DASIA AND VARIA AND PROSGEGRAMMENI
+1F9C          ; mapped                 ; 1F24 03B9     # 1.1  GREEK CAPITAL LETTER ETA WITH PSILI AND OXIA AND PROSGEGRAMMENI
+1F9D          ; mapped                 ; 1F25 03B9     # 1.1  GREEK CAPITAL LETTER ETA WITH DASIA AND OXIA AND PROSGEGRAMMENI
+1F9E          ; mapped                 ; 1F26 03B9     # 1.1  GREEK CAPITAL LETTER ETA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI
+1F9F          ; mapped                 ; 1F27 03B9     # 1.1  GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
+1FA0          ; mapped                 ; 1F60 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH PSILI AND YPOGEGRAMMENI
+1FA1          ; mapped                 ; 1F61 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH DASIA AND YPOGEGRAMMENI
+1FA2          ; mapped                 ; 1F62 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH PSILI AND VARIA AND YPOGEGRAMMENI
+1FA3          ; mapped                 ; 1F63 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH DASIA AND VARIA AND YPOGEGRAMMENI
+1FA4          ; mapped                 ; 1F64 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH PSILI AND OXIA AND YPOGEGRAMMENI
+1FA5          ; mapped                 ; 1F65 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH DASIA AND OXIA AND YPOGEGRAMMENI
+1FA6          ; mapped                 ; 1F66 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH PSILI AND PERISPOMENI AND YPOGEGRAMMENI
+1FA7          ; mapped                 ; 1F67 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI
+1FA8          ; mapped                 ; 1F60 03B9     # 1.1  GREEK CAPITAL LETTER OMEGA WITH PSILI AND PROSGEGRAMMENI
+1FA9          ; mapped                 ; 1F61 03B9     # 1.1  GREEK CAPITAL LETTER OMEGA WITH DASIA AND PROSGEGRAMMENI
+1FAA          ; mapped                 ; 1F62 03B9     # 1.1  GREEK CAPITAL LETTER OMEGA WITH PSILI AND VARIA AND PROSGEGRAMMENI
+1FAB          ; mapped                 ; 1F63 03B9     # 1.1  GREEK CAPITAL LETTER OMEGA WITH DASIA AND VARIA AND PROSGEGRAMMENI
+1FAC          ; mapped                 ; 1F64 03B9     # 1.1  GREEK CAPITAL LETTER OMEGA WITH PSILI AND OXIA AND PROSGEGRAMMENI
+1FAD          ; mapped                 ; 1F65 03B9     # 1.1  GREEK CAPITAL LETTER OMEGA WITH DASIA AND OXIA AND PROSGEGRAMMENI
+1FAE          ; mapped                 ; 1F66 03B9     # 1.1  GREEK CAPITAL LETTER OMEGA WITH PSILI AND PERISPOMENI AND PROSGEGRAMMENI
+1FAF          ; mapped                 ; 1F67 03B9     # 1.1  GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
+1FB0..1FB1    ; valid                                  # 1.1  GREEK SMALL LETTER ALPHA WITH VRACHY..GREEK SMALL LETTER ALPHA WITH MACRON
+1FB2          ; mapped                 ; 1F70 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH VARIA AND YPOGEGRAMMENI
+1FB3          ; mapped                 ; 03B1 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH YPOGEGRAMMENI
+1FB4          ; mapped                 ; 03AC 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
+1FB5          ; disallowed                             # NA   <reserved-1FB5>
+1FB6          ; valid                                  # 1.1  GREEK SMALL LETTER ALPHA WITH PERISPOMENI
+1FB7          ; mapped                 ; 1FB6 03B9     # 1.1  GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI
+1FB8          ; mapped                 ; 1FB0          # 1.1  GREEK CAPITAL LETTER ALPHA WITH VRACHY
+1FB9          ; mapped                 ; 1FB1          # 1.1  GREEK CAPITAL LETTER ALPHA WITH MACRON
+1FBA          ; mapped                 ; 1F70          # 1.1  GREEK CAPITAL LETTER ALPHA WITH VARIA
+1FBB          ; mapped                 ; 03AC          # 1.1  GREEK CAPITAL LETTER ALPHA WITH OXIA
+1FBC          ; mapped                 ; 03B1 03B9     # 1.1  GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
+1FBD          ; disallowed_STD3_mapped ; 0020 0313     # 1.1  GREEK KORONIS
+1FBE          ; mapped                 ; 03B9          # 1.1  GREEK PROSGEGRAMMENI
+1FBF          ; disallowed_STD3_mapped ; 0020 0313     # 1.1  GREEK PSILI
+1FC0          ; disallowed_STD3_mapped ; 0020 0342     # 1.1  GREEK PERISPOMENI
+1FC1          ; disallowed_STD3_mapped ; 0020 0308 0342 #1.1  GREEK DIALYTIKA AND PERISPOMENI
+1FC2          ; mapped                 ; 1F74 03B9     # 1.1  GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI
+1FC3          ; mapped                 ; 03B7 03B9     # 1.1  GREEK SMALL LETTER ETA WITH YPOGEGRAMMENI
+1FC4          ; mapped                 ; 03AE 03B9     # 1.1  GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
+1FC5          ; disallowed                             # NA   <reserved-1FC5>
+1FC6          ; valid                                  # 1.1  GREEK SMALL LETTER ETA WITH PERISPOMENI
+1FC7          ; mapped                 ; 1FC6 03B9     # 1.1  GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI
+1FC8          ; mapped                 ; 1F72          # 1.1  GREEK CAPITAL LETTER EPSILON WITH VARIA
+1FC9          ; mapped                 ; 03AD          # 1.1  GREEK CAPITAL LETTER EPSILON WITH OXIA
+1FCA          ; mapped                 ; 1F74          # 1.1  GREEK CAPITAL LETTER ETA WITH VARIA
+1FCB          ; mapped                 ; 03AE          # 1.1  GREEK CAPITAL LETTER ETA WITH OXIA
+1FCC          ; mapped                 ; 03B7 03B9     # 1.1  GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
+1FCD          ; disallowed_STD3_mapped ; 0020 0313 0300 #1.1  GREEK PSILI AND VARIA
+1FCE          ; disallowed_STD3_mapped ; 0020 0313 0301 #1.1  GREEK PSILI AND OXIA
+1FCF          ; disallowed_STD3_mapped ; 0020 0313 0342 #1.1  GREEK PSILI AND PERISPOMENI
+1FD0..1FD2    ; valid                                  # 1.1  GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND VARIA
+1FD3          ; mapped                 ; 0390          # 1.1  GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
+1FD4..1FD5    ; disallowed                             # NA   <reserved-1FD4>..<reserved-1FD5>
+1FD6..1FD7    ; valid                                  # 1.1  GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI
+1FD8          ; mapped                 ; 1FD0          # 1.1  GREEK CAPITAL LETTER IOTA WITH VRACHY
+1FD9          ; mapped                 ; 1FD1          # 1.1  GREEK CAPITAL LETTER IOTA WITH MACRON
+1FDA          ; mapped                 ; 1F76          # 1.1  GREEK CAPITAL LETTER IOTA WITH VARIA
+1FDB          ; mapped                 ; 03AF          # 1.1  GREEK CAPITAL LETTER IOTA WITH OXIA
+1FDC          ; disallowed                             # NA   <reserved-1FDC>
+1FDD          ; disallowed_STD3_mapped ; 0020 0314 0300 #1.1  GREEK DASIA AND VARIA
+1FDE          ; disallowed_STD3_mapped ; 0020 0314 0301 #1.1  GREEK DASIA AND OXIA
+1FDF          ; disallowed_STD3_mapped ; 0020 0314 0342 #1.1  GREEK DASIA AND PERISPOMENI
+1FE0..1FE2    ; valid                                  # 1.1  GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA
+1FE3          ; mapped                 ; 03B0          # 1.1  GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA
+1FE4..1FE7    ; valid                                  # 1.1  GREEK SMALL LETTER RHO WITH PSILI..GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI
+1FE8          ; mapped                 ; 1FE0          # 1.1  GREEK CAPITAL LETTER UPSILON WITH VRACHY
+1FE9          ; mapped                 ; 1FE1          # 1.1  GREEK CAPITAL LETTER UPSILON WITH MACRON
+1FEA          ; mapped                 ; 1F7A          # 1.1  GREEK CAPITAL LETTER UPSILON WITH VARIA
+1FEB          ; mapped                 ; 03CD          # 1.1  GREEK CAPITAL LETTER UPSILON WITH OXIA
+1FEC          ; mapped                 ; 1FE5          # 1.1  GREEK CAPITAL LETTER RHO WITH DASIA
+1FED          ; disallowed_STD3_mapped ; 0020 0308 0300 #1.1  GREEK DIALYTIKA AND VARIA
+1FEE          ; disallowed_STD3_mapped ; 0020 0308 0301 #1.1  GREEK DIALYTIKA AND OXIA
+1FEF          ; disallowed_STD3_mapped ; 0060          # 1.1  GREEK VARIA
+1FF0..1FF1    ; disallowed                             # NA   <reserved-1FF0>..<reserved-1FF1>
+1FF2          ; mapped                 ; 1F7C 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI
+1FF3          ; mapped                 ; 03C9 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH YPOGEGRAMMENI
+1FF4          ; mapped                 ; 03CE 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
+1FF5          ; disallowed                             # NA   <reserved-1FF5>
+1FF6          ; valid                                  # 1.1  GREEK SMALL LETTER OMEGA WITH PERISPOMENI
+1FF7          ; mapped                 ; 1FF6 03B9     # 1.1  GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI
+1FF8          ; mapped                 ; 1F78          # 1.1  GREEK CAPITAL LETTER OMICRON WITH VARIA
+1FF9          ; mapped                 ; 03CC          # 1.1  GREEK CAPITAL LETTER OMICRON WITH OXIA
+1FFA          ; mapped                 ; 1F7C          # 1.1  GREEK CAPITAL LETTER OMEGA WITH VARIA
+1FFB          ; mapped                 ; 03CE          # 1.1  GREEK CAPITAL LETTER OMEGA WITH OXIA
+1FFC          ; mapped                 ; 03C9 03B9     # 1.1  GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
+1FFD          ; disallowed_STD3_mapped ; 0020 0301     # 1.1  GREEK OXIA
+1FFE          ; disallowed_STD3_mapped ; 0020 0314     # 1.1  GREEK DASIA
+1FFF          ; disallowed                             # NA   <reserved-1FFF>
+2000..200A    ; disallowed_STD3_mapped ; 0020          # 1.1  EN QUAD..HAIR SPACE
+200B          ; ignored                                # 1.1  ZERO WIDTH SPACE
+200C..200D    ; deviation              ;               # 1.1  ZERO WIDTH NON-JOINER..ZERO WIDTH JOINER
+200E..200F    ; disallowed                             # 1.1  LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
+2010          ; valid                  ;      ; NV8    # 1.1  HYPHEN
+2011          ; mapped                 ; 2010          # 1.1  NON-BREAKING HYPHEN
+2012..2016    ; valid                  ;      ; NV8    # 1.1  FIGURE DASH..DOUBLE VERTICAL LINE
+2017          ; disallowed_STD3_mapped ; 0020 0333     # 1.1  DOUBLE LOW LINE
+2018..2023    ; valid                  ;      ; NV8    # 1.1  LEFT SINGLE QUOTATION MARK..TRIANGULAR BULLET
+2024..2026    ; disallowed                             # 1.1  ONE DOT LEADER..HORIZONTAL ELLIPSIS
+2027          ; valid                  ;      ; NV8    # 1.1  HYPHENATION POINT
+2028..202E    ; disallowed                             # 1.1  LINE SEPARATOR..RIGHT-TO-LEFT OVERRIDE
+202F          ; disallowed_STD3_mapped ; 0020          # 3.0  NARROW NO-BREAK SPACE
+2030..2032    ; valid                  ;      ; NV8    # 1.1  PER MILLE SIGN..PRIME
+2033          ; mapped                 ; 2032 2032     # 1.1  DOUBLE PRIME
+2034          ; mapped                 ; 2032 2032 2032 #1.1  TRIPLE PRIME
+2035          ; valid                  ;      ; NV8    # 1.1  REVERSED PRIME
+2036          ; mapped                 ; 2035 2035     # 1.1  REVERSED DOUBLE PRIME
+2037          ; mapped                 ; 2035 2035 2035 #1.1  REVERSED TRIPLE PRIME
+2038..203B    ; valid                  ;      ; NV8    # 1.1  CARET..REFERENCE MARK
+203C          ; disallowed_STD3_mapped ; 0021 0021     # 1.1  DOUBLE EXCLAMATION MARK
+203D          ; valid                  ;      ; NV8    # 1.1  INTERROBANG
+203E          ; disallowed_STD3_mapped ; 0020 0305     # 1.1  OVERLINE
+203F..2046    ; valid                  ;      ; NV8    # 1.1  UNDERTIE..RIGHT SQUARE BRACKET WITH QUILL
+2047          ; disallowed_STD3_mapped ; 003F 003F     # 3.2  DOUBLE QUESTION MARK
+2048          ; disallowed_STD3_mapped ; 003F 0021     # 3.0  QUESTION EXCLAMATION MARK
+2049          ; disallowed_STD3_mapped ; 0021 003F     # 3.0  EXCLAMATION QUESTION MARK
+204A..204D    ; valid                  ;      ; NV8    # 3.0  TIRONIAN SIGN ET..BLACK RIGHTWARDS BULLET
+204E..2052    ; valid                  ;      ; NV8    # 3.2  LOW ASTERISK..COMMERCIAL MINUS SIGN
+2053..2054    ; valid                  ;      ; NV8    # 4.0  SWUNG DASH..INVERTED UNDERTIE
+2055..2056    ; valid                  ;      ; NV8    # 4.1  FLOWER PUNCTUATION MARK..THREE DOT PUNCTUATION
+2057          ; mapped                 ; 2032 2032 2032 2032 #3.2 QUADRUPLE PRIME
+2058..205E    ; valid                  ;      ; NV8    # 4.1  FOUR DOT PUNCTUATION..VERTICAL FOUR DOTS
+205F          ; disallowed_STD3_mapped ; 0020          # 3.2  MEDIUM MATHEMATICAL SPACE
+2060          ; ignored                                # 3.2  WORD JOINER
+2061..2063    ; disallowed                             # 3.2  FUNCTION APPLICATION..INVISIBLE SEPARATOR
+2064          ; ignored                                # 5.1  INVISIBLE PLUS
+2065          ; disallowed                             # NA   <reserved-2065>
+2066..2069    ; disallowed                             # 6.3  LEFT-TO-RIGHT ISOLATE..POP DIRECTIONAL ISOLATE
+206A..206F    ; disallowed                             # 1.1  INHIBIT SYMMETRIC SWAPPING..NOMINAL DIGIT SHAPES
+2070          ; mapped                 ; 0030          # 1.1  SUPERSCRIPT ZERO
+2071          ; mapped                 ; 0069          # 3.2  SUPERSCRIPT LATIN SMALL LETTER I
+2072..2073    ; disallowed                             # NA   <reserved-2072>..<reserved-2073>
+2074          ; mapped                 ; 0034          # 1.1  SUPERSCRIPT FOUR
+2075          ; mapped                 ; 0035          # 1.1  SUPERSCRIPT FIVE
+2076          ; mapped                 ; 0036          # 1.1  SUPERSCRIPT SIX
+2077          ; mapped                 ; 0037          # 1.1  SUPERSCRIPT SEVEN
+2078          ; mapped                 ; 0038          # 1.1  SUPERSCRIPT EIGHT
+2079          ; mapped                 ; 0039          # 1.1  SUPERSCRIPT NINE
+207A          ; disallowed_STD3_mapped ; 002B          # 1.1  SUPERSCRIPT PLUS SIGN
+207B          ; mapped                 ; 2212          # 1.1  SUPERSCRIPT MINUS
+207C          ; disallowed_STD3_mapped ; 003D          # 1.1  SUPERSCRIPT EQUALS SIGN
+207D          ; disallowed_STD3_mapped ; 0028          # 1.1  SUPERSCRIPT LEFT PARENTHESIS
+207E          ; disallowed_STD3_mapped ; 0029          # 1.1  SUPERSCRIPT RIGHT PARENTHESIS
+207F          ; mapped                 ; 006E          # 1.1  SUPERSCRIPT LATIN SMALL LETTER N
+2080          ; mapped                 ; 0030          # 1.1  SUBSCRIPT ZERO
+2081          ; mapped                 ; 0031          # 1.1  SUBSCRIPT ONE
+2082          ; mapped                 ; 0032          # 1.1  SUBSCRIPT TWO
+2083          ; mapped                 ; 0033          # 1.1  SUBSCRIPT THREE
+2084          ; mapped                 ; 0034          # 1.1  SUBSCRIPT FOUR
+2085          ; mapped                 ; 0035          # 1.1  SUBSCRIPT FIVE
+2086          ; mapped                 ; 0036          # 1.1  SUBSCRIPT SIX
+2087          ; mapped                 ; 0037          # 1.1  SUBSCRIPT SEVEN
+2088          ; mapped                 ; 0038          # 1.1  SUBSCRIPT EIGHT
+2089          ; mapped                 ; 0039          # 1.1  SUBSCRIPT NINE
+208A          ; disallowed_STD3_mapped ; 002B          # 1.1  SUBSCRIPT PLUS SIGN
+208B          ; mapped                 ; 2212          # 1.1  SUBSCRIPT MINUS
+208C          ; disallowed_STD3_mapped ; 003D          # 1.1  SUBSCRIPT EQUALS SIGN
+208D          ; disallowed_STD3_mapped ; 0028          # 1.1  SUBSCRIPT LEFT PARENTHESIS
+208E          ; disallowed_STD3_mapped ; 0029          # 1.1  SUBSCRIPT RIGHT PARENTHESIS
+208F          ; disallowed                             # NA   <reserved-208F>
+2090          ; mapped                 ; 0061          # 4.1  LATIN SUBSCRIPT SMALL LETTER A
+2091          ; mapped                 ; 0065          # 4.1  LATIN SUBSCRIPT SMALL LETTER E
+2092          ; mapped                 ; 006F          # 4.1  LATIN SUBSCRIPT SMALL LETTER O
+2093          ; mapped                 ; 0078          # 4.1  LATIN SUBSCRIPT SMALL LETTER X
+2094          ; mapped                 ; 0259          # 4.1  LATIN SUBSCRIPT SMALL LETTER SCHWA
+2095          ; mapped                 ; 0068          # 6.0  LATIN SUBSCRIPT SMALL LETTER H
+2096          ; mapped                 ; 006B          # 6.0  LATIN SUBSCRIPT SMALL LETTER K
+2097          ; mapped                 ; 006C          # 6.0  LATIN SUBSCRIPT SMALL LETTER L
+2098          ; mapped                 ; 006D          # 6.0  LATIN SUBSCRIPT SMALL LETTER M
+2099          ; mapped                 ; 006E          # 6.0  LATIN SUBSCRIPT SMALL LETTER N
+209A          ; mapped                 ; 0070          # 6.0  LATIN SUBSCRIPT SMALL LETTER P
+209B          ; mapped                 ; 0073          # 6.0  LATIN SUBSCRIPT SMALL LETTER S
+209C          ; mapped                 ; 0074          # 6.0  LATIN SUBSCRIPT SMALL LETTER T
+209D..209F    ; disallowed                             # NA   <reserved-209D>..<reserved-209F>
+20A0..20A7    ; valid                  ;      ; NV8    # 1.1  EURO-CURRENCY SIGN..PESETA SIGN
+20A8          ; mapped                 ; 0072 0073     # 1.1  RUPEE SIGN
+20A9..20AA    ; valid                  ;      ; NV8    # 1.1  WON SIGN..NEW SHEQEL SIGN
+20AB          ; valid                  ;      ; NV8    # 2.0  DONG SIGN
+20AC          ; valid                  ;      ; NV8    # 2.1  EURO SIGN
+20AD..20AF    ; valid                  ;      ; NV8    # 3.0  KIP SIGN..DRACHMA SIGN
+20B0..20B1    ; valid                  ;      ; NV8    # 3.2  GERMAN PENNY SIGN..PESO SIGN
+20B2..20B5    ; valid                  ;      ; NV8    # 4.1  GUARANI SIGN..CEDI SIGN
+20B6..20B8    ; valid                  ;      ; NV8    # 5.2  LIVRE TOURNOIS SIGN..TENGE SIGN
+20B9          ; valid                  ;      ; NV8    # 6.0  INDIAN RUPEE SIGN
+20BA          ; valid                  ;      ; NV8    # 6.2  TURKISH LIRA SIGN
+20BB..20BD    ; valid                  ;      ; NV8    # 7.0  NORDIC MARK SIGN..RUBLE SIGN
+20BE          ; valid                  ;      ; NV8    # 8.0  LARI SIGN
+20BF          ; valid                  ;      ; NV8    # 10.0 BITCOIN SIGN
+20C0          ; valid                  ;      ; NV8    # 14.0 SOM SIGN
+20C1..20CF    ; disallowed                             # NA   <reserved-20C1>..<reserved-20CF>
+20D0..20E1    ; valid                  ;      ; NV8    # 1.1  COMBINING LEFT HARPOON ABOVE..COMBINING LEFT RIGHT ARROW ABOVE
+20E2..20E3    ; valid                  ;      ; NV8    # 3.0  COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING KEYCAP
+20E4..20EA    ; valid                  ;      ; NV8    # 3.2  COMBINING ENCLOSING UPWARD POINTING TRIANGLE..COMBINING LEFTWARDS ARROW OVERLAY
+20EB          ; valid                  ;      ; NV8    # 4.1  COMBINING LONG DOUBLE SOLIDUS OVERLAY
+20EC..20EF    ; valid                  ;      ; NV8    # 5.0  COMBINING RIGHTWARDS HARPOON WITH BARB DOWNWARDS..COMBINING RIGHT ARROW BELOW
+20F0          ; valid                  ;      ; NV8    # 5.1  COMBINING ASTERISK ABOVE
+20F1..20FF    ; disallowed                             # NA   <reserved-20F1>..<reserved-20FF>
+2100          ; disallowed_STD3_mapped ; 0061 002F 0063 #1.1  ACCOUNT OF
+2101          ; disallowed_STD3_mapped ; 0061 002F 0073 #1.1  ADDRESSED TO THE SUBJECT
+2102          ; mapped                 ; 0063          # 1.1  DOUBLE-STRUCK CAPITAL C
+2103          ; mapped                 ; 00B0 0063     # 1.1  DEGREE CELSIUS
+2104          ; valid                  ;      ; NV8    # 1.1  CENTRE LINE SYMBOL
+2105          ; disallowed_STD3_mapped ; 0063 002F 006F #1.1  CARE OF
+2106          ; disallowed_STD3_mapped ; 0063 002F 0075 #1.1  CADA UNA
+2107          ; mapped                 ; 025B          # 1.1  EULER CONSTANT
+2108          ; valid                  ;      ; NV8    # 1.1  SCRUPLE
+2109          ; mapped                 ; 00B0 0066     # 1.1  DEGREE FAHRENHEIT
+210A          ; mapped                 ; 0067          # 1.1  SCRIPT SMALL G
+210B..210E    ; mapped                 ; 0068          # 1.1  SCRIPT CAPITAL H..PLANCK CONSTANT
+210F          ; mapped                 ; 0127          # 1.1  PLANCK CONSTANT OVER TWO PI
+2110..2111    ; mapped                 ; 0069          # 1.1  SCRIPT CAPITAL I..BLACK-LETTER CAPITAL I
+2112..2113    ; mapped                 ; 006C          # 1.1  SCRIPT CAPITAL L..SCRIPT SMALL L
+2114          ; valid                  ;      ; NV8    # 1.1  L B BAR SYMBOL
+2115          ; mapped                 ; 006E          # 1.1  DOUBLE-STRUCK CAPITAL N
+2116          ; mapped                 ; 006E 006F     # 1.1  NUMERO SIGN
+2117..2118    ; valid                  ;      ; NV8    # 1.1  SOUND RECORDING COPYRIGHT..SCRIPT CAPITAL P
+2119          ; mapped                 ; 0070          # 1.1  DOUBLE-STRUCK CAPITAL P
+211A          ; mapped                 ; 0071          # 1.1  DOUBLE-STRUCK CAPITAL Q
+211B..211D    ; mapped                 ; 0072          # 1.1  SCRIPT CAPITAL R..DOUBLE-STRUCK CAPITAL R
+211E..211F    ; valid                  ;      ; NV8    # 1.1  PRESCRIPTION TAKE..RESPONSE
+2120          ; mapped                 ; 0073 006D     # 1.1  SERVICE MARK
+2121          ; mapped                 ; 0074 0065 006C #1.1  TELEPHONE SIGN
+2122          ; mapped                 ; 0074 006D     # 1.1  TRADE MARK SIGN
+2123          ; valid                  ;      ; NV8    # 1.1  VERSICLE
+2124          ; mapped                 ; 007A          # 1.1  DOUBLE-STRUCK CAPITAL Z
+2125          ; valid                  ;      ; NV8    # 1.1  OUNCE SIGN
+2126          ; mapped                 ; 03C9          # 1.1  OHM SIGN
+2127          ; valid                  ;      ; NV8    # 1.1  INVERTED OHM SIGN
+2128          ; mapped                 ; 007A          # 1.1  BLACK-LETTER CAPITAL Z
+2129          ; valid                  ;      ; NV8    # 1.1  TURNED GREEK SMALL LETTER IOTA
+212A          ; mapped                 ; 006B          # 1.1  KELVIN SIGN
+212B          ; mapped                 ; 00E5          # 1.1  ANGSTROM SIGN
+212C          ; mapped                 ; 0062          # 1.1  SCRIPT CAPITAL B
+212D          ; mapped                 ; 0063          # 1.1  BLACK-LETTER CAPITAL C
+212E          ; valid                  ;      ; NV8    # 1.1  ESTIMATED SYMBOL
+212F..2130    ; mapped                 ; 0065          # 1.1  SCRIPT SMALL E..SCRIPT CAPITAL E
+2131          ; mapped                 ; 0066          # 1.1  SCRIPT CAPITAL F
+2132          ; disallowed                             # 1.1  TURNED CAPITAL F
+2133          ; mapped                 ; 006D          # 1.1  SCRIPT CAPITAL M
+2134          ; mapped                 ; 006F          # 1.1  SCRIPT SMALL O
+2135          ; mapped                 ; 05D0          # 1.1  ALEF SYMBOL
+2136          ; mapped                 ; 05D1          # 1.1  BET SYMBOL
+2137          ; mapped                 ; 05D2          # 1.1  GIMEL SYMBOL
+2138          ; mapped                 ; 05D3          # 1.1  DALET SYMBOL
+2139          ; mapped                 ; 0069          # 3.0  INFORMATION SOURCE
+213A          ; valid                  ;      ; NV8    # 3.0  ROTATED CAPITAL Q
+213B          ; mapped                 ; 0066 0061 0078 #4.0  FACSIMILE SIGN
+213C          ; mapped                 ; 03C0          # 4.1  DOUBLE-STRUCK SMALL PI
+213D..213E    ; mapped                 ; 03B3          # 3.2  DOUBLE-STRUCK SMALL GAMMA..DOUBLE-STRUCK CAPITAL GAMMA
+213F          ; mapped                 ; 03C0          # 3.2  DOUBLE-STRUCK CAPITAL PI
+2140          ; mapped                 ; 2211          # 3.2  DOUBLE-STRUCK N-ARY SUMMATION
+2141..2144    ; valid                  ;      ; NV8    # 3.2  TURNED SANS-SERIF CAPITAL G..TURNED SANS-SERIF CAPITAL Y
+2145..2146    ; mapped                 ; 0064          # 3.2  DOUBLE-STRUCK ITALIC CAPITAL D..DOUBLE-STRUCK ITALIC SMALL D
+2147          ; mapped                 ; 0065          # 3.2  DOUBLE-STRUCK ITALIC SMALL E
+2148          ; mapped                 ; 0069          # 3.2  DOUBLE-STRUCK ITALIC SMALL I
+2149          ; mapped                 ; 006A          # 3.2  DOUBLE-STRUCK ITALIC SMALL J
+214A..214B    ; valid                  ;      ; NV8    # 3.2  PROPERTY LINE..TURNED AMPERSAND
+214C          ; valid                  ;      ; NV8    # 4.1  PER SIGN
+214D          ; valid                  ;      ; NV8    # 5.0  AKTIESELSKAB
+214E          ; valid                                  # 5.0  TURNED SMALL F
+214F          ; valid                  ;      ; NV8    # 5.1  SYMBOL FOR SAMARITAN SOURCE
+2150          ; mapped                 ; 0031 2044 0037 #5.2  VULGAR FRACTION ONE SEVENTH
+2151          ; mapped                 ; 0031 2044 0039 #5.2  VULGAR FRACTION ONE NINTH
+2152          ; mapped                 ; 0031 2044 0031 0030 #5.2 VULGAR FRACTION ONE TENTH
+2153          ; mapped                 ; 0031 2044 0033 #1.1  VULGAR FRACTION ONE THIRD
+2154          ; mapped                 ; 0032 2044 0033 #1.1  VULGAR FRACTION TWO THIRDS
+2155          ; mapped                 ; 0031 2044 0035 #1.1  VULGAR FRACTION ONE FIFTH
+2156          ; mapped                 ; 0032 2044 0035 #1.1  VULGAR FRACTION TWO FIFTHS
+2157          ; mapped                 ; 0033 2044 0035 #1.1  VULGAR FRACTION THREE FIFTHS
+2158          ; mapped                 ; 0034 2044 0035 #1.1  VULGAR FRACTION FOUR FIFTHS
+2159          ; mapped                 ; 0031 2044 0036 #1.1  VULGAR FRACTION ONE SIXTH
+215A          ; mapped                 ; 0035 2044 0036 #1.1  VULGAR FRACTION FIVE SIXTHS
+215B          ; mapped                 ; 0031 2044 0038 #1.1  VULGAR FRACTION ONE EIGHTH
+215C          ; mapped                 ; 0033 2044 0038 #1.1  VULGAR FRACTION THREE EIGHTHS
+215D          ; mapped                 ; 0035 2044 0038 #1.1  VULGAR FRACTION FIVE EIGHTHS
+215E          ; mapped                 ; 0037 2044 0038 #1.1  VULGAR FRACTION SEVEN EIGHTHS
+215F          ; mapped                 ; 0031 2044     # 1.1  FRACTION NUMERATOR ONE
+2160          ; mapped                 ; 0069          # 1.1  ROMAN NUMERAL ONE
+2161          ; mapped                 ; 0069 0069     # 1.1  ROMAN NUMERAL TWO
+2162          ; mapped                 ; 0069 0069 0069 #1.1  ROMAN NUMERAL THREE
+2163          ; mapped                 ; 0069 0076     # 1.1  ROMAN NUMERAL FOUR
+2164          ; mapped                 ; 0076          # 1.1  ROMAN NUMERAL FIVE
+2165          ; mapped                 ; 0076 0069     # 1.1  ROMAN NUMERAL SIX
+2166          ; mapped                 ; 0076 0069 0069 #1.1  ROMAN NUMERAL SEVEN
+2167          ; mapped                 ; 0076 0069 0069 0069 #1.1 ROMAN NUMERAL EIGHT
+2168          ; mapped                 ; 0069 0078     # 1.1  ROMAN NUMERAL NINE
+2169          ; mapped                 ; 0078          # 1.1  ROMAN NUMERAL TEN
+216A          ; mapped                 ; 0078 0069     # 1.1  ROMAN NUMERAL ELEVEN
+216B          ; mapped                 ; 0078 0069 0069 #1.1  ROMAN NUMERAL TWELVE
+216C          ; mapped                 ; 006C          # 1.1  ROMAN NUMERAL FIFTY
+216D          ; mapped                 ; 0063          # 1.1  ROMAN NUMERAL ONE HUNDRED
+216E          ; mapped                 ; 0064          # 1.1  ROMAN NUMERAL FIVE HUNDRED
+216F          ; mapped                 ; 006D          # 1.1  ROMAN NUMERAL ONE THOUSAND
+2170          ; mapped                 ; 0069          # 1.1  SMALL ROMAN NUMERAL ONE
+2171          ; mapped                 ; 0069 0069     # 1.1  SMALL ROMAN NUMERAL TWO
+2172          ; mapped                 ; 0069 0069 0069 #1.1  SMALL ROMAN NUMERAL THREE
+2173          ; mapped                 ; 0069 0076     # 1.1  SMALL ROMAN NUMERAL FOUR
+2174          ; mapped                 ; 0076          # 1.1  SMALL ROMAN NUMERAL FIVE
+2175          ; mapped                 ; 0076 0069     # 1.1  SMALL ROMAN NUMERAL SIX
+2176          ; mapped                 ; 0076 0069 0069 #1.1  SMALL ROMAN NUMERAL SEVEN
+2177          ; mapped                 ; 0076 0069 0069 0069 #1.1 SMALL ROMAN NUMERAL EIGHT
+2178          ; mapped                 ; 0069 0078     # 1.1  SMALL ROMAN NUMERAL NINE
+2179          ; mapped                 ; 0078          # 1.1  SMALL ROMAN NUMERAL TEN
+217A          ; mapped                 ; 0078 0069     # 1.1  SMALL ROMAN NUMERAL ELEVEN
+217B          ; mapped                 ; 0078 0069 0069 #1.1  SMALL ROMAN NUMERAL TWELVE
+217C          ; mapped                 ; 006C          # 1.1  SMALL ROMAN NUMERAL FIFTY
+217D          ; mapped                 ; 0063          # 1.1  SMALL ROMAN NUMERAL ONE HUNDRED
+217E          ; mapped                 ; 0064          # 1.1  SMALL ROMAN NUMERAL FIVE HUNDRED
+217F          ; mapped                 ; 006D          # 1.1  SMALL ROMAN NUMERAL ONE THOUSAND
+2180..2182    ; valid                  ;      ; NV8    # 1.1  ROMAN NUMERAL ONE THOUSAND C D..ROMAN NUMERAL TEN THOUSAND
+2183          ; disallowed                             # 3.0  ROMAN NUMERAL REVERSED ONE HUNDRED
+2184          ; valid                                  # 5.0  LATIN SMALL LETTER REVERSED C
+2185..2188    ; valid                  ;      ; NV8    # 5.1  ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
+2189          ; mapped                 ; 0030 2044 0033 #5.2  VULGAR FRACTION ZERO THIRDS
+218A..218B    ; valid                  ;      ; NV8    # 8.0  TURNED DIGIT TWO..TURNED DIGIT THREE
+218C..218F    ; disallowed                             # NA   <reserved-218C>..<reserved-218F>
+2190..21EA    ; valid                  ;      ; NV8    # 1.1  LEFTWARDS ARROW..UPWARDS WHITE ARROW FROM BAR
+21EB..21F3    ; valid                  ;      ; NV8    # 3.0  UPWARDS WHITE ARROW ON PEDESTAL..UP DOWN WHITE ARROW
+21F4..21FF    ; valid                  ;      ; NV8    # 3.2  RIGHT ARROW WITH SMALL CIRCLE..LEFT RIGHT OPEN-HEADED ARROW
+2200..222B    ; valid                  ;      ; NV8    # 1.1  FOR ALL..INTEGRAL
+222C          ; mapped                 ; 222B 222B     # 1.1  DOUBLE INTEGRAL
+222D          ; mapped                 ; 222B 222B 222B #1.1  TRIPLE INTEGRAL
+222E          ; valid                  ;      ; NV8    # 1.1  CONTOUR INTEGRAL
+222F          ; mapped                 ; 222E 222E     # 1.1  SURFACE INTEGRAL
+2230          ; mapped                 ; 222E 222E 222E #1.1  VOLUME INTEGRAL
+2231..225F    ; valid                  ;      ; NV8    # 1.1  CLOCKWISE INTEGRAL..QUESTIONED EQUAL TO
+2260          ; disallowed_STD3_valid                  # 1.1  NOT EQUAL TO
+2261..226D    ; valid                  ;      ; NV8    # 1.1  IDENTICAL TO..NOT EQUIVALENT TO
+226E..226F    ; disallowed_STD3_valid                  # 1.1  NOT LESS-THAN..NOT GREATER-THAN
+2270..22F1    ; valid                  ;      ; NV8    # 1.1  NEITHER LESS-THAN NOR EQUAL TO..DOWN RIGHT DIAGONAL ELLIPSIS
+22F2..22FF    ; valid                  ;      ; NV8    # 3.2  ELEMENT OF WITH LONG HORIZONTAL STROKE..Z NOTATION BAG MEMBERSHIP
+2300          ; valid                  ;      ; NV8    # 1.1  DIAMETER SIGN
+2301          ; valid                  ;      ; NV8    # 3.0  ELECTRIC ARROW
+2302..2328    ; valid                  ;      ; NV8    # 1.1  HOUSE..KEYBOARD
+2329          ; mapped                 ; 3008          # 1.1  LEFT-POINTING ANGLE BRACKET
+232A          ; mapped                 ; 3009          # 1.1  RIGHT-POINTING ANGLE BRACKET
+232B..237A    ; valid                  ;      ; NV8    # 1.1  ERASE TO THE LEFT..APL FUNCTIONAL SYMBOL ALPHA
+237B          ; valid                  ;      ; NV8    # 3.0  NOT CHECK MARK
+237C          ; valid                  ;      ; NV8    # 3.2  RIGHT ANGLE WITH DOWNWARDS ZIGZAG ARROW
+237D..239A    ; valid                  ;      ; NV8    # 3.0  SHOULDERED OPEN BOX..CLEAR SCREEN SYMBOL
+239B..23CE    ; valid                  ;      ; NV8    # 3.2  LEFT PARENTHESIS UPPER HOOK..RETURN SYMBOL
+23CF..23D0    ; valid                  ;      ; NV8    # 4.0  EJECT SYMBOL..VERTICAL LINE EXTENSION
+23D1..23DB    ; valid                  ;      ; NV8    # 4.1  METRICAL BREVE..FUSE
+23DC..23E7    ; valid                  ;      ; NV8    # 5.0  TOP PARENTHESIS..ELECTRICAL INTERSECTION
+23E8          ; valid                  ;      ; NV8    # 5.2  DECIMAL EXPONENT SYMBOL
+23E9..23F3    ; valid                  ;      ; NV8    # 6.0  BLACK RIGHT-POINTING DOUBLE TRIANGLE..HOURGLASS WITH FLOWING SAND
+23F4..23FA    ; valid                  ;      ; NV8    # 7.0  BLACK MEDIUM LEFT-POINTING TRIANGLE..BLACK CIRCLE FOR RECORD
+23FB..23FE    ; valid                  ;      ; NV8    # 9.0  POWER SYMBOL..POWER SLEEP SYMBOL
+23FF          ; valid                  ;      ; NV8    # 10.0 OBSERVER EYE SYMBOL
+2400..2424    ; valid                  ;      ; NV8    # 1.1  SYMBOL FOR NULL..SYMBOL FOR NEWLINE
+2425..2426    ; valid                  ;      ; NV8    # 3.0  SYMBOL FOR DELETE FORM TWO..SYMBOL FOR SUBSTITUTE FORM TWO
+2427..243F    ; disallowed                             # NA   <reserved-2427>..<reserved-243F>
+2440..244A    ; valid                  ;      ; NV8    # 1.1  OCR HOOK..OCR DOUBLE BACKSLASH
+244B..245F    ; disallowed                             # NA   <reserved-244B>..<reserved-245F>
+2460          ; mapped                 ; 0031          # 1.1  CIRCLED DIGIT ONE
+2461          ; mapped                 ; 0032          # 1.1  CIRCLED DIGIT TWO
+2462          ; mapped                 ; 0033          # 1.1  CIRCLED DIGIT THREE
+2463          ; mapped                 ; 0034          # 1.1  CIRCLED DIGIT FOUR
+2464          ; mapped                 ; 0035          # 1.1  CIRCLED DIGIT FIVE
+2465          ; mapped                 ; 0036          # 1.1  CIRCLED DIGIT SIX
+2466          ; mapped                 ; 0037          # 1.1  CIRCLED DIGIT SEVEN
+2467          ; mapped                 ; 0038          # 1.1  CIRCLED DIGIT EIGHT
+2468          ; mapped                 ; 0039          # 1.1  CIRCLED DIGIT NINE
+2469          ; mapped                 ; 0031 0030     # 1.1  CIRCLED NUMBER TEN
+246A          ; mapped                 ; 0031 0031     # 1.1  CIRCLED NUMBER ELEVEN
+246B          ; mapped                 ; 0031 0032     # 1.1  CIRCLED NUMBER TWELVE
+246C          ; mapped                 ; 0031 0033     # 1.1  CIRCLED NUMBER THIRTEEN
+246D          ; mapped                 ; 0031 0034     # 1.1  CIRCLED NUMBER FOURTEEN
+246E          ; mapped                 ; 0031 0035     # 1.1  CIRCLED NUMBER FIFTEEN
+246F          ; mapped                 ; 0031 0036     # 1.1  CIRCLED NUMBER SIXTEEN
+2470          ; mapped                 ; 0031 0037     # 1.1  CIRCLED NUMBER SEVENTEEN
+2471          ; mapped                 ; 0031 0038     # 1.1  CIRCLED NUMBER EIGHTEEN
+2472          ; mapped                 ; 0031 0039     # 1.1  CIRCLED NUMBER NINETEEN
+2473          ; mapped                 ; 0032 0030     # 1.1  CIRCLED NUMBER TWENTY
+2474          ; disallowed_STD3_mapped ; 0028 0031 0029 #1.1  PARENTHESIZED DIGIT ONE
+2475          ; disallowed_STD3_mapped ; 0028 0032 0029 #1.1  PARENTHESIZED DIGIT TWO
+2476          ; disallowed_STD3_mapped ; 0028 0033 0029 #1.1  PARENTHESIZED DIGIT THREE
+2477          ; disallowed_STD3_mapped ; 0028 0034 0029 #1.1  PARENTHESIZED DIGIT FOUR
+2478          ; disallowed_STD3_mapped ; 0028 0035 0029 #1.1  PARENTHESIZED DIGIT FIVE
+2479          ; disallowed_STD3_mapped ; 0028 0036 0029 #1.1  PARENTHESIZED DIGIT SIX
+247A          ; disallowed_STD3_mapped ; 0028 0037 0029 #1.1  PARENTHESIZED DIGIT SEVEN
+247B          ; disallowed_STD3_mapped ; 0028 0038 0029 #1.1  PARENTHESIZED DIGIT EIGHT
+247C          ; disallowed_STD3_mapped ; 0028 0039 0029 #1.1  PARENTHESIZED DIGIT NINE
+247D          ; disallowed_STD3_mapped ; 0028 0031 0030 0029 #1.1 PARENTHESIZED NUMBER TEN
+247E          ; disallowed_STD3_mapped ; 0028 0031 0031 0029 #1.1 PARENTHESIZED NUMBER ELEVEN
+247F          ; disallowed_STD3_mapped ; 0028 0031 0032 0029 #1.1 PARENTHESIZED NUMBER TWELVE
+2480          ; disallowed_STD3_mapped ; 0028 0031 0033 0029 #1.1 PARENTHESIZED NUMBER THIRTEEN
+2481          ; disallowed_STD3_mapped ; 0028 0031 0034 0029 #1.1 PARENTHESIZED NUMBER FOURTEEN
+2482          ; disallowed_STD3_mapped ; 0028 0031 0035 0029 #1.1 PARENTHESIZED NUMBER FIFTEEN
+2483          ; disallowed_STD3_mapped ; 0028 0031 0036 0029 #1.1 PARENTHESIZED NUMBER SIXTEEN
+2484          ; disallowed_STD3_mapped ; 0028 0031 0037 0029 #1.1 PARENTHESIZED NUMBER SEVENTEEN
+2485          ; disallowed_STD3_mapped ; 0028 0031 0038 0029 #1.1 PARENTHESIZED NUMBER EIGHTEEN
+2486          ; disallowed_STD3_mapped ; 0028 0031 0039 0029 #1.1 PARENTHESIZED NUMBER NINETEEN
+2487          ; disallowed_STD3_mapped ; 0028 0032 0030 0029 #1.1 PARENTHESIZED NUMBER TWENTY
+2488..249B    ; disallowed                             # 1.1  DIGIT ONE FULL STOP..NUMBER TWENTY FULL STOP
+249C          ; disallowed_STD3_mapped ; 0028 0061 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER A
+249D          ; disallowed_STD3_mapped ; 0028 0062 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER B
+249E          ; disallowed_STD3_mapped ; 0028 0063 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER C
+249F          ; disallowed_STD3_mapped ; 0028 0064 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER D
+24A0          ; disallowed_STD3_mapped ; 0028 0065 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER E
+24A1          ; disallowed_STD3_mapped ; 0028 0066 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER F
+24A2          ; disallowed_STD3_mapped ; 0028 0067 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER G
+24A3          ; disallowed_STD3_mapped ; 0028 0068 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER H
+24A4          ; disallowed_STD3_mapped ; 0028 0069 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER I
+24A5          ; disallowed_STD3_mapped ; 0028 006A 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER J
+24A6          ; disallowed_STD3_mapped ; 0028 006B 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER K
+24A7          ; disallowed_STD3_mapped ; 0028 006C 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER L
+24A8          ; disallowed_STD3_mapped ; 0028 006D 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER M
+24A9          ; disallowed_STD3_mapped ; 0028 006E 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER N
+24AA          ; disallowed_STD3_mapped ; 0028 006F 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER O
+24AB          ; disallowed_STD3_mapped ; 0028 0070 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER P
+24AC          ; disallowed_STD3_mapped ; 0028 0071 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER Q
+24AD          ; disallowed_STD3_mapped ; 0028 0072 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER R
+24AE          ; disallowed_STD3_mapped ; 0028 0073 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER S
+24AF          ; disallowed_STD3_mapped ; 0028 0074 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER T
+24B0          ; disallowed_STD3_mapped ; 0028 0075 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER U
+24B1          ; disallowed_STD3_mapped ; 0028 0076 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER V
+24B2          ; disallowed_STD3_mapped ; 0028 0077 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER W
+24B3          ; disallowed_STD3_mapped ; 0028 0078 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER X
+24B4          ; disallowed_STD3_mapped ; 0028 0079 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER Y
+24B5          ; disallowed_STD3_mapped ; 0028 007A 0029 #1.1  PARENTHESIZED LATIN SMALL LETTER Z
+24B6          ; mapped                 ; 0061          # 1.1  CIRCLED LATIN CAPITAL LETTER A
+24B7          ; mapped                 ; 0062          # 1.1  CIRCLED LATIN CAPITAL LETTER B
+24B8          ; mapped                 ; 0063          # 1.1  CIRCLED LATIN CAPITAL LETTER C
+24B9          ; mapped                 ; 0064          # 1.1  CIRCLED LATIN CAPITAL LETTER D
+24BA          ; mapped                 ; 0065          # 1.1  CIRCLED LATIN CAPITAL LETTER E
+24BB          ; mapped                 ; 0066          # 1.1  CIRCLED LATIN CAPITAL LETTER F
+24BC          ; mapped                 ; 0067          # 1.1  CIRCLED LATIN CAPITAL LETTER G
+24BD          ; mapped                 ; 0068          # 1.1  CIRCLED LATIN CAPITAL LETTER H
+24BE          ; mapped                 ; 0069          # 1.1  CIRCLED LATIN CAPITAL LETTER I
+24BF          ; mapped                 ; 006A          # 1.1  CIRCLED LATIN CAPITAL LETTER J
+24C0          ; mapped                 ; 006B          # 1.1  CIRCLED LATIN CAPITAL LETTER K
+24C1          ; mapped                 ; 006C          # 1.1  CIRCLED LATIN CAPITAL LETTER L
+24C2          ; mapped                 ; 006D          # 1.1  CIRCLED LATIN CAPITAL LETTER M
+24C3          ; mapped                 ; 006E          # 1.1  CIRCLED LATIN CAPITAL LETTER N
+24C4          ; mapped                 ; 006F          # 1.1  CIRCLED LATIN CAPITAL LETTER O
+24C5          ; mapped                 ; 0070          # 1.1  CIRCLED LATIN CAPITAL LETTER P
+24C6          ; mapped                 ; 0071          # 1.1  CIRCLED LATIN CAPITAL LETTER Q
+24C7          ; mapped                 ; 0072          # 1.1  CIRCLED LATIN CAPITAL LETTER R
+24C8          ; mapped                 ; 0073          # 1.1  CIRCLED LATIN CAPITAL LETTER S
+24C9          ; mapped                 ; 0074          # 1.1  CIRCLED LATIN CAPITAL LETTER T
+24CA          ; mapped                 ; 0075          # 1.1  CIRCLED LATIN CAPITAL LETTER U
+24CB          ; mapped                 ; 0076          # 1.1  CIRCLED LATIN CAPITAL LETTER V
+24CC          ; mapped                 ; 0077          # 1.1  CIRCLED LATIN CAPITAL LETTER W
+24CD          ; mapped                 ; 0078          # 1.1  CIRCLED LATIN CAPITAL LETTER X
+24CE          ; mapped                 ; 0079          # 1.1  CIRCLED LATIN CAPITAL LETTER Y
+24CF          ; mapped                 ; 007A          # 1.1  CIRCLED LATIN CAPITAL LETTER Z
+24D0          ; mapped                 ; 0061          # 1.1  CIRCLED LATIN SMALL LETTER A
+24D1          ; mapped                 ; 0062          # 1.1  CIRCLED LATIN SMALL LETTER B
+24D2          ; mapped                 ; 0063          # 1.1  CIRCLED LATIN SMALL LETTER C
+24D3          ; mapped                 ; 0064          # 1.1  CIRCLED LATIN SMALL LETTER D
+24D4          ; mapped                 ; 0065          # 1.1  CIRCLED LATIN SMALL LETTER E
+24D5          ; mapped                 ; 0066          # 1.1  CIRCLED LATIN SMALL LETTER F
+24D6          ; mapped                 ; 0067          # 1.1  CIRCLED LATIN SMALL LETTER G
+24D7          ; mapped                 ; 0068          # 1.1  CIRCLED LATIN SMALL LETTER H
+24D8          ; mapped                 ; 0069          # 1.1  CIRCLED LATIN SMALL LETTER I
+24D9          ; mapped                 ; 006A          # 1.1  CIRCLED LATIN SMALL LETTER J
+24DA          ; mapped                 ; 006B          # 1.1  CIRCLED LATIN SMALL LETTER K
+24DB          ; mapped                 ; 006C          # 1.1  CIRCLED LATIN SMALL LETTER L
+24DC          ; mapped                 ; 006D          # 1.1  CIRCLED LATIN SMALL LETTER M
+24DD          ; mapped                 ; 006E          # 1.1  CIRCLED LATIN SMALL LETTER N
+24DE          ; mapped                 ; 006F          # 1.1  CIRCLED LATIN SMALL LETTER O
+24DF          ; mapped                 ; 0070          # 1.1  CIRCLED LATIN SMALL LETTER P
+24E0          ; mapped                 ; 0071          # 1.1  CIRCLED LATIN SMALL LETTER Q
+24E1          ; mapped                 ; 0072          # 1.1  CIRCLED LATIN SMALL LETTER R
+24E2          ; mapped                 ; 0073          # 1.1  CIRCLED LATIN SMALL LETTER S
+24E3          ; mapped                 ; 0074          # 1.1  CIRCLED LATIN SMALL LETTER T
+24E4          ; mapped                 ; 0075          # 1.1  CIRCLED LATIN SMALL LETTER U
+24E5          ; mapped                 ; 0076          # 1.1  CIRCLED LATIN SMALL LETTER V
+24E6          ; mapped                 ; 0077          # 1.1  CIRCLED LATIN SMALL LETTER W
+24E7          ; mapped                 ; 0078          # 1.1  CIRCLED LATIN SMALL LETTER X
+24E8          ; mapped                 ; 0079          # 1.1  CIRCLED LATIN SMALL LETTER Y
+24E9          ; mapped                 ; 007A          # 1.1  CIRCLED LATIN SMALL LETTER Z
+24EA          ; mapped                 ; 0030          # 1.1  CIRCLED DIGIT ZERO
+24EB..24FE    ; valid                  ;      ; NV8    # 3.2  NEGATIVE CIRCLED NUMBER ELEVEN..DOUBLE CIRCLED NUMBER TEN
+24FF          ; valid                  ;      ; NV8    # 4.0  NEGATIVE CIRCLED DIGIT ZERO
+2500..2595    ; valid                  ;      ; NV8    # 1.1  BOX DRAWINGS LIGHT HORIZONTAL..RIGHT ONE EIGHTH BLOCK
+2596..259F    ; valid                  ;      ; NV8    # 3.2  QUADRANT LOWER LEFT..QUADRANT UPPER RIGHT AND LOWER LEFT AND LOWER RIGHT
+25A0..25EF    ; valid                  ;      ; NV8    # 1.1  BLACK SQUARE..LARGE CIRCLE
+25F0..25F7    ; valid                  ;      ; NV8    # 3.0  WHITE SQUARE WITH UPPER LEFT QUADRANT..WHITE CIRCLE WITH UPPER RIGHT QUADRANT
+25F8..25FF    ; valid                  ;      ; NV8    # 3.2  UPPER LEFT TRIANGLE..LOWER RIGHT TRIANGLE
+2600..2613    ; valid                  ;      ; NV8    # 1.1  BLACK SUN WITH RAYS..SALTIRE
+2614..2615    ; valid                  ;      ; NV8    # 4.0  UMBRELLA WITH RAIN DROPS..HOT BEVERAGE
+2616..2617    ; valid                  ;      ; NV8    # 3.2  WHITE SHOGI PIECE..BLACK SHOGI PIECE
+2618          ; valid                  ;      ; NV8    # 4.1  SHAMROCK
+2619          ; valid                  ;      ; NV8    # 3.0  REVERSED ROTATED FLORAL HEART BULLET
+261A..266F    ; valid                  ;      ; NV8    # 1.1  BLACK LEFT POINTING INDEX..MUSIC SHARP SIGN
+2670..2671    ; valid                  ;      ; NV8    # 3.0  WEST SYRIAC CROSS..EAST SYRIAC CROSS
+2672..267D    ; valid                  ;      ; NV8    # 3.2  UNIVERSAL RECYCLING SYMBOL..PARTIALLY-RECYCLED PAPER SYMBOL
+267E..267F    ; valid                  ;      ; NV8    # 4.1  PERMANENT PAPER SIGN..WHEELCHAIR SYMBOL
+2680..2689    ; valid                  ;      ; NV8    # 3.2  DIE FACE-1..BLACK CIRCLE WITH TWO WHITE DOTS
+268A..2691    ; valid                  ;      ; NV8    # 4.0  MONOGRAM FOR YANG..BLACK FLAG
+2692..269C    ; valid                  ;      ; NV8    # 4.1  HAMMER AND PICK..FLEUR-DE-LIS
+269D          ; valid                  ;      ; NV8    # 5.1  OUTLINED WHITE STAR
+269E..269F    ; valid                  ;      ; NV8    # 5.2  THREE LINES CONVERGING RIGHT..THREE LINES CONVERGING LEFT
+26A0..26A1    ; valid                  ;      ; NV8    # 4.0  WARNING SIGN..HIGH VOLTAGE SIGN
+26A2..26B1    ; valid                  ;      ; NV8    # 4.1  DOUBLED FEMALE SIGN..FUNERAL URN
+26B2          ; valid                  ;      ; NV8    # 5.0  NEUTER
+26B3..26BC    ; valid                  ;      ; NV8    # 5.1  CERES..SESQUIQUADRATE
+26BD..26BF    ; valid                  ;      ; NV8    # 5.2  SOCCER BALL..SQUARED KEY
+26C0..26C3    ; valid                  ;      ; NV8    # 5.1  WHITE DRAUGHTS MAN..BLACK DRAUGHTS KING
+26C4..26CD    ; valid                  ;      ; NV8    # 5.2  SNOWMAN WITHOUT SNOW..DISABLED CAR
+26CE          ; valid                  ;      ; NV8    # 6.0  OPHIUCHUS
+26CF..26E1    ; valid                  ;      ; NV8    # 5.2  PICK..RESTRICTED LEFT ENTRY-2
+26E2          ; valid                  ;      ; NV8    # 6.0  ASTRONOMICAL SYMBOL FOR URANUS
+26E3          ; valid                  ;      ; NV8    # 5.2  HEAVY CIRCLE WITH STROKE AND TWO DOTS ABOVE
+26E4..26E7    ; valid                  ;      ; NV8    # 6.0  PENTAGRAM..INVERTED PENTAGRAM
+26E8..26FF    ; valid                  ;      ; NV8    # 5.2  BLACK CROSS ON SHIELD..WHITE FLAG WITH HORIZONTAL MIDDLE BLACK STRIPE
+2700          ; valid                  ;      ; NV8    # 7.0  BLACK SAFETY SCISSORS
+2701..2704    ; valid                  ;      ; NV8    # 1.1  UPPER BLADE SCISSORS..WHITE SCISSORS
+2705          ; valid                  ;      ; NV8    # 6.0  WHITE HEAVY CHECK MARK
+2706..2709    ; valid                  ;      ; NV8    # 1.1  TELEPHONE LOCATION SIGN..ENVELOPE
+270A..270B    ; valid                  ;      ; NV8    # 6.0  RAISED FIST..RAISED HAND
+270C..2727    ; valid                  ;      ; NV8    # 1.1  VICTORY HAND..WHITE FOUR POINTED STAR
+2728          ; valid                  ;      ; NV8    # 6.0  SPARKLES
+2729..274B    ; valid                  ;      ; NV8    # 1.1  STRESS OUTLINED WHITE STAR..HEAVY EIGHT TEARDROP-SPOKED PROPELLER ASTERISK
+274C          ; valid                  ;      ; NV8    # 6.0  CROSS MARK
+274D          ; valid                  ;      ; NV8    # 1.1  SHADOWED WHITE CIRCLE
+274E          ; valid                  ;      ; NV8    # 6.0  NEGATIVE SQUARED CROSS MARK
+274F..2752    ; valid                  ;      ; NV8    # 1.1  LOWER RIGHT DROP-SHADOWED WHITE SQUARE..UPPER RIGHT SHADOWED WHITE SQUARE
+2753..2755    ; valid                  ;      ; NV8    # 6.0  BLACK QUESTION MARK ORNAMENT..WHITE EXCLAMATION MARK ORNAMENT
+2756          ; valid                  ;      ; NV8    # 1.1  BLACK DIAMOND MINUS WHITE X
+2757          ; valid                  ;      ; NV8    # 5.2  HEAVY EXCLAMATION MARK SYMBOL
+2758..275E    ; valid                  ;      ; NV8    # 1.1  LIGHT VERTICAL BAR..HEAVY DOUBLE COMMA QUOTATION MARK ORNAMENT
+275F..2760    ; valid                  ;      ; NV8    # 6.0  HEAVY LOW SINGLE COMMA QUOTATION MARK ORNAMENT..HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
+2761..2767    ; valid                  ;      ; NV8    # 1.1  CURVED STEM PARAGRAPH SIGN ORNAMENT..ROTATED FLORAL HEART BULLET
+2768..2775    ; valid                  ;      ; NV8    # 3.2  MEDIUM LEFT PARENTHESIS ORNAMENT..MEDIUM RIGHT CURLY BRACKET ORNAMENT
+2776..2794    ; valid                  ;      ; NV8    # 1.1  DINGBAT NEGATIVE CIRCLED DIGIT ONE..HEAVY WIDE-HEADED RIGHTWARDS ARROW
+2795..2797    ; valid                  ;      ; NV8    # 6.0  HEAVY PLUS SIGN..HEAVY DIVISION SIGN
+2798..27AF    ; valid                  ;      ; NV8    # 1.1  HEAVY SOUTH EAST ARROW..NOTCHED LOWER RIGHT-SHADOWED WHITE RIGHTWARDS ARROW
+27B0          ; valid                  ;      ; NV8    # 6.0  CURLY LOOP
+27B1..27BE    ; valid                  ;      ; NV8    # 1.1  NOTCHED UPPER RIGHT-SHADOWED WHITE RIGHTWARDS ARROW..OPEN-OUTLINED RIGHTWARDS ARROW
+27BF          ; valid                  ;      ; NV8    # 6.0  DOUBLE CURLY LOOP
+27C0..27C6    ; valid                  ;      ; NV8    # 4.1  THREE DIMENSIONAL ANGLE..RIGHT S-SHAPED BAG DELIMITER
+27C7..27CA    ; valid                  ;      ; NV8    # 5.0  OR WITH DOT INSIDE..VERTICAL BAR WITH HORIZONTAL STROKE
+27CB          ; valid                  ;      ; NV8    # 6.1  MATHEMATICAL RISING DIAGONAL
+27CC          ; valid                  ;      ; NV8    # 5.1  LONG DIVISION
+27CD          ; valid                  ;      ; NV8    # 6.1  MATHEMATICAL FALLING DIAGONAL
+27CE..27CF    ; valid                  ;      ; NV8    # 6.0  SQUARED LOGICAL AND..SQUARED LOGICAL OR
+27D0..27EB    ; valid                  ;      ; NV8    # 3.2  WHITE DIAMOND WITH CENTRED DOT..MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
+27EC..27EF    ; valid                  ;      ; NV8    # 5.1  MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET..MATHEMATICAL RIGHT FLATTENED PARENTHESIS
+27F0..27FF    ; valid                  ;      ; NV8    # 3.2  UPWARDS QUADRUPLE ARROW..LONG RIGHTWARDS SQUIGGLE ARROW
+2800..28FF    ; valid                  ;      ; NV8    # 3.0  BRAILLE PATTERN BLANK..BRAILLE PATTERN DOTS-12345678
+2900..2A0B    ; valid                  ;      ; NV8    # 3.2  RIGHTWARDS TWO-HEADED ARROW WITH VERTICAL STROKE..SUMMATION WITH INTEGRAL
+2A0C          ; mapped                 ; 222B 222B 222B 222B #3.2 QUADRUPLE INTEGRAL OPERATOR
+2A0D..2A73    ; valid                  ;      ; NV8    # 3.2  FINITE PART INTEGRAL..EQUALS SIGN ABOVE TILDE OPERATOR
+2A74          ; disallowed_STD3_mapped ; 003A 003A 003D #3.2  DOUBLE COLON EQUAL
+2A75          ; disallowed_STD3_mapped ; 003D 003D     # 3.2  TWO CONSECUTIVE EQUALS SIGNS
+2A76          ; disallowed_STD3_mapped ; 003D 003D 003D #3.2  THREE CONSECUTIVE EQUALS SIGNS
+2A77..2ADB    ; valid                  ;      ; NV8    # 3.2  EQUALS SIGN WITH TWO DOTS ABOVE AND TWO DOTS BELOW..TRANSVERSAL INTERSECTION
+2ADC          ; mapped                 ; 2ADD 0338     # 3.2  FORKING
+2ADD..2AFF    ; valid                  ;      ; NV8    # 3.2  NONFORKING..N-ARY WHITE VERTICAL BAR
+2B00..2B0D    ; valid                  ;      ; NV8    # 4.0  NORTH EAST WHITE ARROW..UP DOWN BLACK ARROW
+2B0E..2B13    ; valid                  ;      ; NV8    # 4.1  RIGHTWARDS ARROW WITH TIP DOWNWARDS..SQUARE WITH BOTTOM HALF BLACK
+2B14..2B1A    ; valid                  ;      ; NV8    # 5.0  SQUARE WITH UPPER RIGHT DIAGONAL HALF BLACK..DOTTED SQUARE
+2B1B..2B1F    ; valid                  ;      ; NV8    # 5.1  BLACK LARGE SQUARE..BLACK PENTAGON
+2B20..2B23    ; valid                  ;      ; NV8    # 5.0  WHITE PENTAGON..HORIZONTAL BLACK HEXAGON
+2B24..2B4C    ; valid                  ;      ; NV8    # 5.1  BLACK LARGE CIRCLE..RIGHTWARDS ARROW ABOVE REVERSE TILDE OPERATOR
+2B4D..2B4F    ; valid                  ;      ; NV8    # 7.0  DOWNWARDS TRIANGLE-HEADED ZIGZAG ARROW..SHORT BACKSLANTED SOUTH ARROW
+2B50..2B54    ; valid                  ;      ; NV8    # 5.1  WHITE MEDIUM STAR..WHITE RIGHT-POINTING PENTAGON
+2B55..2B59    ; valid                  ;      ; NV8    # 5.2  HEAVY LARGE CIRCLE..HEAVY CIRCLED SALTIRE
+2B5A..2B73    ; valid                  ;      ; NV8    # 7.0  SLANTED NORTH ARROW WITH HOOKED HEAD..DOWNWARDS TRIANGLE-HEADED ARROW TO BAR
+2B74..2B75    ; disallowed                             # NA   <reserved-2B74>..<reserved-2B75>
+2B76..2B95    ; valid                  ;      ; NV8    # 7.0  NORTH WEST TRIANGLE-HEADED ARROW TO BAR..RIGHTWARDS BLACK ARROW
+2B96          ; disallowed                             # NA   <reserved-2B96>
+2B97          ; valid                  ;      ; NV8    # 13.0 SYMBOL FOR TYPE A ELECTRONICS
+2B98..2BB9    ; valid                  ;      ; NV8    # 7.0  THREE-D TOP-LIGHTED LEFTWARDS EQUILATERAL ARROWHEAD..UP ARROWHEAD IN A RECTANGLE BOX
+2BBA..2BBC    ; valid                  ;      ; NV8    # 11.0 OVERLAPPING WHITE SQUARES..OVERLAPPING BLACK SQUARES
+2BBD..2BC8    ; valid                  ;      ; NV8    # 7.0  BALLOT BOX WITH LIGHT X..BLACK MEDIUM RIGHT-POINTING TRIANGLE CENTRED
+2BC9          ; valid                  ;      ; NV8    # 12.0 NEPTUNE FORM TWO
+2BCA..2BD1    ; valid                  ;      ; NV8    # 7.0  TOP HALF BLACK CIRCLE..UNCERTAINTY SIGN
+2BD2          ; valid                  ;      ; NV8    # 10.0 GROUP MARK
+2BD3..2BEB    ; valid                  ;      ; NV8    # 11.0 PLUTO FORM TWO..STAR WITH RIGHT HALF BLACK
+2BEC..2BEF    ; valid                  ;      ; NV8    # 8.0  LEFTWARDS TWO-HEADED ARROW WITH TRIANGLE ARROWHEADS..DOWNWARDS TWO-HEADED ARROW WITH TRIANGLE ARROWHEADS
+2BF0..2BFE    ; valid                  ;      ; NV8    # 11.0 ERIS FORM ONE..REVERSED RIGHT ANGLE
+2BFF          ; valid                  ;      ; NV8    # 12.0 HELLSCHREIBER PAUSE SYMBOL
+2C00          ; mapped                 ; 2C30          # 4.1  GLAGOLITIC CAPITAL LETTER AZU
+2C01          ; mapped                 ; 2C31          # 4.1  GLAGOLITIC CAPITAL LETTER BUKY
+2C02          ; mapped                 ; 2C32          # 4.1  GLAGOLITIC CAPITAL LETTER VEDE
+2C03          ; mapped                 ; 2C33          # 4.1  GLAGOLITIC CAPITAL LETTER GLAGOLI
+2C04          ; mapped                 ; 2C34          # 4.1  GLAGOLITIC CAPITAL LETTER DOBRO
+2C05          ; mapped                 ; 2C35          # 4.1  GLAGOLITIC CAPITAL LETTER YESTU
+2C06          ; mapped                 ; 2C36          # 4.1  GLAGOLITIC CAPITAL LETTER ZHIVETE
+2C07          ; mapped                 ; 2C37          # 4.1  GLAGOLITIC CAPITAL LETTER DZELO
+2C08          ; mapped                 ; 2C38          # 4.1  GLAGOLITIC CAPITAL LETTER ZEMLJA
+2C09          ; mapped                 ; 2C39          # 4.1  GLAGOLITIC CAPITAL LETTER IZHE
+2C0A          ; mapped                 ; 2C3A          # 4.1  GLAGOLITIC CAPITAL LETTER INITIAL IZHE
+2C0B          ; mapped                 ; 2C3B          # 4.1  GLAGOLITIC CAPITAL LETTER I
+2C0C          ; mapped                 ; 2C3C          # 4.1  GLAGOLITIC CAPITAL LETTER DJERVI
+2C0D          ; mapped                 ; 2C3D          # 4.1  GLAGOLITIC CAPITAL LETTER KAKO
+2C0E          ; mapped                 ; 2C3E          # 4.1  GLAGOLITIC CAPITAL LETTER LJUDIJE
+2C0F          ; mapped                 ; 2C3F          # 4.1  GLAGOLITIC CAPITAL LETTER MYSLITE
+2C10          ; mapped                 ; 2C40          # 4.1  GLAGOLITIC CAPITAL LETTER NASHI
+2C11          ; mapped                 ; 2C41          # 4.1  GLAGOLITIC CAPITAL LETTER ONU
+2C12          ; mapped                 ; 2C42          # 4.1  GLAGOLITIC CAPITAL LETTER POKOJI
+2C13          ; mapped                 ; 2C43          # 4.1  GLAGOLITIC CAPITAL LETTER RITSI
+2C14          ; mapped                 ; 2C44          # 4.1  GLAGOLITIC CAPITAL LETTER SLOVO
+2C15          ; mapped                 ; 2C45          # 4.1  GLAGOLITIC CAPITAL LETTER TVRIDO
+2C16          ; mapped                 ; 2C46          # 4.1  GLAGOLITIC CAPITAL LETTER UKU
+2C17          ; mapped                 ; 2C47          # 4.1  GLAGOLITIC CAPITAL LETTER FRITU
+2C18          ; mapped                 ; 2C48          # 4.1  GLAGOLITIC CAPITAL LETTER HERU
+2C19          ; mapped                 ; 2C49          # 4.1  GLAGOLITIC CAPITAL LETTER OTU
+2C1A          ; mapped                 ; 2C4A          # 4.1  GLAGOLITIC CAPITAL LETTER PE
+2C1B          ; mapped                 ; 2C4B          # 4.1  GLAGOLITIC CAPITAL LETTER SHTA
+2C1C          ; mapped                 ; 2C4C          # 4.1  GLAGOLITIC CAPITAL LETTER TSI
+2C1D          ; mapped                 ; 2C4D          # 4.1  GLAGOLITIC CAPITAL LETTER CHRIVI
+2C1E          ; mapped                 ; 2C4E          # 4.1  GLAGOLITIC CAPITAL LETTER SHA
+2C1F          ; mapped                 ; 2C4F          # 4.1  GLAGOLITIC CAPITAL LETTER YERU
+2C20          ; mapped                 ; 2C50          # 4.1  GLAGOLITIC CAPITAL LETTER YERI
+2C21          ; mapped                 ; 2C51          # 4.1  GLAGOLITIC CAPITAL LETTER YATI
+2C22          ; mapped                 ; 2C52          # 4.1  GLAGOLITIC CAPITAL LETTER SPIDERY HA
+2C23          ; mapped                 ; 2C53          # 4.1  GLAGOLITIC CAPITAL LETTER YU
+2C24          ; mapped                 ; 2C54          # 4.1  GLAGOLITIC CAPITAL LETTER SMALL YUS
+2C25          ; mapped                 ; 2C55          # 4.1  GLAGOLITIC CAPITAL LETTER SMALL YUS WITH TAIL
+2C26          ; mapped                 ; 2C56          # 4.1  GLAGOLITIC CAPITAL LETTER YO
+2C27          ; mapped                 ; 2C57          # 4.1  GLAGOLITIC CAPITAL LETTER IOTATED SMALL YUS
+2C28          ; mapped                 ; 2C58          # 4.1  GLAGOLITIC CAPITAL LETTER BIG YUS
+2C29          ; mapped                 ; 2C59          # 4.1  GLAGOLITIC CAPITAL LETTER IOTATED BIG YUS
+2C2A          ; mapped                 ; 2C5A          # 4.1  GLAGOLITIC CAPITAL LETTER FITA
+2C2B          ; mapped                 ; 2C5B          # 4.1  GLAGOLITIC CAPITAL LETTER IZHITSA
+2C2C          ; mapped                 ; 2C5C          # 4.1  GLAGOLITIC CAPITAL LETTER SHTAPIC
+2C2D          ; mapped                 ; 2C5D          # 4.1  GLAGOLITIC CAPITAL LETTER TROKUTASTI A
+2C2E          ; mapped                 ; 2C5E          # 4.1  GLAGOLITIC CAPITAL LETTER LATINATE MYSLITE
+2C2F          ; mapped                 ; 2C5F          # 14.0 GLAGOLITIC CAPITAL LETTER CAUDATE CHRIVI
+2C30..2C5E    ; valid                                  # 4.1  GLAGOLITIC SMALL LETTER AZU..GLAGOLITIC SMALL LETTER LATINATE MYSLITE
+2C5F          ; valid                                  # 14.0 GLAGOLITIC SMALL LETTER CAUDATE CHRIVI
+2C60          ; mapped                 ; 2C61          # 5.0  LATIN CAPITAL LETTER L WITH DOUBLE BAR
+2C61          ; valid                                  # 5.0  LATIN SMALL LETTER L WITH DOUBLE BAR
+2C62          ; mapped                 ; 026B          # 5.0  LATIN CAPITAL LETTER L WITH MIDDLE TILDE
+2C63          ; mapped                 ; 1D7D          # 5.0  LATIN CAPITAL LETTER P WITH STROKE
+2C64          ; mapped                 ; 027D          # 5.0  LATIN CAPITAL LETTER R WITH TAIL
+2C65..2C66    ; valid                                  # 5.0  LATIN SMALL LETTER A WITH STROKE..LATIN SMALL LETTER T WITH DIAGONAL STROKE
+2C67          ; mapped                 ; 2C68          # 5.0  LATIN CAPITAL LETTER H WITH DESCENDER
+2C68          ; valid                                  # 5.0  LATIN SMALL LETTER H WITH DESCENDER
+2C69          ; mapped                 ; 2C6A          # 5.0  LATIN CAPITAL LETTER K WITH DESCENDER
+2C6A          ; valid                                  # 5.0  LATIN SMALL LETTER K WITH DESCENDER
+2C6B          ; mapped                 ; 2C6C          # 5.0  LATIN CAPITAL LETTER Z WITH DESCENDER
+2C6C          ; valid                                  # 5.0  LATIN SMALL LETTER Z WITH DESCENDER
+2C6D          ; mapped                 ; 0251          # 5.1  LATIN CAPITAL LETTER ALPHA
+2C6E          ; mapped                 ; 0271          # 5.1  LATIN CAPITAL LETTER M WITH HOOK
+2C6F          ; mapped                 ; 0250          # 5.1  LATIN CAPITAL LETTER TURNED A
+2C70          ; mapped                 ; 0252          # 5.2  LATIN CAPITAL LETTER TURNED ALPHA
+2C71          ; valid                                  # 5.1  LATIN SMALL LETTER V WITH RIGHT HOOK
+2C72          ; mapped                 ; 2C73          # 5.1  LATIN CAPITAL LETTER W WITH HOOK
+2C73          ; valid                                  # 5.1  LATIN SMALL LETTER W WITH HOOK
+2C74          ; valid                                  # 5.0  LATIN SMALL LETTER V WITH CURL
+2C75          ; mapped                 ; 2C76          # 5.0  LATIN CAPITAL LETTER HALF H
+2C76..2C77    ; valid                                  # 5.0  LATIN SMALL LETTER HALF H..LATIN SMALL LETTER TAILLESS PHI
+2C78..2C7B    ; valid                                  # 5.1  LATIN SMALL LETTER E WITH NOTCH..LATIN LETTER SMALL CAPITAL TURNED E
+2C7C          ; mapped                 ; 006A          # 5.1  LATIN SUBSCRIPT SMALL LETTER J
+2C7D          ; mapped                 ; 0076          # 5.1  MODIFIER LETTER CAPITAL V
+2C7E          ; mapped                 ; 023F          # 5.2  LATIN CAPITAL LETTER S WITH SWASH TAIL
+2C7F          ; mapped                 ; 0240          # 5.2  LATIN CAPITAL LETTER Z WITH SWASH TAIL
+2C80          ; mapped                 ; 2C81          # 4.1  COPTIC CAPITAL LETTER ALFA
+2C81          ; valid                                  # 4.1  COPTIC SMALL LETTER ALFA
+2C82          ; mapped                 ; 2C83          # 4.1  COPTIC CAPITAL LETTER VIDA
+2C83          ; valid                                  # 4.1  COPTIC SMALL LETTER VIDA
+2C84          ; mapped                 ; 2C85          # 4.1  COPTIC CAPITAL LETTER GAMMA
+2C85          ; valid                                  # 4.1  COPTIC SMALL LETTER GAMMA
+2C86          ; mapped                 ; 2C87          # 4.1  COPTIC CAPITAL LETTER DALDA
+2C87          ; valid                                  # 4.1  COPTIC SMALL LETTER DALDA
+2C88          ; mapped                 ; 2C89          # 4.1  COPTIC CAPITAL LETTER EIE
+2C89          ; valid                                  # 4.1  COPTIC SMALL LETTER EIE
+2C8A          ; mapped                 ; 2C8B          # 4.1  COPTIC CAPITAL LETTER SOU
+2C8B          ; valid                                  # 4.1  COPTIC SMALL LETTER SOU
+2C8C          ; mapped                 ; 2C8D          # 4.1  COPTIC CAPITAL LETTER ZATA
+2C8D          ; valid                                  # 4.1  COPTIC SMALL LETTER ZATA
+2C8E          ; mapped                 ; 2C8F          # 4.1  COPTIC CAPITAL LETTER HATE
+2C8F          ; valid                                  # 4.1  COPTIC SMALL LETTER HATE
+2C90          ; mapped                 ; 2C91          # 4.1  COPTIC CAPITAL LETTER THETHE
+2C91          ; valid                                  # 4.1  COPTIC SMALL LETTER THETHE
+2C92          ; mapped                 ; 2C93          # 4.1  COPTIC CAPITAL LETTER IAUDA
+2C93          ; valid                                  # 4.1  COPTIC SMALL LETTER IAUDA
+2C94          ; mapped                 ; 2C95          # 4.1  COPTIC CAPITAL LETTER KAPA
+2C95          ; valid                                  # 4.1  COPTIC SMALL LETTER KAPA
+2C96          ; mapped                 ; 2C97          # 4.1  COPTIC CAPITAL LETTER LAULA
+2C97          ; valid                                  # 4.1  COPTIC SMALL LETTER LAULA
+2C98          ; mapped                 ; 2C99          # 4.1  COPTIC CAPITAL LETTER MI
+2C99          ; valid                                  # 4.1  COPTIC SMALL LETTER MI
+2C9A          ; mapped                 ; 2C9B          # 4.1  COPTIC CAPITAL LETTER NI
+2C9B          ; valid                                  # 4.1  COPTIC SMALL LETTER NI
+2C9C          ; mapped                 ; 2C9D          # 4.1  COPTIC CAPITAL LETTER KSI
+2C9D          ; valid                                  # 4.1  COPTIC SMALL LETTER KSI
+2C9E          ; mapped                 ; 2C9F          # 4.1  COPTIC CAPITAL LETTER O
+2C9F          ; valid                                  # 4.1  COPTIC SMALL LETTER O
+2CA0          ; mapped                 ; 2CA1          # 4.1  COPTIC CAPITAL LETTER PI
+2CA1          ; valid                                  # 4.1  COPTIC SMALL LETTER PI
+2CA2          ; mapped                 ; 2CA3          # 4.1  COPTIC CAPITAL LETTER RO
+2CA3          ; valid                                  # 4.1  COPTIC SMALL LETTER RO
+2CA4          ; mapped                 ; 2CA5          # 4.1  COPTIC CAPITAL LETTER SIMA
+2CA5          ; valid                                  # 4.1  COPTIC SMALL LETTER SIMA
+2CA6          ; mapped                 ; 2CA7          # 4.1  COPTIC CAPITAL LETTER TAU
+2CA7          ; valid                                  # 4.1  COPTIC SMALL LETTER TAU
+2CA8          ; mapped                 ; 2CA9          # 4.1  COPTIC CAPITAL LETTER UA
+2CA9          ; valid                                  # 4.1  COPTIC SMALL LETTER UA
+2CAA          ; mapped                 ; 2CAB          # 4.1  COPTIC CAPITAL LETTER FI
+2CAB          ; valid                                  # 4.1  COPTIC SMALL LETTER FI
+2CAC          ; mapped                 ; 2CAD          # 4.1  COPTIC CAPITAL LETTER KHI
+2CAD          ; valid                                  # 4.1  COPTIC SMALL LETTER KHI
+2CAE          ; mapped                 ; 2CAF          # 4.1  COPTIC CAPITAL LETTER PSI
+2CAF          ; valid                                  # 4.1  COPTIC SMALL LETTER PSI
+2CB0          ; mapped                 ; 2CB1          # 4.1  COPTIC CAPITAL LETTER OOU
+2CB1          ; valid                                  # 4.1  COPTIC SMALL LETTER OOU
+2CB2          ; mapped                 ; 2CB3          # 4.1  COPTIC CAPITAL LETTER DIALECT-P ALEF
+2CB3          ; valid                                  # 4.1  COPTIC SMALL LETTER DIALECT-P ALEF
+2CB4          ; mapped                 ; 2CB5          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC AIN
+2CB5          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC AIN
+2CB6          ; mapped                 ; 2CB7          # 4.1  COPTIC CAPITAL LETTER CRYPTOGRAMMIC EIE
+2CB7          ; valid                                  # 4.1  COPTIC SMALL LETTER CRYPTOGRAMMIC EIE
+2CB8          ; mapped                 ; 2CB9          # 4.1  COPTIC CAPITAL LETTER DIALECT-P KAPA
+2CB9          ; valid                                  # 4.1  COPTIC SMALL LETTER DIALECT-P KAPA
+2CBA          ; mapped                 ; 2CBB          # 4.1  COPTIC CAPITAL LETTER DIALECT-P NI
+2CBB          ; valid                                  # 4.1  COPTIC SMALL LETTER DIALECT-P NI
+2CBC          ; mapped                 ; 2CBD          # 4.1  COPTIC CAPITAL LETTER CRYPTOGRAMMIC NI
+2CBD          ; valid                                  # 4.1  COPTIC SMALL LETTER CRYPTOGRAMMIC NI
+2CBE          ; mapped                 ; 2CBF          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC OOU
+2CBF          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC OOU
+2CC0          ; mapped                 ; 2CC1          # 4.1  COPTIC CAPITAL LETTER SAMPI
+2CC1          ; valid                                  # 4.1  COPTIC SMALL LETTER SAMPI
+2CC2          ; mapped                 ; 2CC3          # 4.1  COPTIC CAPITAL LETTER CROSSED SHEI
+2CC3          ; valid                                  # 4.1  COPTIC SMALL LETTER CROSSED SHEI
+2CC4          ; mapped                 ; 2CC5          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC SHEI
+2CC5          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC SHEI
+2CC6          ; mapped                 ; 2CC7          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC ESH
+2CC7          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC ESH
+2CC8          ; mapped                 ; 2CC9          # 4.1  COPTIC CAPITAL LETTER AKHMIMIC KHEI
+2CC9          ; valid                                  # 4.1  COPTIC SMALL LETTER AKHMIMIC KHEI
+2CCA          ; mapped                 ; 2CCB          # 4.1  COPTIC CAPITAL LETTER DIALECT-P HORI
+2CCB          ; valid                                  # 4.1  COPTIC SMALL LETTER DIALECT-P HORI
+2CCC          ; mapped                 ; 2CCD          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC HORI
+2CCD          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC HORI
+2CCE          ; mapped                 ; 2CCF          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC HA
+2CCF          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC HA
+2CD0          ; mapped                 ; 2CD1          # 4.1  COPTIC CAPITAL LETTER L-SHAPED HA
+2CD1          ; valid                                  # 4.1  COPTIC SMALL LETTER L-SHAPED HA
+2CD2          ; mapped                 ; 2CD3          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC HEI
+2CD3          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC HEI
+2CD4          ; mapped                 ; 2CD5          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC HAT
+2CD5          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC HAT
+2CD6          ; mapped                 ; 2CD7          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC GANGIA
+2CD7          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC GANGIA
+2CD8          ; mapped                 ; 2CD9          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC DJA
+2CD9          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC DJA
+2CDA          ; mapped                 ; 2CDB          # 4.1  COPTIC CAPITAL LETTER OLD COPTIC SHIMA
+2CDB          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD COPTIC SHIMA
+2CDC          ; mapped                 ; 2CDD          # 4.1  COPTIC CAPITAL LETTER OLD NUBIAN SHIMA
+2CDD          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD NUBIAN SHIMA
+2CDE          ; mapped                 ; 2CDF          # 4.1  COPTIC CAPITAL LETTER OLD NUBIAN NGI
+2CDF          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD NUBIAN NGI
+2CE0          ; mapped                 ; 2CE1          # 4.1  COPTIC CAPITAL LETTER OLD NUBIAN NYI
+2CE1          ; valid                                  # 4.1  COPTIC SMALL LETTER OLD NUBIAN NYI
+2CE2          ; mapped                 ; 2CE3          # 4.1  COPTIC CAPITAL LETTER OLD NUBIAN WAU
+2CE3..2CE4    ; valid                                  # 4.1  COPTIC SMALL LETTER OLD NUBIAN WAU..COPTIC SYMBOL KAI
+2CE5..2CEA    ; valid                  ;      ; NV8    # 4.1  COPTIC SYMBOL MI RO..COPTIC SYMBOL SHIMA SIMA
+2CEB          ; mapped                 ; 2CEC          # 5.2  COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI
+2CEC          ; valid                                  # 5.2  COPTIC SMALL LETTER CRYPTOGRAMMIC SHEI
+2CED          ; mapped                 ; 2CEE          # 5.2  COPTIC CAPITAL LETTER CRYPTOGRAMMIC GANGIA
+2CEE..2CF1    ; valid                                  # 5.2  COPTIC SMALL LETTER CRYPTOGRAMMIC GANGIA..COPTIC COMBINING SPIRITUS LENIS
+2CF2          ; mapped                 ; 2CF3          # 6.1  COPTIC CAPITAL LETTER BOHAIRIC KHEI
+2CF3          ; valid                                  # 6.1  COPTIC SMALL LETTER BOHAIRIC KHEI
+2CF4..2CF8    ; disallowed                             # NA   <reserved-2CF4>..<reserved-2CF8>
+2CF9..2CFF    ; valid                  ;      ; NV8    # 4.1  COPTIC OLD NUBIAN FULL STOP..COPTIC MORPHOLOGICAL DIVIDER
+2D00..2D25    ; valid                                  # 4.1  GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
+2D26          ; disallowed                             # NA   <reserved-2D26>
+2D27          ; valid                                  # 6.1  GEORGIAN SMALL LETTER YN
+2D28..2D2C    ; disallowed                             # NA   <reserved-2D28>..<reserved-2D2C>
+2D2D          ; valid                                  # 6.1  GEORGIAN SMALL LETTER AEN
+2D2E..2D2F    ; disallowed                             # NA   <reserved-2D2E>..<reserved-2D2F>
+2D30..2D65    ; valid                                  # 4.1  TIFINAGH LETTER YA..TIFINAGH LETTER YAZZ
+2D66..2D67    ; valid                                  # 6.1  TIFINAGH LETTER YE..TIFINAGH LETTER YO
+2D68..2D6E    ; disallowed                             # NA   <reserved-2D68>..<reserved-2D6E>
+2D6F          ; mapped                 ; 2D61          # 4.1  TIFINAGH MODIFIER LETTER LABIALIZATION MARK
+2D70          ; valid                  ;      ; NV8    # 6.0  TIFINAGH SEPARATOR MARK
+2D71..2D7E    ; disallowed                             # NA   <reserved-2D71>..<reserved-2D7E>
+2D7F          ; valid                                  # 6.0  TIFINAGH CONSONANT JOINER
+2D80..2D96    ; valid                                  # 4.1  ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
+2D97..2D9F    ; disallowed                             # NA   <reserved-2D97>..<reserved-2D9F>
+2DA0..2DA6    ; valid                                  # 4.1  ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
+2DA7          ; disallowed                             # NA   <reserved-2DA7>
+2DA8..2DAE    ; valid                                  # 4.1  ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
+2DAF          ; disallowed                             # NA   <reserved-2DAF>
+2DB0..2DB6    ; valid                                  # 4.1  ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
+2DB7          ; disallowed                             # NA   <reserved-2DB7>
+2DB8..2DBE    ; valid                                  # 4.1  ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
+2DBF          ; disallowed                             # NA   <reserved-2DBF>
+2DC0..2DC6    ; valid                                  # 4.1  ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
+2DC7          ; disallowed                             # NA   <reserved-2DC7>
+2DC8..2DCE    ; valid                                  # 4.1  ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
+2DCF          ; disallowed                             # NA   <reserved-2DCF>
+2DD0..2DD6    ; valid                                  # 4.1  ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
+2DD7          ; disallowed                             # NA   <reserved-2DD7>
+2DD8..2DDE    ; valid                                  # 4.1  ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
+2DDF          ; disallowed                             # NA   <reserved-2DDF>
+2DE0..2DFF    ; valid                                  # 5.1  COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
+2E00..2E17    ; valid                  ;      ; NV8    # 4.1  RIGHT ANGLE SUBSTITUTION MARKER..DOUBLE OBLIQUE HYPHEN
+2E18..2E1B    ; valid                  ;      ; NV8    # 5.1  INVERTED INTERROBANG..TILDE WITH RING ABOVE
+2E1C..2E1D    ; valid                  ;      ; NV8    # 4.1  LEFT LOW PARAPHRASE BRACKET..RIGHT LOW PARAPHRASE BRACKET
+2E1E..2E2E    ; valid                  ;      ; NV8    # 5.1  TILDE WITH DOT ABOVE..REVERSED QUESTION MARK
+2E2F          ; valid                                  # 5.1  VERTICAL TILDE
+2E30          ; valid                  ;      ; NV8    # 5.1  RING POINT
+2E31          ; valid                  ;      ; NV8    # 5.2  WORD SEPARATOR MIDDLE DOT
+2E32..2E3B    ; valid                  ;      ; NV8    # 6.1  TURNED COMMA..THREE-EM DASH
+2E3C..2E42    ; valid                  ;      ; NV8    # 7.0  STENOGRAPHIC FULL STOP..DOUBLE LOW-REVERSED-9 QUOTATION MARK
+2E43..2E44    ; valid                  ;      ; NV8    # 9.0  DASH WITH LEFT UPTURN..DOUBLE SUSPENSION MARK
+2E45..2E49    ; valid                  ;      ; NV8    # 10.0 INVERTED LOW KAVYKA..DOUBLE STACKED COMMA
+2E4A..2E4E    ; valid                  ;      ; NV8    # 11.0 DOTTED SOLIDUS..PUNCTUS ELEVATUS MARK
+2E4F          ; valid                  ;      ; NV8    # 12.0 CORNISH VERSE DIVIDER
+2E50..2E52    ; valid                  ;      ; NV8    # 13.0 CROSS PATTY WITH RIGHT CROSSBAR..TIRONIAN SIGN CAPITAL ET
+2E53..2E5D    ; valid                  ;      ; NV8    # 14.0 MEDIEVAL EXCLAMATION MARK..OBLIQUE HYPHEN
+2E5E..2E7F    ; disallowed                             # NA   <reserved-2E5E>..<reserved-2E7F>
+2E80..2E99    ; valid                  ;      ; NV8    # 3.0  CJK RADICAL REPEAT..CJK RADICAL RAP
+2E9A          ; disallowed                             # NA   <reserved-2E9A>
+2E9B..2E9E    ; valid                  ;      ; NV8    # 3.0  CJK RADICAL CHOKE..CJK RADICAL DEATH
+2E9F          ; mapped                 ; 6BCD          # 3.0  CJK RADICAL MOTHER
+2EA0..2EF2    ; valid                  ;      ; NV8    # 3.0  CJK RADICAL CIVILIAN..CJK RADICAL J-SIMPLIFIED TURTLE
+2EF3          ; mapped                 ; 9F9F          # 3.0  CJK RADICAL C-SIMPLIFIED TURTLE
+2EF4..2EFF    ; disallowed                             # NA   <reserved-2EF4>..<reserved-2EFF>
+2F00          ; mapped                 ; 4E00          # 3.0  KANGXI RADICAL ONE
+2F01          ; mapped                 ; 4E28          # 3.0  KANGXI RADICAL LINE
+2F02          ; mapped                 ; 4E36          # 3.0  KANGXI RADICAL DOT
+2F03          ; mapped                 ; 4E3F          # 3.0  KANGXI RADICAL SLASH
+2F04          ; mapped                 ; 4E59          # 3.0  KANGXI RADICAL SECOND
+2F05          ; mapped                 ; 4E85          # 3.0  KANGXI RADICAL HOOK
+2F06          ; mapped                 ; 4E8C          # 3.0  KANGXI RADICAL TWO
+2F07          ; mapped                 ; 4EA0          # 3.0  KANGXI RADICAL LID
+2F08          ; mapped                 ; 4EBA          # 3.0  KANGXI RADICAL MAN
+2F09          ; mapped                 ; 513F          # 3.0  KANGXI RADICAL LEGS
+2F0A          ; mapped                 ; 5165          # 3.0  KANGXI RADICAL ENTER
+2F0B          ; mapped                 ; 516B          # 3.0  KANGXI RADICAL EIGHT
+2F0C          ; mapped                 ; 5182          # 3.0  KANGXI RADICAL DOWN BOX
+2F0D          ; mapped                 ; 5196          # 3.0  KANGXI RADICAL COVER
+2F0E          ; mapped                 ; 51AB          # 3.0  KANGXI RADICAL ICE
+2F0F          ; mapped                 ; 51E0          # 3.0  KANGXI RADICAL TABLE
+2F10          ; mapped                 ; 51F5          # 3.0  KANGXI RADICAL OPEN BOX
+2F11          ; mapped                 ; 5200          # 3.0  KANGXI RADICAL KNIFE
+2F12          ; mapped                 ; 529B          # 3.0  KANGXI RADICAL POWER
+2F13          ; mapped                 ; 52F9          # 3.0  KANGXI RADICAL WRAP
+2F14          ; mapped                 ; 5315          # 3.0  KANGXI RADICAL SPOON
+2F15          ; mapped                 ; 531A          # 3.0  KANGXI RADICAL RIGHT OPEN BOX
+2F16          ; mapped                 ; 5338          # 3.0  KANGXI RADICAL HIDING ENCLOSURE
+2F17          ; mapped                 ; 5341          # 3.0  KANGXI RADICAL TEN
+2F18          ; mapped                 ; 535C          # 3.0  KANGXI RADICAL DIVINATION
+2F19          ; mapped                 ; 5369          # 3.0  KANGXI RADICAL SEAL
+2F1A          ; mapped                 ; 5382          # 3.0  KANGXI RADICAL CLIFF
+2F1B          ; mapped                 ; 53B6          # 3.0  KANGXI RADICAL PRIVATE
+2F1C          ; mapped                 ; 53C8          # 3.0  KANGXI RADICAL AGAIN
+2F1D          ; mapped                 ; 53E3          # 3.0  KANGXI RADICAL MOUTH
+2F1E          ; mapped                 ; 56D7          # 3.0  KANGXI RADICAL ENCLOSURE
+2F1F          ; mapped                 ; 571F          # 3.0  KANGXI RADICAL EARTH
+2F20          ; mapped                 ; 58EB          # 3.0  KANGXI RADICAL SCHOLAR
+2F21          ; mapped                 ; 5902          # 3.0  KANGXI RADICAL GO
+2F22          ; mapped                 ; 590A          # 3.0  KANGXI RADICAL GO SLOWLY
+2F23          ; mapped                 ; 5915          # 3.0  KANGXI RADICAL EVENING
+2F24          ; mapped                 ; 5927          # 3.0  KANGXI RADICAL BIG
+2F25          ; mapped                 ; 5973          # 3.0  KANGXI RADICAL WOMAN
+2F26          ; mapped                 ; 5B50          # 3.0  KANGXI RADICAL CHILD
+2F27          ; mapped                 ; 5B80          # 3.0  KANGXI RADICAL ROOF
+2F28          ; mapped                 ; 5BF8          # 3.0  KANGXI RADICAL INCH
+2F29          ; mapped                 ; 5C0F          # 3.0  KANGXI RADICAL SMALL
+2F2A          ; mapped                 ; 5C22          # 3.0  KANGXI RADICAL LAME
+2F2B          ; mapped                 ; 5C38          # 3.0  KANGXI RADICAL CORPSE
+2F2C          ; mapped                 ; 5C6E          # 3.0  KANGXI RADICAL SPROUT
+2F2D          ; mapped                 ; 5C71          # 3.0  KANGXI RADICAL MOUNTAIN
+2F2E          ; mapped                 ; 5DDB          # 3.0  KANGXI RADICAL RIVER
+2F2F          ; mapped                 ; 5DE5          # 3.0  KANGXI RADICAL WORK
+2F30          ; mapped                 ; 5DF1          # 3.0  KANGXI RADICAL ONESELF
+2F31          ; mapped                 ; 5DFE          # 3.0  KANGXI RADICAL TURBAN
+2F32          ; mapped                 ; 5E72          # 3.0  KANGXI RADICAL DRY
+2F33          ; mapped                 ; 5E7A          # 3.0  KANGXI RADICAL SHORT THREAD
+2F34          ; mapped                 ; 5E7F          # 3.0  KANGXI RADICAL DOTTED CLIFF
+2F35          ; mapped                 ; 5EF4          # 3.0  KANGXI RADICAL LONG STRIDE
+2F36          ; mapped                 ; 5EFE          # 3.0  KANGXI RADICAL TWO HANDS
+2F37          ; mapped                 ; 5F0B          # 3.0  KANGXI RADICAL SHOOT
+2F38          ; mapped                 ; 5F13          # 3.0  KANGXI RADICAL BOW
+2F39          ; mapped                 ; 5F50          # 3.0  KANGXI RADICAL SNOUT
+2F3A          ; mapped                 ; 5F61          # 3.0  KANGXI RADICAL BRISTLE
+2F3B          ; mapped                 ; 5F73          # 3.0  KANGXI RADICAL STEP
+2F3C          ; mapped                 ; 5FC3          # 3.0  KANGXI RADICAL HEART
+2F3D          ; mapped                 ; 6208          # 3.0  KANGXI RADICAL HALBERD
+2F3E          ; mapped                 ; 6236          # 3.0  KANGXI RADICAL DOOR
+2F3F          ; mapped                 ; 624B          # 3.0  KANGXI RADICAL HAND
+2F40          ; mapped                 ; 652F          # 3.0  KANGXI RADICAL BRANCH
+2F41          ; mapped                 ; 6534          # 3.0  KANGXI RADICAL RAP
+2F42          ; mapped                 ; 6587          # 3.0  KANGXI RADICAL SCRIPT
+2F43          ; mapped                 ; 6597          # 3.0  KANGXI RADICAL DIPPER
+2F44          ; mapped                 ; 65A4          # 3.0  KANGXI RADICAL AXE
+2F45          ; mapped                 ; 65B9          # 3.0  KANGXI RADICAL SQUARE
+2F46          ; mapped                 ; 65E0          # 3.0  KANGXI RADICAL NOT
+2F47          ; mapped                 ; 65E5          # 3.0  KANGXI RADICAL SUN
+2F48          ; mapped                 ; 66F0          # 3.0  KANGXI RADICAL SAY
+2F49          ; mapped                 ; 6708          # 3.0  KANGXI RADICAL MOON
+2F4A          ; mapped                 ; 6728          # 3.0  KANGXI RADICAL TREE
+2F4B          ; mapped                 ; 6B20          # 3.0  KANGXI RADICAL LACK
+2F4C          ; mapped                 ; 6B62          # 3.0  KANGXI RADICAL STOP
+2F4D          ; mapped                 ; 6B79          # 3.0  KANGXI RADICAL DEATH
+2F4E          ; mapped                 ; 6BB3          # 3.0  KANGXI RADICAL WEAPON
+2F4F          ; mapped                 ; 6BCB          # 3.0  KANGXI RADICAL DO NOT
+2F50          ; mapped                 ; 6BD4          # 3.0  KANGXI RADICAL COMPARE
+2F51          ; mapped                 ; 6BDB          # 3.0  KANGXI RADICAL FUR
+2F52          ; mapped                 ; 6C0F          # 3.0  KANGXI RADICAL CLAN
+2F53          ; mapped                 ; 6C14          # 3.0  KANGXI RADICAL STEAM
+2F54          ; mapped                 ; 6C34          # 3.0  KANGXI RADICAL WATER
+2F55          ; mapped                 ; 706B          # 3.0  KANGXI RADICAL FIRE
+2F56          ; mapped                 ; 722A          # 3.0  KANGXI RADICAL CLAW
+2F57          ; mapped                 ; 7236          # 3.0  KANGXI RADICAL FATHER
+2F58          ; mapped                 ; 723B          # 3.0  KANGXI RADICAL DOUBLE X
+2F59          ; mapped                 ; 723F          # 3.0  KANGXI RADICAL HALF TREE TRUNK
+2F5A          ; mapped                 ; 7247          # 3.0  KANGXI RADICAL SLICE
+2F5B          ; mapped                 ; 7259          # 3.0  KANGXI RADICAL FANG
+2F5C          ; mapped                 ; 725B          # 3.0  KANGXI RADICAL COW
+2F5D          ; mapped                 ; 72AC          # 3.0  KANGXI RADICAL DOG
+2F5E          ; mapped                 ; 7384          # 3.0  KANGXI RADICAL PROFOUND
+2F5F          ; mapped                 ; 7389          # 3.0  KANGXI RADICAL JADE
+2F60          ; mapped                 ; 74DC          # 3.0  KANGXI RADICAL MELON
+2F61          ; mapped                 ; 74E6          # 3.0  KANGXI RADICAL TILE
+2F62          ; mapped                 ; 7518          # 3.0  KANGXI RADICAL SWEET
+2F63          ; mapped                 ; 751F          # 3.0  KANGXI RADICAL LIFE
+2F64          ; mapped                 ; 7528          # 3.0  KANGXI RADICAL USE
+2F65          ; mapped                 ; 7530          # 3.0  KANGXI RADICAL FIELD
+2F66          ; mapped                 ; 758B          # 3.0  KANGXI RADICAL BOLT OF CLOTH
+2F67          ; mapped                 ; 7592          # 3.0  KANGXI RADICAL SICKNESS
+2F68          ; mapped                 ; 7676          # 3.0  KANGXI RADICAL DOTTED TENT
+2F69          ; mapped                 ; 767D          # 3.0  KANGXI RADICAL WHITE
+2F6A          ; mapped                 ; 76AE          # 3.0  KANGXI RADICAL SKIN
+2F6B          ; mapped                 ; 76BF          # 3.0  KANGXI RADICAL DISH
+2F6C          ; mapped                 ; 76EE          # 3.0  KANGXI RADICAL EYE
+2F6D          ; mapped                 ; 77DB          # 3.0  KANGXI RADICAL SPEAR
+2F6E          ; mapped                 ; 77E2          # 3.0  KANGXI RADICAL ARROW
+2F6F          ; mapped                 ; 77F3          # 3.0  KANGXI RADICAL STONE
+2F70          ; mapped                 ; 793A          # 3.0  KANGXI RADICAL SPIRIT
+2F71          ; mapped                 ; 79B8          # 3.0  KANGXI RADICAL TRACK
+2F72          ; mapped                 ; 79BE          # 3.0  KANGXI RADICAL GRAIN
+2F73          ; mapped                 ; 7A74          # 3.0  KANGXI RADICAL CAVE
+2F74          ; mapped                 ; 7ACB          # 3.0  KANGXI RADICAL STAND
+2F75          ; mapped                 ; 7AF9          # 3.0  KANGXI RADICAL BAMBOO
+2F76          ; mapped                 ; 7C73          # 3.0  KANGXI RADICAL RICE
+2F77          ; mapped                 ; 7CF8          # 3.0  KANGXI RADICAL SILK
+2F78          ; mapped                 ; 7F36          # 3.0  KANGXI RADICAL JAR
+2F79          ; mapped                 ; 7F51          # 3.0  KANGXI RADICAL NET
+2F7A          ; mapped                 ; 7F8A          # 3.0  KANGXI RADICAL SHEEP
+2F7B          ; mapped                 ; 7FBD          # 3.0  KANGXI RADICAL FEATHER
+2F7C          ; mapped                 ; 8001          # 3.0  KANGXI RADICAL OLD
+2F7D          ; mapped                 ; 800C          # 3.0  KANGXI RADICAL AND
+2F7E          ; mapped                 ; 8012          # 3.0  KANGXI RADICAL PLOW
+2F7F          ; mapped                 ; 8033          # 3.0  KANGXI RADICAL EAR
+2F80          ; mapped                 ; 807F          # 3.0  KANGXI RADICAL BRUSH
+2F81          ; mapped                 ; 8089          # 3.0  KANGXI RADICAL MEAT
+2F82          ; mapped                 ; 81E3          # 3.0  KANGXI RADICAL MINISTER
+2F83          ; mapped                 ; 81EA          # 3.0  KANGXI RADICAL SELF
+2F84          ; mapped                 ; 81F3          # 3.0  KANGXI RADICAL ARRIVE
+2F85          ; mapped                 ; 81FC          # 3.0  KANGXI RADICAL MORTAR
+2F86          ; mapped                 ; 820C          # 3.0  KANGXI RADICAL TONGUE
+2F87          ; mapped                 ; 821B          # 3.0  KANGXI RADICAL OPPOSE
+2F88          ; mapped                 ; 821F          # 3.0  KANGXI RADICAL BOAT
+2F89          ; mapped                 ; 826E          # 3.0  KANGXI RADICAL STOPPING
+2F8A          ; mapped                 ; 8272          # 3.0  KANGXI RADICAL COLOR
+2F8B          ; mapped                 ; 8278          # 3.0  KANGXI RADICAL GRASS
+2F8C          ; mapped                 ; 864D          # 3.0  KANGXI RADICAL TIGER
+2F8D          ; mapped                 ; 866B          # 3.0  KANGXI RADICAL INSECT
+2F8E          ; mapped                 ; 8840          # 3.0  KANGXI RADICAL BLOOD
+2F8F          ; mapped                 ; 884C          # 3.0  KANGXI RADICAL WALK ENCLOSURE
+2F90          ; mapped                 ; 8863          # 3.0  KANGXI RADICAL CLOTHES
+2F91          ; mapped                 ; 897E          # 3.0  KANGXI RADICAL WEST
+2F92          ; mapped                 ; 898B          # 3.0  KANGXI RADICAL SEE
+2F93          ; mapped                 ; 89D2          # 3.0  KANGXI RADICAL HORN
+2F94          ; mapped                 ; 8A00          # 3.0  KANGXI RADICAL SPEECH
+2F95          ; mapped                 ; 8C37          # 3.0  KANGXI RADICAL VALLEY
+2F96          ; mapped                 ; 8C46          # 3.0  KANGXI RADICAL BEAN
+2F97          ; mapped                 ; 8C55          # 3.0  KANGXI RADICAL PIG
+2F98          ; mapped                 ; 8C78          # 3.0  KANGXI RADICAL BADGER
+2F99          ; mapped                 ; 8C9D          # 3.0  KANGXI RADICAL SHELL
+2F9A          ; mapped                 ; 8D64          # 3.0  KANGXI RADICAL RED
+2F9B          ; mapped                 ; 8D70          # 3.0  KANGXI RADICAL RUN
+2F9C          ; mapped                 ; 8DB3          # 3.0  KANGXI RADICAL FOOT
+2F9D          ; mapped                 ; 8EAB          # 3.0  KANGXI RADICAL BODY
+2F9E          ; mapped                 ; 8ECA          # 3.0  KANGXI RADICAL CART
+2F9F          ; mapped                 ; 8F9B          # 3.0  KANGXI RADICAL BITTER
+2FA0          ; mapped                 ; 8FB0          # 3.0  KANGXI RADICAL MORNING
+2FA1          ; mapped                 ; 8FB5          # 3.0  KANGXI RADICAL WALK
+2FA2          ; mapped                 ; 9091          # 3.0  KANGXI RADICAL CITY
+2FA3          ; mapped                 ; 9149          # 3.0  KANGXI RADICAL WINE
+2FA4          ; mapped                 ; 91C6          # 3.0  KANGXI RADICAL DISTINGUISH
+2FA5          ; mapped                 ; 91CC          # 3.0  KANGXI RADICAL VILLAGE
+2FA6          ; mapped                 ; 91D1          # 3.0  KANGXI RADICAL GOLD
+2FA7          ; mapped                 ; 9577          # 3.0  KANGXI RADICAL LONG
+2FA8          ; mapped                 ; 9580          # 3.0  KANGXI RADICAL GATE
+2FA9          ; mapped                 ; 961C          # 3.0  KANGXI RADICAL MOUND
+2FAA          ; mapped                 ; 96B6          # 3.0  KANGXI RADICAL SLAVE
+2FAB          ; mapped                 ; 96B9          # 3.0  KANGXI RADICAL SHORT TAILED BIRD
+2FAC          ; mapped                 ; 96E8          # 3.0  KANGXI RADICAL RAIN
+2FAD          ; mapped                 ; 9751          # 3.0  KANGXI RADICAL BLUE
+2FAE          ; mapped                 ; 975E          # 3.0  KANGXI RADICAL WRONG
+2FAF          ; mapped                 ; 9762          # 3.0  KANGXI RADICAL FACE
+2FB0          ; mapped                 ; 9769          # 3.0  KANGXI RADICAL LEATHER
+2FB1          ; mapped                 ; 97CB          # 3.0  KANGXI RADICAL TANNED LEATHER
+2FB2          ; mapped                 ; 97ED          # 3.0  KANGXI RADICAL LEEK
+2FB3          ; mapped                 ; 97F3          # 3.0  KANGXI RADICAL SOUND
+2FB4          ; mapped                 ; 9801          # 3.0  KANGXI RADICAL LEAF
+2FB5          ; mapped                 ; 98A8          # 3.0  KANGXI RADICAL WIND
+2FB6          ; mapped                 ; 98DB          # 3.0  KANGXI RADICAL FLY
+2FB7          ; mapped                 ; 98DF          # 3.0  KANGXI RADICAL EAT
+2FB8          ; mapped                 ; 9996          # 3.0  KANGXI RADICAL HEAD
+2FB9          ; mapped                 ; 9999          # 3.0  KANGXI RADICAL FRAGRANT
+2FBA          ; mapped                 ; 99AC          # 3.0  KANGXI RADICAL HORSE
+2FBB          ; mapped                 ; 9AA8          # 3.0  KANGXI RADICAL BONE
+2FBC          ; mapped                 ; 9AD8          # 3.0  KANGXI RADICAL TALL
+2FBD          ; mapped                 ; 9ADF          # 3.0  KANGXI RADICAL HAIR
+2FBE          ; mapped                 ; 9B25          # 3.0  KANGXI RADICAL FIGHT
+2FBF          ; mapped                 ; 9B2F          # 3.0  KANGXI RADICAL SACRIFICIAL WINE
+2FC0          ; mapped                 ; 9B32          # 3.0  KANGXI RADICAL CAULDRON
+2FC1          ; mapped                 ; 9B3C          # 3.0  KANGXI RADICAL GHOST
+2FC2          ; mapped                 ; 9B5A          # 3.0  KANGXI RADICAL FISH
+2FC3          ; mapped                 ; 9CE5          # 3.0  KANGXI RADICAL BIRD
+2FC4          ; mapped                 ; 9E75          # 3.0  KANGXI RADICAL SALT
+2FC5          ; mapped                 ; 9E7F          # 3.0  KANGXI RADICAL DEER
+2FC6          ; mapped                 ; 9EA5          # 3.0  KANGXI RADICAL WHEAT
+2FC7          ; mapped                 ; 9EBB          # 3.0  KANGXI RADICAL HEMP
+2FC8          ; mapped                 ; 9EC3          # 3.0  KANGXI RADICAL YELLOW
+2FC9          ; mapped                 ; 9ECD          # 3.0  KANGXI RADICAL MILLET
+2FCA          ; mapped                 ; 9ED1          # 3.0  KANGXI RADICAL BLACK
+2FCB          ; mapped                 ; 9EF9          # 3.0  KANGXI RADICAL EMBROIDERY
+2FCC          ; mapped                 ; 9EFD          # 3.0  KANGXI RADICAL FROG
+2FCD          ; mapped                 ; 9F0E          # 3.0  KANGXI RADICAL TRIPOD
+2FCE          ; mapped                 ; 9F13          # 3.0  KANGXI RADICAL DRUM
+2FCF          ; mapped                 ; 9F20          # 3.0  KANGXI RADICAL RAT
+2FD0          ; mapped                 ; 9F3B          # 3.0  KANGXI RADICAL NOSE
+2FD1          ; mapped                 ; 9F4A          # 3.0  KANGXI RADICAL EVEN
+2FD2          ; mapped                 ; 9F52          # 3.0  KANGXI RADICAL TOOTH
+2FD3          ; mapped                 ; 9F8D          # 3.0  KANGXI RADICAL DRAGON
+2FD4          ; mapped                 ; 9F9C          # 3.0  KANGXI RADICAL TURTLE
+2FD5          ; mapped                 ; 9FA0          # 3.0  KANGXI RADICAL FLUTE
+2FD6..2FEF    ; disallowed                             # NA   <reserved-2FD6>..<reserved-2FEF>
+2FF0..2FFB    ; disallowed                             # 3.0  IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER OVERLAID
+2FFC..2FFF    ; disallowed                             # NA   <reserved-2FFC>..<reserved-2FFF>
+3000          ; disallowed_STD3_mapped ; 0020          # 1.1  IDEOGRAPHIC SPACE
+3001          ; valid                  ;      ; NV8    # 1.1  IDEOGRAPHIC COMMA
+3002          ; mapped                 ; 002E          # 1.1  IDEOGRAPHIC FULL STOP
+3003..3004    ; valid                  ;      ; NV8    # 1.1  DITTO MARK..JAPANESE INDUSTRIAL STANDARD SYMBOL
+3005..3007    ; valid                                  # 1.1  IDEOGRAPHIC ITERATION MARK..IDEOGRAPHIC NUMBER ZERO
+3008..3029    ; valid                  ;      ; NV8    # 1.1  LEFT ANGLE BRACKET..HANGZHOU NUMERAL NINE
+302A..302D    ; valid                                  # 1.1  IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
+302E..3035    ; valid                  ;      ; NV8    # 1.1  HANGUL SINGLE DOT TONE MARK..VERTICAL KANA REPEAT MARK LOWER HALF
+3036          ; mapped                 ; 3012          # 1.1  CIRCLED POSTAL MARK
+3037          ; valid                  ;      ; NV8    # 1.1  IDEOGRAPHIC TELEGRAPH LINE FEED SEPARATOR SYMBOL
+3038          ; mapped                 ; 5341          # 3.0  HANGZHOU NUMERAL TEN
+3039          ; mapped                 ; 5344          # 3.0  HANGZHOU NUMERAL TWENTY
+303A          ; mapped                 ; 5345          # 3.0  HANGZHOU NUMERAL THIRTY
+303B          ; valid                  ;      ; NV8    # 3.2  VERTICAL IDEOGRAPHIC ITERATION MARK
+303C          ; valid                                  # 3.2  MASU MARK
+303D          ; valid                  ;      ; NV8    # 3.2  PART ALTERNATION MARK
+303E          ; valid                  ;      ; NV8    # 3.0  IDEOGRAPHIC VARIATION INDICATOR
+303F          ; valid                  ;      ; NV8    # 1.1  IDEOGRAPHIC HALF FILL SPACE
+3040          ; disallowed                             # NA   <reserved-3040>
+3041..3094    ; valid                                  # 1.1  HIRAGANA LETTER SMALL A..HIRAGANA LETTER VU
+3095..3096    ; valid                                  # 3.2  HIRAGANA LETTER SMALL KA..HIRAGANA LETTER SMALL KE
+3097..3098    ; disallowed                             # NA   <reserved-3097>..<reserved-3098>
+3099..309A    ; valid                                  # 1.1  COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+309B          ; disallowed_STD3_mapped ; 0020 3099     # 1.1  KATAKANA-HIRAGANA VOICED SOUND MARK
+309C          ; disallowed_STD3_mapped ; 0020 309A     # 1.1  KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+309D..309E    ; valid                                  # 1.1  HIRAGANA ITERATION MARK..HIRAGANA VOICED ITERATION MARK
+309F          ; mapped                 ; 3088 308A     # 3.2  HIRAGANA DIGRAPH YORI
+30A0          ; valid                  ;      ; NV8    # 3.2  KATAKANA-HIRAGANA DOUBLE HYPHEN
+30A1..30FE    ; valid                                  # 1.1  KATAKANA LETTER SMALL A..KATAKANA VOICED ITERATION MARK
+30FF          ; mapped                 ; 30B3 30C8     # 3.2  KATAKANA DIGRAPH KOTO
+3100..3104    ; disallowed                             # NA   <reserved-3100>..<reserved-3104>
+3105..312C    ; valid                                  # 1.1  BOPOMOFO LETTER B..BOPOMOFO LETTER GN
+312D          ; valid                                  # 5.1  BOPOMOFO LETTER IH
+312E          ; valid                                  # 10.0 BOPOMOFO LETTER O WITH DOT ABOVE
+312F          ; valid                                  # 11.0 BOPOMOFO LETTER NN
+3130          ; disallowed                             # NA   <reserved-3130>
+3131          ; mapped                 ; 1100          # 1.1  HANGUL LETTER KIYEOK
+3132          ; mapped                 ; 1101          # 1.1  HANGUL LETTER SSANGKIYEOK
+3133          ; mapped                 ; 11AA          # 1.1  HANGUL LETTER KIYEOK-SIOS
+3134          ; mapped                 ; 1102          # 1.1  HANGUL LETTER NIEUN
+3135          ; mapped                 ; 11AC          # 1.1  HANGUL LETTER NIEUN-CIEUC
+3136          ; mapped                 ; 11AD          # 1.1  HANGUL LETTER NIEUN-HIEUH
+3137          ; mapped                 ; 1103          # 1.1  HANGUL LETTER TIKEUT
+3138          ; mapped                 ; 1104          # 1.1  HANGUL LETTER SSANGTIKEUT
+3139          ; mapped                 ; 1105          # 1.1  HANGUL LETTER RIEUL
+313A          ; mapped                 ; 11B0          # 1.1  HANGUL LETTER RIEUL-KIYEOK
+313B          ; mapped                 ; 11B1          # 1.1  HANGUL LETTER RIEUL-MIEUM
+313C          ; mapped                 ; 11B2          # 1.1  HANGUL LETTER RIEUL-PIEUP
+313D          ; mapped                 ; 11B3          # 1.1  HANGUL LETTER RIEUL-SIOS
+313E          ; mapped                 ; 11B4          # 1.1  HANGUL LETTER RIEUL-THIEUTH
+313F          ; mapped                 ; 11B5          # 1.1  HANGUL LETTER RIEUL-PHIEUPH
+3140          ; mapped                 ; 111A          # 1.1  HANGUL LETTER RIEUL-HIEUH
+3141          ; mapped                 ; 1106          # 1.1  HANGUL LETTER MIEUM
+3142          ; mapped                 ; 1107          # 1.1  HANGUL LETTER PIEUP
+3143          ; mapped                 ; 1108          # 1.1  HANGUL LETTER SSANGPIEUP
+3144          ; mapped                 ; 1121          # 1.1  HANGUL LETTER PIEUP-SIOS
+3145          ; mapped                 ; 1109          # 1.1  HANGUL LETTER SIOS
+3146          ; mapped                 ; 110A          # 1.1  HANGUL LETTER SSANGSIOS
+3147          ; mapped                 ; 110B          # 1.1  HANGUL LETTER IEUNG
+3148          ; mapped                 ; 110C          # 1.1  HANGUL LETTER CIEUC
+3149          ; mapped                 ; 110D          # 1.1  HANGUL LETTER SSANGCIEUC
+314A          ; mapped                 ; 110E          # 1.1  HANGUL LETTER CHIEUCH
+314B          ; mapped                 ; 110F          # 1.1  HANGUL LETTER KHIEUKH
+314C          ; mapped                 ; 1110          # 1.1  HANGUL LETTER THIEUTH
+314D          ; mapped                 ; 1111          # 1.1  HANGUL LETTER PHIEUPH
+314E          ; mapped                 ; 1112          # 1.1  HANGUL LETTER HIEUH
+314F          ; mapped                 ; 1161          # 1.1  HANGUL LETTER A
+3150          ; mapped                 ; 1162          # 1.1  HANGUL LETTER AE
+3151          ; mapped                 ; 1163          # 1.1  HANGUL LETTER YA
+3152          ; mapped                 ; 1164          # 1.1  HANGUL LETTER YAE
+3153          ; mapped                 ; 1165          # 1.1  HANGUL LETTER EO
+3154          ; mapped                 ; 1166          # 1.1  HANGUL LETTER E
+3155          ; mapped                 ; 1167          # 1.1  HANGUL LETTER YEO
+3156          ; mapped                 ; 1168          # 1.1  HANGUL LETTER YE
+3157          ; mapped                 ; 1169          # 1.1  HANGUL LETTER O
+3158          ; mapped                 ; 116A          # 1.1  HANGUL LETTER WA
+3159          ; mapped                 ; 116B          # 1.1  HANGUL LETTER WAE
+315A          ; mapped                 ; 116C          # 1.1  HANGUL LETTER OE
+315B          ; mapped                 ; 116D          # 1.1  HANGUL LETTER YO
+315C          ; mapped                 ; 116E          # 1.1  HANGUL LETTER U
+315D          ; mapped                 ; 116F          # 1.1  HANGUL LETTER WEO
+315E          ; mapped                 ; 1170          # 1.1  HANGUL LETTER WE
+315F          ; mapped                 ; 1171          # 1.1  HANGUL LETTER WI
+3160          ; mapped                 ; 1172          # 1.1  HANGUL LETTER YU
+3161          ; mapped                 ; 1173          # 1.1  HANGUL LETTER EU
+3162          ; mapped                 ; 1174          # 1.1  HANGUL LETTER YI
+3163          ; mapped                 ; 1175          # 1.1  HANGUL LETTER I
+3164          ; disallowed                             # 1.1  HANGUL FILLER
+3165          ; mapped                 ; 1114          # 1.1  HANGUL LETTER SSANGNIEUN
+3166          ; mapped                 ; 1115          # 1.1  HANGUL LETTER NIEUN-TIKEUT
+3167          ; mapped                 ; 11C7          # 1.1  HANGUL LETTER NIEUN-SIOS
+3168          ; mapped                 ; 11C8          # 1.1  HANGUL LETTER NIEUN-PANSIOS
+3169          ; mapped                 ; 11CC          # 1.1  HANGUL LETTER RIEUL-KIYEOK-SIOS
+316A          ; mapped                 ; 11CE          # 1.1  HANGUL LETTER RIEUL-TIKEUT
+316B          ; mapped                 ; 11D3          # 1.1  HANGUL LETTER RIEUL-PIEUP-SIOS
+316C          ; mapped                 ; 11D7          # 1.1  HANGUL LETTER RIEUL-PANSIOS
+316D          ; mapped                 ; 11D9          # 1.1  HANGUL LETTER RIEUL-YEORINHIEUH
+316E          ; mapped                 ; 111C          # 1.1  HANGUL LETTER MIEUM-PIEUP
+316F          ; mapped                 ; 11DD          # 1.1  HANGUL LETTER MIEUM-SIOS
+3170          ; mapped                 ; 11DF          # 1.1  HANGUL LETTER MIEUM-PANSIOS
+3171          ; mapped                 ; 111D          # 1.1  HANGUL LETTER KAPYEOUNMIEUM
+3172          ; mapped                 ; 111E          # 1.1  HANGUL LETTER PIEUP-KIYEOK
+3173          ; mapped                 ; 1120          # 1.1  HANGUL LETTER PIEUP-TIKEUT
+3174          ; mapped                 ; 1122          # 1.1  HANGUL LETTER PIEUP-SIOS-KIYEOK
+3175          ; mapped                 ; 1123          # 1.1  HANGUL LETTER PIEUP-SIOS-TIKEUT
+3176          ; mapped                 ; 1127          # 1.1  HANGUL LETTER PIEUP-CIEUC
+3177          ; mapped                 ; 1129          # 1.1  HANGUL LETTER PIEUP-THIEUTH
+3178          ; mapped                 ; 112B          # 1.1  HANGUL LETTER KAPYEOUNPIEUP
+3179          ; mapped                 ; 112C          # 1.1  HANGUL LETTER KAPYEOUNSSANGPIEUP
+317A          ; mapped                 ; 112D          # 1.1  HANGUL LETTER SIOS-KIYEOK
+317B          ; mapped                 ; 112E          # 1.1  HANGUL LETTER SIOS-NIEUN
+317C          ; mapped                 ; 112F          # 1.1  HANGUL LETTER SIOS-TIKEUT
+317D          ; mapped                 ; 1132          # 1.1  HANGUL LETTER SIOS-PIEUP
+317E          ; mapped                 ; 1136          # 1.1  HANGUL LETTER SIOS-CIEUC
+317F          ; mapped                 ; 1140          # 1.1  HANGUL LETTER PANSIOS
+3180          ; mapped                 ; 1147          # 1.1  HANGUL LETTER SSANGIEUNG
+3181          ; mapped                 ; 114C          # 1.1  HANGUL LETTER YESIEUNG
+3182          ; mapped                 ; 11F1          # 1.1  HANGUL LETTER YESIEUNG-SIOS
+3183          ; mapped                 ; 11F2          # 1.1  HANGUL LETTER YESIEUNG-PANSIOS
+3184          ; mapped                 ; 1157          # 1.1  HANGUL LETTER KAPYEOUNPHIEUPH
+3185          ; mapped                 ; 1158          # 1.1  HANGUL LETTER SSANGHIEUH
+3186          ; mapped                 ; 1159          # 1.1  HANGUL LETTER YEORINHIEUH
+3187          ; mapped                 ; 1184          # 1.1  HANGUL LETTER YO-YA
+3188          ; mapped                 ; 1185          # 1.1  HANGUL LETTER YO-YAE
+3189          ; mapped                 ; 1188          # 1.1  HANGUL LETTER YO-I
+318A          ; mapped                 ; 1191          # 1.1  HANGUL LETTER YU-YEO
+318B          ; mapped                 ; 1192          # 1.1  HANGUL LETTER YU-YE
+318C          ; mapped                 ; 1194          # 1.1  HANGUL LETTER YU-I
+318D          ; mapped                 ; 119E          # 1.1  HANGUL LETTER ARAEA
+318E          ; mapped                 ; 11A1          # 1.1  HANGUL LETTER ARAEAE
+318F          ; disallowed                             # NA   <reserved-318F>
+3190..3191    ; valid                  ;      ; NV8    # 1.1  IDEOGRAPHIC ANNOTATION LINKING MARK..IDEOGRAPHIC ANNOTATION REVERSE MARK
+3192          ; mapped                 ; 4E00          # 1.1  IDEOGRAPHIC ANNOTATION ONE MARK
+3193          ; mapped                 ; 4E8C          # 1.1  IDEOGRAPHIC ANNOTATION TWO MARK
+3194          ; mapped                 ; 4E09          # 1.1  IDEOGRAPHIC ANNOTATION THREE MARK
+3195          ; mapped                 ; 56DB          # 1.1  IDEOGRAPHIC ANNOTATION FOUR MARK
+3196          ; mapped                 ; 4E0A          # 1.1  IDEOGRAPHIC ANNOTATION TOP MARK
+3197          ; mapped                 ; 4E2D          # 1.1  IDEOGRAPHIC ANNOTATION MIDDLE MARK
+3198          ; mapped                 ; 4E0B          # 1.1  IDEOGRAPHIC ANNOTATION BOTTOM MARK
+3199          ; mapped                 ; 7532          # 1.1  IDEOGRAPHIC ANNOTATION FIRST MARK
+319A          ; mapped                 ; 4E59          # 1.1  IDEOGRAPHIC ANNOTATION SECOND MARK
+319B          ; mapped                 ; 4E19          # 1.1  IDEOGRAPHIC ANNOTATION THIRD MARK
+319C          ; mapped                 ; 4E01          # 1.1  IDEOGRAPHIC ANNOTATION FOURTH MARK
+319D          ; mapped                 ; 5929          # 1.1  IDEOGRAPHIC ANNOTATION HEAVEN MARK
+319E          ; mapped                 ; 5730          # 1.1  IDEOGRAPHIC ANNOTATION EARTH MARK
+319F          ; mapped                 ; 4EBA          # 1.1  IDEOGRAPHIC ANNOTATION MAN MARK
+31A0..31B7    ; valid                                  # 3.0  BOPOMOFO LETTER BU..BOPOMOFO FINAL LETTER H
+31B8..31BA    ; valid                                  # 6.0  BOPOMOFO LETTER GH..BOPOMOFO LETTER ZY
+31BB..31BF    ; valid                                  # 13.0 BOPOMOFO FINAL LETTER G..BOPOMOFO LETTER AH
+31C0..31CF    ; valid                  ;      ; NV8    # 4.1  CJK STROKE T..CJK STROKE N
+31D0..31E3    ; valid                  ;      ; NV8    # 5.1  CJK STROKE H..CJK STROKE Q
+31E4..31EF    ; disallowed                             # NA   <reserved-31E4>..<reserved-31EF>
+31F0..31FF    ; valid                                  # 3.2  KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
+3200          ; disallowed_STD3_mapped ; 0028 1100 0029 #1.1  PARENTHESIZED HANGUL KIYEOK
+3201          ; disallowed_STD3_mapped ; 0028 1102 0029 #1.1  PARENTHESIZED HANGUL NIEUN
+3202          ; disallowed_STD3_mapped ; 0028 1103 0029 #1.1  PARENTHESIZED HANGUL TIKEUT
+3203          ; disallowed_STD3_mapped ; 0028 1105 0029 #1.1  PARENTHESIZED HANGUL RIEUL
+3204          ; disallowed_STD3_mapped ; 0028 1106 0029 #1.1  PARENTHESIZED HANGUL MIEUM
+3205          ; disallowed_STD3_mapped ; 0028 1107 0029 #1.1  PARENTHESIZED HANGUL PIEUP
+3206          ; disallowed_STD3_mapped ; 0028 1109 0029 #1.1  PARENTHESIZED HANGUL SIOS
+3207          ; disallowed_STD3_mapped ; 0028 110B 0029 #1.1  PARENTHESIZED HANGUL IEUNG
+3208          ; disallowed_STD3_mapped ; 0028 110C 0029 #1.1  PARENTHESIZED HANGUL CIEUC
+3209          ; disallowed_STD3_mapped ; 0028 110E 0029 #1.1  PARENTHESIZED HANGUL CHIEUCH
+320A          ; disallowed_STD3_mapped ; 0028 110F 0029 #1.1  PARENTHESIZED HANGUL KHIEUKH
+320B          ; disallowed_STD3_mapped ; 0028 1110 0029 #1.1  PARENTHESIZED HANGUL THIEUTH
+320C          ; disallowed_STD3_mapped ; 0028 1111 0029 #1.1  PARENTHESIZED HANGUL PHIEUPH
+320D          ; disallowed_STD3_mapped ; 0028 1112 0029 #1.1  PARENTHESIZED HANGUL HIEUH
+320E          ; disallowed_STD3_mapped ; 0028 AC00 0029 #1.1  PARENTHESIZED HANGUL KIYEOK A
+320F          ; disallowed_STD3_mapped ; 0028 B098 0029 #1.1  PARENTHESIZED HANGUL NIEUN A
+3210          ; disallowed_STD3_mapped ; 0028 B2E4 0029 #1.1  PARENTHESIZED HANGUL TIKEUT A
+3211          ; disallowed_STD3_mapped ; 0028 B77C 0029 #1.1  PARENTHESIZED HANGUL RIEUL A
+3212          ; disallowed_STD3_mapped ; 0028 B9C8 0029 #1.1  PARENTHESIZED HANGUL MIEUM A
+3213          ; disallowed_STD3_mapped ; 0028 BC14 0029 #1.1  PARENTHESIZED HANGUL PIEUP A
+3214          ; disallowed_STD3_mapped ; 0028 C0AC 0029 #1.1  PARENTHESIZED HANGUL SIOS A
+3215          ; disallowed_STD3_mapped ; 0028 C544 0029 #1.1  PARENTHESIZED HANGUL IEUNG A
+3216          ; disallowed_STD3_mapped ; 0028 C790 0029 #1.1  PARENTHESIZED HANGUL CIEUC A
+3217          ; disallowed_STD3_mapped ; 0028 CC28 0029 #1.1  PARENTHESIZED HANGUL CHIEUCH A
+3218          ; disallowed_STD3_mapped ; 0028 CE74 0029 #1.1  PARENTHESIZED HANGUL KHIEUKH A
+3219          ; disallowed_STD3_mapped ; 0028 D0C0 0029 #1.1  PARENTHESIZED HANGUL THIEUTH A
+321A          ; disallowed_STD3_mapped ; 0028 D30C 0029 #1.1  PARENTHESIZED HANGUL PHIEUPH A
+321B          ; disallowed_STD3_mapped ; 0028 D558 0029 #1.1  PARENTHESIZED HANGUL HIEUH A
+321C          ; disallowed_STD3_mapped ; 0028 C8FC 0029 #1.1  PARENTHESIZED HANGUL CIEUC U
+321D          ; disallowed_STD3_mapped ; 0028 C624 C804 0029 #4.0 PARENTHESIZED KOREAN CHARACTER OJEON
+321E          ; disallowed_STD3_mapped ; 0028 C624 D6C4 0029 #4.0 PARENTHESIZED KOREAN CHARACTER O HU
+321F          ; disallowed                             # NA   <reserved-321F>
+3220          ; disallowed_STD3_mapped ; 0028 4E00 0029 #1.1  PARENTHESIZED IDEOGRAPH ONE
+3221          ; disallowed_STD3_mapped ; 0028 4E8C 0029 #1.1  PARENTHESIZED IDEOGRAPH TWO
+3222          ; disallowed_STD3_mapped ; 0028 4E09 0029 #1.1  PARENTHESIZED IDEOGRAPH THREE
+3223          ; disallowed_STD3_mapped ; 0028 56DB 0029 #1.1  PARENTHESIZED IDEOGRAPH FOUR
+3224          ; disallowed_STD3_mapped ; 0028 4E94 0029 #1.1  PARENTHESIZED IDEOGRAPH FIVE
+3225          ; disallowed_STD3_mapped ; 0028 516D 0029 #1.1  PARENTHESIZED IDEOGRAPH SIX
+3226          ; disallowed_STD3_mapped ; 0028 4E03 0029 #1.1  PARENTHESIZED IDEOGRAPH SEVEN
+3227          ; disallowed_STD3_mapped ; 0028 516B 0029 #1.1  PARENTHESIZED IDEOGRAPH EIGHT
+3228          ; disallowed_STD3_mapped ; 0028 4E5D 0029 #1.1  PARENTHESIZED IDEOGRAPH NINE
+3229          ; disallowed_STD3_mapped ; 0028 5341 0029 #1.1  PARENTHESIZED IDEOGRAPH TEN
+322A          ; disallowed_STD3_mapped ; 0028 6708 0029 #1.1  PARENTHESIZED IDEOGRAPH MOON
+322B          ; disallowed_STD3_mapped ; 0028 706B 0029 #1.1  PARENTHESIZED IDEOGRAPH FIRE
+322C          ; disallowed_STD3_mapped ; 0028 6C34 0029 #1.1  PARENTHESIZED IDEOGRAPH WATER
+322D          ; disallowed_STD3_mapped ; 0028 6728 0029 #1.1  PARENTHESIZED IDEOGRAPH WOOD
+322E          ; disallowed_STD3_mapped ; 0028 91D1 0029 #1.1  PARENTHESIZED IDEOGRAPH METAL
+322F          ; disallowed_STD3_mapped ; 0028 571F 0029 #1.1  PARENTHESIZED IDEOGRAPH EARTH
+3230          ; disallowed_STD3_mapped ; 0028 65E5 0029 #1.1  PARENTHESIZED IDEOGRAPH SUN
+3231          ; disallowed_STD3_mapped ; 0028 682A 0029 #1.1  PARENTHESIZED IDEOGRAPH STOCK
+3232          ; disallowed_STD3_mapped ; 0028 6709 0029 #1.1  PARENTHESIZED IDEOGRAPH HAVE
+3233          ; disallowed_STD3_mapped ; 0028 793E 0029 #1.1  PARENTHESIZED IDEOGRAPH SOCIETY
+3234          ; disallowed_STD3_mapped ; 0028 540D 0029 #1.1  PARENTHESIZED IDEOGRAPH NAME
+3235          ; disallowed_STD3_mapped ; 0028 7279 0029 #1.1  PARENTHESIZED IDEOGRAPH SPECIAL
+3236          ; disallowed_STD3_mapped ; 0028 8CA1 0029 #1.1  PARENTHESIZED IDEOGRAPH FINANCIAL
+3237          ; disallowed_STD3_mapped ; 0028 795D 0029 #1.1  PARENTHESIZED IDEOGRAPH CONGRATULATION
+3238          ; disallowed_STD3_mapped ; 0028 52B4 0029 #1.1  PARENTHESIZED IDEOGRAPH LABOR
+3239          ; disallowed_STD3_mapped ; 0028 4EE3 0029 #1.1  PARENTHESIZED IDEOGRAPH REPRESENT
+323A          ; disallowed_STD3_mapped ; 0028 547C 0029 #1.1  PARENTHESIZED IDEOGRAPH CALL
+323B          ; disallowed_STD3_mapped ; 0028 5B66 0029 #1.1  PARENTHESIZED IDEOGRAPH STUDY
+323C          ; disallowed_STD3_mapped ; 0028 76E3 0029 #1.1  PARENTHESIZED IDEOGRAPH SUPERVISE
+323D          ; disallowed_STD3_mapped ; 0028 4F01 0029 #1.1  PARENTHESIZED IDEOGRAPH ENTERPRISE
+323E          ; disallowed_STD3_mapped ; 0028 8CC7 0029 #1.1  PARENTHESIZED IDEOGRAPH RESOURCE
+323F          ; disallowed_STD3_mapped ; 0028 5354 0029 #1.1  PARENTHESIZED IDEOGRAPH ALLIANCE
+3240          ; disallowed_STD3_mapped ; 0028 796D 0029 #1.1  PARENTHESIZED IDEOGRAPH FESTIVAL
+3241          ; disallowed_STD3_mapped ; 0028 4F11 0029 #1.1  PARENTHESIZED IDEOGRAPH REST
+3242          ; disallowed_STD3_mapped ; 0028 81EA 0029 #1.1  PARENTHESIZED IDEOGRAPH SELF
+3243          ; disallowed_STD3_mapped ; 0028 81F3 0029 #1.1  PARENTHESIZED IDEOGRAPH REACH
+3244          ; mapped                 ; 554F          # 5.2  CIRCLED IDEOGRAPH QUESTION
+3245          ; mapped                 ; 5E7C          # 5.2  CIRCLED IDEOGRAPH KINDERGARTEN
+3246          ; mapped                 ; 6587          # 5.2  CIRCLED IDEOGRAPH SCHOOL
+3247          ; mapped                 ; 7B8F          # 5.2  CIRCLED IDEOGRAPH KOTO
+3248..324F    ; valid                  ;      ; NV8    # 5.2  CIRCLED NUMBER TEN ON BLACK SQUARE..CIRCLED NUMBER EIGHTY ON BLACK SQUARE
+3250          ; mapped                 ; 0070 0074 0065 #4.0  PARTNERSHIP SIGN
+3251          ; mapped                 ; 0032 0031     # 3.2  CIRCLED NUMBER TWENTY ONE
+3252          ; mapped                 ; 0032 0032     # 3.2  CIRCLED NUMBER TWENTY TWO
+3253          ; mapped                 ; 0032 0033     # 3.2  CIRCLED NUMBER TWENTY THREE
+3254          ; mapped                 ; 0032 0034     # 3.2  CIRCLED NUMBER TWENTY FOUR
+3255          ; mapped                 ; 0032 0035     # 3.2  CIRCLED NUMBER TWENTY FIVE
+3256          ; mapped                 ; 0032 0036     # 3.2  CIRCLED NUMBER TWENTY SIX
+3257          ; mapped                 ; 0032 0037     # 3.2  CIRCLED NUMBER TWENTY SEVEN
+3258          ; mapped                 ; 0032 0038     # 3.2  CIRCLED NUMBER TWENTY EIGHT
+3259          ; mapped                 ; 0032 0039     # 3.2  CIRCLED NUMBER TWENTY NINE
+325A          ; mapped                 ; 0033 0030     # 3.2  CIRCLED NUMBER THIRTY
+325B          ; mapped                 ; 0033 0031     # 3.2  CIRCLED NUMBER THIRTY ONE
+325C          ; mapped                 ; 0033 0032     # 3.2  CIRCLED NUMBER THIRTY TWO
+325D          ; mapped                 ; 0033 0033     # 3.2  CIRCLED NUMBER THIRTY THREE
+325E          ; mapped                 ; 0033 0034     # 3.2  CIRCLED NUMBER THIRTY FOUR
+325F          ; mapped                 ; 0033 0035     # 3.2  CIRCLED NUMBER THIRTY FIVE
+3260          ; mapped                 ; 1100          # 1.1  CIRCLED HANGUL KIYEOK
+3261          ; mapped                 ; 1102          # 1.1  CIRCLED HANGUL NIEUN
+3262          ; mapped                 ; 1103          # 1.1  CIRCLED HANGUL TIKEUT
+3263          ; mapped                 ; 1105          # 1.1  CIRCLED HANGUL RIEUL
+3264          ; mapped                 ; 1106          # 1.1  CIRCLED HANGUL MIEUM
+3265          ; mapped                 ; 1107          # 1.1  CIRCLED HANGUL PIEUP
+3266          ; mapped                 ; 1109          # 1.1  CIRCLED HANGUL SIOS
+3267          ; mapped                 ; 110B          # 1.1  CIRCLED HANGUL IEUNG
+3268          ; mapped                 ; 110C          # 1.1  CIRCLED HANGUL CIEUC
+3269          ; mapped                 ; 110E          # 1.1  CIRCLED HANGUL CHIEUCH
+326A          ; mapped                 ; 110F          # 1.1  CIRCLED HANGUL KHIEUKH
+326B          ; mapped                 ; 1110          # 1.1  CIRCLED HANGUL THIEUTH
+326C          ; mapped                 ; 1111          # 1.1  CIRCLED HANGUL PHIEUPH
+326D          ; mapped                 ; 1112          # 1.1  CIRCLED HANGUL HIEUH
+326E          ; mapped                 ; AC00          # 1.1  CIRCLED HANGUL KIYEOK A
+326F          ; mapped                 ; B098          # 1.1  CIRCLED HANGUL NIEUN A
+3270          ; mapped                 ; B2E4          # 1.1  CIRCLED HANGUL TIKEUT A
+3271          ; mapped                 ; B77C          # 1.1  CIRCLED HANGUL RIEUL A
+3272          ; mapped                 ; B9C8          # 1.1  CIRCLED HANGUL MIEUM A
+3273          ; mapped                 ; BC14          # 1.1  CIRCLED HANGUL PIEUP A
+3274          ; mapped                 ; C0AC          # 1.1  CIRCLED HANGUL SIOS A
+3275          ; mapped                 ; C544          # 1.1  CIRCLED HANGUL IEUNG A
+3276          ; mapped                 ; C790          # 1.1  CIRCLED HANGUL CIEUC A
+3277          ; mapped                 ; CC28          # 1.1  CIRCLED HANGUL CHIEUCH A
+3278          ; mapped                 ; CE74          # 1.1  CIRCLED HANGUL KHIEUKH A
+3279          ; mapped                 ; D0C0          # 1.1  CIRCLED HANGUL THIEUTH A
+327A          ; mapped                 ; D30C          # 1.1  CIRCLED HANGUL PHIEUPH A
+327B          ; mapped                 ; D558          # 1.1  CIRCLED HANGUL HIEUH A
+327C          ; mapped                 ; CC38 ACE0     # 4.0  CIRCLED KOREAN CHARACTER CHAMKO
+327D          ; mapped                 ; C8FC C758     # 4.0  CIRCLED KOREAN CHARACTER JUEUI
+327E          ; mapped                 ; C6B0          # 4.1  CIRCLED HANGUL IEUNG U
+327F          ; valid                  ;      ; NV8    # 1.1  KOREAN STANDARD SYMBOL
+3280          ; mapped                 ; 4E00          # 1.1  CIRCLED IDEOGRAPH ONE
+3281          ; mapped                 ; 4E8C          # 1.1  CIRCLED IDEOGRAPH TWO
+3282          ; mapped                 ; 4E09          # 1.1  CIRCLED IDEOGRAPH THREE
+3283          ; mapped                 ; 56DB          # 1.1  CIRCLED IDEOGRAPH FOUR
+3284          ; mapped                 ; 4E94          # 1.1  CIRCLED IDEOGRAPH FIVE
+3285          ; mapped                 ; 516D          # 1.1  CIRCLED IDEOGRAPH SIX
+3286          ; mapped                 ; 4E03          # 1.1  CIRCLED IDEOGRAPH SEVEN
+3287          ; mapped                 ; 516B          # 1.1  CIRCLED IDEOGRAPH EIGHT
+3288          ; mapped                 ; 4E5D          # 1.1  CIRCLED IDEOGRAPH NINE
+3289          ; mapped                 ; 5341          # 1.1  CIRCLED IDEOGRAPH TEN
+328A          ; mapped                 ; 6708          # 1.1  CIRCLED IDEOGRAPH MOON
+328B          ; mapped                 ; 706B          # 1.1  CIRCLED IDEOGRAPH FIRE
+328C          ; mapped                 ; 6C34          # 1.1  CIRCLED IDEOGRAPH WATER
+328D          ; mapped                 ; 6728          # 1.1  CIRCLED IDEOGRAPH WOOD
+328E          ; mapped                 ; 91D1          # 1.1  CIRCLED IDEOGRAPH METAL
+328F          ; mapped                 ; 571F          # 1.1  CIRCLED IDEOGRAPH EARTH
+3290          ; mapped                 ; 65E5          # 1.1  CIRCLED IDEOGRAPH SUN
+3291          ; mapped                 ; 682A          # 1.1  CIRCLED IDEOGRAPH STOCK
+3292          ; mapped                 ; 6709          # 1.1  CIRCLED IDEOGRAPH HAVE
+3293          ; mapped                 ; 793E          # 1.1  CIRCLED IDEOGRAPH SOCIETY
+3294          ; mapped                 ; 540D          # 1.1  CIRCLED IDEOGRAPH NAME
+3295          ; mapped                 ; 7279          # 1.1  CIRCLED IDEOGRAPH SPECIAL
+3296          ; mapped                 ; 8CA1          # 1.1  CIRCLED IDEOGRAPH FINANCIAL
+3297          ; mapped                 ; 795D          # 1.1  CIRCLED IDEOGRAPH CONGRATULATION
+3298          ; mapped                 ; 52B4          # 1.1  CIRCLED IDEOGRAPH LABOR
+3299          ; mapped                 ; 79D8          # 1.1  CIRCLED IDEOGRAPH SECRET
+329A          ; mapped                 ; 7537          # 1.1  CIRCLED IDEOGRAPH MALE
+329B          ; mapped                 ; 5973          # 1.1  CIRCLED IDEOGRAPH FEMALE
+329C          ; mapped                 ; 9069          # 1.1  CIRCLED IDEOGRAPH SUITABLE
+329D          ; mapped                 ; 512A          # 1.1  CIRCLED IDEOGRAPH EXCELLENT
+329E          ; mapped                 ; 5370          # 1.1  CIRCLED IDEOGRAPH PRINT
+329F          ; mapped                 ; 6CE8          # 1.1  CIRCLED IDEOGRAPH ATTENTION
+32A0          ; mapped                 ; 9805          # 1.1  CIRCLED IDEOGRAPH ITEM
+32A1          ; mapped                 ; 4F11          # 1.1  CIRCLED IDEOGRAPH REST
+32A2          ; mapped                 ; 5199          # 1.1  CIRCLED IDEOGRAPH COPY
+32A3          ; mapped                 ; 6B63          # 1.1  CIRCLED IDEOGRAPH CORRECT
+32A4          ; mapped                 ; 4E0A          # 1.1  CIRCLED IDEOGRAPH HIGH
+32A5          ; mapped                 ; 4E2D          # 1.1  CIRCLED IDEOGRAPH CENTRE
+32A6          ; mapped                 ; 4E0B          # 1.1  CIRCLED IDEOGRAPH LOW
+32A7          ; mapped                 ; 5DE6          # 1.1  CIRCLED IDEOGRAPH LEFT
+32A8          ; mapped                 ; 53F3          # 1.1  CIRCLED IDEOGRAPH RIGHT
+32A9          ; mapped                 ; 533B          # 1.1  CIRCLED IDEOGRAPH MEDICINE
+32AA          ; mapped                 ; 5B97          # 1.1  CIRCLED IDEOGRAPH RELIGION
+32AB          ; mapped                 ; 5B66          # 1.1  CIRCLED IDEOGRAPH STUDY
+32AC          ; mapped                 ; 76E3          # 1.1  CIRCLED IDEOGRAPH SUPERVISE
+32AD          ; mapped                 ; 4F01          # 1.1  CIRCLED IDEOGRAPH ENTERPRISE
+32AE          ; mapped                 ; 8CC7          # 1.1  CIRCLED IDEOGRAPH RESOURCE
+32AF          ; mapped                 ; 5354          # 1.1  CIRCLED IDEOGRAPH ALLIANCE
+32B0          ; mapped                 ; 591C          # 1.1  CIRCLED IDEOGRAPH NIGHT
+32B1          ; mapped                 ; 0033 0036     # 3.2  CIRCLED NUMBER THIRTY SIX
+32B2          ; mapped                 ; 0033 0037     # 3.2  CIRCLED NUMBER THIRTY SEVEN
+32B3          ; mapped                 ; 0033 0038     # 3.2  CIRCLED NUMBER THIRTY EIGHT
+32B4          ; mapped                 ; 0033 0039     # 3.2  CIRCLED NUMBER THIRTY NINE
+32B5          ; mapped                 ; 0034 0030     # 3.2  CIRCLED NUMBER FORTY
+32B6          ; mapped                 ; 0034 0031     # 3.2  CIRCLED NUMBER FORTY ONE
+32B7          ; mapped                 ; 0034 0032     # 3.2  CIRCLED NUMBER FORTY TWO
+32B8          ; mapped                 ; 0034 0033     # 3.2  CIRCLED NUMBER FORTY THREE
+32B9          ; mapped                 ; 0034 0034     # 3.2  CIRCLED NUMBER FORTY FOUR
+32BA          ; mapped                 ; 0034 0035     # 3.2  CIRCLED NUMBER FORTY FIVE
+32BB          ; mapped                 ; 0034 0036     # 3.2  CIRCLED NUMBER FORTY SIX
+32BC          ; mapped                 ; 0034 0037     # 3.2  CIRCLED NUMBER FORTY SEVEN
+32BD          ; mapped                 ; 0034 0038     # 3.2  CIRCLED NUMBER FORTY EIGHT
+32BE          ; mapped                 ; 0034 0039     # 3.2  CIRCLED NUMBER FORTY NINE
+32BF          ; mapped                 ; 0035 0030     # 3.2  CIRCLED NUMBER FIFTY
+32C0          ; mapped                 ; 0031 6708     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR JANUARY
+32C1          ; mapped                 ; 0032 6708     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR FEBRUARY
+32C2          ; mapped                 ; 0033 6708     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR MARCH
+32C3          ; mapped                 ; 0034 6708     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR APRIL
+32C4          ; mapped                 ; 0035 6708     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR MAY
+32C5          ; mapped                 ; 0036 6708     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR JUNE
+32C6          ; mapped                 ; 0037 6708     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR JULY
+32C7          ; mapped                 ; 0038 6708     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR AUGUST
+32C8          ; mapped                 ; 0039 6708     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR SEPTEMBER
+32C9          ; mapped                 ; 0031 0030 6708 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR OCTOBER
+32CA          ; mapped                 ; 0031 0031 6708 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR NOVEMBER
+32CB          ; mapped                 ; 0031 0032 6708 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DECEMBER
+32CC          ; mapped                 ; 0068 0067     # 4.0  SQUARE HG
+32CD          ; mapped                 ; 0065 0072 0067 #4.0  SQUARE ERG
+32CE          ; mapped                 ; 0065 0076     # 4.0  SQUARE EV
+32CF          ; mapped                 ; 006C 0074 0064 #4.0  LIMITED LIABILITY SIGN
+32D0          ; mapped                 ; 30A2          # 1.1  CIRCLED KATAKANA A
+32D1          ; mapped                 ; 30A4          # 1.1  CIRCLED KATAKANA I
+32D2          ; mapped                 ; 30A6          # 1.1  CIRCLED KATAKANA U
+32D3          ; mapped                 ; 30A8          # 1.1  CIRCLED KATAKANA E
+32D4          ; mapped                 ; 30AA          # 1.1  CIRCLED KATAKANA O
+32D5          ; mapped                 ; 30AB          # 1.1  CIRCLED KATAKANA KA
+32D6          ; mapped                 ; 30AD          # 1.1  CIRCLED KATAKANA KI
+32D7          ; mapped                 ; 30AF          # 1.1  CIRCLED KATAKANA KU
+32D8          ; mapped                 ; 30B1          # 1.1  CIRCLED KATAKANA KE
+32D9          ; mapped                 ; 30B3          # 1.1  CIRCLED KATAKANA KO
+32DA          ; mapped                 ; 30B5          # 1.1  CIRCLED KATAKANA SA
+32DB          ; mapped                 ; 30B7          # 1.1  CIRCLED KATAKANA SI
+32DC          ; mapped                 ; 30B9          # 1.1  CIRCLED KATAKANA SU
+32DD          ; mapped                 ; 30BB          # 1.1  CIRCLED KATAKANA SE
+32DE          ; mapped                 ; 30BD          # 1.1  CIRCLED KATAKANA SO
+32DF          ; mapped                 ; 30BF          # 1.1  CIRCLED KATAKANA TA
+32E0          ; mapped                 ; 30C1          # 1.1  CIRCLED KATAKANA TI
+32E1          ; mapped                 ; 30C4          # 1.1  CIRCLED KATAKANA TU
+32E2          ; mapped                 ; 30C6          # 1.1  CIRCLED KATAKANA TE
+32E3          ; mapped                 ; 30C8          # 1.1  CIRCLED KATAKANA TO
+32E4          ; mapped                 ; 30CA          # 1.1  CIRCLED KATAKANA NA
+32E5          ; mapped                 ; 30CB          # 1.1  CIRCLED KATAKANA NI
+32E6          ; mapped                 ; 30CC          # 1.1  CIRCLED KATAKANA NU
+32E7          ; mapped                 ; 30CD          # 1.1  CIRCLED KATAKANA NE
+32E8          ; mapped                 ; 30CE          # 1.1  CIRCLED KATAKANA NO
+32E9          ; mapped                 ; 30CF          # 1.1  CIRCLED KATAKANA HA
+32EA          ; mapped                 ; 30D2          # 1.1  CIRCLED KATAKANA HI
+32EB          ; mapped                 ; 30D5          # 1.1  CIRCLED KATAKANA HU
+32EC          ; mapped                 ; 30D8          # 1.1  CIRCLED KATAKANA HE
+32ED          ; mapped                 ; 30DB          # 1.1  CIRCLED KATAKANA HO
+32EE          ; mapped                 ; 30DE          # 1.1  CIRCLED KATAKANA MA
+32EF          ; mapped                 ; 30DF          # 1.1  CIRCLED KATAKANA MI
+32F0          ; mapped                 ; 30E0          # 1.1  CIRCLED KATAKANA MU
+32F1          ; mapped                 ; 30E1          # 1.1  CIRCLED KATAKANA ME
+32F2          ; mapped                 ; 30E2          # 1.1  CIRCLED KATAKANA MO
+32F3          ; mapped                 ; 30E4          # 1.1  CIRCLED KATAKANA YA
+32F4          ; mapped                 ; 30E6          # 1.1  CIRCLED KATAKANA YU
+32F5          ; mapped                 ; 30E8          # 1.1  CIRCLED KATAKANA YO
+32F6          ; mapped                 ; 30E9          # 1.1  CIRCLED KATAKANA RA
+32F7          ; mapped                 ; 30EA          # 1.1  CIRCLED KATAKANA RI
+32F8          ; mapped                 ; 30EB          # 1.1  CIRCLED KATAKANA RU
+32F9          ; mapped                 ; 30EC          # 1.1  CIRCLED KATAKANA RE
+32FA          ; mapped                 ; 30ED          # 1.1  CIRCLED KATAKANA RO
+32FB          ; mapped                 ; 30EF          # 1.1  CIRCLED KATAKANA WA
+32FC          ; mapped                 ; 30F0          # 1.1  CIRCLED KATAKANA WI
+32FD          ; mapped                 ; 30F1          # 1.1  CIRCLED KATAKANA WE
+32FE          ; mapped                 ; 30F2          # 1.1  CIRCLED KATAKANA WO
+32FF          ; mapped                 ; 4EE4 548C     # 12.1 SQUARE ERA NAME REIWA
+3300          ; mapped                 ; 30A2 30D1 30FC 30C8 #1.1 SQUARE APAATO
+3301          ; mapped                 ; 30A2 30EB 30D5 30A1 #1.1 SQUARE ARUHUA
+3302          ; mapped                 ; 30A2 30F3 30DA 30A2 #1.1 SQUARE ANPEA
+3303          ; mapped                 ; 30A2 30FC 30EB #1.1  SQUARE AARU
+3304          ; mapped                 ; 30A4 30CB 30F3 30B0 #1.1 SQUARE ININGU
+3305          ; mapped                 ; 30A4 30F3 30C1 #1.1  SQUARE INTI
+3306          ; mapped                 ; 30A6 30A9 30F3 #1.1  SQUARE UON
+3307          ; mapped                 ; 30A8 30B9 30AF 30FC 30C9 #1.1 SQUARE ESUKUUDO
+3308          ; mapped                 ; 30A8 30FC 30AB 30FC #1.1 SQUARE EEKAA
+3309          ; mapped                 ; 30AA 30F3 30B9 #1.1  SQUARE ONSU
+330A          ; mapped                 ; 30AA 30FC 30E0 #1.1  SQUARE OOMU
+330B          ; mapped                 ; 30AB 30A4 30EA #1.1  SQUARE KAIRI
+330C          ; mapped                 ; 30AB 30E9 30C3 30C8 #1.1 SQUARE KARATTO
+330D          ; mapped                 ; 30AB 30ED 30EA 30FC #1.1 SQUARE KARORII
+330E          ; mapped                 ; 30AC 30ED 30F3 #1.1  SQUARE GARON
+330F          ; mapped                 ; 30AC 30F3 30DE #1.1  SQUARE GANMA
+3310          ; mapped                 ; 30AE 30AC     # 1.1  SQUARE GIGA
+3311          ; mapped                 ; 30AE 30CB 30FC #1.1  SQUARE GINII
+3312          ; mapped                 ; 30AD 30E5 30EA 30FC #1.1 SQUARE KYURII
+3313          ; mapped                 ; 30AE 30EB 30C0 30FC #1.1 SQUARE GIRUDAA
+3314          ; mapped                 ; 30AD 30ED     # 1.1  SQUARE KIRO
+3315          ; mapped                 ; 30AD 30ED 30B0 30E9 30E0 #1.1 SQUARE KIROGURAMU
+3316          ; mapped                 ; 30AD 30ED 30E1 30FC 30C8 30EB #1.1 SQUARE KIROMEETORU
+3317          ; mapped                 ; 30AD 30ED 30EF 30C3 30C8 #1.1 SQUARE KIROWATTO
+3318          ; mapped                 ; 30B0 30E9 30E0 #1.1  SQUARE GURAMU
+3319          ; mapped                 ; 30B0 30E9 30E0 30C8 30F3 #1.1 SQUARE GURAMUTON
+331A          ; mapped                 ; 30AF 30EB 30BC 30A4 30ED #1.1 SQUARE KURUZEIRO
+331B          ; mapped                 ; 30AF 30ED 30FC 30CD #1.1 SQUARE KUROONE
+331C          ; mapped                 ; 30B1 30FC 30B9 #1.1  SQUARE KEESU
+331D          ; mapped                 ; 30B3 30EB 30CA #1.1  SQUARE KORUNA
+331E          ; mapped                 ; 30B3 30FC 30DD #1.1  SQUARE KOOPO
+331F          ; mapped                 ; 30B5 30A4 30AF 30EB #1.1 SQUARE SAIKURU
+3320          ; mapped                 ; 30B5 30F3 30C1 30FC 30E0 #1.1 SQUARE SANTIIMU
+3321          ; mapped                 ; 30B7 30EA 30F3 30B0 #1.1 SQUARE SIRINGU
+3322          ; mapped                 ; 30BB 30F3 30C1 #1.1  SQUARE SENTI
+3323          ; mapped                 ; 30BB 30F3 30C8 #1.1  SQUARE SENTO
+3324          ; mapped                 ; 30C0 30FC 30B9 #1.1  SQUARE DAASU
+3325          ; mapped                 ; 30C7 30B7     # 1.1  SQUARE DESI
+3326          ; mapped                 ; 30C9 30EB     # 1.1  SQUARE DORU
+3327          ; mapped                 ; 30C8 30F3     # 1.1  SQUARE TON
+3328          ; mapped                 ; 30CA 30CE     # 1.1  SQUARE NANO
+3329          ; mapped                 ; 30CE 30C3 30C8 #1.1  SQUARE NOTTO
+332A          ; mapped                 ; 30CF 30A4 30C4 #1.1  SQUARE HAITU
+332B          ; mapped                 ; 30D1 30FC 30BB 30F3 30C8 #1.1 SQUARE PAASENTO
+332C          ; mapped                 ; 30D1 30FC 30C4 #1.1  SQUARE PAATU
+332D          ; mapped                 ; 30D0 30FC 30EC 30EB #1.1 SQUARE BAARERU
+332E          ; mapped                 ; 30D4 30A2 30B9 30C8 30EB #1.1 SQUARE PIASUTORU
+332F          ; mapped                 ; 30D4 30AF 30EB #1.1  SQUARE PIKURU
+3330          ; mapped                 ; 30D4 30B3     # 1.1  SQUARE PIKO
+3331          ; mapped                 ; 30D3 30EB     # 1.1  SQUARE BIRU
+3332          ; mapped                 ; 30D5 30A1 30E9 30C3 30C9 #1.1 SQUARE HUARADDO
+3333          ; mapped                 ; 30D5 30A3 30FC 30C8 #1.1 SQUARE HUIITO
+3334          ; mapped                 ; 30D6 30C3 30B7 30A7 30EB #1.1 SQUARE BUSSYERU
+3335          ; mapped                 ; 30D5 30E9 30F3 #1.1  SQUARE HURAN
+3336          ; mapped                 ; 30D8 30AF 30BF 30FC 30EB #1.1 SQUARE HEKUTAARU
+3337          ; mapped                 ; 30DA 30BD     # 1.1  SQUARE PESO
+3338          ; mapped                 ; 30DA 30CB 30D2 #1.1  SQUARE PENIHI
+3339          ; mapped                 ; 30D8 30EB 30C4 #1.1  SQUARE HERUTU
+333A          ; mapped                 ; 30DA 30F3 30B9 #1.1  SQUARE PENSU
+333B          ; mapped                 ; 30DA 30FC 30B8 #1.1  SQUARE PEEZI
+333C          ; mapped                 ; 30D9 30FC 30BF #1.1  SQUARE BEETA
+333D          ; mapped                 ; 30DD 30A4 30F3 30C8 #1.1 SQUARE POINTO
+333E          ; mapped                 ; 30DC 30EB 30C8 #1.1  SQUARE BORUTO
+333F          ; mapped                 ; 30DB 30F3     # 1.1  SQUARE HON
+3340          ; mapped                 ; 30DD 30F3 30C9 #1.1  SQUARE PONDO
+3341          ; mapped                 ; 30DB 30FC 30EB #1.1  SQUARE HOORU
+3342          ; mapped                 ; 30DB 30FC 30F3 #1.1  SQUARE HOON
+3343          ; mapped                 ; 30DE 30A4 30AF 30ED #1.1 SQUARE MAIKURO
+3344          ; mapped                 ; 30DE 30A4 30EB #1.1  SQUARE MAIRU
+3345          ; mapped                 ; 30DE 30C3 30CF #1.1  SQUARE MAHHA
+3346          ; mapped                 ; 30DE 30EB 30AF #1.1  SQUARE MARUKU
+3347          ; mapped                 ; 30DE 30F3 30B7 30E7 30F3 #1.1 SQUARE MANSYON
+3348          ; mapped                 ; 30DF 30AF 30ED 30F3 #1.1 SQUARE MIKURON
+3349          ; mapped                 ; 30DF 30EA     # 1.1  SQUARE MIRI
+334A          ; mapped                 ; 30DF 30EA 30D0 30FC 30EB #1.1 SQUARE MIRIBAARU
+334B          ; mapped                 ; 30E1 30AC     # 1.1  SQUARE MEGA
+334C          ; mapped                 ; 30E1 30AC 30C8 30F3 #1.1 SQUARE MEGATON
+334D          ; mapped                 ; 30E1 30FC 30C8 30EB #1.1 SQUARE MEETORU
+334E          ; mapped                 ; 30E4 30FC 30C9 #1.1  SQUARE YAADO
+334F          ; mapped                 ; 30E4 30FC 30EB #1.1  SQUARE YAARU
+3350          ; mapped                 ; 30E6 30A2 30F3 #1.1  SQUARE YUAN
+3351          ; mapped                 ; 30EA 30C3 30C8 30EB #1.1 SQUARE RITTORU
+3352          ; mapped                 ; 30EA 30E9     # 1.1  SQUARE RIRA
+3353          ; mapped                 ; 30EB 30D4 30FC #1.1  SQUARE RUPII
+3354          ; mapped                 ; 30EB 30FC 30D6 30EB #1.1 SQUARE RUUBURU
+3355          ; mapped                 ; 30EC 30E0     # 1.1  SQUARE REMU
+3356          ; mapped                 ; 30EC 30F3 30C8 30B2 30F3 #1.1 SQUARE RENTOGEN
+3357          ; mapped                 ; 30EF 30C3 30C8 #1.1  SQUARE WATTO
+3358          ; mapped                 ; 0030 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR ZERO
+3359          ; mapped                 ; 0031 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR ONE
+335A          ; mapped                 ; 0032 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TWO
+335B          ; mapped                 ; 0033 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR THREE
+335C          ; mapped                 ; 0034 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR FOUR
+335D          ; mapped                 ; 0035 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR FIVE
+335E          ; mapped                 ; 0036 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR SIX
+335F          ; mapped                 ; 0037 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR SEVEN
+3360          ; mapped                 ; 0038 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR EIGHT
+3361          ; mapped                 ; 0039 70B9     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR NINE
+3362          ; mapped                 ; 0031 0030 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TEN
+3363          ; mapped                 ; 0031 0031 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR ELEVEN
+3364          ; mapped                 ; 0031 0032 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TWELVE
+3365          ; mapped                 ; 0031 0033 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR THIRTEEN
+3366          ; mapped                 ; 0031 0034 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR FOURTEEN
+3367          ; mapped                 ; 0031 0035 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR FIFTEEN
+3368          ; mapped                 ; 0031 0036 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR SIXTEEN
+3369          ; mapped                 ; 0031 0037 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR SEVENTEEN
+336A          ; mapped                 ; 0031 0038 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR EIGHTEEN
+336B          ; mapped                 ; 0031 0039 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR NINETEEN
+336C          ; mapped                 ; 0032 0030 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TWENTY
+336D          ; mapped                 ; 0032 0031 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TWENTY-ONE
+336E          ; mapped                 ; 0032 0032 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TWENTY-TWO
+336F          ; mapped                 ; 0032 0033 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TWENTY-THREE
+3370          ; mapped                 ; 0032 0034 70B9 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR HOUR TWENTY-FOUR
+3371          ; mapped                 ; 0068 0070 0061 #1.1  SQUARE HPA
+3372          ; mapped                 ; 0064 0061     # 1.1  SQUARE DA
+3373          ; mapped                 ; 0061 0075     # 1.1  SQUARE AU
+3374          ; mapped                 ; 0062 0061 0072 #1.1  SQUARE BAR
+3375          ; mapped                 ; 006F 0076     # 1.1  SQUARE OV
+3376          ; mapped                 ; 0070 0063     # 1.1  SQUARE PC
+3377          ; mapped                 ; 0064 006D     # 4.0  SQUARE DM
+3378          ; mapped                 ; 0064 006D 0032 #4.0  SQUARE DM SQUARED
+3379          ; mapped                 ; 0064 006D 0033 #4.0  SQUARE DM CUBED
+337A          ; mapped                 ; 0069 0075     # 4.0  SQUARE IU
+337B          ; mapped                 ; 5E73 6210     # 1.1  SQUARE ERA NAME HEISEI
+337C          ; mapped                 ; 662D 548C     # 1.1  SQUARE ERA NAME SYOUWA
+337D          ; mapped                 ; 5927 6B63     # 1.1  SQUARE ERA NAME TAISYOU
+337E          ; mapped                 ; 660E 6CBB     # 1.1  SQUARE ERA NAME MEIZI
+337F          ; mapped                 ; 682A 5F0F 4F1A 793E #1.1 SQUARE CORPORATION
+3380          ; mapped                 ; 0070 0061     # 1.1  SQUARE PA AMPS
+3381          ; mapped                 ; 006E 0061     # 1.1  SQUARE NA
+3382          ; mapped                 ; 03BC 0061     # 1.1  SQUARE MU A
+3383          ; mapped                 ; 006D 0061     # 1.1  SQUARE MA
+3384          ; mapped                 ; 006B 0061     # 1.1  SQUARE KA
+3385          ; mapped                 ; 006B 0062     # 1.1  SQUARE KB
+3386          ; mapped                 ; 006D 0062     # 1.1  SQUARE MB
+3387          ; mapped                 ; 0067 0062     # 1.1  SQUARE GB
+3388          ; mapped                 ; 0063 0061 006C #1.1  SQUARE CAL
+3389          ; mapped                 ; 006B 0063 0061 006C #1.1 SQUARE KCAL
+338A          ; mapped                 ; 0070 0066     # 1.1  SQUARE PF
+338B          ; mapped                 ; 006E 0066     # 1.1  SQUARE NF
+338C          ; mapped                 ; 03BC 0066     # 1.1  SQUARE MU F
+338D          ; mapped                 ; 03BC 0067     # 1.1  SQUARE MU G
+338E          ; mapped                 ; 006D 0067     # 1.1  SQUARE MG
+338F          ; mapped                 ; 006B 0067     # 1.1  SQUARE KG
+3390          ; mapped                 ; 0068 007A     # 1.1  SQUARE HZ
+3391          ; mapped                 ; 006B 0068 007A #1.1  SQUARE KHZ
+3392          ; mapped                 ; 006D 0068 007A #1.1  SQUARE MHZ
+3393          ; mapped                 ; 0067 0068 007A #1.1  SQUARE GHZ
+3394          ; mapped                 ; 0074 0068 007A #1.1  SQUARE THZ
+3395          ; mapped                 ; 03BC 006C     # 1.1  SQUARE MU L
+3396          ; mapped                 ; 006D 006C     # 1.1  SQUARE ML
+3397          ; mapped                 ; 0064 006C     # 1.1  SQUARE DL
+3398          ; mapped                 ; 006B 006C     # 1.1  SQUARE KL
+3399          ; mapped                 ; 0066 006D     # 1.1  SQUARE FM
+339A          ; mapped                 ; 006E 006D     # 1.1  SQUARE NM
+339B          ; mapped                 ; 03BC 006D     # 1.1  SQUARE MU M
+339C          ; mapped                 ; 006D 006D     # 1.1  SQUARE MM
+339D          ; mapped                 ; 0063 006D     # 1.1  SQUARE CM
+339E          ; mapped                 ; 006B 006D     # 1.1  SQUARE KM
+339F          ; mapped                 ; 006D 006D 0032 #1.1  SQUARE MM SQUARED
+33A0          ; mapped                 ; 0063 006D 0032 #1.1  SQUARE CM SQUARED
+33A1          ; mapped                 ; 006D 0032     # 1.1  SQUARE M SQUARED
+33A2          ; mapped                 ; 006B 006D 0032 #1.1  SQUARE KM SQUARED
+33A3          ; mapped                 ; 006D 006D 0033 #1.1  SQUARE MM CUBED
+33A4          ; mapped                 ; 0063 006D 0033 #1.1  SQUARE CM CUBED
+33A5          ; mapped                 ; 006D 0033     # 1.1  SQUARE M CUBED
+33A6          ; mapped                 ; 006B 006D 0033 #1.1  SQUARE KM CUBED
+33A7          ; mapped                 ; 006D 2215 0073 #1.1  SQUARE M OVER S
+33A8          ; mapped                 ; 006D 2215 0073 0032 #1.1 SQUARE M OVER S SQUARED
+33A9          ; mapped                 ; 0070 0061     # 1.1  SQUARE PA
+33AA          ; mapped                 ; 006B 0070 0061 #1.1  SQUARE KPA
+33AB          ; mapped                 ; 006D 0070 0061 #1.1  SQUARE MPA
+33AC          ; mapped                 ; 0067 0070 0061 #1.1  SQUARE GPA
+33AD          ; mapped                 ; 0072 0061 0064 #1.1  SQUARE RAD
+33AE          ; mapped                 ; 0072 0061 0064 2215 0073 #1.1 SQUARE RAD OVER S
+33AF          ; mapped                 ; 0072 0061 0064 2215 0073 0032 #1.1 SQUARE RAD OVER S SQUARED
+33B0          ; mapped                 ; 0070 0073     # 1.1  SQUARE PS
+33B1          ; mapped                 ; 006E 0073     # 1.1  SQUARE NS
+33B2          ; mapped                 ; 03BC 0073     # 1.1  SQUARE MU S
+33B3          ; mapped                 ; 006D 0073     # 1.1  SQUARE MS
+33B4          ; mapped                 ; 0070 0076     # 1.1  SQUARE PV
+33B5          ; mapped                 ; 006E 0076     # 1.1  SQUARE NV
+33B6          ; mapped                 ; 03BC 0076     # 1.1  SQUARE MU V
+33B7          ; mapped                 ; 006D 0076     # 1.1  SQUARE MV
+33B8          ; mapped                 ; 006B 0076     # 1.1  SQUARE KV
+33B9          ; mapped                 ; 006D 0076     # 1.1  SQUARE MV MEGA
+33BA          ; mapped                 ; 0070 0077     # 1.1  SQUARE PW
+33BB          ; mapped                 ; 006E 0077     # 1.1  SQUARE NW
+33BC          ; mapped                 ; 03BC 0077     # 1.1  SQUARE MU W
+33BD          ; mapped                 ; 006D 0077     # 1.1  SQUARE MW
+33BE          ; mapped                 ; 006B 0077     # 1.1  SQUARE KW
+33BF          ; mapped                 ; 006D 0077     # 1.1  SQUARE MW MEGA
+33C0          ; mapped                 ; 006B 03C9     # 1.1  SQUARE K OHM
+33C1          ; mapped                 ; 006D 03C9     # 1.1  SQUARE M OHM
+33C2          ; disallowed                             # 1.1  SQUARE AM
+33C3          ; mapped                 ; 0062 0071     # 1.1  SQUARE BQ
+33C4          ; mapped                 ; 0063 0063     # 1.1  SQUARE CC
+33C5          ; mapped                 ; 0063 0064     # 1.1  SQUARE CD
+33C6          ; mapped                 ; 0063 2215 006B 0067 #1.1 SQUARE C OVER KG
+33C7          ; disallowed                             # 1.1  SQUARE CO
+33C8          ; mapped                 ; 0064 0062     # 1.1  SQUARE DB
+33C9          ; mapped                 ; 0067 0079     # 1.1  SQUARE GY
+33CA          ; mapped                 ; 0068 0061     # 1.1  SQUARE HA
+33CB          ; mapped                 ; 0068 0070     # 1.1  SQUARE HP
+33CC          ; mapped                 ; 0069 006E     # 1.1  SQUARE IN
+33CD          ; mapped                 ; 006B 006B     # 1.1  SQUARE KK
+33CE          ; mapped                 ; 006B 006D     # 1.1  SQUARE KM CAPITAL
+33CF          ; mapped                 ; 006B 0074     # 1.1  SQUARE KT
+33D0          ; mapped                 ; 006C 006D     # 1.1  SQUARE LM
+33D1          ; mapped                 ; 006C 006E     # 1.1  SQUARE LN
+33D2          ; mapped                 ; 006C 006F 0067 #1.1  SQUARE LOG
+33D3          ; mapped                 ; 006C 0078     # 1.1  SQUARE LX
+33D4          ; mapped                 ; 006D 0062     # 1.1  SQUARE MB SMALL
+33D5          ; mapped                 ; 006D 0069 006C #1.1  SQUARE MIL
+33D6          ; mapped                 ; 006D 006F 006C #1.1  SQUARE MOL
+33D7          ; mapped                 ; 0070 0068     # 1.1  SQUARE PH
+33D8          ; disallowed                             # 1.1  SQUARE PM
+33D9          ; mapped                 ; 0070 0070 006D #1.1  SQUARE PPM
+33DA          ; mapped                 ; 0070 0072     # 1.1  SQUARE PR
+33DB          ; mapped                 ; 0073 0072     # 1.1  SQUARE SR
+33DC          ; mapped                 ; 0073 0076     # 1.1  SQUARE SV
+33DD          ; mapped                 ; 0077 0062     # 1.1  SQUARE WB
+33DE          ; mapped                 ; 0076 2215 006D #4.0  SQUARE V OVER M
+33DF          ; mapped                 ; 0061 2215 006D #4.0  SQUARE A OVER M
+33E0          ; mapped                 ; 0031 65E5     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY ONE
+33E1          ; mapped                 ; 0032 65E5     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWO
+33E2          ; mapped                 ; 0033 65E5     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY THREE
+33E3          ; mapped                 ; 0034 65E5     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY FOUR
+33E4          ; mapped                 ; 0035 65E5     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY FIVE
+33E5          ; mapped                 ; 0036 65E5     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY SIX
+33E6          ; mapped                 ; 0037 65E5     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY SEVEN
+33E7          ; mapped                 ; 0038 65E5     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY EIGHT
+33E8          ; mapped                 ; 0039 65E5     # 1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY NINE
+33E9          ; mapped                 ; 0031 0030 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TEN
+33EA          ; mapped                 ; 0031 0031 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY ELEVEN
+33EB          ; mapped                 ; 0031 0032 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWELVE
+33EC          ; mapped                 ; 0031 0033 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY THIRTEEN
+33ED          ; mapped                 ; 0031 0034 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY FOURTEEN
+33EE          ; mapped                 ; 0031 0035 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY FIFTEEN
+33EF          ; mapped                 ; 0031 0036 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY SIXTEEN
+33F0          ; mapped                 ; 0031 0037 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY SEVENTEEN
+33F1          ; mapped                 ; 0031 0038 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY EIGHTEEN
+33F2          ; mapped                 ; 0031 0039 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY NINETEEN
+33F3          ; mapped                 ; 0032 0030 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY
+33F4          ; mapped                 ; 0032 0031 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY-ONE
+33F5          ; mapped                 ; 0032 0032 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY-TWO
+33F6          ; mapped                 ; 0032 0033 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY-THREE
+33F7          ; mapped                 ; 0032 0034 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY-FOUR
+33F8          ; mapped                 ; 0032 0035 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY-FIVE
+33F9          ; mapped                 ; 0032 0036 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY-SIX
+33FA          ; mapped                 ; 0032 0037 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY-SEVEN
+33FB          ; mapped                 ; 0032 0038 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY-EIGHT
+33FC          ; mapped                 ; 0032 0039 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY TWENTY-NINE
+33FD          ; mapped                 ; 0033 0030 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY THIRTY
+33FE          ; mapped                 ; 0033 0031 65E5 #1.1  IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY THIRTY-ONE
+33FF          ; mapped                 ; 0067 0061 006C #4.0  SQUARE GAL
+3400..4DB5    ; valid                                  # 3.0  CJK UNIFIED IDEOGRAPH-3400..CJK UNIFIED IDEOGRAPH-4DB5
+4DB6..4DBF    ; valid                                  # 13.0 CJK UNIFIED IDEOGRAPH-4DB6..CJK UNIFIED IDEOGRAPH-4DBF
+4DC0..4DFF    ; valid                  ;      ; NV8    # 4.0  HEXAGRAM FOR THE CREATIVE HEAVEN..HEXAGRAM FOR BEFORE COMPLETION
+4E00..9FA5    ; valid                                  # 1.1  CJK UNIFIED IDEOGRAPH-4E00..CJK UNIFIED IDEOGRAPH-9FA5
+9FA6..9FBB    ; valid                                  # 4.1  CJK UNIFIED IDEOGRAPH-9FA6..CJK UNIFIED IDEOGRAPH-9FBB
+9FBC..9FC3    ; valid                                  # 5.1  CJK UNIFIED IDEOGRAPH-9FBC..CJK UNIFIED IDEOGRAPH-9FC3
+9FC4..9FCB    ; valid                                  # 5.2  CJK UNIFIED IDEOGRAPH-9FC4..CJK UNIFIED IDEOGRAPH-9FCB
+9FCC          ; valid                                  # 6.1  CJK UNIFIED IDEOGRAPH-9FCC
+9FCD..9FD5    ; valid                                  # 8.0  CJK UNIFIED IDEOGRAPH-9FCD..CJK UNIFIED IDEOGRAPH-9FD5
+9FD6..9FEA    ; valid                                  # 10.0 CJK UNIFIED IDEOGRAPH-9FD6..CJK UNIFIED IDEOGRAPH-9FEA
+9FEB..9FEF    ; valid                                  # 11.0 CJK UNIFIED IDEOGRAPH-9FEB..CJK UNIFIED IDEOGRAPH-9FEF
+9FF0..9FFC    ; valid                                  # 13.0 CJK UNIFIED IDEOGRAPH-9FF0..CJK UNIFIED IDEOGRAPH-9FFC
+9FFD..9FFF    ; valid                                  # 14.0 CJK UNIFIED IDEOGRAPH-9FFD..CJK UNIFIED IDEOGRAPH-9FFF
+A000..A48C    ; valid                                  # 3.0  YI SYLLABLE IT..YI SYLLABLE YYR
+A48D..A48F    ; disallowed                             # NA   <reserved-A48D>..<reserved-A48F>
+A490..A4A1    ; valid                  ;      ; NV8    # 3.0  YI RADICAL QOT..YI RADICAL GA
+A4A2..A4A3    ; valid                  ;      ; NV8    # 3.2  YI RADICAL ZUP..YI RADICAL CYT
+A4A4..A4B3    ; valid                  ;      ; NV8    # 3.0  YI RADICAL DDUR..YI RADICAL JO
+A4B4          ; valid                  ;      ; NV8    # 3.2  YI RADICAL NZUP
+A4B5..A4C0    ; valid                  ;      ; NV8    # 3.0  YI RADICAL JJY..YI RADICAL SHAT
+A4C1          ; valid                  ;      ; NV8    # 3.2  YI RADICAL ZUR
+A4C2..A4C4    ; valid                  ;      ; NV8    # 3.0  YI RADICAL SHOP..YI RADICAL ZZIET
+A4C5          ; valid                  ;      ; NV8    # 3.2  YI RADICAL NBIE
+A4C6          ; valid                  ;      ; NV8    # 3.0  YI RADICAL KE
+A4C7..A4CF    ; disallowed                             # NA   <reserved-A4C7>..<reserved-A4CF>
+A4D0..A4FD    ; valid                                  # 5.2  LISU LETTER BA..LISU LETTER TONE MYA JEU
+A4FE..A4FF    ; valid                  ;      ; NV8    # 5.2  LISU PUNCTUATION COMMA..LISU PUNCTUATION FULL STOP
+A500..A60C    ; valid                                  # 5.1  VAI SYLLABLE EE..VAI SYLLABLE LENGTHENER
+A60D..A60F    ; valid                  ;      ; NV8    # 5.1  VAI COMMA..VAI QUESTION MARK
+A610..A62B    ; valid                                  # 5.1  VAI SYLLABLE NDOLE FA..VAI SYLLABLE NDOLE DO
+A62C..A63F    ; disallowed                             # NA   <reserved-A62C>..<reserved-A63F>
+A640          ; mapped                 ; A641          # 5.1  CYRILLIC CAPITAL LETTER ZEMLYA
+A641          ; valid                                  # 5.1  CYRILLIC SMALL LETTER ZEMLYA
+A642          ; mapped                 ; A643          # 5.1  CYRILLIC CAPITAL LETTER DZELO
+A643          ; valid                                  # 5.1  CYRILLIC SMALL LETTER DZELO
+A644          ; mapped                 ; A645          # 5.1  CYRILLIC CAPITAL LETTER REVERSED DZE
+A645          ; valid                                  # 5.1  CYRILLIC SMALL LETTER REVERSED DZE
+A646          ; mapped                 ; A647          # 5.1  CYRILLIC CAPITAL LETTER IOTA
+A647          ; valid                                  # 5.1  CYRILLIC SMALL LETTER IOTA
+A648          ; mapped                 ; A649          # 5.1  CYRILLIC CAPITAL LETTER DJERV
+A649          ; valid                                  # 5.1  CYRILLIC SMALL LETTER DJERV
+A64A          ; mapped                 ; A64B          # 5.1  CYRILLIC CAPITAL LETTER MONOGRAPH UK
+A64B          ; valid                                  # 5.1  CYRILLIC SMALL LETTER MONOGRAPH UK
+A64C          ; mapped                 ; A64D          # 5.1  CYRILLIC CAPITAL LETTER BROAD OMEGA
+A64D          ; valid                                  # 5.1  CYRILLIC SMALL LETTER BROAD OMEGA
+A64E          ; mapped                 ; A64F          # 5.1  CYRILLIC CAPITAL LETTER NEUTRAL YER
+A64F          ; valid                                  # 5.1  CYRILLIC SMALL LETTER NEUTRAL YER
+A650          ; mapped                 ; A651          # 5.1  CYRILLIC CAPITAL LETTER YERU WITH BACK YER
+A651          ; valid                                  # 5.1  CYRILLIC SMALL LETTER YERU WITH BACK YER
+A652          ; mapped                 ; A653          # 5.1  CYRILLIC CAPITAL LETTER IOTIFIED YAT
+A653          ; valid                                  # 5.1  CYRILLIC SMALL LETTER IOTIFIED YAT
+A654          ; mapped                 ; A655          # 5.1  CYRILLIC CAPITAL LETTER REVERSED YU
+A655          ; valid                                  # 5.1  CYRILLIC SMALL LETTER REVERSED YU
+A656          ; mapped                 ; A657          # 5.1  CYRILLIC CAPITAL LETTER IOTIFIED A
+A657          ; valid                                  # 5.1  CYRILLIC SMALL LETTER IOTIFIED A
+A658          ; mapped                 ; A659          # 5.1  CYRILLIC CAPITAL LETTER CLOSED LITTLE YUS
+A659          ; valid                                  # 5.1  CYRILLIC SMALL LETTER CLOSED LITTLE YUS
+A65A          ; mapped                 ; A65B          # 5.1  CYRILLIC CAPITAL LETTER BLENDED YUS
+A65B          ; valid                                  # 5.1  CYRILLIC SMALL LETTER BLENDED YUS
+A65C          ; mapped                 ; A65D          # 5.1  CYRILLIC CAPITAL LETTER IOTIFIED CLOSED LITTLE YUS
+A65D          ; valid                                  # 5.1  CYRILLIC SMALL LETTER IOTIFIED CLOSED LITTLE YUS
+A65E          ; mapped                 ; A65F          # 5.1  CYRILLIC CAPITAL LETTER YN
+A65F          ; valid                                  # 5.1  CYRILLIC SMALL LETTER YN
+A660          ; mapped                 ; A661          # 6.0  CYRILLIC CAPITAL LETTER REVERSED TSE
+A661          ; valid                                  # 6.0  CYRILLIC SMALL LETTER REVERSED TSE
+A662          ; mapped                 ; A663          # 5.1  CYRILLIC CAPITAL LETTER SOFT DE
+A663          ; valid                                  # 5.1  CYRILLIC SMALL LETTER SOFT DE
+A664          ; mapped                 ; A665          # 5.1  CYRILLIC CAPITAL LETTER SOFT EL
+A665          ; valid                                  # 5.1  CYRILLIC SMALL LETTER SOFT EL
+A666          ; mapped                 ; A667          # 5.1  CYRILLIC CAPITAL LETTER SOFT EM
+A667          ; valid                                  # 5.1  CYRILLIC SMALL LETTER SOFT EM
+A668          ; mapped                 ; A669          # 5.1  CYRILLIC CAPITAL LETTER MONOCULAR O
+A669          ; valid                                  # 5.1  CYRILLIC SMALL LETTER MONOCULAR O
+A66A          ; mapped                 ; A66B          # 5.1  CYRILLIC CAPITAL LETTER BINOCULAR O
+A66B          ; valid                                  # 5.1  CYRILLIC SMALL LETTER BINOCULAR O
+A66C          ; mapped                 ; A66D          # 5.1  CYRILLIC CAPITAL LETTER DOUBLE MONOCULAR O
+A66D..A66F    ; valid                                  # 5.1  CYRILLIC SMALL LETTER DOUBLE MONOCULAR O..COMBINING CYRILLIC VZMET
+A670..A673    ; valid                  ;      ; NV8    # 5.1  COMBINING CYRILLIC TEN MILLIONS SIGN..SLAVONIC ASTERISK
+A674..A67B    ; valid                                  # 6.1  COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC LETTER OMEGA
+A67C..A67D    ; valid                                  # 5.1  COMBINING CYRILLIC KAVYKA..COMBINING CYRILLIC PAYEROK
+A67E          ; valid                  ;      ; NV8    # 5.1  CYRILLIC KAVYKA
+A67F          ; valid                                  # 5.1  CYRILLIC PAYEROK
+A680          ; mapped                 ; A681          # 5.1  CYRILLIC CAPITAL LETTER DWE
+A681          ; valid                                  # 5.1  CYRILLIC SMALL LETTER DWE
+A682          ; mapped                 ; A683          # 5.1  CYRILLIC CAPITAL LETTER DZWE
+A683          ; valid                                  # 5.1  CYRILLIC SMALL LETTER DZWE
+A684          ; mapped                 ; A685          # 5.1  CYRILLIC CAPITAL LETTER ZHWE
+A685          ; valid                                  # 5.1  CYRILLIC SMALL LETTER ZHWE
+A686          ; mapped                 ; A687          # 5.1  CYRILLIC CAPITAL LETTER CCHE
+A687          ; valid                                  # 5.1  CYRILLIC SMALL LETTER CCHE
+A688          ; mapped                 ; A689          # 5.1  CYRILLIC CAPITAL LETTER DZZE
+A689          ; valid                                  # 5.1  CYRILLIC SMALL LETTER DZZE
+A68A          ; mapped                 ; A68B          # 5.1  CYRILLIC CAPITAL LETTER TE WITH MIDDLE HOOK
+A68B          ; valid                                  # 5.1  CYRILLIC SMALL LETTER TE WITH MIDDLE HOOK
+A68C          ; mapped                 ; A68D          # 5.1  CYRILLIC CAPITAL LETTER TWE
+A68D          ; valid                                  # 5.1  CYRILLIC SMALL LETTER TWE
+A68E          ; mapped                 ; A68F          # 5.1  CYRILLIC CAPITAL LETTER TSWE
+A68F          ; valid                                  # 5.1  CYRILLIC SMALL LETTER TSWE
+A690          ; mapped                 ; A691          # 5.1  CYRILLIC CAPITAL LETTER TSSE
+A691          ; valid                                  # 5.1  CYRILLIC SMALL LETTER TSSE
+A692          ; mapped                 ; A693          # 5.1  CYRILLIC CAPITAL LETTER TCHE
+A693          ; valid                                  # 5.1  CYRILLIC SMALL LETTER TCHE
+A694          ; mapped                 ; A695          # 5.1  CYRILLIC CAPITAL LETTER HWE
+A695          ; valid                                  # 5.1  CYRILLIC SMALL LETTER HWE
+A696          ; mapped                 ; A697          # 5.1  CYRILLIC CAPITAL LETTER SHWE
+A697          ; valid                                  # 5.1  CYRILLIC SMALL LETTER SHWE
+A698          ; mapped                 ; A699          # 7.0  CYRILLIC CAPITAL LETTER DOUBLE O
+A699          ; valid                                  # 7.0  CYRILLIC SMALL LETTER DOUBLE O
+A69A          ; mapped                 ; A69B          # 7.0  CYRILLIC CAPITAL LETTER CROSSED O
+A69B          ; valid                                  # 7.0  CYRILLIC SMALL LETTER CROSSED O
+A69C          ; mapped                 ; 044A          # 7.0  MODIFIER LETTER CYRILLIC HARD SIGN
+A69D          ; mapped                 ; 044C          # 7.0  MODIFIER LETTER CYRILLIC SOFT SIGN
+A69E          ; valid                                  # 8.0  COMBINING CYRILLIC LETTER EF
+A69F          ; valid                                  # 6.1  COMBINING CYRILLIC LETTER IOTIFIED E
+A6A0..A6E5    ; valid                                  # 5.2  BAMUM LETTER A..BAMUM LETTER KI
+A6E6..A6EF    ; valid                  ;      ; NV8    # 5.2  BAMUM LETTER MO..BAMUM LETTER KOGHOM
+A6F0..A6F1    ; valid                                  # 5.2  BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
+A6F2..A6F7    ; valid                  ;      ; NV8    # 5.2  BAMUM NJAEMLI..BAMUM QUESTION MARK
+A6F8..A6FF    ; disallowed                             # NA   <reserved-A6F8>..<reserved-A6FF>
+A700..A716    ; valid                  ;      ; NV8    # 4.1  MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER EXTRA-LOW LEFT-STEM TONE BAR
+A717..A71A    ; valid                                  # 5.0  MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOWER RIGHT CORNER ANGLE
+A71B..A71F    ; valid                                  # 5.1  MODIFIER LETTER RAISED UP ARROW..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
+A720..A721    ; valid                  ;      ; NV8    # 5.0  MODIFIER LETTER STRESS AND HIGH TONE..MODIFIER LETTER STRESS AND LOW TONE
+A722          ; mapped                 ; A723          # 5.1  LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF
+A723          ; valid                                  # 5.1  LATIN SMALL LETTER EGYPTOLOGICAL ALEF
+A724          ; mapped                 ; A725          # 5.1  LATIN CAPITAL LETTER EGYPTOLOGICAL AIN
+A725          ; valid                                  # 5.1  LATIN SMALL LETTER EGYPTOLOGICAL AIN
+A726          ; mapped                 ; A727          # 5.1  LATIN CAPITAL LETTER HENG
+A727          ; valid                                  # 5.1  LATIN SMALL LETTER HENG
+A728          ; mapped                 ; A729          # 5.1  LATIN CAPITAL LETTER TZ
+A729          ; valid                                  # 5.1  LATIN SMALL LETTER TZ
+A72A          ; mapped                 ; A72B          # 5.1  LATIN CAPITAL LETTER TRESILLO
+A72B          ; valid                                  # 5.1  LATIN SMALL LETTER TRESILLO
+A72C          ; mapped                 ; A72D          # 5.1  LATIN CAPITAL LETTER CUATRILLO
+A72D          ; valid                                  # 5.1  LATIN SMALL LETTER CUATRILLO
+A72E          ; mapped                 ; A72F          # 5.1  LATIN CAPITAL LETTER CUATRILLO WITH COMMA
+A72F..A731    ; valid                                  # 5.1  LATIN SMALL LETTER CUATRILLO WITH COMMA..LATIN LETTER SMALL CAPITAL S
+A732          ; mapped                 ; A733          # 5.1  LATIN CAPITAL LETTER AA
+A733          ; valid                                  # 5.1  LATIN SMALL LETTER AA
+A734          ; mapped                 ; A735          # 5.1  LATIN CAPITAL LETTER AO
+A735          ; valid                                  # 5.1  LATIN SMALL LETTER AO
+A736          ; mapped                 ; A737          # 5.1  LATIN CAPITAL LETTER AU
+A737          ; valid                                  # 5.1  LATIN SMALL LETTER AU
+A738          ; mapped                 ; A739          # 5.1  LATIN CAPITAL LETTER AV
+A739          ; valid                                  # 5.1  LATIN SMALL LETTER AV
+A73A          ; mapped                 ; A73B          # 5.1  LATIN CAPITAL LETTER AV WITH HORIZONTAL BAR
+A73B          ; valid                                  # 5.1  LATIN SMALL LETTER AV WITH HORIZONTAL BAR
+A73C          ; mapped                 ; A73D          # 5.1  LATIN CAPITAL LETTER AY
+A73D          ; valid                                  # 5.1  LATIN SMALL LETTER AY
+A73E          ; mapped                 ; A73F          # 5.1  LATIN CAPITAL LETTER REVERSED C WITH DOT
+A73F          ; valid                                  # 5.1  LATIN SMALL LETTER REVERSED C WITH DOT
+A740          ; mapped                 ; A741          # 5.1  LATIN CAPITAL LETTER K WITH STROKE
+A741          ; valid                                  # 5.1  LATIN SMALL LETTER K WITH STROKE
+A742          ; mapped                 ; A743          # 5.1  LATIN CAPITAL LETTER K WITH DIAGONAL STROKE
+A743          ; valid                                  # 5.1  LATIN SMALL LETTER K WITH DIAGONAL STROKE
+A744          ; mapped                 ; A745          # 5.1  LATIN CAPITAL LETTER K WITH STROKE AND DIAGONAL STROKE
+A745          ; valid                                  # 5.1  LATIN SMALL LETTER K WITH STROKE AND DIAGONAL STROKE
+A746          ; mapped                 ; A747          # 5.1  LATIN CAPITAL LETTER BROKEN L
+A747          ; valid                                  # 5.1  LATIN SMALL LETTER BROKEN L
+A748          ; mapped                 ; A749          # 5.1  LATIN CAPITAL LETTER L WITH HIGH STROKE
+A749          ; valid                                  # 5.1  LATIN SMALL LETTER L WITH HIGH STROKE
+A74A          ; mapped                 ; A74B          # 5.1  LATIN CAPITAL LETTER O WITH LONG STROKE OVERLAY
+A74B          ; valid                                  # 5.1  LATIN SMALL LETTER O WITH LONG STROKE OVERLAY
+A74C          ; mapped                 ; A74D          # 5.1  LATIN CAPITAL LETTER O WITH LOOP
+A74D          ; valid                                  # 5.1  LATIN SMALL LETTER O WITH LOOP
+A74E          ; mapped                 ; A74F          # 5.1  LATIN CAPITAL LETTER OO
+A74F          ; valid                                  # 5.1  LATIN SMALL LETTER OO
+A750          ; mapped                 ; A751          # 5.1  LATIN CAPITAL LETTER P WITH STROKE THROUGH DESCENDER
+A751          ; valid                                  # 5.1  LATIN SMALL LETTER P WITH STROKE THROUGH DESCENDER
+A752          ; mapped                 ; A753          # 5.1  LATIN CAPITAL LETTER P WITH FLOURISH
+A753          ; valid                                  # 5.1  LATIN SMALL LETTER P WITH FLOURISH
+A754          ; mapped                 ; A755          # 5.1  LATIN CAPITAL LETTER P WITH SQUIRREL TAIL
+A755          ; valid                                  # 5.1  LATIN SMALL LETTER P WITH SQUIRREL TAIL
+A756          ; mapped                 ; A757          # 5.1  LATIN CAPITAL LETTER Q WITH STROKE THROUGH DESCENDER
+A757          ; valid                                  # 5.1  LATIN SMALL LETTER Q WITH STROKE THROUGH DESCENDER
+A758          ; mapped                 ; A759          # 5.1  LATIN CAPITAL LETTER Q WITH DIAGONAL STROKE
+A759          ; valid                                  # 5.1  LATIN SMALL LETTER Q WITH DIAGONAL STROKE
+A75A          ; mapped                 ; A75B          # 5.1  LATIN CAPITAL LETTER R ROTUNDA
+A75B          ; valid                                  # 5.1  LATIN SMALL LETTER R ROTUNDA
+A75C          ; mapped                 ; A75D          # 5.1  LATIN CAPITAL LETTER RUM ROTUNDA
+A75D          ; valid                                  # 5.1  LATIN SMALL LETTER RUM ROTUNDA
+A75E          ; mapped                 ; A75F          # 5.1  LATIN CAPITAL LETTER V WITH DIAGONAL STROKE
+A75F          ; valid                                  # 5.1  LATIN SMALL LETTER V WITH DIAGONAL STROKE
+A760          ; mapped                 ; A761          # 5.1  LATIN CAPITAL LETTER VY
+A761          ; valid                                  # 5.1  LATIN SMALL LETTER VY
+A762          ; mapped                 ; A763          # 5.1  LATIN CAPITAL LETTER VISIGOTHIC Z
+A763          ; valid                                  # 5.1  LATIN SMALL LETTER VISIGOTHIC Z
+A764          ; mapped                 ; A765          # 5.1  LATIN CAPITAL LETTER THORN WITH STROKE
+A765          ; valid                                  # 5.1  LATIN SMALL LETTER THORN WITH STROKE
+A766          ; mapped                 ; A767          # 5.1  LATIN CAPITAL LETTER THORN WITH STROKE THROUGH DESCENDER
+A767          ; valid                                  # 5.1  LATIN SMALL LETTER THORN WITH STROKE THROUGH DESCENDER
+A768          ; mapped                 ; A769          # 5.1  LATIN CAPITAL LETTER VEND
+A769          ; valid                                  # 5.1  LATIN SMALL LETTER VEND
+A76A          ; mapped                 ; A76B          # 5.1  LATIN CAPITAL LETTER ET
+A76B          ; valid                                  # 5.1  LATIN SMALL LETTER ET
+A76C          ; mapped                 ; A76D          # 5.1  LATIN CAPITAL LETTER IS
+A76D          ; valid                                  # 5.1  LATIN SMALL LETTER IS
+A76E          ; mapped                 ; A76F          # 5.1  LATIN CAPITAL LETTER CON
+A76F          ; valid                                  # 5.1  LATIN SMALL LETTER CON
+A770          ; mapped                 ; A76F          # 5.1  MODIFIER LETTER US
+A771..A778    ; valid                                  # 5.1  LATIN SMALL LETTER DUM..LATIN SMALL LETTER UM
+A779          ; mapped                 ; A77A          # 5.1  LATIN CAPITAL LETTER INSULAR D
+A77A          ; valid                                  # 5.1  LATIN SMALL LETTER INSULAR D
+A77B          ; mapped                 ; A77C          # 5.1  LATIN CAPITAL LETTER INSULAR F
+A77C          ; valid                                  # 5.1  LATIN SMALL LETTER INSULAR F
+A77D          ; mapped                 ; 1D79          # 5.1  LATIN CAPITAL LETTER INSULAR G
+A77E          ; mapped                 ; A77F          # 5.1  LATIN CAPITAL LETTER TURNED INSULAR G
+A77F          ; valid                                  # 5.1  LATIN SMALL LETTER TURNED INSULAR G
+A780          ; mapped                 ; A781          # 5.1  LATIN CAPITAL LETTER TURNED L
+A781          ; valid                                  # 5.1  LATIN SMALL LETTER TURNED L
+A782          ; mapped                 ; A783          # 5.1  LATIN CAPITAL LETTER INSULAR R
+A783          ; valid                                  # 5.1  LATIN SMALL LETTER INSULAR R
+A784          ; mapped                 ; A785          # 5.1  LATIN CAPITAL LETTER INSULAR S
+A785          ; valid                                  # 5.1  LATIN SMALL LETTER INSULAR S
+A786          ; mapped                 ; A787          # 5.1  LATIN CAPITAL LETTER INSULAR T
+A787..A788    ; valid                                  # 5.1  LATIN SMALL LETTER INSULAR T..MODIFIER LETTER LOW CIRCUMFLEX ACCENT
+A789..A78A    ; valid                  ;      ; NV8    # 5.1  MODIFIER LETTER COLON..MODIFIER LETTER SHORT EQUALS SIGN
+A78B          ; mapped                 ; A78C          # 5.1  LATIN CAPITAL LETTER SALTILLO
+A78C          ; valid                                  # 5.1  LATIN SMALL LETTER SALTILLO
+A78D          ; mapped                 ; 0265          # 6.0  LATIN CAPITAL LETTER TURNED H
+A78E          ; valid                                  # 6.0  LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
+A78F          ; valid                                  # 8.0  LATIN LETTER SINOLOGICAL DOT
+A790          ; mapped                 ; A791          # 6.0  LATIN CAPITAL LETTER N WITH DESCENDER
+A791          ; valid                                  # 6.0  LATIN SMALL LETTER N WITH DESCENDER
+A792          ; mapped                 ; A793          # 6.1  LATIN CAPITAL LETTER C WITH BAR
+A793          ; valid                                  # 6.1  LATIN SMALL LETTER C WITH BAR
+A794..A795    ; valid                                  # 7.0  LATIN SMALL LETTER C WITH PALATAL HOOK..LATIN SMALL LETTER H WITH PALATAL HOOK
+A796          ; mapped                 ; A797          # 7.0  LATIN CAPITAL LETTER B WITH FLOURISH
+A797          ; valid                                  # 7.0  LATIN SMALL LETTER B WITH FLOURISH
+A798          ; mapped                 ; A799          # 7.0  LATIN CAPITAL LETTER F WITH STROKE
+A799          ; valid                                  # 7.0  LATIN SMALL LETTER F WITH STROKE
+A79A          ; mapped                 ; A79B          # 7.0  LATIN CAPITAL LETTER VOLAPUK AE
+A79B          ; valid                                  # 7.0  LATIN SMALL LETTER VOLAPUK AE
+A79C          ; mapped                 ; A79D          # 7.0  LATIN CAPITAL LETTER VOLAPUK OE
+A79D          ; valid                                  # 7.0  LATIN SMALL LETTER VOLAPUK OE
+A79E          ; mapped                 ; A79F          # 7.0  LATIN CAPITAL LETTER VOLAPUK UE
+A79F          ; valid                                  # 7.0  LATIN SMALL LETTER VOLAPUK UE
+A7A0          ; mapped                 ; A7A1          # 6.0  LATIN CAPITAL LETTER G WITH OBLIQUE STROKE
+A7A1          ; valid                                  # 6.0  LATIN SMALL LETTER G WITH OBLIQUE STROKE
+A7A2          ; mapped                 ; A7A3          # 6.0  LATIN CAPITAL LETTER K WITH OBLIQUE STROKE
+A7A3          ; valid                                  # 6.0  LATIN SMALL LETTER K WITH OBLIQUE STROKE
+A7A4          ; mapped                 ; A7A5          # 6.0  LATIN CAPITAL LETTER N WITH OBLIQUE STROKE
+A7A5          ; valid                                  # 6.0  LATIN SMALL LETTER N WITH OBLIQUE STROKE
+A7A6          ; mapped                 ; A7A7          # 6.0  LATIN CAPITAL LETTER R WITH OBLIQUE STROKE
+A7A7          ; valid                                  # 6.0  LATIN SMALL LETTER R WITH OBLIQUE STROKE
+A7A8          ; mapped                 ; A7A9          # 6.0  LATIN CAPITAL LETTER S WITH OBLIQUE STROKE
+A7A9          ; valid                                  # 6.0  LATIN SMALL LETTER S WITH OBLIQUE STROKE
+A7AA          ; mapped                 ; 0266          # 6.1  LATIN CAPITAL LETTER H WITH HOOK
+A7AB          ; mapped                 ; 025C          # 7.0  LATIN CAPITAL LETTER REVERSED OPEN E
+A7AC          ; mapped                 ; 0261          # 7.0  LATIN CAPITAL LETTER SCRIPT G
+A7AD          ; mapped                 ; 026C          # 7.0  LATIN CAPITAL LETTER L WITH BELT
+A7AE          ; mapped                 ; 026A          # 9.0  LATIN CAPITAL LETTER SMALL CAPITAL I
+A7AF          ; valid                                  # 11.0 LATIN LETTER SMALL CAPITAL Q
+A7B0          ; mapped                 ; 029E          # 7.0  LATIN CAPITAL LETTER TURNED K
+A7B1          ; mapped                 ; 0287          # 7.0  LATIN CAPITAL LETTER TURNED T
+A7B2          ; mapped                 ; 029D          # 8.0  LATIN CAPITAL LETTER J WITH CROSSED-TAIL
+A7B3          ; mapped                 ; AB53          # 8.0  LATIN CAPITAL LETTER CHI
+A7B4          ; mapped                 ; A7B5          # 8.0  LATIN CAPITAL LETTER BETA
+A7B5          ; valid                                  # 8.0  LATIN SMALL LETTER BETA
+A7B6          ; mapped                 ; A7B7          # 8.0  LATIN CAPITAL LETTER OMEGA
+A7B7          ; valid                                  # 8.0  LATIN SMALL LETTER OMEGA
+A7B8          ; mapped                 ; A7B9          # 11.0 LATIN CAPITAL LETTER U WITH STROKE
+A7B9          ; valid                                  # 11.0 LATIN SMALL LETTER U WITH STROKE
+A7BA          ; mapped                 ; A7BB          # 12.0 LATIN CAPITAL LETTER GLOTTAL A
+A7BB          ; valid                                  # 12.0 LATIN SMALL LETTER GLOTTAL A
+A7BC          ; mapped                 ; A7BD          # 12.0 LATIN CAPITAL LETTER GLOTTAL I
+A7BD          ; valid                                  # 12.0 LATIN SMALL LETTER GLOTTAL I
+A7BE          ; mapped                 ; A7BF          # 12.0 LATIN CAPITAL LETTER GLOTTAL U
+A7BF          ; valid                                  # 12.0 LATIN SMALL LETTER GLOTTAL U
+A7C0          ; mapped                 ; A7C1          # 14.0 LATIN CAPITAL LETTER OLD POLISH O
+A7C1          ; valid                                  # 14.0 LATIN SMALL LETTER OLD POLISH O
+A7C2          ; mapped                 ; A7C3          # 12.0 LATIN CAPITAL LETTER ANGLICANA W
+A7C3          ; valid                                  # 12.0 LATIN SMALL LETTER ANGLICANA W
+A7C4          ; mapped                 ; A794          # 12.0 LATIN CAPITAL LETTER C WITH PALATAL HOOK
+A7C5          ; mapped                 ; 0282          # 12.0 LATIN CAPITAL LETTER S WITH HOOK
+A7C6          ; mapped                 ; 1D8E          # 12.0 LATIN CAPITAL LETTER Z WITH PALATAL HOOK
+A7C7          ; mapped                 ; A7C8          # 13.0 LATIN CAPITAL LETTER D WITH SHORT STROKE OVERLAY
+A7C8          ; valid                                  # 13.0 LATIN SMALL LETTER D WITH SHORT STROKE OVERLAY
+A7C9          ; mapped                 ; A7CA          # 13.0 LATIN CAPITAL LETTER S WITH SHORT STROKE OVERLAY
+A7CA          ; valid                                  # 13.0 LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+A7CB..A7CF    ; disallowed                             # NA   <reserved-A7CB>..<reserved-A7CF>
+A7D0          ; mapped                 ; A7D1          # 14.0 LATIN CAPITAL LETTER CLOSED INSULAR G
+A7D1          ; valid                                  # 14.0 LATIN SMALL LETTER CLOSED INSULAR G
+A7D2          ; disallowed                             # NA   <reserved-A7D2>
+A7D3          ; valid                                  # 14.0 LATIN SMALL LETTER DOUBLE THORN
+A7D4          ; disallowed                             # NA   <reserved-A7D4>
+A7D5          ; valid                                  # 14.0 LATIN SMALL LETTER DOUBLE WYNN
+A7D6          ; mapped                 ; A7D7          # 14.0 LATIN CAPITAL LETTER MIDDLE SCOTS S
+A7D7          ; valid                                  # 14.0 LATIN SMALL LETTER MIDDLE SCOTS S
+A7D8          ; mapped                 ; A7D9          # 14.0 LATIN CAPITAL LETTER SIGMOID S
+A7D9          ; valid                                  # 14.0 LATIN SMALL LETTER SIGMOID S
+A7DA..A7F1    ; disallowed                             # NA   <reserved-A7DA>..<reserved-A7F1>
+A7F2          ; mapped                 ; 0063          # 14.0 MODIFIER LETTER CAPITAL C
+A7F3          ; mapped                 ; 0066          # 14.0 MODIFIER LETTER CAPITAL F
+A7F4          ; mapped                 ; 0071          # 14.0 MODIFIER LETTER CAPITAL Q
+A7F5          ; mapped                 ; A7F6          # 13.0 LATIN CAPITAL LETTER REVERSED HALF H
+A7F6          ; valid                                  # 13.0 LATIN SMALL LETTER REVERSED HALF H
+A7F7          ; valid                                  # 7.0  LATIN EPIGRAPHIC LETTER SIDEWAYS I
+A7F8          ; mapped                 ; 0127          # 6.1  MODIFIER LETTER CAPITAL H WITH STROKE
+A7F9          ; mapped                 ; 0153          # 6.1  MODIFIER LETTER SMALL LIGATURE OE
+A7FA          ; valid                                  # 6.0  LATIN LETTER SMALL CAPITAL TURNED M
+A7FB..A7FF    ; valid                                  # 5.1  LATIN EPIGRAPHIC LETTER REVERSED F..LATIN EPIGRAPHIC LETTER ARCHAIC M
+A800..A827    ; valid                                  # 4.1  SYLOTI NAGRI LETTER A..SYLOTI NAGRI VOWEL SIGN OO
+A828..A82B    ; valid                  ;      ; NV8    # 4.1  SYLOTI NAGRI POETRY MARK-1..SYLOTI NAGRI POETRY MARK-4
+A82C          ; valid                                  # 13.0 SYLOTI NAGRI SIGN ALTERNATE HASANTA
+A82D..A82F    ; disallowed                             # NA   <reserved-A82D>..<reserved-A82F>
+A830..A839    ; valid                  ;      ; NV8    # 5.2  NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC QUANTITY MARK
+A83A..A83F    ; disallowed                             # NA   <reserved-A83A>..<reserved-A83F>
+A840..A873    ; valid                                  # 5.0  PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
+A874..A877    ; valid                  ;      ; NV8    # 5.0  PHAGS-PA SINGLE HEAD MARK..PHAGS-PA MARK DOUBLE SHAD
+A878..A87F    ; disallowed                             # NA   <reserved-A878>..<reserved-A87F>
+A880..A8C4    ; valid                                  # 5.1  SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VIRAMA
+A8C5          ; valid                                  # 9.0  SAURASHTRA SIGN CANDRABINDU
+A8C6..A8CD    ; disallowed                             # NA   <reserved-A8C6>..<reserved-A8CD>
+A8CE..A8CF    ; valid                  ;      ; NV8    # 5.1  SAURASHTRA DANDA..SAURASHTRA DOUBLE DANDA
+A8D0..A8D9    ; valid                                  # 5.1  SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
+A8DA..A8DF    ; disallowed                             # NA   <reserved-A8DA>..<reserved-A8DF>
+A8E0..A8F7    ; valid                                  # 5.2  COMBINING DEVANAGARI DIGIT ZERO..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
+A8F8..A8FA    ; valid                  ;      ; NV8    # 5.2  DEVANAGARI SIGN PUSHPIKA..DEVANAGARI CARET
+A8FB          ; valid                                  # 5.2  DEVANAGARI HEADSTROKE
+A8FC          ; valid                  ;      ; NV8    # 8.0  DEVANAGARI SIGN SIDDHAM
+A8FD          ; valid                                  # 8.0  DEVANAGARI JAIN OM
+A8FE..A8FF    ; valid                                  # 11.0 DEVANAGARI LETTER AY..DEVANAGARI VOWEL SIGN AY
+A900..A92D    ; valid                                  # 5.1  KAYAH LI DIGIT ZERO..KAYAH LI TONE CALYA PLOPHU
+A92E..A92F    ; valid                  ;      ; NV8    # 5.1  KAYAH LI SIGN CWI..KAYAH LI SIGN SHYA
+A930..A953    ; valid                                  # 5.1  REJANG LETTER KA..REJANG VIRAMA
+A954..A95E    ; disallowed                             # NA   <reserved-A954>..<reserved-A95E>
+A95F          ; valid                  ;      ; NV8    # 5.1  REJANG SECTION MARK
+A960..A97C    ; valid                  ;      ; NV8    # 5.2  HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
+A97D..A97F    ; disallowed                             # NA   <reserved-A97D>..<reserved-A97F>
+A980..A9C0    ; valid                                  # 5.2  JAVANESE SIGN PANYANGGA..JAVANESE PANGKON
+A9C1..A9CD    ; valid                  ;      ; NV8    # 5.2  JAVANESE LEFT RERENGGAN..JAVANESE TURNED PADA PISELEH
+A9CE          ; disallowed                             # NA   <reserved-A9CE>
+A9CF..A9D9    ; valid                                  # 5.2  JAVANESE PANGRANGKEP..JAVANESE DIGIT NINE
+A9DA..A9DD    ; disallowed                             # NA   <reserved-A9DA>..<reserved-A9DD>
+A9DE..A9DF    ; valid                  ;      ; NV8    # 5.2  JAVANESE PADA TIRTA TUMETES..JAVANESE PADA ISEN-ISEN
+A9E0..A9FE    ; valid                                  # 7.0  MYANMAR LETTER SHAN GHA..MYANMAR LETTER TAI LAING BHA
+A9FF          ; disallowed                             # NA   <reserved-A9FF>
+AA00..AA36    ; valid                                  # 5.1  CHAM LETTER A..CHAM CONSONANT SIGN WA
+AA37..AA3F    ; disallowed                             # NA   <reserved-AA37>..<reserved-AA3F>
+AA40..AA4D    ; valid                                  # 5.1  CHAM LETTER FINAL K..CHAM CONSONANT SIGN FINAL H
+AA4E..AA4F    ; disallowed                             # NA   <reserved-AA4E>..<reserved-AA4F>
+AA50..AA59    ; valid                                  # 5.1  CHAM DIGIT ZERO..CHAM DIGIT NINE
+AA5A..AA5B    ; disallowed                             # NA   <reserved-AA5A>..<reserved-AA5B>
+AA5C..AA5F    ; valid                  ;      ; NV8    # 5.1  CHAM PUNCTUATION SPIRAL..CHAM PUNCTUATION TRIPLE DANDA
+AA60..AA76    ; valid                                  # 5.2  MYANMAR LETTER KHAMTI GA..MYANMAR LOGOGRAM KHAMTI HM
+AA77..AA79    ; valid                  ;      ; NV8    # 5.2  MYANMAR SYMBOL AITON EXCLAMATION..MYANMAR SYMBOL AITON TWO
+AA7A..AA7B    ; valid                                  # 5.2  MYANMAR LETTER AITON RA..MYANMAR SIGN PAO KAREN TONE
+AA7C..AA7F    ; valid                                  # 7.0  MYANMAR SIGN TAI LAING TONE-2..MYANMAR LETTER SHWE PALAUNG SHA
+AA80..AAC2    ; valid                                  # 5.2  TAI VIET LETTER LOW KO..TAI VIET TONE MAI SONG
+AAC3..AADA    ; disallowed                             # NA   <reserved-AAC3>..<reserved-AADA>
+AADB..AADD    ; valid                                  # 5.2  TAI VIET SYMBOL KON..TAI VIET SYMBOL SAM
+AADE..AADF    ; valid                  ;      ; NV8    # 5.2  TAI VIET SYMBOL HO HOI..TAI VIET SYMBOL KOI KOI
+AAE0..AAEF    ; valid                                  # 6.1  MEETEI MAYEK LETTER E..MEETEI MAYEK VOWEL SIGN AAU
+AAF0..AAF1    ; valid                  ;      ; NV8    # 6.1  MEETEI MAYEK CHEIKHAN..MEETEI MAYEK AHANG KHUDAM
+AAF2..AAF6    ; valid                                  # 6.1  MEETEI MAYEK ANJI..MEETEI MAYEK VIRAMA
+AAF7..AB00    ; disallowed                             # NA   <reserved-AAF7>..<reserved-AB00>
+AB01..AB06    ; valid                                  # 6.0  ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
+AB07..AB08    ; disallowed                             # NA   <reserved-AB07>..<reserved-AB08>
+AB09..AB0E    ; valid                                  # 6.0  ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
+AB0F..AB10    ; disallowed                             # NA   <reserved-AB0F>..<reserved-AB10>
+AB11..AB16    ; valid                                  # 6.0  ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
+AB17..AB1F    ; disallowed                             # NA   <reserved-AB17>..<reserved-AB1F>
+AB20..AB26    ; valid                                  # 6.0  ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
+AB27          ; disallowed                             # NA   <reserved-AB27>
+AB28..AB2E    ; valid                                  # 6.0  ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
+AB2F          ; disallowed                             # NA   <reserved-AB2F>
+AB30..AB5A    ; valid                                  # 7.0  LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
+AB5B          ; valid                  ;      ; NV8    # 7.0  MODIFIER BREVE WITH INVERTED BREVE
+AB5C          ; mapped                 ; A727          # 7.0  MODIFIER LETTER SMALL HENG
+AB5D          ; mapped                 ; AB37          # 7.0  MODIFIER LETTER SMALL L WITH INVERTED LAZY S
+AB5E          ; mapped                 ; 026B          # 7.0  MODIFIER LETTER SMALL L WITH MIDDLE TILDE
+AB5F          ; mapped                 ; AB52          # 7.0  MODIFIER LETTER SMALL U WITH LEFT HOOK
+AB60..AB63    ; valid                                  # 8.0  LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER UO
+AB64..AB65    ; valid                                  # 7.0  LATIN SMALL LETTER INVERTED ALPHA..GREEK LETTER SMALL CAPITAL OMEGA
+AB66..AB67    ; valid                                  # 12.0 LATIN SMALL LETTER DZ DIGRAPH WITH RETROFLEX HOOK..LATIN SMALL LETTER TS DIGRAPH WITH RETROFLEX HOOK
+AB68          ; valid                                  # 13.0 LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
+AB69          ; mapped                 ; 028D          # 13.0 MODIFIER LETTER SMALL TURNED W
+AB6A..AB6B    ; valid                  ;      ; NV8    # 13.0 MODIFIER LETTER LEFT TACK..MODIFIER LETTER RIGHT TACK
+AB6C..AB6F    ; disallowed                             # NA   <reserved-AB6C>..<reserved-AB6F>
+AB70          ; mapped                 ; 13A0          # 8.0  CHEROKEE SMALL LETTER A
+AB71          ; mapped                 ; 13A1          # 8.0  CHEROKEE SMALL LETTER E
+AB72          ; mapped                 ; 13A2          # 8.0  CHEROKEE SMALL LETTER I
+AB73          ; mapped                 ; 13A3          # 8.0  CHEROKEE SMALL LETTER O
+AB74          ; mapped                 ; 13A4          # 8.0  CHEROKEE SMALL LETTER U
+AB75          ; mapped                 ; 13A5          # 8.0  CHEROKEE SMALL LETTER V
+AB76          ; mapped                 ; 13A6          # 8.0  CHEROKEE SMALL LETTER GA
+AB77          ; mapped                 ; 13A7          # 8.0  CHEROKEE SMALL LETTER KA
+AB78          ; mapped                 ; 13A8          # 8.0  CHEROKEE SMALL LETTER GE
+AB79          ; mapped                 ; 13A9          # 8.0  CHEROKEE SMALL LETTER GI
+AB7A          ; mapped                 ; 13AA          # 8.0  CHEROKEE SMALL LETTER GO
+AB7B          ; mapped                 ; 13AB          # 8.0  CHEROKEE SMALL LETTER GU
+AB7C          ; mapped                 ; 13AC          # 8.0  CHEROKEE SMALL LETTER GV
+AB7D          ; mapped                 ; 13AD          # 8.0  CHEROKEE SMALL LETTER HA
+AB7E          ; mapped                 ; 13AE          # 8.0  CHEROKEE SMALL LETTER HE
+AB7F          ; mapped                 ; 13AF          # 8.0  CHEROKEE SMALL LETTER HI
+AB80          ; mapped                 ; 13B0          # 8.0  CHEROKEE SMALL LETTER HO
+AB81          ; mapped                 ; 13B1          # 8.0  CHEROKEE SMALL LETTER HU
+AB82          ; mapped                 ; 13B2          # 8.0  CHEROKEE SMALL LETTER HV
+AB83          ; mapped                 ; 13B3          # 8.0  CHEROKEE SMALL LETTER LA
+AB84          ; mapped                 ; 13B4          # 8.0  CHEROKEE SMALL LETTER LE
+AB85          ; mapped                 ; 13B5          # 8.0  CHEROKEE SMALL LETTER LI
+AB86          ; mapped                 ; 13B6          # 8.0  CHEROKEE SMALL LETTER LO
+AB87          ; mapped                 ; 13B7          # 8.0  CHEROKEE SMALL LETTER LU
+AB88          ; mapped                 ; 13B8          # 8.0  CHEROKEE SMALL LETTER LV
+AB89          ; mapped                 ; 13B9          # 8.0  CHEROKEE SMALL LETTER MA
+AB8A          ; mapped                 ; 13BA          # 8.0  CHEROKEE SMALL LETTER ME
+AB8B          ; mapped                 ; 13BB          # 8.0  CHEROKEE SMALL LETTER MI
+AB8C          ; mapped                 ; 13BC          # 8.0  CHEROKEE SMALL LETTER MO
+AB8D          ; mapped                 ; 13BD          # 8.0  CHEROKEE SMALL LETTER MU
+AB8E          ; mapped                 ; 13BE          # 8.0  CHEROKEE SMALL LETTER NA
+AB8F          ; mapped                 ; 13BF          # 8.0  CHEROKEE SMALL LETTER HNA
+AB90          ; mapped                 ; 13C0          # 8.0  CHEROKEE SMALL LETTER NAH
+AB91          ; mapped                 ; 13C1          # 8.0  CHEROKEE SMALL LETTER NE
+AB92          ; mapped                 ; 13C2          # 8.0  CHEROKEE SMALL LETTER NI
+AB93          ; mapped                 ; 13C3          # 8.0  CHEROKEE SMALL LETTER NO
+AB94          ; mapped                 ; 13C4          # 8.0  CHEROKEE SMALL LETTER NU
+AB95          ; mapped                 ; 13C5          # 8.0  CHEROKEE SMALL LETTER NV
+AB96          ; mapped                 ; 13C6          # 8.0  CHEROKEE SMALL LETTER QUA
+AB97          ; mapped                 ; 13C7          # 8.0  CHEROKEE SMALL LETTER QUE
+AB98          ; mapped                 ; 13C8          # 8.0  CHEROKEE SMALL LETTER QUI
+AB99          ; mapped                 ; 13C9          # 8.0  CHEROKEE SMALL LETTER QUO
+AB9A          ; mapped                 ; 13CA          # 8.0  CHEROKEE SMALL LETTER QUU
+AB9B          ; mapped                 ; 13CB          # 8.0  CHEROKEE SMALL LETTER QUV
+AB9C          ; mapped                 ; 13CC          # 8.0  CHEROKEE SMALL LETTER SA
+AB9D          ; mapped                 ; 13CD          # 8.0  CHEROKEE SMALL LETTER S
+AB9E          ; mapped                 ; 13CE          # 8.0  CHEROKEE SMALL LETTER SE
+AB9F          ; mapped                 ; 13CF          # 8.0  CHEROKEE SMALL LETTER SI
+ABA0          ; mapped                 ; 13D0          # 8.0  CHEROKEE SMALL LETTER SO
+ABA1          ; mapped                 ; 13D1          # 8.0  CHEROKEE SMALL LETTER SU
+ABA2          ; mapped                 ; 13D2          # 8.0  CHEROKEE SMALL LETTER SV
+ABA3          ; mapped                 ; 13D3          # 8.0  CHEROKEE SMALL LETTER DA
+ABA4          ; mapped                 ; 13D4          # 8.0  CHEROKEE SMALL LETTER TA
+ABA5          ; mapped                 ; 13D5          # 8.0  CHEROKEE SMALL LETTER DE
+ABA6          ; mapped                 ; 13D6          # 8.0  CHEROKEE SMALL LETTER TE
+ABA7          ; mapped                 ; 13D7          # 8.0  CHEROKEE SMALL LETTER DI
+ABA8          ; mapped                 ; 13D8          # 8.0  CHEROKEE SMALL LETTER TI
+ABA9          ; mapped                 ; 13D9          # 8.0  CHEROKEE SMALL LETTER DO
+ABAA          ; mapped                 ; 13DA          # 8.0  CHEROKEE SMALL LETTER DU
+ABAB          ; mapped                 ; 13DB          # 8.0  CHEROKEE SMALL LETTER DV
+ABAC          ; mapped                 ; 13DC          # 8.0  CHEROKEE SMALL LETTER DLA
+ABAD          ; mapped                 ; 13DD          # 8.0  CHEROKEE SMALL LETTER TLA
+ABAE          ; mapped                 ; 13DE          # 8.0  CHEROKEE SMALL LETTER TLE
+ABAF          ; mapped                 ; 13DF          # 8.0  CHEROKEE SMALL LETTER TLI
+ABB0          ; mapped                 ; 13E0          # 8.0  CHEROKEE SMALL LETTER TLO
+ABB1          ; mapped                 ; 13E1          # 8.0  CHEROKEE SMALL LETTER TLU
+ABB2          ; mapped                 ; 13E2          # 8.0  CHEROKEE SMALL LETTER TLV
+ABB3          ; mapped                 ; 13E3          # 8.0  CHEROKEE SMALL LETTER TSA
+ABB4          ; mapped                 ; 13E4          # 8.0  CHEROKEE SMALL LETTER TSE
+ABB5          ; mapped                 ; 13E5          # 8.0  CHEROKEE SMALL LETTER TSI
+ABB6          ; mapped                 ; 13E6          # 8.0  CHEROKEE SMALL LETTER TSO
+ABB7          ; mapped                 ; 13E7          # 8.0  CHEROKEE SMALL LETTER TSU
+ABB8          ; mapped                 ; 13E8          # 8.0  CHEROKEE SMALL LETTER TSV
+ABB9          ; mapped                 ; 13E9          # 8.0  CHEROKEE SMALL LETTER WA
+ABBA          ; mapped                 ; 13EA          # 8.0  CHEROKEE SMALL LETTER WE
+ABBB          ; mapped                 ; 13EB          # 8.0  CHEROKEE SMALL LETTER WI
+ABBC          ; mapped                 ; 13EC          # 8.0  CHEROKEE SMALL LETTER WO
+ABBD          ; mapped                 ; 13ED          # 8.0  CHEROKEE SMALL LETTER WU
+ABBE          ; mapped                 ; 13EE          # 8.0  CHEROKEE SMALL LETTER WV
+ABBF          ; mapped                 ; 13EF          # 8.0  CHEROKEE SMALL LETTER YA
+ABC0..ABEA    ; valid                                  # 5.2  MEETEI MAYEK LETTER KOK..MEETEI MAYEK VOWEL SIGN NUNG
+ABEB          ; valid                  ;      ; NV8    # 5.2  MEETEI MAYEK CHEIKHEI
+ABEC..ABED    ; valid                                  # 5.2  MEETEI MAYEK LUM IYEK..MEETEI MAYEK APUN IYEK
+ABEE..ABEF    ; disallowed                             # NA   <reserved-ABEE>..<reserved-ABEF>
+ABF0..ABF9    ; valid                                  # 5.2  MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
+ABFA..ABFF    ; disallowed                             # NA   <reserved-ABFA>..<reserved-ABFF>
+AC00..D7A3    ; valid                                  # 2.0  HANGUL SYLLABLE GA..HANGUL SYLLABLE HIH
+D7A4..D7AF    ; disallowed                             # NA   <reserved-D7A4>..<reserved-D7AF>
+D7B0..D7C6    ; valid                  ;      ; NV8    # 5.2  HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
+D7C7..D7CA    ; disallowed                             # NA   <reserved-D7C7>..<reserved-D7CA>
+D7CB..D7FB    ; valid                  ;      ; NV8    # 5.2  HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
+D7FC..D7FF    ; disallowed                             # NA   <reserved-D7FC>..<reserved-D7FF>
+D800..DFFF    ; disallowed                             # 2.0  <surrogate-D800>..<surrogate-DFFF>
+E000..F8FF    ; disallowed                             # 1.1  <private-use-E000>..<private-use-F8FF>
+F900          ; mapped                 ; 8C48          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F900
+F901          ; mapped                 ; 66F4          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F901
+F902          ; mapped                 ; 8ECA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F902
+F903          ; mapped                 ; 8CC8          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F903
+F904          ; mapped                 ; 6ED1          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F904
+F905          ; mapped                 ; 4E32          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F905
+F906          ; mapped                 ; 53E5          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F906
+F907..F908    ; mapped                 ; 9F9C          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F907..CJK COMPATIBILITY IDEOGRAPH-F908
+F909          ; mapped                 ; 5951          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F909
+F90A          ; mapped                 ; 91D1          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F90A
+F90B          ; mapped                 ; 5587          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F90B
+F90C          ; mapped                 ; 5948          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F90C
+F90D          ; mapped                 ; 61F6          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F90D
+F90E          ; mapped                 ; 7669          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F90E
+F90F          ; mapped                 ; 7F85          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F90F
+F910          ; mapped                 ; 863F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F910
+F911          ; mapped                 ; 87BA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F911
+F912          ; mapped                 ; 88F8          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F912
+F913          ; mapped                 ; 908F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F913
+F914          ; mapped                 ; 6A02          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F914
+F915          ; mapped                 ; 6D1B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F915
+F916          ; mapped                 ; 70D9          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F916
+F917          ; mapped                 ; 73DE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F917
+F918          ; mapped                 ; 843D          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F918
+F919          ; mapped                 ; 916A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F919
+F91A          ; mapped                 ; 99F1          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F91A
+F91B          ; mapped                 ; 4E82          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F91B
+F91C          ; mapped                 ; 5375          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F91C
+F91D          ; mapped                 ; 6B04          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F91D
+F91E          ; mapped                 ; 721B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F91E
+F91F          ; mapped                 ; 862D          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F91F
+F920          ; mapped                 ; 9E1E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F920
+F921          ; mapped                 ; 5D50          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F921
+F922          ; mapped                 ; 6FEB          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F922
+F923          ; mapped                 ; 85CD          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F923
+F924          ; mapped                 ; 8964          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F924
+F925          ; mapped                 ; 62C9          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F925
+F926          ; mapped                 ; 81D8          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F926
+F927          ; mapped                 ; 881F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F927
+F928          ; mapped                 ; 5ECA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F928
+F929          ; mapped                 ; 6717          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F929
+F92A          ; mapped                 ; 6D6A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F92A
+F92B          ; mapped                 ; 72FC          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F92B
+F92C          ; mapped                 ; 90CE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F92C
+F92D          ; mapped                 ; 4F86          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F92D
+F92E          ; mapped                 ; 51B7          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F92E
+F92F          ; mapped                 ; 52DE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F92F
+F930          ; mapped                 ; 64C4          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F930
+F931          ; mapped                 ; 6AD3          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F931
+F932          ; mapped                 ; 7210          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F932
+F933          ; mapped                 ; 76E7          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F933
+F934          ; mapped                 ; 8001          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F934
+F935          ; mapped                 ; 8606          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F935
+F936          ; mapped                 ; 865C          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F936
+F937          ; mapped                 ; 8DEF          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F937
+F938          ; mapped                 ; 9732          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F938
+F939          ; mapped                 ; 9B6F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F939
+F93A          ; mapped                 ; 9DFA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F93A
+F93B          ; mapped                 ; 788C          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F93B
+F93C          ; mapped                 ; 797F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F93C
+F93D          ; mapped                 ; 7DA0          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F93D
+F93E          ; mapped                 ; 83C9          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F93E
+F93F          ; mapped                 ; 9304          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F93F
+F940          ; mapped                 ; 9E7F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F940
+F941          ; mapped                 ; 8AD6          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F941
+F942          ; mapped                 ; 58DF          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F942
+F943          ; mapped                 ; 5F04          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F943
+F944          ; mapped                 ; 7C60          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F944
+F945          ; mapped                 ; 807E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F945
+F946          ; mapped                 ; 7262          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F946
+F947          ; mapped                 ; 78CA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F947
+F948          ; mapped                 ; 8CC2          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F948
+F949          ; mapped                 ; 96F7          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F949
+F94A          ; mapped                 ; 58D8          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F94A
+F94B          ; mapped                 ; 5C62          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F94B
+F94C          ; mapped                 ; 6A13          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F94C
+F94D          ; mapped                 ; 6DDA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F94D
+F94E          ; mapped                 ; 6F0F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F94E
+F94F          ; mapped                 ; 7D2F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F94F
+F950          ; mapped                 ; 7E37          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F950
+F951          ; mapped                 ; 964B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F951
+F952          ; mapped                 ; 52D2          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F952
+F953          ; mapped                 ; 808B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F953
+F954          ; mapped                 ; 51DC          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F954
+F955          ; mapped                 ; 51CC          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F955
+F956          ; mapped                 ; 7A1C          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F956
+F957          ; mapped                 ; 7DBE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F957
+F958          ; mapped                 ; 83F1          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F958
+F959          ; mapped                 ; 9675          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F959
+F95A          ; mapped                 ; 8B80          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F95A
+F95B          ; mapped                 ; 62CF          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F95B
+F95C          ; mapped                 ; 6A02          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F95C
+F95D          ; mapped                 ; 8AFE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F95D
+F95E          ; mapped                 ; 4E39          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F95E
+F95F          ; mapped                 ; 5BE7          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F95F
+F960          ; mapped                 ; 6012          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F960
+F961          ; mapped                 ; 7387          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F961
+F962          ; mapped                 ; 7570          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F962
+F963          ; mapped                 ; 5317          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F963
+F964          ; mapped                 ; 78FB          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F964
+F965          ; mapped                 ; 4FBF          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F965
+F966          ; mapped                 ; 5FA9          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F966
+F967          ; mapped                 ; 4E0D          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F967
+F968          ; mapped                 ; 6CCC          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F968
+F969          ; mapped                 ; 6578          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F969
+F96A          ; mapped                 ; 7D22          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F96A
+F96B          ; mapped                 ; 53C3          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F96B
+F96C          ; mapped                 ; 585E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F96C
+F96D          ; mapped                 ; 7701          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F96D
+F96E          ; mapped                 ; 8449          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F96E
+F96F          ; mapped                 ; 8AAA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F96F
+F970          ; mapped                 ; 6BBA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F970
+F971          ; mapped                 ; 8FB0          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F971
+F972          ; mapped                 ; 6C88          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F972
+F973          ; mapped                 ; 62FE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F973
+F974          ; mapped                 ; 82E5          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F974
+F975          ; mapped                 ; 63A0          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F975
+F976          ; mapped                 ; 7565          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F976
+F977          ; mapped                 ; 4EAE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F977
+F978          ; mapped                 ; 5169          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F978
+F979          ; mapped                 ; 51C9          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F979
+F97A          ; mapped                 ; 6881          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F97A
+F97B          ; mapped                 ; 7CE7          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F97B
+F97C          ; mapped                 ; 826F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F97C
+F97D          ; mapped                 ; 8AD2          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F97D
+F97E          ; mapped                 ; 91CF          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F97E
+F97F          ; mapped                 ; 52F5          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F97F
+F980          ; mapped                 ; 5442          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F980
+F981          ; mapped                 ; 5973          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F981
+F982          ; mapped                 ; 5EEC          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F982
+F983          ; mapped                 ; 65C5          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F983
+F984          ; mapped                 ; 6FFE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F984
+F985          ; mapped                 ; 792A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F985
+F986          ; mapped                 ; 95AD          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F986
+F987          ; mapped                 ; 9A6A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F987
+F988          ; mapped                 ; 9E97          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F988
+F989          ; mapped                 ; 9ECE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F989
+F98A          ; mapped                 ; 529B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F98A
+F98B          ; mapped                 ; 66C6          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F98B
+F98C          ; mapped                 ; 6B77          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F98C
+F98D          ; mapped                 ; 8F62          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F98D
+F98E          ; mapped                 ; 5E74          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F98E
+F98F          ; mapped                 ; 6190          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F98F
+F990          ; mapped                 ; 6200          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F990
+F991          ; mapped                 ; 649A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F991
+F992          ; mapped                 ; 6F23          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F992
+F993          ; mapped                 ; 7149          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F993
+F994          ; mapped                 ; 7489          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F994
+F995          ; mapped                 ; 79CA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F995
+F996          ; mapped                 ; 7DF4          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F996
+F997          ; mapped                 ; 806F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F997
+F998          ; mapped                 ; 8F26          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F998
+F999          ; mapped                 ; 84EE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F999
+F99A          ; mapped                 ; 9023          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F99A
+F99B          ; mapped                 ; 934A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F99B
+F99C          ; mapped                 ; 5217          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F99C
+F99D          ; mapped                 ; 52A3          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F99D
+F99E          ; mapped                 ; 54BD          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F99E
+F99F          ; mapped                 ; 70C8          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F99F
+F9A0          ; mapped                 ; 88C2          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A0
+F9A1          ; mapped                 ; 8AAA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A1
+F9A2          ; mapped                 ; 5EC9          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A2
+F9A3          ; mapped                 ; 5FF5          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A3
+F9A4          ; mapped                 ; 637B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A4
+F9A5          ; mapped                 ; 6BAE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A5
+F9A6          ; mapped                 ; 7C3E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A6
+F9A7          ; mapped                 ; 7375          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A7
+F9A8          ; mapped                 ; 4EE4          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A8
+F9A9          ; mapped                 ; 56F9          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9A9
+F9AA          ; mapped                 ; 5BE7          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9AA
+F9AB          ; mapped                 ; 5DBA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9AB
+F9AC          ; mapped                 ; 601C          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9AC
+F9AD          ; mapped                 ; 73B2          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9AD
+F9AE          ; mapped                 ; 7469          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9AE
+F9AF          ; mapped                 ; 7F9A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9AF
+F9B0          ; mapped                 ; 8046          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B0
+F9B1          ; mapped                 ; 9234          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B1
+F9B2          ; mapped                 ; 96F6          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B2
+F9B3          ; mapped                 ; 9748          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B3
+F9B4          ; mapped                 ; 9818          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B4
+F9B5          ; mapped                 ; 4F8B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B5
+F9B6          ; mapped                 ; 79AE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B6
+F9B7          ; mapped                 ; 91B4          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B7
+F9B8          ; mapped                 ; 96B8          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B8
+F9B9          ; mapped                 ; 60E1          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9B9
+F9BA          ; mapped                 ; 4E86          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9BA
+F9BB          ; mapped                 ; 50DA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9BB
+F9BC          ; mapped                 ; 5BEE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9BC
+F9BD          ; mapped                 ; 5C3F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9BD
+F9BE          ; mapped                 ; 6599          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9BE
+F9BF          ; mapped                 ; 6A02          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9BF
+F9C0          ; mapped                 ; 71CE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C0
+F9C1          ; mapped                 ; 7642          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C1
+F9C2          ; mapped                 ; 84FC          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C2
+F9C3          ; mapped                 ; 907C          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C3
+F9C4          ; mapped                 ; 9F8D          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C4
+F9C5          ; mapped                 ; 6688          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C5
+F9C6          ; mapped                 ; 962E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C6
+F9C7          ; mapped                 ; 5289          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C7
+F9C8          ; mapped                 ; 677B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C8
+F9C9          ; mapped                 ; 67F3          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9C9
+F9CA          ; mapped                 ; 6D41          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9CA
+F9CB          ; mapped                 ; 6E9C          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9CB
+F9CC          ; mapped                 ; 7409          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9CC
+F9CD          ; mapped                 ; 7559          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9CD
+F9CE          ; mapped                 ; 786B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9CE
+F9CF          ; mapped                 ; 7D10          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9CF
+F9D0          ; mapped                 ; 985E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D0
+F9D1          ; mapped                 ; 516D          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D1
+F9D2          ; mapped                 ; 622E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D2
+F9D3          ; mapped                 ; 9678          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D3
+F9D4          ; mapped                 ; 502B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D4
+F9D5          ; mapped                 ; 5D19          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D5
+F9D6          ; mapped                 ; 6DEA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D6
+F9D7          ; mapped                 ; 8F2A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D7
+F9D8          ; mapped                 ; 5F8B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D8
+F9D9          ; mapped                 ; 6144          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9D9
+F9DA          ; mapped                 ; 6817          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9DA
+F9DB          ; mapped                 ; 7387          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9DB
+F9DC          ; mapped                 ; 9686          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9DC
+F9DD          ; mapped                 ; 5229          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9DD
+F9DE          ; mapped                 ; 540F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9DE
+F9DF          ; mapped                 ; 5C65          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9DF
+F9E0          ; mapped                 ; 6613          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E0
+F9E1          ; mapped                 ; 674E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E1
+F9E2          ; mapped                 ; 68A8          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E2
+F9E3          ; mapped                 ; 6CE5          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E3
+F9E4          ; mapped                 ; 7406          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E4
+F9E5          ; mapped                 ; 75E2          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E5
+F9E6          ; mapped                 ; 7F79          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E6
+F9E7          ; mapped                 ; 88CF          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E7
+F9E8          ; mapped                 ; 88E1          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E8
+F9E9          ; mapped                 ; 91CC          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9E9
+F9EA          ; mapped                 ; 96E2          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9EA
+F9EB          ; mapped                 ; 533F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9EB
+F9EC          ; mapped                 ; 6EBA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9EC
+F9ED          ; mapped                 ; 541D          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9ED
+F9EE          ; mapped                 ; 71D0          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9EE
+F9EF          ; mapped                 ; 7498          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9EF
+F9F0          ; mapped                 ; 85FA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F0
+F9F1          ; mapped                 ; 96A3          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F1
+F9F2          ; mapped                 ; 9C57          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F2
+F9F3          ; mapped                 ; 9E9F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F3
+F9F4          ; mapped                 ; 6797          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F4
+F9F5          ; mapped                 ; 6DCB          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F5
+F9F6          ; mapped                 ; 81E8          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F6
+F9F7          ; mapped                 ; 7ACB          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F7
+F9F8          ; mapped                 ; 7B20          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F8
+F9F9          ; mapped                 ; 7C92          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9F9
+F9FA          ; mapped                 ; 72C0          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9FA
+F9FB          ; mapped                 ; 7099          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9FB
+F9FC          ; mapped                 ; 8B58          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9FC
+F9FD          ; mapped                 ; 4EC0          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9FD
+F9FE          ; mapped                 ; 8336          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9FE
+F9FF          ; mapped                 ; 523A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-F9FF
+FA00          ; mapped                 ; 5207          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA00
+FA01          ; mapped                 ; 5EA6          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA01
+FA02          ; mapped                 ; 62D3          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA02
+FA03          ; mapped                 ; 7CD6          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA03
+FA04          ; mapped                 ; 5B85          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA04
+FA05          ; mapped                 ; 6D1E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA05
+FA06          ; mapped                 ; 66B4          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA06
+FA07          ; mapped                 ; 8F3B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA07
+FA08          ; mapped                 ; 884C          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA08
+FA09          ; mapped                 ; 964D          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA09
+FA0A          ; mapped                 ; 898B          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA0A
+FA0B          ; mapped                 ; 5ED3          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA0B
+FA0C          ; mapped                 ; 5140          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA0C
+FA0D          ; mapped                 ; 55C0          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA0D
+FA0E..FA0F    ; valid                                  # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA0E..CJK COMPATIBILITY IDEOGRAPH-FA0F
+FA10          ; mapped                 ; 585A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA10
+FA11          ; valid                                  # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA11
+FA12          ; mapped                 ; 6674          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA12
+FA13..FA14    ; valid                                  # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA13..CJK COMPATIBILITY IDEOGRAPH-FA14
+FA15          ; mapped                 ; 51DE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA15
+FA16          ; mapped                 ; 732A          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA16
+FA17          ; mapped                 ; 76CA          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA17
+FA18          ; mapped                 ; 793C          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA18
+FA19          ; mapped                 ; 795E          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA19
+FA1A          ; mapped                 ; 7965          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA1A
+FA1B          ; mapped                 ; 798F          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA1B
+FA1C          ; mapped                 ; 9756          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA1C
+FA1D          ; mapped                 ; 7CBE          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA1D
+FA1E          ; mapped                 ; 7FBD          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA1E
+FA1F          ; valid                                  # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA1F
+FA20          ; mapped                 ; 8612          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA20
+FA21          ; valid                                  # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA21
+FA22          ; mapped                 ; 8AF8          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA22
+FA23..FA24    ; valid                                  # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA23..CJK COMPATIBILITY IDEOGRAPH-FA24
+FA25          ; mapped                 ; 9038          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA25
+FA26          ; mapped                 ; 90FD          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA26
+FA27..FA29    ; valid                                  # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA27..CJK COMPATIBILITY IDEOGRAPH-FA29
+FA2A          ; mapped                 ; 98EF          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA2A
+FA2B          ; mapped                 ; 98FC          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA2B
+FA2C          ; mapped                 ; 9928          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA2C
+FA2D          ; mapped                 ; 9DB4          # 1.1  CJK COMPATIBILITY IDEOGRAPH-FA2D
+FA2E          ; mapped                 ; 90DE          # 6.1  CJK COMPATIBILITY IDEOGRAPH-FA2E
+FA2F          ; mapped                 ; 96B7          # 6.1  CJK COMPATIBILITY IDEOGRAPH-FA2F
+FA30          ; mapped                 ; 4FAE          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA30
+FA31          ; mapped                 ; 50E7          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA31
+FA32          ; mapped                 ; 514D          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA32
+FA33          ; mapped                 ; 52C9          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA33
+FA34          ; mapped                 ; 52E4          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA34
+FA35          ; mapped                 ; 5351          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA35
+FA36          ; mapped                 ; 559D          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA36
+FA37          ; mapped                 ; 5606          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA37
+FA38          ; mapped                 ; 5668          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA38
+FA39          ; mapped                 ; 5840          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA39
+FA3A          ; mapped                 ; 58A8          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA3A
+FA3B          ; mapped                 ; 5C64          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA3B
+FA3C          ; mapped                 ; 5C6E          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA3C
+FA3D          ; mapped                 ; 6094          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA3D
+FA3E          ; mapped                 ; 6168          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA3E
+FA3F          ; mapped                 ; 618E          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA3F
+FA40          ; mapped                 ; 61F2          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA40
+FA41          ; mapped                 ; 654F          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA41
+FA42          ; mapped                 ; 65E2          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA42
+FA43          ; mapped                 ; 6691          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA43
+FA44          ; mapped                 ; 6885          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA44
+FA45          ; mapped                 ; 6D77          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA45
+FA46          ; mapped                 ; 6E1A          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA46
+FA47          ; mapped                 ; 6F22          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA47
+FA48          ; mapped                 ; 716E          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA48
+FA49          ; mapped                 ; 722B          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA49
+FA4A          ; mapped                 ; 7422          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA4A
+FA4B          ; mapped                 ; 7891          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA4B
+FA4C          ; mapped                 ; 793E          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA4C
+FA4D          ; mapped                 ; 7949          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA4D
+FA4E          ; mapped                 ; 7948          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA4E
+FA4F          ; mapped                 ; 7950          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA4F
+FA50          ; mapped                 ; 7956          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA50
+FA51          ; mapped                 ; 795D          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA51
+FA52          ; mapped                 ; 798D          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA52
+FA53          ; mapped                 ; 798E          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA53
+FA54          ; mapped                 ; 7A40          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA54
+FA55          ; mapped                 ; 7A81          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA55
+FA56          ; mapped                 ; 7BC0          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA56
+FA57          ; mapped                 ; 7DF4          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA57
+FA58          ; mapped                 ; 7E09          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA58
+FA59          ; mapped                 ; 7E41          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA59
+FA5A          ; mapped                 ; 7F72          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA5A
+FA5B          ; mapped                 ; 8005          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA5B
+FA5C          ; mapped                 ; 81ED          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA5C
+FA5D..FA5E    ; mapped                 ; 8279          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA5D..CJK COMPATIBILITY IDEOGRAPH-FA5E
+FA5F          ; mapped                 ; 8457          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA5F
+FA60          ; mapped                 ; 8910          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA60
+FA61          ; mapped                 ; 8996          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA61
+FA62          ; mapped                 ; 8B01          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA62
+FA63          ; mapped                 ; 8B39          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA63
+FA64          ; mapped                 ; 8CD3          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA64
+FA65          ; mapped                 ; 8D08          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA65
+FA66          ; mapped                 ; 8FB6          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA66
+FA67          ; mapped                 ; 9038          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA67
+FA68          ; mapped                 ; 96E3          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA68
+FA69          ; mapped                 ; 97FF          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA69
+FA6A          ; mapped                 ; 983B          # 3.2  CJK COMPATIBILITY IDEOGRAPH-FA6A
+FA6B          ; mapped                 ; 6075          # 5.2  CJK COMPATIBILITY IDEOGRAPH-FA6B
+FA6C          ; mapped                 ; 242EE         # 5.2  CJK COMPATIBILITY IDEOGRAPH-FA6C
+FA6D          ; mapped                 ; 8218          # 5.2  CJK COMPATIBILITY IDEOGRAPH-FA6D
+FA6E..FA6F    ; disallowed                             # NA   <reserved-FA6E>..<reserved-FA6F>
+FA70          ; mapped                 ; 4E26          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA70
+FA71          ; mapped                 ; 51B5          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA71
+FA72          ; mapped                 ; 5168          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA72
+FA73          ; mapped                 ; 4F80          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA73
+FA74          ; mapped                 ; 5145          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA74
+FA75          ; mapped                 ; 5180          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA75
+FA76          ; mapped                 ; 52C7          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA76
+FA77          ; mapped                 ; 52FA          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA77
+FA78          ; mapped                 ; 559D          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA78
+FA79          ; mapped                 ; 5555          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA79
+FA7A          ; mapped                 ; 5599          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA7A
+FA7B          ; mapped                 ; 55E2          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA7B
+FA7C          ; mapped                 ; 585A          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA7C
+FA7D          ; mapped                 ; 58B3          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA7D
+FA7E          ; mapped                 ; 5944          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA7E
+FA7F          ; mapped                 ; 5954          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA7F
+FA80          ; mapped                 ; 5A62          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA80
+FA81          ; mapped                 ; 5B28          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA81
+FA82          ; mapped                 ; 5ED2          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA82
+FA83          ; mapped                 ; 5ED9          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA83
+FA84          ; mapped                 ; 5F69          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA84
+FA85          ; mapped                 ; 5FAD          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA85
+FA86          ; mapped                 ; 60D8          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA86
+FA87          ; mapped                 ; 614E          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA87
+FA88          ; mapped                 ; 6108          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA88
+FA89          ; mapped                 ; 618E          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA89
+FA8A          ; mapped                 ; 6160          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA8A
+FA8B          ; mapped                 ; 61F2          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA8B
+FA8C          ; mapped                 ; 6234          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA8C
+FA8D          ; mapped                 ; 63C4          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA8D
+FA8E          ; mapped                 ; 641C          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA8E
+FA8F          ; mapped                 ; 6452          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA8F
+FA90          ; mapped                 ; 6556          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA90
+FA91          ; mapped                 ; 6674          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA91
+FA92          ; mapped                 ; 6717          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA92
+FA93          ; mapped                 ; 671B          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA93
+FA94          ; mapped                 ; 6756          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA94
+FA95          ; mapped                 ; 6B79          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA95
+FA96          ; mapped                 ; 6BBA          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA96
+FA97          ; mapped                 ; 6D41          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA97
+FA98          ; mapped                 ; 6EDB          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA98
+FA99          ; mapped                 ; 6ECB          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA99
+FA9A          ; mapped                 ; 6F22          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA9A
+FA9B          ; mapped                 ; 701E          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA9B
+FA9C          ; mapped                 ; 716E          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA9C
+FA9D          ; mapped                 ; 77A7          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA9D
+FA9E          ; mapped                 ; 7235          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA9E
+FA9F          ; mapped                 ; 72AF          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FA9F
+FAA0          ; mapped                 ; 732A          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA0
+FAA1          ; mapped                 ; 7471          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA1
+FAA2          ; mapped                 ; 7506          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA2
+FAA3          ; mapped                 ; 753B          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA3
+FAA4          ; mapped                 ; 761D          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA4
+FAA5          ; mapped                 ; 761F          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA5
+FAA6          ; mapped                 ; 76CA          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA6
+FAA7          ; mapped                 ; 76DB          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA7
+FAA8          ; mapped                 ; 76F4          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA8
+FAA9          ; mapped                 ; 774A          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAA9
+FAAA          ; mapped                 ; 7740          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAAA
+FAAB          ; mapped                 ; 78CC          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAAB
+FAAC          ; mapped                 ; 7AB1          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAAC
+FAAD          ; mapped                 ; 7BC0          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAAD
+FAAE          ; mapped                 ; 7C7B          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAAE
+FAAF          ; mapped                 ; 7D5B          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAAF
+FAB0          ; mapped                 ; 7DF4          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB0
+FAB1          ; mapped                 ; 7F3E          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB1
+FAB2          ; mapped                 ; 8005          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB2
+FAB3          ; mapped                 ; 8352          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB3
+FAB4          ; mapped                 ; 83EF          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB4
+FAB5          ; mapped                 ; 8779          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB5
+FAB6          ; mapped                 ; 8941          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB6
+FAB7          ; mapped                 ; 8986          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB7
+FAB8          ; mapped                 ; 8996          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB8
+FAB9          ; mapped                 ; 8ABF          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAB9
+FABA          ; mapped                 ; 8AF8          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FABA
+FABB          ; mapped                 ; 8ACB          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FABB
+FABC          ; mapped                 ; 8B01          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FABC
+FABD          ; mapped                 ; 8AFE          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FABD
+FABE          ; mapped                 ; 8AED          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FABE
+FABF          ; mapped                 ; 8B39          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FABF
+FAC0          ; mapped                 ; 8B8A          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC0
+FAC1          ; mapped                 ; 8D08          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC1
+FAC2          ; mapped                 ; 8F38          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC2
+FAC3          ; mapped                 ; 9072          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC3
+FAC4          ; mapped                 ; 9199          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC4
+FAC5          ; mapped                 ; 9276          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC5
+FAC6          ; mapped                 ; 967C          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC6
+FAC7          ; mapped                 ; 96E3          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC7
+FAC8          ; mapped                 ; 9756          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC8
+FAC9          ; mapped                 ; 97DB          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAC9
+FACA          ; mapped                 ; 97FF          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FACA
+FACB          ; mapped                 ; 980B          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FACB
+FACC          ; mapped                 ; 983B          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FACC
+FACD          ; mapped                 ; 9B12          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FACD
+FACE          ; mapped                 ; 9F9C          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FACE
+FACF          ; mapped                 ; 2284A         # 4.1  CJK COMPATIBILITY IDEOGRAPH-FACF
+FAD0          ; mapped                 ; 22844         # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD0
+FAD1          ; mapped                 ; 233D5         # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD1
+FAD2          ; mapped                 ; 3B9D          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD2
+FAD3          ; mapped                 ; 4018          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD3
+FAD4          ; mapped                 ; 4039          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD4
+FAD5          ; mapped                 ; 25249         # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD5
+FAD6          ; mapped                 ; 25CD0         # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD6
+FAD7          ; mapped                 ; 27ED3         # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD7
+FAD8          ; mapped                 ; 9F43          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD8
+FAD9          ; mapped                 ; 9F8E          # 4.1  CJK COMPATIBILITY IDEOGRAPH-FAD9
+FADA..FAFF    ; disallowed                             # NA   <reserved-FADA>..<reserved-FAFF>
+FB00          ; mapped                 ; 0066 0066     # 1.1  LATIN SMALL LIGATURE FF
+FB01          ; mapped                 ; 0066 0069     # 1.1  LATIN SMALL LIGATURE FI
+FB02          ; mapped                 ; 0066 006C     # 1.1  LATIN SMALL LIGATURE FL
+FB03          ; mapped                 ; 0066 0066 0069 #1.1  LATIN SMALL LIGATURE FFI
+FB04          ; mapped                 ; 0066 0066 006C #1.1  LATIN SMALL LIGATURE FFL
+FB05..FB06    ; mapped                 ; 0073 0074     # 1.1  LATIN SMALL LIGATURE LONG S T..LATIN SMALL LIGATURE ST
+FB07..FB12    ; disallowed                             # NA   <reserved-FB07>..<reserved-FB12>
+FB13          ; mapped                 ; 0574 0576     # 1.1  ARMENIAN SMALL LIGATURE MEN NOW
+FB14          ; mapped                 ; 0574 0565     # 1.1  ARMENIAN SMALL LIGATURE MEN ECH
+FB15          ; mapped                 ; 0574 056B     # 1.1  ARMENIAN SMALL LIGATURE MEN INI
+FB16          ; mapped                 ; 057E 0576     # 1.1  ARMENIAN SMALL LIGATURE VEW NOW
+FB17          ; mapped                 ; 0574 056D     # 1.1  ARMENIAN SMALL LIGATURE MEN XEH
+FB18..FB1C    ; disallowed                             # NA   <reserved-FB18>..<reserved-FB1C>
+FB1D          ; mapped                 ; 05D9 05B4     # 3.0  HEBREW LETTER YOD WITH HIRIQ
+FB1E          ; valid                                  # 1.1  HEBREW POINT JUDEO-SPANISH VARIKA
+FB1F          ; mapped                 ; 05F2 05B7     # 1.1  HEBREW LIGATURE YIDDISH YOD YOD PATAH
+FB20          ; mapped                 ; 05E2          # 1.1  HEBREW LETTER ALTERNATIVE AYIN
+FB21          ; mapped                 ; 05D0          # 1.1  HEBREW LETTER WIDE ALEF
+FB22          ; mapped                 ; 05D3          # 1.1  HEBREW LETTER WIDE DALET
+FB23          ; mapped                 ; 05D4          # 1.1  HEBREW LETTER WIDE HE
+FB24          ; mapped                 ; 05DB          # 1.1  HEBREW LETTER WIDE KAF
+FB25          ; mapped                 ; 05DC          # 1.1  HEBREW LETTER WIDE LAMED
+FB26          ; mapped                 ; 05DD          # 1.1  HEBREW LETTER WIDE FINAL MEM
+FB27          ; mapped                 ; 05E8          # 1.1  HEBREW LETTER WIDE RESH
+FB28          ; mapped                 ; 05EA          # 1.1  HEBREW LETTER WIDE TAV
+FB29          ; disallowed_STD3_mapped ; 002B          # 1.1  HEBREW LETTER ALTERNATIVE PLUS SIGN
+FB2A          ; mapped                 ; 05E9 05C1     # 1.1  HEBREW LETTER SHIN WITH SHIN DOT
+FB2B          ; mapped                 ; 05E9 05C2     # 1.1  HEBREW LETTER SHIN WITH SIN DOT
+FB2C          ; mapped                 ; 05E9 05BC 05C1 #1.1  HEBREW LETTER SHIN WITH DAGESH AND SHIN DOT
+FB2D          ; mapped                 ; 05E9 05BC 05C2 #1.1  HEBREW LETTER SHIN WITH DAGESH AND SIN DOT
+FB2E          ; mapped                 ; 05D0 05B7     # 1.1  HEBREW LETTER ALEF WITH PATAH
+FB2F          ; mapped                 ; 05D0 05B8     # 1.1  HEBREW LETTER ALEF WITH QAMATS
+FB30          ; mapped                 ; 05D0 05BC     # 1.1  HEBREW LETTER ALEF WITH MAPIQ
+FB31          ; mapped                 ; 05D1 05BC     # 1.1  HEBREW LETTER BET WITH DAGESH
+FB32          ; mapped                 ; 05D2 05BC     # 1.1  HEBREW LETTER GIMEL WITH DAGESH
+FB33          ; mapped                 ; 05D3 05BC     # 1.1  HEBREW LETTER DALET WITH DAGESH
+FB34          ; mapped                 ; 05D4 05BC     # 1.1  HEBREW LETTER HE WITH MAPIQ
+FB35          ; mapped                 ; 05D5 05BC     # 1.1  HEBREW LETTER VAV WITH DAGESH
+FB36          ; mapped                 ; 05D6 05BC     # 1.1  HEBREW LETTER ZAYIN WITH DAGESH
+FB37          ; disallowed                             # NA   <reserved-FB37>
+FB38          ; mapped                 ; 05D8 05BC     # 1.1  HEBREW LETTER TET WITH DAGESH
+FB39          ; mapped                 ; 05D9 05BC     # 1.1  HEBREW LETTER YOD WITH DAGESH
+FB3A          ; mapped                 ; 05DA 05BC     # 1.1  HEBREW LETTER FINAL KAF WITH DAGESH
+FB3B          ; mapped                 ; 05DB 05BC     # 1.1  HEBREW LETTER KAF WITH DAGESH
+FB3C          ; mapped                 ; 05DC 05BC     # 1.1  HEBREW LETTER LAMED WITH DAGESH
+FB3D          ; disallowed                             # NA   <reserved-FB3D>
+FB3E          ; mapped                 ; 05DE 05BC     # 1.1  HEBREW LETTER MEM WITH DAGESH
+FB3F          ; disallowed                             # NA   <reserved-FB3F>
+FB40          ; mapped                 ; 05E0 05BC     # 1.1  HEBREW LETTER NUN WITH DAGESH
+FB41          ; mapped                 ; 05E1 05BC     # 1.1  HEBREW LETTER SAMEKH WITH DAGESH
+FB42          ; disallowed                             # NA   <reserved-FB42>
+FB43          ; mapped                 ; 05E3 05BC     # 1.1  HEBREW LETTER FINAL PE WITH DAGESH
+FB44          ; mapped                 ; 05E4 05BC     # 1.1  HEBREW LETTER PE WITH DAGESH
+FB45          ; disallowed                             # NA   <reserved-FB45>
+FB46          ; mapped                 ; 05E6 05BC     # 1.1  HEBREW LETTER TSADI WITH DAGESH
+FB47          ; mapped                 ; 05E7 05BC     # 1.1  HEBREW LETTER QOF WITH DAGESH
+FB48          ; mapped                 ; 05E8 05BC     # 1.1  HEBREW LETTER RESH WITH DAGESH
+FB49          ; mapped                 ; 05E9 05BC     # 1.1  HEBREW LETTER SHIN WITH DAGESH
+FB4A          ; mapped                 ; 05EA 05BC     # 1.1  HEBREW LETTER TAV WITH DAGESH
+FB4B          ; mapped                 ; 05D5 05B9     # 1.1  HEBREW LETTER VAV WITH HOLAM
+FB4C          ; mapped                 ; 05D1 05BF     # 1.1  HEBREW LETTER BET WITH RAFE
+FB4D          ; mapped                 ; 05DB 05BF     # 1.1  HEBREW LETTER KAF WITH RAFE
+FB4E          ; mapped                 ; 05E4 05BF     # 1.1  HEBREW LETTER PE WITH RAFE
+FB4F          ; mapped                 ; 05D0 05DC     # 1.1  HEBREW LIGATURE ALEF LAMED
+FB50..FB51    ; mapped                 ; 0671          # 1.1  ARABIC LETTER ALEF WASLA ISOLATED FORM..ARABIC LETTER ALEF WASLA FINAL FORM
+FB52..FB55    ; mapped                 ; 067B          # 1.1  ARABIC LETTER BEEH ISOLATED FORM..ARABIC LETTER BEEH MEDIAL FORM
+FB56..FB59    ; mapped                 ; 067E          # 1.1  ARABIC LETTER PEH ISOLATED FORM..ARABIC LETTER PEH MEDIAL FORM
+FB5A..FB5D    ; mapped                 ; 0680          # 1.1  ARABIC LETTER BEHEH ISOLATED FORM..ARABIC LETTER BEHEH MEDIAL FORM
+FB5E..FB61    ; mapped                 ; 067A          # 1.1  ARABIC LETTER TTEHEH ISOLATED FORM..ARABIC LETTER TTEHEH MEDIAL FORM
+FB62..FB65    ; mapped                 ; 067F          # 1.1  ARABIC LETTER TEHEH ISOLATED FORM..ARABIC LETTER TEHEH MEDIAL FORM
+FB66..FB69    ; mapped                 ; 0679          # 1.1  ARABIC LETTER TTEH ISOLATED FORM..ARABIC LETTER TTEH MEDIAL FORM
+FB6A..FB6D    ; mapped                 ; 06A4          # 1.1  ARABIC LETTER VEH ISOLATED FORM..ARABIC LETTER VEH MEDIAL FORM
+FB6E..FB71    ; mapped                 ; 06A6          # 1.1  ARABIC LETTER PEHEH ISOLATED FORM..ARABIC LETTER PEHEH MEDIAL FORM
+FB72..FB75    ; mapped                 ; 0684          # 1.1  ARABIC LETTER DYEH ISOLATED FORM..ARABIC LETTER DYEH MEDIAL FORM
+FB76..FB79    ; mapped                 ; 0683          # 1.1  ARABIC LETTER NYEH ISOLATED FORM..ARABIC LETTER NYEH MEDIAL FORM
+FB7A..FB7D    ; mapped                 ; 0686          # 1.1  ARABIC LETTER TCHEH ISOLATED FORM..ARABIC LETTER TCHEH MEDIAL FORM
+FB7E..FB81    ; mapped                 ; 0687          # 1.1  ARABIC LETTER TCHEHEH ISOLATED FORM..ARABIC LETTER TCHEHEH MEDIAL FORM
+FB82..FB83    ; mapped                 ; 068D          # 1.1  ARABIC LETTER DDAHAL ISOLATED FORM..ARABIC LETTER DDAHAL FINAL FORM
+FB84..FB85    ; mapped                 ; 068C          # 1.1  ARABIC LETTER DAHAL ISOLATED FORM..ARABIC LETTER DAHAL FINAL FORM
+FB86..FB87    ; mapped                 ; 068E          # 1.1  ARABIC LETTER DUL ISOLATED FORM..ARABIC LETTER DUL FINAL FORM
+FB88..FB89    ; mapped                 ; 0688          # 1.1  ARABIC LETTER DDAL ISOLATED FORM..ARABIC LETTER DDAL FINAL FORM
+FB8A..FB8B    ; mapped                 ; 0698          # 1.1  ARABIC LETTER JEH ISOLATED FORM..ARABIC LETTER JEH FINAL FORM
+FB8C..FB8D    ; mapped                 ; 0691          # 1.1  ARABIC LETTER RREH ISOLATED FORM..ARABIC LETTER RREH FINAL FORM
+FB8E..FB91    ; mapped                 ; 06A9          # 1.1  ARABIC LETTER KEHEH ISOLATED FORM..ARABIC LETTER KEHEH MEDIAL FORM
+FB92..FB95    ; mapped                 ; 06AF          # 1.1  ARABIC LETTER GAF ISOLATED FORM..ARABIC LETTER GAF MEDIAL FORM
+FB96..FB99    ; mapped                 ; 06B3          # 1.1  ARABIC LETTER GUEH ISOLATED FORM..ARABIC LETTER GUEH MEDIAL FORM
+FB9A..FB9D    ; mapped                 ; 06B1          # 1.1  ARABIC LETTER NGOEH ISOLATED FORM..ARABIC LETTER NGOEH MEDIAL FORM
+FB9E..FB9F    ; mapped                 ; 06BA          # 1.1  ARABIC LETTER NOON GHUNNA ISOLATED FORM..ARABIC LETTER NOON GHUNNA FINAL FORM
+FBA0..FBA3    ; mapped                 ; 06BB          # 1.1  ARABIC LETTER RNOON ISOLATED FORM..ARABIC LETTER RNOON MEDIAL FORM
+FBA4..FBA5    ; mapped                 ; 06C0          # 1.1  ARABIC LETTER HEH WITH YEH ABOVE ISOLATED FORM..ARABIC LETTER HEH WITH YEH ABOVE FINAL FORM
+FBA6..FBA9    ; mapped                 ; 06C1          # 1.1  ARABIC LETTER HEH GOAL ISOLATED FORM..ARABIC LETTER HEH GOAL MEDIAL FORM
+FBAA..FBAD    ; mapped                 ; 06BE          # 1.1  ARABIC LETTER HEH DOACHASHMEE ISOLATED FORM..ARABIC LETTER HEH DOACHASHMEE MEDIAL FORM
+FBAE..FBAF    ; mapped                 ; 06D2          # 1.1  ARABIC LETTER YEH BARREE ISOLATED FORM..ARABIC LETTER YEH BARREE FINAL FORM
+FBB0..FBB1    ; mapped                 ; 06D3          # 1.1  ARABIC LETTER YEH BARREE WITH HAMZA ABOVE ISOLATED FORM..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
+FBB2..FBC1    ; valid                  ;      ; NV8    # 6.0  ARABIC SYMBOL DOT ABOVE..ARABIC SYMBOL SMALL TAH BELOW
+FBC2          ; valid                  ;      ; NV8    # 14.0 ARABIC SYMBOL WASLA ABOVE
+FBC3..FBD2    ; disallowed                             # NA   <reserved-FBC3>..<reserved-FBD2>
+FBD3..FBD6    ; mapped                 ; 06AD          # 1.1  ARABIC LETTER NG ISOLATED FORM..ARABIC LETTER NG MEDIAL FORM
+FBD7..FBD8    ; mapped                 ; 06C7          # 1.1  ARABIC LETTER U ISOLATED FORM..ARABIC LETTER U FINAL FORM
+FBD9..FBDA    ; mapped                 ; 06C6          # 1.1  ARABIC LETTER OE ISOLATED FORM..ARABIC LETTER OE FINAL FORM
+FBDB..FBDC    ; mapped                 ; 06C8          # 1.1  ARABIC LETTER YU ISOLATED FORM..ARABIC LETTER YU FINAL FORM
+FBDD          ; mapped                 ; 06C7 0674     # 1.1  ARABIC LETTER U WITH HAMZA ABOVE ISOLATED FORM
+FBDE..FBDF    ; mapped                 ; 06CB          # 1.1  ARABIC LETTER VE ISOLATED FORM..ARABIC LETTER VE FINAL FORM
+FBE0..FBE1    ; mapped                 ; 06C5          # 1.1  ARABIC LETTER KIRGHIZ OE ISOLATED FORM..ARABIC LETTER KIRGHIZ OE FINAL FORM
+FBE2..FBE3    ; mapped                 ; 06C9          # 1.1  ARABIC LETTER KIRGHIZ YU ISOLATED FORM..ARABIC LETTER KIRGHIZ YU FINAL FORM
+FBE4..FBE7    ; mapped                 ; 06D0          # 1.1  ARABIC LETTER E ISOLATED FORM..ARABIC LETTER E MEDIAL FORM
+FBE8..FBE9    ; mapped                 ; 0649          # 1.1  ARABIC LETTER UIGHUR KAZAKH KIRGHIZ ALEF MAKSURA INITIAL FORM..ARABIC LETTER UIGHUR KAZAKH KIRGHIZ ALEF MAKSURA MEDIAL FORM
+FBEA..FBEB    ; mapped                 ; 0626 0627     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH ALEF ISOLATED FORM..ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH ALEF FINAL FORM
+FBEC..FBED    ; mapped                 ; 0626 06D5     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH AE ISOLATED FORM..ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH AE FINAL FORM
+FBEE..FBEF    ; mapped                 ; 0626 0648     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH WAW ISOLATED FORM..ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH WAW FINAL FORM
+FBF0..FBF1    ; mapped                 ; 0626 06C7     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH U ISOLATED FORM..ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH U FINAL FORM
+FBF2..FBF3    ; mapped                 ; 0626 06C6     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH OE ISOLATED FORM..ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH OE FINAL FORM
+FBF4..FBF5    ; mapped                 ; 0626 06C8     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH YU ISOLATED FORM..ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH YU FINAL FORM
+FBF6..FBF8    ; mapped                 ; 0626 06D0     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH E ISOLATED FORM..ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH E INITIAL FORM
+FBF9..FBFB    ; mapped                 ; 0626 0649     # 1.1  ARABIC LIGATURE UIGHUR KIRGHIZ YEH WITH HAMZA ABOVE WITH ALEF MAKSURA ISOLATED FORM..ARABIC LIGATURE UIGHUR KIRGHIZ YEH WITH HAMZA ABOVE WITH ALEF MAKSURA INITIAL FORM
+FBFC..FBFF    ; mapped                 ; 06CC          # 1.1  ARABIC LETTER FARSI YEH ISOLATED FORM..ARABIC LETTER FARSI YEH MEDIAL FORM
+FC00          ; mapped                 ; 0626 062C     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH JEEM ISOLATED FORM
+FC01          ; mapped                 ; 0626 062D     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH HAH ISOLATED FORM
+FC02          ; mapped                 ; 0626 0645     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH MEEM ISOLATED FORM
+FC03          ; mapped                 ; 0626 0649     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH ALEF MAKSURA ISOLATED FORM
+FC04          ; mapped                 ; 0626 064A     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH YEH ISOLATED FORM
+FC05          ; mapped                 ; 0628 062C     # 1.1  ARABIC LIGATURE BEH WITH JEEM ISOLATED FORM
+FC06          ; mapped                 ; 0628 062D     # 1.1  ARABIC LIGATURE BEH WITH HAH ISOLATED FORM
+FC07          ; mapped                 ; 0628 062E     # 1.1  ARABIC LIGATURE BEH WITH KHAH ISOLATED FORM
+FC08          ; mapped                 ; 0628 0645     # 1.1  ARABIC LIGATURE BEH WITH MEEM ISOLATED FORM
+FC09          ; mapped                 ; 0628 0649     # 1.1  ARABIC LIGATURE BEH WITH ALEF MAKSURA ISOLATED FORM
+FC0A          ; mapped                 ; 0628 064A     # 1.1  ARABIC LIGATURE BEH WITH YEH ISOLATED FORM
+FC0B          ; mapped                 ; 062A 062C     # 1.1  ARABIC LIGATURE TEH WITH JEEM ISOLATED FORM
+FC0C          ; mapped                 ; 062A 062D     # 1.1  ARABIC LIGATURE TEH WITH HAH ISOLATED FORM
+FC0D          ; mapped                 ; 062A 062E     # 1.1  ARABIC LIGATURE TEH WITH KHAH ISOLATED FORM
+FC0E          ; mapped                 ; 062A 0645     # 1.1  ARABIC LIGATURE TEH WITH MEEM ISOLATED FORM
+FC0F          ; mapped                 ; 062A 0649     # 1.1  ARABIC LIGATURE TEH WITH ALEF MAKSURA ISOLATED FORM
+FC10          ; mapped                 ; 062A 064A     # 1.1  ARABIC LIGATURE TEH WITH YEH ISOLATED FORM
+FC11          ; mapped                 ; 062B 062C     # 1.1  ARABIC LIGATURE THEH WITH JEEM ISOLATED FORM
+FC12          ; mapped                 ; 062B 0645     # 1.1  ARABIC LIGATURE THEH WITH MEEM ISOLATED FORM
+FC13          ; mapped                 ; 062B 0649     # 1.1  ARABIC LIGATURE THEH WITH ALEF MAKSURA ISOLATED FORM
+FC14          ; mapped                 ; 062B 064A     # 1.1  ARABIC LIGATURE THEH WITH YEH ISOLATED FORM
+FC15          ; mapped                 ; 062C 062D     # 1.1  ARABIC LIGATURE JEEM WITH HAH ISOLATED FORM
+FC16          ; mapped                 ; 062C 0645     # 1.1  ARABIC LIGATURE JEEM WITH MEEM ISOLATED FORM
+FC17          ; mapped                 ; 062D 062C     # 1.1  ARABIC LIGATURE HAH WITH JEEM ISOLATED FORM
+FC18          ; mapped                 ; 062D 0645     # 1.1  ARABIC LIGATURE HAH WITH MEEM ISOLATED FORM
+FC19          ; mapped                 ; 062E 062C     # 1.1  ARABIC LIGATURE KHAH WITH JEEM ISOLATED FORM
+FC1A          ; mapped                 ; 062E 062D     # 1.1  ARABIC LIGATURE KHAH WITH HAH ISOLATED FORM
+FC1B          ; mapped                 ; 062E 0645     # 1.1  ARABIC LIGATURE KHAH WITH MEEM ISOLATED FORM
+FC1C          ; mapped                 ; 0633 062C     # 1.1  ARABIC LIGATURE SEEN WITH JEEM ISOLATED FORM
+FC1D          ; mapped                 ; 0633 062D     # 1.1  ARABIC LIGATURE SEEN WITH HAH ISOLATED FORM
+FC1E          ; mapped                 ; 0633 062E     # 1.1  ARABIC LIGATURE SEEN WITH KHAH ISOLATED FORM
+FC1F          ; mapped                 ; 0633 0645     # 1.1  ARABIC LIGATURE SEEN WITH MEEM ISOLATED FORM
+FC20          ; mapped                 ; 0635 062D     # 1.1  ARABIC LIGATURE SAD WITH HAH ISOLATED FORM
+FC21          ; mapped                 ; 0635 0645     # 1.1  ARABIC LIGATURE SAD WITH MEEM ISOLATED FORM
+FC22          ; mapped                 ; 0636 062C     # 1.1  ARABIC LIGATURE DAD WITH JEEM ISOLATED FORM
+FC23          ; mapped                 ; 0636 062D     # 1.1  ARABIC LIGATURE DAD WITH HAH ISOLATED FORM
+FC24          ; mapped                 ; 0636 062E     # 1.1  ARABIC LIGATURE DAD WITH KHAH ISOLATED FORM
+FC25          ; mapped                 ; 0636 0645     # 1.1  ARABIC LIGATURE DAD WITH MEEM ISOLATED FORM
+FC26          ; mapped                 ; 0637 062D     # 1.1  ARABIC LIGATURE TAH WITH HAH ISOLATED FORM
+FC27          ; mapped                 ; 0637 0645     # 1.1  ARABIC LIGATURE TAH WITH MEEM ISOLATED FORM
+FC28          ; mapped                 ; 0638 0645     # 1.1  ARABIC LIGATURE ZAH WITH MEEM ISOLATED FORM
+FC29          ; mapped                 ; 0639 062C     # 1.1  ARABIC LIGATURE AIN WITH JEEM ISOLATED FORM
+FC2A          ; mapped                 ; 0639 0645     # 1.1  ARABIC LIGATURE AIN WITH MEEM ISOLATED FORM
+FC2B          ; mapped                 ; 063A 062C     # 1.1  ARABIC LIGATURE GHAIN WITH JEEM ISOLATED FORM
+FC2C          ; mapped                 ; 063A 0645     # 1.1  ARABIC LIGATURE GHAIN WITH MEEM ISOLATED FORM
+FC2D          ; mapped                 ; 0641 062C     # 1.1  ARABIC LIGATURE FEH WITH JEEM ISOLATED FORM
+FC2E          ; mapped                 ; 0641 062D     # 1.1  ARABIC LIGATURE FEH WITH HAH ISOLATED FORM
+FC2F          ; mapped                 ; 0641 062E     # 1.1  ARABIC LIGATURE FEH WITH KHAH ISOLATED FORM
+FC30          ; mapped                 ; 0641 0645     # 1.1  ARABIC LIGATURE FEH WITH MEEM ISOLATED FORM
+FC31          ; mapped                 ; 0641 0649     # 1.1  ARABIC LIGATURE FEH WITH ALEF MAKSURA ISOLATED FORM
+FC32          ; mapped                 ; 0641 064A     # 1.1  ARABIC LIGATURE FEH WITH YEH ISOLATED FORM
+FC33          ; mapped                 ; 0642 062D     # 1.1  ARABIC LIGATURE QAF WITH HAH ISOLATED FORM
+FC34          ; mapped                 ; 0642 0645     # 1.1  ARABIC LIGATURE QAF WITH MEEM ISOLATED FORM
+FC35          ; mapped                 ; 0642 0649     # 1.1  ARABIC LIGATURE QAF WITH ALEF MAKSURA ISOLATED FORM
+FC36          ; mapped                 ; 0642 064A     # 1.1  ARABIC LIGATURE QAF WITH YEH ISOLATED FORM
+FC37          ; mapped                 ; 0643 0627     # 1.1  ARABIC LIGATURE KAF WITH ALEF ISOLATED FORM
+FC38          ; mapped                 ; 0643 062C     # 1.1  ARABIC LIGATURE KAF WITH JEEM ISOLATED FORM
+FC39          ; mapped                 ; 0643 062D     # 1.1  ARABIC LIGATURE KAF WITH HAH ISOLATED FORM
+FC3A          ; mapped                 ; 0643 062E     # 1.1  ARABIC LIGATURE KAF WITH KHAH ISOLATED FORM
+FC3B          ; mapped                 ; 0643 0644     # 1.1  ARABIC LIGATURE KAF WITH LAM ISOLATED FORM
+FC3C          ; mapped                 ; 0643 0645     # 1.1  ARABIC LIGATURE KAF WITH MEEM ISOLATED FORM
+FC3D          ; mapped                 ; 0643 0649     # 1.1  ARABIC LIGATURE KAF WITH ALEF MAKSURA ISOLATED FORM
+FC3E          ; mapped                 ; 0643 064A     # 1.1  ARABIC LIGATURE KAF WITH YEH ISOLATED FORM
+FC3F          ; mapped                 ; 0644 062C     # 1.1  ARABIC LIGATURE LAM WITH JEEM ISOLATED FORM
+FC40          ; mapped                 ; 0644 062D     # 1.1  ARABIC LIGATURE LAM WITH HAH ISOLATED FORM
+FC41          ; mapped                 ; 0644 062E     # 1.1  ARABIC LIGATURE LAM WITH KHAH ISOLATED FORM
+FC42          ; mapped                 ; 0644 0645     # 1.1  ARABIC LIGATURE LAM WITH MEEM ISOLATED FORM
+FC43          ; mapped                 ; 0644 0649     # 1.1  ARABIC LIGATURE LAM WITH ALEF MAKSURA ISOLATED FORM
+FC44          ; mapped                 ; 0644 064A     # 1.1  ARABIC LIGATURE LAM WITH YEH ISOLATED FORM
+FC45          ; mapped                 ; 0645 062C     # 1.1  ARABIC LIGATURE MEEM WITH JEEM ISOLATED FORM
+FC46          ; mapped                 ; 0645 062D     # 1.1  ARABIC LIGATURE MEEM WITH HAH ISOLATED FORM
+FC47          ; mapped                 ; 0645 062E     # 1.1  ARABIC LIGATURE MEEM WITH KHAH ISOLATED FORM
+FC48          ; mapped                 ; 0645 0645     # 1.1  ARABIC LIGATURE MEEM WITH MEEM ISOLATED FORM
+FC49          ; mapped                 ; 0645 0649     # 1.1  ARABIC LIGATURE MEEM WITH ALEF MAKSURA ISOLATED FORM
+FC4A          ; mapped                 ; 0645 064A     # 1.1  ARABIC LIGATURE MEEM WITH YEH ISOLATED FORM
+FC4B          ; mapped                 ; 0646 062C     # 1.1  ARABIC LIGATURE NOON WITH JEEM ISOLATED FORM
+FC4C          ; mapped                 ; 0646 062D     # 1.1  ARABIC LIGATURE NOON WITH HAH ISOLATED FORM
+FC4D          ; mapped                 ; 0646 062E     # 1.1  ARABIC LIGATURE NOON WITH KHAH ISOLATED FORM
+FC4E          ; mapped                 ; 0646 0645     # 1.1  ARABIC LIGATURE NOON WITH MEEM ISOLATED FORM
+FC4F          ; mapped                 ; 0646 0649     # 1.1  ARABIC LIGATURE NOON WITH ALEF MAKSURA ISOLATED FORM
+FC50          ; mapped                 ; 0646 064A     # 1.1  ARABIC LIGATURE NOON WITH YEH ISOLATED FORM
+FC51          ; mapped                 ; 0647 062C     # 1.1  ARABIC LIGATURE HEH WITH JEEM ISOLATED FORM
+FC52          ; mapped                 ; 0647 0645     # 1.1  ARABIC LIGATURE HEH WITH MEEM ISOLATED FORM
+FC53          ; mapped                 ; 0647 0649     # 1.1  ARABIC LIGATURE HEH WITH ALEF MAKSURA ISOLATED FORM
+FC54          ; mapped                 ; 0647 064A     # 1.1  ARABIC LIGATURE HEH WITH YEH ISOLATED FORM
+FC55          ; mapped                 ; 064A 062C     # 1.1  ARABIC LIGATURE YEH WITH JEEM ISOLATED FORM
+FC56          ; mapped                 ; 064A 062D     # 1.1  ARABIC LIGATURE YEH WITH HAH ISOLATED FORM
+FC57          ; mapped                 ; 064A 062E     # 1.1  ARABIC LIGATURE YEH WITH KHAH ISOLATED FORM
+FC58          ; mapped                 ; 064A 0645     # 1.1  ARABIC LIGATURE YEH WITH MEEM ISOLATED FORM
+FC59          ; mapped                 ; 064A 0649     # 1.1  ARABIC LIGATURE YEH WITH ALEF MAKSURA ISOLATED FORM
+FC5A          ; mapped                 ; 064A 064A     # 1.1  ARABIC LIGATURE YEH WITH YEH ISOLATED FORM
+FC5B          ; mapped                 ; 0630 0670     # 1.1  ARABIC LIGATURE THAL WITH SUPERSCRIPT ALEF ISOLATED FORM
+FC5C          ; mapped                 ; 0631 0670     # 1.1  ARABIC LIGATURE REH WITH SUPERSCRIPT ALEF ISOLATED FORM
+FC5D          ; mapped                 ; 0649 0670     # 1.1  ARABIC LIGATURE ALEF MAKSURA WITH SUPERSCRIPT ALEF ISOLATED FORM
+FC5E          ; disallowed_STD3_mapped ; 0020 064C 0651 #1.1  ARABIC LIGATURE SHADDA WITH DAMMATAN ISOLATED FORM
+FC5F          ; disallowed_STD3_mapped ; 0020 064D 0651 #1.1  ARABIC LIGATURE SHADDA WITH KASRATAN ISOLATED FORM
+FC60          ; disallowed_STD3_mapped ; 0020 064E 0651 #1.1  ARABIC LIGATURE SHADDA WITH FATHA ISOLATED FORM
+FC61          ; disallowed_STD3_mapped ; 0020 064F 0651 #1.1  ARABIC LIGATURE SHADDA WITH DAMMA ISOLATED FORM
+FC62          ; disallowed_STD3_mapped ; 0020 0650 0651 #1.1  ARABIC LIGATURE SHADDA WITH KASRA ISOLATED FORM
+FC63          ; disallowed_STD3_mapped ; 0020 0651 0670 #1.1  ARABIC LIGATURE SHADDA WITH SUPERSCRIPT ALEF ISOLATED FORM
+FC64          ; mapped                 ; 0626 0631     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH REH FINAL FORM
+FC65          ; mapped                 ; 0626 0632     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH ZAIN FINAL FORM
+FC66          ; mapped                 ; 0626 0645     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH MEEM FINAL FORM
+FC67          ; mapped                 ; 0626 0646     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH NOON FINAL FORM
+FC68          ; mapped                 ; 0626 0649     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH ALEF MAKSURA FINAL FORM
+FC69          ; mapped                 ; 0626 064A     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH YEH FINAL FORM
+FC6A          ; mapped                 ; 0628 0631     # 1.1  ARABIC LIGATURE BEH WITH REH FINAL FORM
+FC6B          ; mapped                 ; 0628 0632     # 1.1  ARABIC LIGATURE BEH WITH ZAIN FINAL FORM
+FC6C          ; mapped                 ; 0628 0645     # 1.1  ARABIC LIGATURE BEH WITH MEEM FINAL FORM
+FC6D          ; mapped                 ; 0628 0646     # 1.1  ARABIC LIGATURE BEH WITH NOON FINAL FORM
+FC6E          ; mapped                 ; 0628 0649     # 1.1  ARABIC LIGATURE BEH WITH ALEF MAKSURA FINAL FORM
+FC6F          ; mapped                 ; 0628 064A     # 1.1  ARABIC LIGATURE BEH WITH YEH FINAL FORM
+FC70          ; mapped                 ; 062A 0631     # 1.1  ARABIC LIGATURE TEH WITH REH FINAL FORM
+FC71          ; mapped                 ; 062A 0632     # 1.1  ARABIC LIGATURE TEH WITH ZAIN FINAL FORM
+FC72          ; mapped                 ; 062A 0645     # 1.1  ARABIC LIGATURE TEH WITH MEEM FINAL FORM
+FC73          ; mapped                 ; 062A 0646     # 1.1  ARABIC LIGATURE TEH WITH NOON FINAL FORM
+FC74          ; mapped                 ; 062A 0649     # 1.1  ARABIC LIGATURE TEH WITH ALEF MAKSURA FINAL FORM
+FC75          ; mapped                 ; 062A 064A     # 1.1  ARABIC LIGATURE TEH WITH YEH FINAL FORM
+FC76          ; mapped                 ; 062B 0631     # 1.1  ARABIC LIGATURE THEH WITH REH FINAL FORM
+FC77          ; mapped                 ; 062B 0632     # 1.1  ARABIC LIGATURE THEH WITH ZAIN FINAL FORM
+FC78          ; mapped                 ; 062B 0645     # 1.1  ARABIC LIGATURE THEH WITH MEEM FINAL FORM
+FC79          ; mapped                 ; 062B 0646     # 1.1  ARABIC LIGATURE THEH WITH NOON FINAL FORM
+FC7A          ; mapped                 ; 062B 0649     # 1.1  ARABIC LIGATURE THEH WITH ALEF MAKSURA FINAL FORM
+FC7B          ; mapped                 ; 062B 064A     # 1.1  ARABIC LIGATURE THEH WITH YEH FINAL FORM
+FC7C          ; mapped                 ; 0641 0649     # 1.1  ARABIC LIGATURE FEH WITH ALEF MAKSURA FINAL FORM
+FC7D          ; mapped                 ; 0641 064A     # 1.1  ARABIC LIGATURE FEH WITH YEH FINAL FORM
+FC7E          ; mapped                 ; 0642 0649     # 1.1  ARABIC LIGATURE QAF WITH ALEF MAKSURA FINAL FORM
+FC7F          ; mapped                 ; 0642 064A     # 1.1  ARABIC LIGATURE QAF WITH YEH FINAL FORM
+FC80          ; mapped                 ; 0643 0627     # 1.1  ARABIC LIGATURE KAF WITH ALEF FINAL FORM
+FC81          ; mapped                 ; 0643 0644     # 1.1  ARABIC LIGATURE KAF WITH LAM FINAL FORM
+FC82          ; mapped                 ; 0643 0645     # 1.1  ARABIC LIGATURE KAF WITH MEEM FINAL FORM
+FC83          ; mapped                 ; 0643 0649     # 1.1  ARABIC LIGATURE KAF WITH ALEF MAKSURA FINAL FORM
+FC84          ; mapped                 ; 0643 064A     # 1.1  ARABIC LIGATURE KAF WITH YEH FINAL FORM
+FC85          ; mapped                 ; 0644 0645     # 1.1  ARABIC LIGATURE LAM WITH MEEM FINAL FORM
+FC86          ; mapped                 ; 0644 0649     # 1.1  ARABIC LIGATURE LAM WITH ALEF MAKSURA FINAL FORM
+FC87          ; mapped                 ; 0644 064A     # 1.1  ARABIC LIGATURE LAM WITH YEH FINAL FORM
+FC88          ; mapped                 ; 0645 0627     # 1.1  ARABIC LIGATURE MEEM WITH ALEF FINAL FORM
+FC89          ; mapped                 ; 0645 0645     # 1.1  ARABIC LIGATURE MEEM WITH MEEM FINAL FORM
+FC8A          ; mapped                 ; 0646 0631     # 1.1  ARABIC LIGATURE NOON WITH REH FINAL FORM
+FC8B          ; mapped                 ; 0646 0632     # 1.1  ARABIC LIGATURE NOON WITH ZAIN FINAL FORM
+FC8C          ; mapped                 ; 0646 0645     # 1.1  ARABIC LIGATURE NOON WITH MEEM FINAL FORM
+FC8D          ; mapped                 ; 0646 0646     # 1.1  ARABIC LIGATURE NOON WITH NOON FINAL FORM
+FC8E          ; mapped                 ; 0646 0649     # 1.1  ARABIC LIGATURE NOON WITH ALEF MAKSURA FINAL FORM
+FC8F          ; mapped                 ; 0646 064A     # 1.1  ARABIC LIGATURE NOON WITH YEH FINAL FORM
+FC90          ; mapped                 ; 0649 0670     # 1.1  ARABIC LIGATURE ALEF MAKSURA WITH SUPERSCRIPT ALEF FINAL FORM
+FC91          ; mapped                 ; 064A 0631     # 1.1  ARABIC LIGATURE YEH WITH REH FINAL FORM
+FC92          ; mapped                 ; 064A 0632     # 1.1  ARABIC LIGATURE YEH WITH ZAIN FINAL FORM
+FC93          ; mapped                 ; 064A 0645     # 1.1  ARABIC LIGATURE YEH WITH MEEM FINAL FORM
+FC94          ; mapped                 ; 064A 0646     # 1.1  ARABIC LIGATURE YEH WITH NOON FINAL FORM
+FC95          ; mapped                 ; 064A 0649     # 1.1  ARABIC LIGATURE YEH WITH ALEF MAKSURA FINAL FORM
+FC96          ; mapped                 ; 064A 064A     # 1.1  ARABIC LIGATURE YEH WITH YEH FINAL FORM
+FC97          ; mapped                 ; 0626 062C     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH JEEM INITIAL FORM
+FC98          ; mapped                 ; 0626 062D     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH HAH INITIAL FORM
+FC99          ; mapped                 ; 0626 062E     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH KHAH INITIAL FORM
+FC9A          ; mapped                 ; 0626 0645     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH MEEM INITIAL FORM
+FC9B          ; mapped                 ; 0626 0647     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH HEH INITIAL FORM
+FC9C          ; mapped                 ; 0628 062C     # 1.1  ARABIC LIGATURE BEH WITH JEEM INITIAL FORM
+FC9D          ; mapped                 ; 0628 062D     # 1.1  ARABIC LIGATURE BEH WITH HAH INITIAL FORM
+FC9E          ; mapped                 ; 0628 062E     # 1.1  ARABIC LIGATURE BEH WITH KHAH INITIAL FORM
+FC9F          ; mapped                 ; 0628 0645     # 1.1  ARABIC LIGATURE BEH WITH MEEM INITIAL FORM
+FCA0          ; mapped                 ; 0628 0647     # 1.1  ARABIC LIGATURE BEH WITH HEH INITIAL FORM
+FCA1          ; mapped                 ; 062A 062C     # 1.1  ARABIC LIGATURE TEH WITH JEEM INITIAL FORM
+FCA2          ; mapped                 ; 062A 062D     # 1.1  ARABIC LIGATURE TEH WITH HAH INITIAL FORM
+FCA3          ; mapped                 ; 062A 062E     # 1.1  ARABIC LIGATURE TEH WITH KHAH INITIAL FORM
+FCA4          ; mapped                 ; 062A 0645     # 1.1  ARABIC LIGATURE TEH WITH MEEM INITIAL FORM
+FCA5          ; mapped                 ; 062A 0647     # 1.1  ARABIC LIGATURE TEH WITH HEH INITIAL FORM
+FCA6          ; mapped                 ; 062B 0645     # 1.1  ARABIC LIGATURE THEH WITH MEEM INITIAL FORM
+FCA7          ; mapped                 ; 062C 062D     # 1.1  ARABIC LIGATURE JEEM WITH HAH INITIAL FORM
+FCA8          ; mapped                 ; 062C 0645     # 1.1  ARABIC LIGATURE JEEM WITH MEEM INITIAL FORM
+FCA9          ; mapped                 ; 062D 062C     # 1.1  ARABIC LIGATURE HAH WITH JEEM INITIAL FORM
+FCAA          ; mapped                 ; 062D 0645     # 1.1  ARABIC LIGATURE HAH WITH MEEM INITIAL FORM
+FCAB          ; mapped                 ; 062E 062C     # 1.1  ARABIC LIGATURE KHAH WITH JEEM INITIAL FORM
+FCAC          ; mapped                 ; 062E 0645     # 1.1  ARABIC LIGATURE KHAH WITH MEEM INITIAL FORM
+FCAD          ; mapped                 ; 0633 062C     # 1.1  ARABIC LIGATURE SEEN WITH JEEM INITIAL FORM
+FCAE          ; mapped                 ; 0633 062D     # 1.1  ARABIC LIGATURE SEEN WITH HAH INITIAL FORM
+FCAF          ; mapped                 ; 0633 062E     # 1.1  ARABIC LIGATURE SEEN WITH KHAH INITIAL FORM
+FCB0          ; mapped                 ; 0633 0645     # 1.1  ARABIC LIGATURE SEEN WITH MEEM INITIAL FORM
+FCB1          ; mapped                 ; 0635 062D     # 1.1  ARABIC LIGATURE SAD WITH HAH INITIAL FORM
+FCB2          ; mapped                 ; 0635 062E     # 1.1  ARABIC LIGATURE SAD WITH KHAH INITIAL FORM
+FCB3          ; mapped                 ; 0635 0645     # 1.1  ARABIC LIGATURE SAD WITH MEEM INITIAL FORM
+FCB4          ; mapped                 ; 0636 062C     # 1.1  ARABIC LIGATURE DAD WITH JEEM INITIAL FORM
+FCB5          ; mapped                 ; 0636 062D     # 1.1  ARABIC LIGATURE DAD WITH HAH INITIAL FORM
+FCB6          ; mapped                 ; 0636 062E     # 1.1  ARABIC LIGATURE DAD WITH KHAH INITIAL FORM
+FCB7          ; mapped                 ; 0636 0645     # 1.1  ARABIC LIGATURE DAD WITH MEEM INITIAL FORM
+FCB8          ; mapped                 ; 0637 062D     # 1.1  ARABIC LIGATURE TAH WITH HAH INITIAL FORM
+FCB9          ; mapped                 ; 0638 0645     # 1.1  ARABIC LIGATURE ZAH WITH MEEM INITIAL FORM
+FCBA          ; mapped                 ; 0639 062C     # 1.1  ARABIC LIGATURE AIN WITH JEEM INITIAL FORM
+FCBB          ; mapped                 ; 0639 0645     # 1.1  ARABIC LIGATURE AIN WITH MEEM INITIAL FORM
+FCBC          ; mapped                 ; 063A 062C     # 1.1  ARABIC LIGATURE GHAIN WITH JEEM INITIAL FORM
+FCBD          ; mapped                 ; 063A 0645     # 1.1  ARABIC LIGATURE GHAIN WITH MEEM INITIAL FORM
+FCBE          ; mapped                 ; 0641 062C     # 1.1  ARABIC LIGATURE FEH WITH JEEM INITIAL FORM
+FCBF          ; mapped                 ; 0641 062D     # 1.1  ARABIC LIGATURE FEH WITH HAH INITIAL FORM
+FCC0          ; mapped                 ; 0641 062E     # 1.1  ARABIC LIGATURE FEH WITH KHAH INITIAL FORM
+FCC1          ; mapped                 ; 0641 0645     # 1.1  ARABIC LIGATURE FEH WITH MEEM INITIAL FORM
+FCC2          ; mapped                 ; 0642 062D     # 1.1  ARABIC LIGATURE QAF WITH HAH INITIAL FORM
+FCC3          ; mapped                 ; 0642 0645     # 1.1  ARABIC LIGATURE QAF WITH MEEM INITIAL FORM
+FCC4          ; mapped                 ; 0643 062C     # 1.1  ARABIC LIGATURE KAF WITH JEEM INITIAL FORM
+FCC5          ; mapped                 ; 0643 062D     # 1.1  ARABIC LIGATURE KAF WITH HAH INITIAL FORM
+FCC6          ; mapped                 ; 0643 062E     # 1.1  ARABIC LIGATURE KAF WITH KHAH INITIAL FORM
+FCC7          ; mapped                 ; 0643 0644     # 1.1  ARABIC LIGATURE KAF WITH LAM INITIAL FORM
+FCC8          ; mapped                 ; 0643 0645     # 1.1  ARABIC LIGATURE KAF WITH MEEM INITIAL FORM
+FCC9          ; mapped                 ; 0644 062C     # 1.1  ARABIC LIGATURE LAM WITH JEEM INITIAL FORM
+FCCA          ; mapped                 ; 0644 062D     # 1.1  ARABIC LIGATURE LAM WITH HAH INITIAL FORM
+FCCB          ; mapped                 ; 0644 062E     # 1.1  ARABIC LIGATURE LAM WITH KHAH INITIAL FORM
+FCCC          ; mapped                 ; 0644 0645     # 1.1  ARABIC LIGATURE LAM WITH MEEM INITIAL FORM
+FCCD          ; mapped                 ; 0644 0647     # 1.1  ARABIC LIGATURE LAM WITH HEH INITIAL FORM
+FCCE          ; mapped                 ; 0645 062C     # 1.1  ARABIC LIGATURE MEEM WITH JEEM INITIAL FORM
+FCCF          ; mapped                 ; 0645 062D     # 1.1  ARABIC LIGATURE MEEM WITH HAH INITIAL FORM
+FCD0          ; mapped                 ; 0645 062E     # 1.1  ARABIC LIGATURE MEEM WITH KHAH INITIAL FORM
+FCD1          ; mapped                 ; 0645 0645     # 1.1  ARABIC LIGATURE MEEM WITH MEEM INITIAL FORM
+FCD2          ; mapped                 ; 0646 062C     # 1.1  ARABIC LIGATURE NOON WITH JEEM INITIAL FORM
+FCD3          ; mapped                 ; 0646 062D     # 1.1  ARABIC LIGATURE NOON WITH HAH INITIAL FORM
+FCD4          ; mapped                 ; 0646 062E     # 1.1  ARABIC LIGATURE NOON WITH KHAH INITIAL FORM
+FCD5          ; mapped                 ; 0646 0645     # 1.1  ARABIC LIGATURE NOON WITH MEEM INITIAL FORM
+FCD6          ; mapped                 ; 0646 0647     # 1.1  ARABIC LIGATURE NOON WITH HEH INITIAL FORM
+FCD7          ; mapped                 ; 0647 062C     # 1.1  ARABIC LIGATURE HEH WITH JEEM INITIAL FORM
+FCD8          ; mapped                 ; 0647 0645     # 1.1  ARABIC LIGATURE HEH WITH MEEM INITIAL FORM
+FCD9          ; mapped                 ; 0647 0670     # 1.1  ARABIC LIGATURE HEH WITH SUPERSCRIPT ALEF INITIAL FORM
+FCDA          ; mapped                 ; 064A 062C     # 1.1  ARABIC LIGATURE YEH WITH JEEM INITIAL FORM
+FCDB          ; mapped                 ; 064A 062D     # 1.1  ARABIC LIGATURE YEH WITH HAH INITIAL FORM
+FCDC          ; mapped                 ; 064A 062E     # 1.1  ARABIC LIGATURE YEH WITH KHAH INITIAL FORM
+FCDD          ; mapped                 ; 064A 0645     # 1.1  ARABIC LIGATURE YEH WITH MEEM INITIAL FORM
+FCDE          ; mapped                 ; 064A 0647     # 1.1  ARABIC LIGATURE YEH WITH HEH INITIAL FORM
+FCDF          ; mapped                 ; 0626 0645     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH MEEM MEDIAL FORM
+FCE0          ; mapped                 ; 0626 0647     # 1.1  ARABIC LIGATURE YEH WITH HAMZA ABOVE WITH HEH MEDIAL FORM
+FCE1          ; mapped                 ; 0628 0645     # 1.1  ARABIC LIGATURE BEH WITH MEEM MEDIAL FORM
+FCE2          ; mapped                 ; 0628 0647     # 1.1  ARABIC LIGATURE BEH WITH HEH MEDIAL FORM
+FCE3          ; mapped                 ; 062A 0645     # 1.1  ARABIC LIGATURE TEH WITH MEEM MEDIAL FORM
+FCE4          ; mapped                 ; 062A 0647     # 1.1  ARABIC LIGATURE TEH WITH HEH MEDIAL FORM
+FCE5          ; mapped                 ; 062B 0645     # 1.1  ARABIC LIGATURE THEH WITH MEEM MEDIAL FORM
+FCE6          ; mapped                 ; 062B 0647     # 1.1  ARABIC LIGATURE THEH WITH HEH MEDIAL FORM
+FCE7          ; mapped                 ; 0633 0645     # 1.1  ARABIC LIGATURE SEEN WITH MEEM MEDIAL FORM
+FCE8          ; mapped                 ; 0633 0647     # 1.1  ARABIC LIGATURE SEEN WITH HEH MEDIAL FORM
+FCE9          ; mapped                 ; 0634 0645     # 1.1  ARABIC LIGATURE SHEEN WITH MEEM MEDIAL FORM
+FCEA          ; mapped                 ; 0634 0647     # 1.1  ARABIC LIGATURE SHEEN WITH HEH MEDIAL FORM
+FCEB          ; mapped                 ; 0643 0644     # 1.1  ARABIC LIGATURE KAF WITH LAM MEDIAL FORM
+FCEC          ; mapped                 ; 0643 0645     # 1.1  ARABIC LIGATURE KAF WITH MEEM MEDIAL FORM
+FCED          ; mapped                 ; 0644 0645     # 1.1  ARABIC LIGATURE LAM WITH MEEM MEDIAL FORM
+FCEE          ; mapped                 ; 0646 0645     # 1.1  ARABIC LIGATURE NOON WITH MEEM MEDIAL FORM
+FCEF          ; mapped                 ; 0646 0647     # 1.1  ARABIC LIGATURE NOON WITH HEH MEDIAL FORM
+FCF0          ; mapped                 ; 064A 0645     # 1.1  ARABIC LIGATURE YEH WITH MEEM MEDIAL FORM
+FCF1          ; mapped                 ; 064A 0647     # 1.1  ARABIC LIGATURE YEH WITH HEH MEDIAL FORM
+FCF2          ; mapped                 ; 0640 064E 0651 #1.1  ARABIC LIGATURE SHADDA WITH FATHA MEDIAL FORM
+FCF3          ; mapped                 ; 0640 064F 0651 #1.1  ARABIC LIGATURE SHADDA WITH DAMMA MEDIAL FORM
+FCF4          ; mapped                 ; 0640 0650 0651 #1.1  ARABIC LIGATURE SHADDA WITH KASRA MEDIAL FORM
+FCF5          ; mapped                 ; 0637 0649     # 1.1  ARABIC LIGATURE TAH WITH ALEF MAKSURA ISOLATED FORM
+FCF6          ; mapped                 ; 0637 064A     # 1.1  ARABIC LIGATURE TAH WITH YEH ISOLATED FORM
+FCF7          ; mapped                 ; 0639 0649     # 1.1  ARABIC LIGATURE AIN WITH ALEF MAKSURA ISOLATED FORM
+FCF8          ; mapped                 ; 0639 064A     # 1.1  ARABIC LIGATURE AIN WITH YEH ISOLATED FORM
+FCF9          ; mapped                 ; 063A 0649     # 1.1  ARABIC LIGATURE GHAIN WITH ALEF MAKSURA ISOLATED FORM
+FCFA          ; mapped                 ; 063A 064A     # 1.1  ARABIC LIGATURE GHAIN WITH YEH ISOLATED FORM
+FCFB          ; mapped                 ; 0633 0649     # 1.1  ARABIC LIGATURE SEEN WITH ALEF MAKSURA ISOLATED FORM
+FCFC          ; mapped                 ; 0633 064A     # 1.1  ARABIC LIGATURE SEEN WITH YEH ISOLATED FORM
+FCFD          ; mapped                 ; 0634 0649     # 1.1  ARABIC LIGATURE SHEEN WITH ALEF MAKSURA ISOLATED FORM
+FCFE          ; mapped                 ; 0634 064A     # 1.1  ARABIC LIGATURE SHEEN WITH YEH ISOLATED FORM
+FCFF          ; mapped                 ; 062D 0649     # 1.1  ARABIC LIGATURE HAH WITH ALEF MAKSURA ISOLATED FORM
+FD00          ; mapped                 ; 062D 064A     # 1.1  ARABIC LIGATURE HAH WITH YEH ISOLATED FORM
+FD01          ; mapped                 ; 062C 0649     # 1.1  ARABIC LIGATURE JEEM WITH ALEF MAKSURA ISOLATED FORM
+FD02          ; mapped                 ; 062C 064A     # 1.1  ARABIC LIGATURE JEEM WITH YEH ISOLATED FORM
+FD03          ; mapped                 ; 062E 0649     # 1.1  ARABIC LIGATURE KHAH WITH ALEF MAKSURA ISOLATED FORM
+FD04          ; mapped                 ; 062E 064A     # 1.1  ARABIC LIGATURE KHAH WITH YEH ISOLATED FORM
+FD05          ; mapped                 ; 0635 0649     # 1.1  ARABIC LIGATURE SAD WITH ALEF MAKSURA ISOLATED FORM
+FD06          ; mapped                 ; 0635 064A     # 1.1  ARABIC LIGATURE SAD WITH YEH ISOLATED FORM
+FD07          ; mapped                 ; 0636 0649     # 1.1  ARABIC LIGATURE DAD WITH ALEF MAKSURA ISOLATED FORM
+FD08          ; mapped                 ; 0636 064A     # 1.1  ARABIC LIGATURE DAD WITH YEH ISOLATED FORM
+FD09          ; mapped                 ; 0634 062C     # 1.1  ARABIC LIGATURE SHEEN WITH JEEM ISOLATED FORM
+FD0A          ; mapped                 ; 0634 062D     # 1.1  ARABIC LIGATURE SHEEN WITH HAH ISOLATED FORM
+FD0B          ; mapped                 ; 0634 062E     # 1.1  ARABIC LIGATURE SHEEN WITH KHAH ISOLATED FORM
+FD0C          ; mapped                 ; 0634 0645     # 1.1  ARABIC LIGATURE SHEEN WITH MEEM ISOLATED FORM
+FD0D          ; mapped                 ; 0634 0631     # 1.1  ARABIC LIGATURE SHEEN WITH REH ISOLATED FORM
+FD0E          ; mapped                 ; 0633 0631     # 1.1  ARABIC LIGATURE SEEN WITH REH ISOLATED FORM
+FD0F          ; mapped                 ; 0635 0631     # 1.1  ARABIC LIGATURE SAD WITH REH ISOLATED FORM
+FD10          ; mapped                 ; 0636 0631     # 1.1  ARABIC LIGATURE DAD WITH REH ISOLATED FORM
+FD11          ; mapped                 ; 0637 0649     # 1.1  ARABIC LIGATURE TAH WITH ALEF MAKSURA FINAL FORM
+FD12          ; mapped                 ; 0637 064A     # 1.1  ARABIC LIGATURE TAH WITH YEH FINAL FORM
+FD13          ; mapped                 ; 0639 0649     # 1.1  ARABIC LIGATURE AIN WITH ALEF MAKSURA FINAL FORM
+FD14          ; mapped                 ; 0639 064A     # 1.1  ARABIC LIGATURE AIN WITH YEH FINAL FORM
+FD15          ; mapped                 ; 063A 0649     # 1.1  ARABIC LIGATURE GHAIN WITH ALEF MAKSURA FINAL FORM
+FD16          ; mapped                 ; 063A 064A     # 1.1  ARABIC LIGATURE GHAIN WITH YEH FINAL FORM
+FD17          ; mapped                 ; 0633 0649     # 1.1  ARABIC LIGATURE SEEN WITH ALEF MAKSURA FINAL FORM
+FD18          ; mapped                 ; 0633 064A     # 1.1  ARABIC LIGATURE SEEN WITH YEH FINAL FORM
+FD19          ; mapped                 ; 0634 0649     # 1.1  ARABIC LIGATURE SHEEN WITH ALEF MAKSURA FINAL FORM
+FD1A          ; mapped                 ; 0634 064A     # 1.1  ARABIC LIGATURE SHEEN WITH YEH FINAL FORM
+FD1B          ; mapped                 ; 062D 0649     # 1.1  ARABIC LIGATURE HAH WITH ALEF MAKSURA FINAL FORM
+FD1C          ; mapped                 ; 062D 064A     # 1.1  ARABIC LIGATURE HAH WITH YEH FINAL FORM
+FD1D          ; mapped                 ; 062C 0649     # 1.1  ARABIC LIGATURE JEEM WITH ALEF MAKSURA FINAL FORM
+FD1E          ; mapped                 ; 062C 064A     # 1.1  ARABIC LIGATURE JEEM WITH YEH FINAL FORM
+FD1F          ; mapped                 ; 062E 0649     # 1.1  ARABIC LIGATURE KHAH WITH ALEF MAKSURA FINAL FORM
+FD20          ; mapped                 ; 062E 064A     # 1.1  ARABIC LIGATURE KHAH WITH YEH FINAL FORM
+FD21          ; mapped                 ; 0635 0649     # 1.1  ARABIC LIGATURE SAD WITH ALEF MAKSURA FINAL FORM
+FD22          ; mapped                 ; 0635 064A     # 1.1  ARABIC LIGATURE SAD WITH YEH FINAL FORM
+FD23          ; mapped                 ; 0636 0649     # 1.1  ARABIC LIGATURE DAD WITH ALEF MAKSURA FINAL FORM
+FD24          ; mapped                 ; 0636 064A     # 1.1  ARABIC LIGATURE DAD WITH YEH FINAL FORM
+FD25          ; mapped                 ; 0634 062C     # 1.1  ARABIC LIGATURE SHEEN WITH JEEM FINAL FORM
+FD26          ; mapped                 ; 0634 062D     # 1.1  ARABIC LIGATURE SHEEN WITH HAH FINAL FORM
+FD27          ; mapped                 ; 0634 062E     # 1.1  ARABIC LIGATURE SHEEN WITH KHAH FINAL FORM
+FD28          ; mapped                 ; 0634 0645     # 1.1  ARABIC LIGATURE SHEEN WITH MEEM FINAL FORM
+FD29          ; mapped                 ; 0634 0631     # 1.1  ARABIC LIGATURE SHEEN WITH REH FINAL FORM
+FD2A          ; mapped                 ; 0633 0631     # 1.1  ARABIC LIGATURE SEEN WITH REH FINAL FORM
+FD2B          ; mapped                 ; 0635 0631     # 1.1  ARABIC LIGATURE SAD WITH REH FINAL FORM
+FD2C          ; mapped                 ; 0636 0631     # 1.1  ARABIC LIGATURE DAD WITH REH FINAL FORM
+FD2D          ; mapped                 ; 0634 062C     # 1.1  ARABIC LIGATURE SHEEN WITH JEEM INITIAL FORM
+FD2E          ; mapped                 ; 0634 062D     # 1.1  ARABIC LIGATURE SHEEN WITH HAH INITIAL FORM
+FD2F          ; mapped                 ; 0634 062E     # 1.1  ARABIC LIGATURE SHEEN WITH KHAH INITIAL FORM
+FD30          ; mapped                 ; 0634 0645     # 1.1  ARABIC LIGATURE SHEEN WITH MEEM INITIAL FORM
+FD31          ; mapped                 ; 0633 0647     # 1.1  ARABIC LIGATURE SEEN WITH HEH INITIAL FORM
+FD32          ; mapped                 ; 0634 0647     # 1.1  ARABIC LIGATURE SHEEN WITH HEH INITIAL FORM
+FD33          ; mapped                 ; 0637 0645     # 1.1  ARABIC LIGATURE TAH WITH MEEM INITIAL FORM
+FD34          ; mapped                 ; 0633 062C     # 1.1  ARABIC LIGATURE SEEN WITH JEEM MEDIAL FORM
+FD35          ; mapped                 ; 0633 062D     # 1.1  ARABIC LIGATURE SEEN WITH HAH MEDIAL FORM
+FD36          ; mapped                 ; 0633 062E     # 1.1  ARABIC LIGATURE SEEN WITH KHAH MEDIAL FORM
+FD37          ; mapped                 ; 0634 062C     # 1.1  ARABIC LIGATURE SHEEN WITH JEEM MEDIAL FORM
+FD38          ; mapped                 ; 0634 062D     # 1.1  ARABIC LIGATURE SHEEN WITH HAH MEDIAL FORM
+FD39          ; mapped                 ; 0634 062E     # 1.1  ARABIC LIGATURE SHEEN WITH KHAH MEDIAL FORM
+FD3A          ; mapped                 ; 0637 0645     # 1.1  ARABIC LIGATURE TAH WITH MEEM MEDIAL FORM
+FD3B          ; mapped                 ; 0638 0645     # 1.1  ARABIC LIGATURE ZAH WITH MEEM MEDIAL FORM
+FD3C..FD3D    ; mapped                 ; 0627 064B     # 1.1  ARABIC LIGATURE ALEF WITH FATHATAN FINAL FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
+FD3E..FD3F    ; valid                  ;      ; NV8    # 1.1  ORNATE LEFT PARENTHESIS..ORNATE RIGHT PARENTHESIS
+FD40..FD4F    ; valid                  ;      ; NV8    # 14.0 ARABIC LIGATURE RAHIMAHU ALLAAH..ARABIC LIGATURE RAHIMAHUM ALLAAH
+FD50          ; mapped                 ; 062A 062C 0645 #1.1  ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM
+FD51..FD52    ; mapped                 ; 062A 062D 062C #1.1  ARABIC LIGATURE TEH WITH HAH WITH JEEM FINAL FORM..ARABIC LIGATURE TEH WITH HAH WITH JEEM INITIAL FORM
+FD53          ; mapped                 ; 062A 062D 0645 #1.1  ARABIC LIGATURE TEH WITH HAH WITH MEEM INITIAL FORM
+FD54          ; mapped                 ; 062A 062E 0645 #1.1  ARABIC LIGATURE TEH WITH KHAH WITH MEEM INITIAL FORM
+FD55          ; mapped                 ; 062A 0645 062C #1.1  ARABIC LIGATURE TEH WITH MEEM WITH JEEM INITIAL FORM
+FD56          ; mapped                 ; 062A 0645 062D #1.1  ARABIC LIGATURE TEH WITH MEEM WITH HAH INITIAL FORM
+FD57          ; mapped                 ; 062A 0645 062E #1.1  ARABIC LIGATURE TEH WITH MEEM WITH KHAH INITIAL FORM
+FD58..FD59    ; mapped                 ; 062C 0645 062D #1.1  ARABIC LIGATURE JEEM WITH MEEM WITH HAH FINAL FORM..ARABIC LIGATURE JEEM WITH MEEM WITH HAH INITIAL FORM
+FD5A          ; mapped                 ; 062D 0645 064A #1.1  ARABIC LIGATURE HAH WITH MEEM WITH YEH FINAL FORM
+FD5B          ; mapped                 ; 062D 0645 0649 #1.1  ARABIC LIGATURE HAH WITH MEEM WITH ALEF MAKSURA FINAL FORM
+FD5C          ; mapped                 ; 0633 062D 062C #1.1  ARABIC LIGATURE SEEN WITH HAH WITH JEEM INITIAL FORM
+FD5D          ; mapped                 ; 0633 062C 062D #1.1  ARABIC LIGATURE SEEN WITH JEEM WITH HAH INITIAL FORM
+FD5E          ; mapped                 ; 0633 062C 0649 #1.1  ARABIC LIGATURE SEEN WITH JEEM WITH ALEF MAKSURA FINAL FORM
+FD5F..FD60    ; mapped                 ; 0633 0645 062D #1.1  ARABIC LIGATURE SEEN WITH MEEM WITH HAH FINAL FORM..ARABIC LIGATURE SEEN WITH MEEM WITH HAH INITIAL FORM
+FD61          ; mapped                 ; 0633 0645 062C #1.1  ARABIC LIGATURE SEEN WITH MEEM WITH JEEM INITIAL FORM
+FD62..FD63    ; mapped                 ; 0633 0645 0645 #1.1  ARABIC LIGATURE SEEN WITH MEEM WITH MEEM FINAL FORM..ARABIC LIGATURE SEEN WITH MEEM WITH MEEM INITIAL FORM
+FD64..FD65    ; mapped                 ; 0635 062D 062D #1.1  ARABIC LIGATURE SAD WITH HAH WITH HAH FINAL FORM..ARABIC LIGATURE SAD WITH HAH WITH HAH INITIAL FORM
+FD66          ; mapped                 ; 0635 0645 0645 #1.1  ARABIC LIGATURE SAD WITH MEEM WITH MEEM FINAL FORM
+FD67..FD68    ; mapped                 ; 0634 062D 0645 #1.1  ARABIC LIGATURE SHEEN WITH HAH WITH MEEM FINAL FORM..ARABIC LIGATURE SHEEN WITH HAH WITH MEEM INITIAL FORM
+FD69          ; mapped                 ; 0634 062C 064A #1.1  ARABIC LIGATURE SHEEN WITH JEEM WITH YEH FINAL FORM
+FD6A..FD6B    ; mapped                 ; 0634 0645 062E #1.1  ARABIC LIGATURE SHEEN WITH MEEM WITH KHAH FINAL FORM..ARABIC LIGATURE SHEEN WITH MEEM WITH KHAH INITIAL FORM
+FD6C..FD6D    ; mapped                 ; 0634 0645 0645 #1.1  ARABIC LIGATURE SHEEN WITH MEEM WITH MEEM FINAL FORM..ARABIC LIGATURE SHEEN WITH MEEM WITH MEEM INITIAL FORM
+FD6E          ; mapped                 ; 0636 062D 0649 #1.1  ARABIC LIGATURE DAD WITH HAH WITH ALEF MAKSURA FINAL FORM
+FD6F..FD70    ; mapped                 ; 0636 062E 0645 #1.1  ARABIC LIGATURE DAD WITH KHAH WITH MEEM FINAL FORM..ARABIC LIGATURE DAD WITH KHAH WITH MEEM INITIAL FORM
+FD71..FD72    ; mapped                 ; 0637 0645 062D #1.1  ARABIC LIGATURE TAH WITH MEEM WITH HAH FINAL FORM..ARABIC LIGATURE TAH WITH MEEM WITH HAH INITIAL FORM
+FD73          ; mapped                 ; 0637 0645 0645 #1.1  ARABIC LIGATURE TAH WITH MEEM WITH MEEM INITIAL FORM
+FD74          ; mapped                 ; 0637 0645 064A #1.1  ARABIC LIGATURE TAH WITH MEEM WITH YEH FINAL FORM
+FD75          ; mapped                 ; 0639 062C 0645 #1.1  ARABIC LIGATURE AIN WITH JEEM WITH MEEM FINAL FORM
+FD76..FD77    ; mapped                 ; 0639 0645 0645 #1.1  ARABIC LIGATURE AIN WITH MEEM WITH MEEM FINAL FORM..ARABIC LIGATURE AIN WITH MEEM WITH MEEM INITIAL FORM
+FD78          ; mapped                 ; 0639 0645 0649 #1.1  ARABIC LIGATURE AIN WITH MEEM WITH ALEF MAKSURA FINAL FORM
+FD79          ; mapped                 ; 063A 0645 0645 #1.1  ARABIC LIGATURE GHAIN WITH MEEM WITH MEEM FINAL FORM
+FD7A          ; mapped                 ; 063A 0645 064A #1.1  ARABIC LIGATURE GHAIN WITH MEEM WITH YEH FINAL FORM
+FD7B          ; mapped                 ; 063A 0645 0649 #1.1  ARABIC LIGATURE GHAIN WITH MEEM WITH ALEF MAKSURA FINAL FORM
+FD7C..FD7D    ; mapped                 ; 0641 062E 0645 #1.1  ARABIC LIGATURE FEH WITH KHAH WITH MEEM FINAL FORM..ARABIC LIGATURE FEH WITH KHAH WITH MEEM INITIAL FORM
+FD7E          ; mapped                 ; 0642 0645 062D #1.1  ARABIC LIGATURE QAF WITH MEEM WITH HAH FINAL FORM
+FD7F          ; mapped                 ; 0642 0645 0645 #1.1  ARABIC LIGATURE QAF WITH MEEM WITH MEEM FINAL FORM
+FD80          ; mapped                 ; 0644 062D 0645 #1.1  ARABIC LIGATURE LAM WITH HAH WITH MEEM FINAL FORM
+FD81          ; mapped                 ; 0644 062D 064A #1.1  ARABIC LIGATURE LAM WITH HAH WITH YEH FINAL FORM
+FD82          ; mapped                 ; 0644 062D 0649 #1.1  ARABIC LIGATURE LAM WITH HAH WITH ALEF MAKSURA FINAL FORM
+FD83..FD84    ; mapped                 ; 0644 062C 062C #1.1  ARABIC LIGATURE LAM WITH JEEM WITH JEEM INITIAL FORM..ARABIC LIGATURE LAM WITH JEEM WITH JEEM FINAL FORM
+FD85..FD86    ; mapped                 ; 0644 062E 0645 #1.1  ARABIC LIGATURE LAM WITH KHAH WITH MEEM FINAL FORM..ARABIC LIGATURE LAM WITH KHAH WITH MEEM INITIAL FORM
+FD87..FD88    ; mapped                 ; 0644 0645 062D #1.1  ARABIC LIGATURE LAM WITH MEEM WITH HAH FINAL FORM..ARABIC LIGATURE LAM WITH MEEM WITH HAH INITIAL FORM
+FD89          ; mapped                 ; 0645 062D 062C #1.1  ARABIC LIGATURE MEEM WITH HAH WITH JEEM INITIAL FORM
+FD8A          ; mapped                 ; 0645 062D 0645 #1.1  ARABIC LIGATURE MEEM WITH HAH WITH MEEM INITIAL FORM
+FD8B          ; mapped                 ; 0645 062D 064A #1.1  ARABIC LIGATURE MEEM WITH HAH WITH YEH FINAL FORM
+FD8C          ; mapped                 ; 0645 062C 062D #1.1  ARABIC LIGATURE MEEM WITH JEEM WITH HAH INITIAL FORM
+FD8D          ; mapped                 ; 0645 062C 0645 #1.1  ARABIC LIGATURE MEEM WITH JEEM WITH MEEM INITIAL FORM
+FD8E          ; mapped                 ; 0645 062E 062C #1.1  ARABIC LIGATURE MEEM WITH KHAH WITH JEEM INITIAL FORM
+FD8F          ; mapped                 ; 0645 062E 0645 #1.1  ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
+FD90..FD91    ; disallowed                             # NA   <reserved-FD90>..<reserved-FD91>
+FD92          ; mapped                 ; 0645 062C 062E #1.1  ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM
+FD93          ; mapped                 ; 0647 0645 062C #1.1  ARABIC LIGATURE HEH WITH MEEM WITH JEEM INITIAL FORM
+FD94          ; mapped                 ; 0647 0645 0645 #1.1  ARABIC LIGATURE HEH WITH MEEM WITH MEEM INITIAL FORM
+FD95          ; mapped                 ; 0646 062D 0645 #1.1  ARABIC LIGATURE NOON WITH HAH WITH MEEM INITIAL FORM
+FD96          ; mapped                 ; 0646 062D 0649 #1.1  ARABIC LIGATURE NOON WITH HAH WITH ALEF MAKSURA FINAL FORM
+FD97..FD98    ; mapped                 ; 0646 062C 0645 #1.1  ARABIC LIGATURE NOON WITH JEEM WITH MEEM FINAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH MEEM INITIAL FORM
+FD99          ; mapped                 ; 0646 062C 0649 #1.1  ARABIC LIGATURE NOON WITH JEEM WITH ALEF MAKSURA FINAL FORM
+FD9A          ; mapped                 ; 0646 0645 064A #1.1  ARABIC LIGATURE NOON WITH MEEM WITH YEH FINAL FORM
+FD9B          ; mapped                 ; 0646 0645 0649 #1.1  ARABIC LIGATURE NOON WITH MEEM WITH ALEF MAKSURA FINAL FORM
+FD9C..FD9D    ; mapped                 ; 064A 0645 0645 #1.1  ARABIC LIGATURE YEH WITH MEEM WITH MEEM FINAL FORM..ARABIC LIGATURE YEH WITH MEEM WITH MEEM INITIAL FORM
+FD9E          ; mapped                 ; 0628 062E 064A #1.1  ARABIC LIGATURE BEH WITH KHAH WITH YEH FINAL FORM
+FD9F          ; mapped                 ; 062A 062C 064A #1.1  ARABIC LIGATURE TEH WITH JEEM WITH YEH FINAL FORM
+FDA0          ; mapped                 ; 062A 062C 0649 #1.1  ARABIC LIGATURE TEH WITH JEEM WITH ALEF MAKSURA FINAL FORM
+FDA1          ; mapped                 ; 062A 062E 064A #1.1  ARABIC LIGATURE TEH WITH KHAH WITH YEH FINAL FORM
+FDA2          ; mapped                 ; 062A 062E 0649 #1.1  ARABIC LIGATURE TEH WITH KHAH WITH ALEF MAKSURA FINAL FORM
+FDA3          ; mapped                 ; 062A 0645 064A #1.1  ARABIC LIGATURE TEH WITH MEEM WITH YEH FINAL FORM
+FDA4          ; mapped                 ; 062A 0645 0649 #1.1  ARABIC LIGATURE TEH WITH MEEM WITH ALEF MAKSURA FINAL FORM
+FDA5          ; mapped                 ; 062C 0645 064A #1.1  ARABIC LIGATURE JEEM WITH MEEM WITH YEH FINAL FORM
+FDA6          ; mapped                 ; 062C 062D 0649 #1.1  ARABIC LIGATURE JEEM WITH HAH WITH ALEF MAKSURA FINAL FORM
+FDA7          ; mapped                 ; 062C 0645 0649 #1.1  ARABIC LIGATURE JEEM WITH MEEM WITH ALEF MAKSURA FINAL FORM
+FDA8          ; mapped                 ; 0633 062E 0649 #1.1  ARABIC LIGATURE SEEN WITH KHAH WITH ALEF MAKSURA FINAL FORM
+FDA9          ; mapped                 ; 0635 062D 064A #1.1  ARABIC LIGATURE SAD WITH HAH WITH YEH FINAL FORM
+FDAA          ; mapped                 ; 0634 062D 064A #1.1  ARABIC LIGATURE SHEEN WITH HAH WITH YEH FINAL FORM
+FDAB          ; mapped                 ; 0636 062D 064A #1.1  ARABIC LIGATURE DAD WITH HAH WITH YEH FINAL FORM
+FDAC          ; mapped                 ; 0644 062C 064A #1.1  ARABIC LIGATURE LAM WITH JEEM WITH YEH FINAL FORM
+FDAD          ; mapped                 ; 0644 0645 064A #1.1  ARABIC LIGATURE LAM WITH MEEM WITH YEH FINAL FORM
+FDAE          ; mapped                 ; 064A 062D 064A #1.1  ARABIC LIGATURE YEH WITH HAH WITH YEH FINAL FORM
+FDAF          ; mapped                 ; 064A 062C 064A #1.1  ARABIC LIGATURE YEH WITH JEEM WITH YEH FINAL FORM
+FDB0          ; mapped                 ; 064A 0645 064A #1.1  ARABIC LIGATURE YEH WITH MEEM WITH YEH FINAL FORM
+FDB1          ; mapped                 ; 0645 0645 064A #1.1  ARABIC LIGATURE MEEM WITH MEEM WITH YEH FINAL FORM
+FDB2          ; mapped                 ; 0642 0645 064A #1.1  ARABIC LIGATURE QAF WITH MEEM WITH YEH FINAL FORM
+FDB3          ; mapped                 ; 0646 062D 064A #1.1  ARABIC LIGATURE NOON WITH HAH WITH YEH FINAL FORM
+FDB4          ; mapped                 ; 0642 0645 062D #1.1  ARABIC LIGATURE QAF WITH MEEM WITH HAH INITIAL FORM
+FDB5          ; mapped                 ; 0644 062D 0645 #1.1  ARABIC LIGATURE LAM WITH HAH WITH MEEM INITIAL FORM
+FDB6          ; mapped                 ; 0639 0645 064A #1.1  ARABIC LIGATURE AIN WITH MEEM WITH YEH FINAL FORM
+FDB7          ; mapped                 ; 0643 0645 064A #1.1  ARABIC LIGATURE KAF WITH MEEM WITH YEH FINAL FORM
+FDB8          ; mapped                 ; 0646 062C 062D #1.1  ARABIC LIGATURE NOON WITH JEEM WITH HAH INITIAL FORM
+FDB9          ; mapped                 ; 0645 062E 064A #1.1  ARABIC LIGATURE MEEM WITH KHAH WITH YEH FINAL FORM
+FDBA          ; mapped                 ; 0644 062C 0645 #1.1  ARABIC LIGATURE LAM WITH JEEM WITH MEEM INITIAL FORM
+FDBB          ; mapped                 ; 0643 0645 0645 #1.1  ARABIC LIGATURE KAF WITH MEEM WITH MEEM FINAL FORM
+FDBC          ; mapped                 ; 0644 062C 0645 #1.1  ARABIC LIGATURE LAM WITH JEEM WITH MEEM FINAL FORM
+FDBD          ; mapped                 ; 0646 062C 062D #1.1  ARABIC LIGATURE NOON WITH JEEM WITH HAH FINAL FORM
+FDBE          ; mapped                 ; 062C 062D 064A #1.1  ARABIC LIGATURE JEEM WITH HAH WITH YEH FINAL FORM
+FDBF          ; mapped                 ; 062D 062C 064A #1.1  ARABIC LIGATURE HAH WITH JEEM WITH YEH FINAL FORM
+FDC0          ; mapped                 ; 0645 062C 064A #1.1  ARABIC LIGATURE MEEM WITH JEEM WITH YEH FINAL FORM
+FDC1          ; mapped                 ; 0641 0645 064A #1.1  ARABIC LIGATURE FEH WITH MEEM WITH YEH FINAL FORM
+FDC2          ; mapped                 ; 0628 062D 064A #1.1  ARABIC LIGATURE BEH WITH HAH WITH YEH FINAL FORM
+FDC3          ; mapped                 ; 0643 0645 0645 #1.1  ARABIC LIGATURE KAF WITH MEEM WITH MEEM INITIAL FORM
+FDC4          ; mapped                 ; 0639 062C 0645 #1.1  ARABIC LIGATURE AIN WITH JEEM WITH MEEM INITIAL FORM
+FDC5          ; mapped                 ; 0635 0645 0645 #1.1  ARABIC LIGATURE SAD WITH MEEM WITH MEEM INITIAL FORM
+FDC6          ; mapped                 ; 0633 062E 064A #1.1  ARABIC LIGATURE SEEN WITH KHAH WITH YEH FINAL FORM
+FDC7          ; mapped                 ; 0646 062C 064A #1.1  ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
+FDC8..FDCE    ; disallowed                             # NA   <reserved-FDC8>..<reserved-FDCE>
+FDCF          ; valid                  ;      ; NV8    # 14.0 ARABIC LIGATURE SALAAMUHU ALAYNAA
+FDD0..FDEF    ; disallowed                             # 3.1  <noncharacter-FDD0>..<noncharacter-FDEF>
+FDF0          ; mapped                 ; 0635 0644 06D2 #1.1  ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM
+FDF1          ; mapped                 ; 0642 0644 06D2 #1.1  ARABIC LIGATURE QALA USED AS KORANIC STOP SIGN ISOLATED FORM
+FDF2          ; mapped                 ; 0627 0644 0644 0647 #1.1 ARABIC LIGATURE ALLAH ISOLATED FORM
+FDF3          ; mapped                 ; 0627 0643 0628 0631 #1.1 ARABIC LIGATURE AKBAR ISOLATED FORM
+FDF4          ; mapped                 ; 0645 062D 0645 062F #1.1 ARABIC LIGATURE MOHAMMAD ISOLATED FORM
+FDF5          ; mapped                 ; 0635 0644 0639 0645 #1.1 ARABIC LIGATURE SALAM ISOLATED FORM
+FDF6          ; mapped                 ; 0631 0633 0648 0644 #1.1 ARABIC LIGATURE RASOUL ISOLATED FORM
+FDF7          ; mapped                 ; 0639 0644 064A 0647 #1.1 ARABIC LIGATURE ALAYHE ISOLATED FORM
+FDF8          ; mapped                 ; 0648 0633 0644 0645 #1.1 ARABIC LIGATURE WASALLAM ISOLATED FORM
+FDF9          ; mapped                 ; 0635 0644 0649 #1.1  ARABIC LIGATURE SALLA ISOLATED FORM
+FDFA          ; disallowed_STD3_mapped ; 0635 0644 0649 0020 0627 0644 0644 0647 0020 0639 0644 064A 0647 0020 0648 0633 0644 0645 #1.1 ARABIC LIGATURE SALLALLAHOU ALAYHE WASALLAM
+FDFB          ; disallowed_STD3_mapped ; 062C 0644 0020 062C 0644 0627 0644 0647 #1.1 ARABIC LIGATURE JALLAJALALOUHOU
+FDFC          ; mapped                 ; 0631 06CC 0627 0644 #3.2 RIAL SIGN
+FDFD          ; valid                  ;      ; NV8    # 4.0  ARABIC LIGATURE BISMILLAH AR-RAHMAN AR-RAHEEM
+FDFE..FDFF    ; valid                  ;      ; NV8    # 14.0 ARABIC LIGATURE SUBHAANAHU WA TAAALAA..ARABIC LIGATURE AZZA WA JALL
+FE00..FE0F    ; ignored                                # 3.2  VARIATION SELECTOR-1..VARIATION SELECTOR-16
+FE10          ; disallowed_STD3_mapped ; 002C          # 4.1  PRESENTATION FORM FOR VERTICAL COMMA
+FE11          ; mapped                 ; 3001          # 4.1  PRESENTATION FORM FOR VERTICAL IDEOGRAPHIC COMMA
+FE12          ; disallowed                             # 4.1  PRESENTATION FORM FOR VERTICAL IDEOGRAPHIC FULL STOP
+FE13          ; disallowed_STD3_mapped ; 003A          # 4.1  PRESENTATION FORM FOR VERTICAL COLON
+FE14          ; disallowed_STD3_mapped ; 003B          # 4.1  PRESENTATION FORM FOR VERTICAL SEMICOLON
+FE15          ; disallowed_STD3_mapped ; 0021          # 4.1  PRESENTATION FORM FOR VERTICAL EXCLAMATION MARK
+FE16          ; disallowed_STD3_mapped ; 003F          # 4.1  PRESENTATION FORM FOR VERTICAL QUESTION MARK
+FE17          ; mapped                 ; 3016          # 4.1  PRESENTATION FORM FOR VERTICAL LEFT WHITE LENTICULAR BRACKET
+FE18          ; mapped                 ; 3017          # 4.1  PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
+FE19          ; disallowed                             # 4.1  PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS
+FE1A..FE1F    ; disallowed                             # NA   <reserved-FE1A>..<reserved-FE1F>
+FE20..FE23    ; valid                                  # 1.1  COMBINING LIGATURE LEFT HALF..COMBINING DOUBLE TILDE RIGHT HALF
+FE24..FE26    ; valid                                  # 5.1  COMBINING MACRON LEFT HALF..COMBINING CONJOINING MACRON
+FE27..FE2D    ; valid                                  # 7.0  COMBINING LIGATURE LEFT HALF BELOW..COMBINING CONJOINING MACRON BELOW
+FE2E..FE2F    ; valid                                  # 8.0  COMBINING CYRILLIC TITLO LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
+FE30          ; disallowed                             # 1.1  PRESENTATION FORM FOR VERTICAL TWO DOT LEADER
+FE31          ; mapped                 ; 2014          # 1.1  PRESENTATION FORM FOR VERTICAL EM DASH
+FE32          ; mapped                 ; 2013          # 1.1  PRESENTATION FORM FOR VERTICAL EN DASH
+FE33..FE34    ; disallowed_STD3_mapped ; 005F          # 1.1  PRESENTATION FORM FOR VERTICAL LOW LINE..PRESENTATION FORM FOR VERTICAL WAVY LOW LINE
+FE35          ; disallowed_STD3_mapped ; 0028          # 1.1  PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
+FE36          ; disallowed_STD3_mapped ; 0029          # 1.1  PRESENTATION FORM FOR VERTICAL RIGHT PARENTHESIS
+FE37          ; disallowed_STD3_mapped ; 007B          # 1.1  PRESENTATION FORM FOR VERTICAL LEFT CURLY BRACKET
+FE38          ; disallowed_STD3_mapped ; 007D          # 1.1  PRESENTATION FORM FOR VERTICAL RIGHT CURLY BRACKET
+FE39          ; mapped                 ; 3014          # 1.1  PRESENTATION FORM FOR VERTICAL LEFT TORTOISE SHELL BRACKET
+FE3A          ; mapped                 ; 3015          # 1.1  PRESENTATION FORM FOR VERTICAL RIGHT TORTOISE SHELL BRACKET
+FE3B          ; mapped                 ; 3010          # 1.1  PRESENTATION FORM FOR VERTICAL LEFT BLACK LENTICULAR BRACKET
+FE3C          ; mapped                 ; 3011          # 1.1  PRESENTATION FORM FOR VERTICAL RIGHT BLACK LENTICULAR BRACKET
+FE3D          ; mapped                 ; 300A          # 1.1  PRESENTATION FORM FOR VERTICAL LEFT DOUBLE ANGLE BRACKET
+FE3E          ; mapped                 ; 300B          # 1.1  PRESENTATION FORM FOR VERTICAL RIGHT DOUBLE ANGLE BRACKET
+FE3F          ; mapped                 ; 3008          # 1.1  PRESENTATION FORM FOR VERTICAL LEFT ANGLE BRACKET
+FE40          ; mapped                 ; 3009          # 1.1  PRESENTATION FORM FOR VERTICAL RIGHT ANGLE BRACKET
+FE41          ; mapped                 ; 300C          # 1.1  PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET
+FE42          ; mapped                 ; 300D          # 1.1  PRESENTATION FORM FOR VERTICAL RIGHT CORNER BRACKET
+FE43          ; mapped                 ; 300E          # 1.1  PRESENTATION FORM FOR VERTICAL LEFT WHITE CORNER BRACKET
+FE44          ; mapped                 ; 300F          # 1.1  PRESENTATION FORM FOR VERTICAL RIGHT WHITE CORNER BRACKET
+FE45..FE46    ; valid                  ;      ; NV8    # 3.2  SESAME DOT..WHITE SESAME DOT
+FE47          ; disallowed_STD3_mapped ; 005B          # 4.0  PRESENTATION FORM FOR VERTICAL LEFT SQUARE BRACKET
+FE48          ; disallowed_STD3_mapped ; 005D          # 4.0  PRESENTATION FORM FOR VERTICAL RIGHT SQUARE BRACKET
+FE49..FE4C    ; disallowed_STD3_mapped ; 0020 0305     # 1.1  DASHED OVERLINE..DOUBLE WAVY OVERLINE
+FE4D..FE4F    ; disallowed_STD3_mapped ; 005F          # 1.1  DASHED LOW LINE..WAVY LOW LINE
+FE50          ; disallowed_STD3_mapped ; 002C          # 1.1  SMALL COMMA
+FE51          ; mapped                 ; 3001          # 1.1  SMALL IDEOGRAPHIC COMMA
+FE52          ; disallowed                             # 1.1  SMALL FULL STOP
+FE53          ; disallowed                             # NA   <reserved-FE53>
+FE54          ; disallowed_STD3_mapped ; 003B          # 1.1  SMALL SEMICOLON
+FE55          ; disallowed_STD3_mapped ; 003A          # 1.1  SMALL COLON
+FE56          ; disallowed_STD3_mapped ; 003F          # 1.1  SMALL QUESTION MARK
+FE57          ; disallowed_STD3_mapped ; 0021          # 1.1  SMALL EXCLAMATION MARK
+FE58          ; mapped                 ; 2014          # 1.1  SMALL EM DASH
+FE59          ; disallowed_STD3_mapped ; 0028          # 1.1  SMALL LEFT PARENTHESIS
+FE5A          ; disallowed_STD3_mapped ; 0029          # 1.1  SMALL RIGHT PARENTHESIS
+FE5B          ; disallowed_STD3_mapped ; 007B          # 1.1  SMALL LEFT CURLY BRACKET
+FE5C          ; disallowed_STD3_mapped ; 007D          # 1.1  SMALL RIGHT CURLY BRACKET
+FE5D          ; mapped                 ; 3014          # 1.1  SMALL LEFT TORTOISE SHELL BRACKET
+FE5E          ; mapped                 ; 3015          # 1.1  SMALL RIGHT TORTOISE SHELL BRACKET
+FE5F          ; disallowed_STD3_mapped ; 0023          # 1.1  SMALL NUMBER SIGN
+FE60          ; disallowed_STD3_mapped ; 0026          # 1.1  SMALL AMPERSAND
+FE61          ; disallowed_STD3_mapped ; 002A          # 1.1  SMALL ASTERISK
+FE62          ; disallowed_STD3_mapped ; 002B          # 1.1  SMALL PLUS SIGN
+FE63          ; mapped                 ; 002D          # 1.1  SMALL HYPHEN-MINUS
+FE64          ; disallowed_STD3_mapped ; 003C          # 1.1  SMALL LESS-THAN SIGN
+FE65          ; disallowed_STD3_mapped ; 003E          # 1.1  SMALL GREATER-THAN SIGN
+FE66          ; disallowed_STD3_mapped ; 003D          # 1.1  SMALL EQUALS SIGN
+FE67          ; disallowed                             # NA   <reserved-FE67>
+FE68          ; disallowed_STD3_mapped ; 005C          # 1.1  SMALL REVERSE SOLIDUS
+FE69          ; disallowed_STD3_mapped ; 0024          # 1.1  SMALL DOLLAR SIGN
+FE6A          ; disallowed_STD3_mapped ; 0025          # 1.1  SMALL PERCENT SIGN
+FE6B          ; disallowed_STD3_mapped ; 0040          # 1.1  SMALL COMMERCIAL AT
+FE6C..FE6F    ; disallowed                             # NA   <reserved-FE6C>..<reserved-FE6F>
+FE70          ; disallowed_STD3_mapped ; 0020 064B     # 1.1  ARABIC FATHATAN ISOLATED FORM
+FE71          ; mapped                 ; 0640 064B     # 1.1  ARABIC TATWEEL WITH FATHATAN ABOVE
+FE72          ; disallowed_STD3_mapped ; 0020 064C     # 1.1  ARABIC DAMMATAN ISOLATED FORM
+FE73          ; valid                                  # 3.2  ARABIC TAIL FRAGMENT
+FE74          ; disallowed_STD3_mapped ; 0020 064D     # 1.1  ARABIC KASRATAN ISOLATED FORM
+FE75          ; disallowed                             # NA   <reserved-FE75>
+FE76          ; disallowed_STD3_mapped ; 0020 064E     # 1.1  ARABIC FATHA ISOLATED FORM
+FE77          ; mapped                 ; 0640 064E     # 1.1  ARABIC FATHA MEDIAL FORM
+FE78          ; disallowed_STD3_mapped ; 0020 064F     # 1.1  ARABIC DAMMA ISOLATED FORM
+FE79          ; mapped                 ; 0640 064F     # 1.1  ARABIC DAMMA MEDIAL FORM
+FE7A          ; disallowed_STD3_mapped ; 0020 0650     # 1.1  ARABIC KASRA ISOLATED FORM
+FE7B          ; mapped                 ; 0640 0650     # 1.1  ARABIC KASRA MEDIAL FORM
+FE7C          ; disallowed_STD3_mapped ; 0020 0651     # 1.1  ARABIC SHADDA ISOLATED FORM
+FE7D          ; mapped                 ; 0640 0651     # 1.1  ARABIC SHADDA MEDIAL FORM
+FE7E          ; disallowed_STD3_mapped ; 0020 0652     # 1.1  ARABIC SUKUN ISOLATED FORM
+FE7F          ; mapped                 ; 0640 0652     # 1.1  ARABIC SUKUN MEDIAL FORM
+FE80          ; mapped                 ; 0621          # 1.1  ARABIC LETTER HAMZA ISOLATED FORM
+FE81..FE82    ; mapped                 ; 0622          # 1.1  ARABIC LETTER ALEF WITH MADDA ABOVE ISOLATED FORM..ARABIC LETTER ALEF WITH MADDA ABOVE FINAL FORM
+FE83..FE84    ; mapped                 ; 0623          # 1.1  ARABIC LETTER ALEF WITH HAMZA ABOVE ISOLATED FORM..ARABIC LETTER ALEF WITH HAMZA ABOVE FINAL FORM
+FE85..FE86    ; mapped                 ; 0624          # 1.1  ARABIC LETTER WAW WITH HAMZA ABOVE ISOLATED FORM..ARABIC LETTER WAW WITH HAMZA ABOVE FINAL FORM
+FE87..FE88    ; mapped                 ; 0625          # 1.1  ARABIC LETTER ALEF WITH HAMZA BELOW ISOLATED FORM..ARABIC LETTER ALEF WITH HAMZA BELOW FINAL FORM
+FE89..FE8C    ; mapped                 ; 0626          # 1.1  ARABIC LETTER YEH WITH HAMZA ABOVE ISOLATED FORM..ARABIC LETTER YEH WITH HAMZA ABOVE MEDIAL FORM
+FE8D..FE8E    ; mapped                 ; 0627          # 1.1  ARABIC LETTER ALEF ISOLATED FORM..ARABIC LETTER ALEF FINAL FORM
+FE8F..FE92    ; mapped                 ; 0628          # 1.1  ARABIC LETTER BEH ISOLATED FORM..ARABIC LETTER BEH MEDIAL FORM
+FE93..FE94    ; mapped                 ; 0629          # 1.1  ARABIC LETTER TEH MARBUTA ISOLATED FORM..ARABIC LETTER TEH MARBUTA FINAL FORM
+FE95..FE98    ; mapped                 ; 062A          # 1.1  ARABIC LETTER TEH ISOLATED FORM..ARABIC LETTER TEH MEDIAL FORM
+FE99..FE9C    ; mapped                 ; 062B          # 1.1  ARABIC LETTER THEH ISOLATED FORM..ARABIC LETTER THEH MEDIAL FORM
+FE9D..FEA0    ; mapped                 ; 062C          # 1.1  ARABIC LETTER JEEM ISOLATED FORM..ARABIC LETTER JEEM MEDIAL FORM
+FEA1..FEA4    ; mapped                 ; 062D          # 1.1  ARABIC LETTER HAH ISOLATED FORM..ARABIC LETTER HAH MEDIAL FORM
+FEA5..FEA8    ; mapped                 ; 062E          # 1.1  ARABIC LETTER KHAH ISOLATED FORM..ARABIC LETTER KHAH MEDIAL FORM
+FEA9..FEAA    ; mapped                 ; 062F          # 1.1  ARABIC LETTER DAL ISOLATED FORM..ARABIC LETTER DAL FINAL FORM
+FEAB..FEAC    ; mapped                 ; 0630          # 1.1  ARABIC LETTER THAL ISOLATED FORM..ARABIC LETTER THAL FINAL FORM
+FEAD..FEAE    ; mapped                 ; 0631          # 1.1  ARABIC LETTER REH ISOLATED FORM..ARABIC LETTER REH FINAL FORM
+FEAF..FEB0    ; mapped                 ; 0632          # 1.1  ARABIC LETTER ZAIN ISOLATED FORM..ARABIC LETTER ZAIN FINAL FORM
+FEB1..FEB4    ; mapped                 ; 0633          # 1.1  ARABIC LETTER SEEN ISOLATED FORM..ARABIC LETTER SEEN MEDIAL FORM
+FEB5..FEB8    ; mapped                 ; 0634          # 1.1  ARABIC LETTER SHEEN ISOLATED FORM..ARABIC LETTER SHEEN MEDIAL FORM
+FEB9..FEBC    ; mapped                 ; 0635          # 1.1  ARABIC LETTER SAD ISOLATED FORM..ARABIC LETTER SAD MEDIAL FORM
+FEBD..FEC0    ; mapped                 ; 0636          # 1.1  ARABIC LETTER DAD ISOLATED FORM..ARABIC LETTER DAD MEDIAL FORM
+FEC1..FEC4    ; mapped                 ; 0637          # 1.1  ARABIC LETTER TAH ISOLATED FORM..ARABIC LETTER TAH MEDIAL FORM
+FEC5..FEC8    ; mapped                 ; 0638          # 1.1  ARABIC LETTER ZAH ISOLATED FORM..ARABIC LETTER ZAH MEDIAL FORM
+FEC9..FECC    ; mapped                 ; 0639          # 1.1  ARABIC LETTER AIN ISOLATED FORM..ARABIC LETTER AIN MEDIAL FORM
+FECD..FED0    ; mapped                 ; 063A          # 1.1  ARABIC LETTER GHAIN ISOLATED FORM..ARABIC LETTER GHAIN MEDIAL FORM
+FED1..FED4    ; mapped                 ; 0641          # 1.1  ARABIC LETTER FEH ISOLATED FORM..ARABIC LETTER FEH MEDIAL FORM
+FED5..FED8    ; mapped                 ; 0642          # 1.1  ARABIC LETTER QAF ISOLATED FORM..ARABIC LETTER QAF MEDIAL FORM
+FED9..FEDC    ; mapped                 ; 0643          # 1.1  ARABIC LETTER KAF ISOLATED FORM..ARABIC LETTER KAF MEDIAL FORM
+FEDD..FEE0    ; mapped                 ; 0644          # 1.1  ARABIC LETTER LAM ISOLATED FORM..ARABIC LETTER LAM MEDIAL FORM
+FEE1..FEE4    ; mapped                 ; 0645          # 1.1  ARABIC LETTER MEEM ISOLATED FORM..ARABIC LETTER MEEM MEDIAL FORM
+FEE5..FEE8    ; mapped                 ; 0646          # 1.1  ARABIC LETTER NOON ISOLATED FORM..ARABIC LETTER NOON MEDIAL FORM
+FEE9..FEEC    ; mapped                 ; 0647          # 1.1  ARABIC LETTER HEH ISOLATED FORM..ARABIC LETTER HEH MEDIAL FORM
+FEED..FEEE    ; mapped                 ; 0648          # 1.1  ARABIC LETTER WAW ISOLATED FORM..ARABIC LETTER WAW FINAL FORM
+FEEF..FEF0    ; mapped                 ; 0649          # 1.1  ARABIC LETTER ALEF MAKSURA ISOLATED FORM..ARABIC LETTER ALEF MAKSURA FINAL FORM
+FEF1..FEF4    ; mapped                 ; 064A          # 1.1  ARABIC LETTER YEH ISOLATED FORM..ARABIC LETTER YEH MEDIAL FORM
+FEF5..FEF6    ; mapped                 ; 0644 0622     # 1.1  ARABIC LIGATURE LAM WITH ALEF WITH MADDA ABOVE ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF WITH MADDA ABOVE FINAL FORM
+FEF7..FEF8    ; mapped                 ; 0644 0623     # 1.1  ARABIC LIGATURE LAM WITH ALEF WITH HAMZA ABOVE ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF WITH HAMZA ABOVE FINAL FORM
+FEF9..FEFA    ; mapped                 ; 0644 0625     # 1.1  ARABIC LIGATURE LAM WITH ALEF WITH HAMZA BELOW ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF WITH HAMZA BELOW FINAL FORM
+FEFB..FEFC    ; mapped                 ; 0644 0627     # 1.1  ARABIC LIGATURE LAM WITH ALEF ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
+FEFD..FEFE    ; disallowed                             # NA   <reserved-FEFD>..<reserved-FEFE>
+FEFF          ; ignored                                # 1.1  ZERO WIDTH NO-BREAK SPACE
+FF00          ; disallowed                             # NA   <reserved-FF00>
+FF01          ; disallowed_STD3_mapped ; 0021          # 1.1  FULLWIDTH EXCLAMATION MARK
+FF02          ; disallowed_STD3_mapped ; 0022          # 1.1  FULLWIDTH QUOTATION MARK
+FF03          ; disallowed_STD3_mapped ; 0023          # 1.1  FULLWIDTH NUMBER SIGN
+FF04          ; disallowed_STD3_mapped ; 0024          # 1.1  FULLWIDTH DOLLAR SIGN
+FF05          ; disallowed_STD3_mapped ; 0025          # 1.1  FULLWIDTH PERCENT SIGN
+FF06          ; disallowed_STD3_mapped ; 0026          # 1.1  FULLWIDTH AMPERSAND
+FF07          ; disallowed_STD3_mapped ; 0027          # 1.1  FULLWIDTH APOSTROPHE
+FF08          ; disallowed_STD3_mapped ; 0028          # 1.1  FULLWIDTH LEFT PARENTHESIS
+FF09          ; disallowed_STD3_mapped ; 0029          # 1.1  FULLWIDTH RIGHT PARENTHESIS
+FF0A          ; disallowed_STD3_mapped ; 002A          # 1.1  FULLWIDTH ASTERISK
+FF0B          ; disallowed_STD3_mapped ; 002B          # 1.1  FULLWIDTH PLUS SIGN
+FF0C          ; disallowed_STD3_mapped ; 002C          # 1.1  FULLWIDTH COMMA
+FF0D          ; mapped                 ; 002D          # 1.1  FULLWIDTH HYPHEN-MINUS
+FF0E          ; mapped                 ; 002E          # 1.1  FULLWIDTH FULL STOP
+FF0F          ; disallowed_STD3_mapped ; 002F          # 1.1  FULLWIDTH SOLIDUS
+FF10          ; mapped                 ; 0030          # 1.1  FULLWIDTH DIGIT ZERO
+FF11          ; mapped                 ; 0031          # 1.1  FULLWIDTH DIGIT ONE
+FF12          ; mapped                 ; 0032          # 1.1  FULLWIDTH DIGIT TWO
+FF13          ; mapped                 ; 0033          # 1.1  FULLWIDTH DIGIT THREE
+FF14          ; mapped                 ; 0034          # 1.1  FULLWIDTH DIGIT FOUR
+FF15          ; mapped                 ; 0035          # 1.1  FULLWIDTH DIGIT FIVE
+FF16          ; mapped                 ; 0036          # 1.1  FULLWIDTH DIGIT SIX
+FF17          ; mapped                 ; 0037          # 1.1  FULLWIDTH DIGIT SEVEN
+FF18          ; mapped                 ; 0038          # 1.1  FULLWIDTH DIGIT EIGHT
+FF19          ; mapped                 ; 0039          # 1.1  FULLWIDTH DIGIT NINE
+FF1A          ; disallowed_STD3_mapped ; 003A          # 1.1  FULLWIDTH COLON
+FF1B          ; disallowed_STD3_mapped ; 003B          # 1.1  FULLWIDTH SEMICOLON
+FF1C          ; disallowed_STD3_mapped ; 003C          # 1.1  FULLWIDTH LESS-THAN SIGN
+FF1D          ; disallowed_STD3_mapped ; 003D          # 1.1  FULLWIDTH EQUALS SIGN
+FF1E          ; disallowed_STD3_mapped ; 003E          # 1.1  FULLWIDTH GREATER-THAN SIGN
+FF1F          ; disallowed_STD3_mapped ; 003F          # 1.1  FULLWIDTH QUESTION MARK
+FF20          ; disallowed_STD3_mapped ; 0040          # 1.1  FULLWIDTH COMMERCIAL AT
+FF21          ; mapped                 ; 0061          # 1.1  FULLWIDTH LATIN CAPITAL LETTER A
+FF22          ; mapped                 ; 0062          # 1.1  FULLWIDTH LATIN CAPITAL LETTER B
+FF23          ; mapped                 ; 0063          # 1.1  FULLWIDTH LATIN CAPITAL LETTER C
+FF24          ; mapped                 ; 0064          # 1.1  FULLWIDTH LATIN CAPITAL LETTER D
+FF25          ; mapped                 ; 0065          # 1.1  FULLWIDTH LATIN CAPITAL LETTER E
+FF26          ; mapped                 ; 0066          # 1.1  FULLWIDTH LATIN CAPITAL LETTER F
+FF27          ; mapped                 ; 0067          # 1.1  FULLWIDTH LATIN CAPITAL LETTER G
+FF28          ; mapped                 ; 0068          # 1.1  FULLWIDTH LATIN CAPITAL LETTER H
+FF29          ; mapped                 ; 0069          # 1.1  FULLWIDTH LATIN CAPITAL LETTER I
+FF2A          ; mapped                 ; 006A          # 1.1  FULLWIDTH LATIN CAPITAL LETTER J
+FF2B          ; mapped                 ; 006B          # 1.1  FULLWIDTH LATIN CAPITAL LETTER K
+FF2C          ; mapped                 ; 006C          # 1.1  FULLWIDTH LATIN CAPITAL LETTER L
+FF2D          ; mapped                 ; 006D          # 1.1  FULLWIDTH LATIN CAPITAL LETTER M
+FF2E          ; mapped                 ; 006E          # 1.1  FULLWIDTH LATIN CAPITAL LETTER N
+FF2F          ; mapped                 ; 006F          # 1.1  FULLWIDTH LATIN CAPITAL LETTER O
+FF30          ; mapped                 ; 0070          # 1.1  FULLWIDTH LATIN CAPITAL LETTER P
+FF31          ; mapped                 ; 0071          # 1.1  FULLWIDTH LATIN CAPITAL LETTER Q
+FF32          ; mapped                 ; 0072          # 1.1  FULLWIDTH LATIN CAPITAL LETTER R
+FF33          ; mapped                 ; 0073          # 1.1  FULLWIDTH LATIN CAPITAL LETTER S
+FF34          ; mapped                 ; 0074          # 1.1  FULLWIDTH LATIN CAPITAL LETTER T
+FF35          ; mapped                 ; 0075          # 1.1  FULLWIDTH LATIN CAPITAL LETTER U
+FF36          ; mapped                 ; 0076          # 1.1  FULLWIDTH LATIN CAPITAL LETTER V
+FF37          ; mapped                 ; 0077          # 1.1  FULLWIDTH LATIN CAPITAL LETTER W
+FF38          ; mapped                 ; 0078          # 1.1  FULLWIDTH LATIN CAPITAL LETTER X
+FF39          ; mapped                 ; 0079          # 1.1  FULLWIDTH LATIN CAPITAL LETTER Y
+FF3A          ; mapped                 ; 007A          # 1.1  FULLWIDTH LATIN CAPITAL LETTER Z
+FF3B          ; disallowed_STD3_mapped ; 005B          # 1.1  FULLWIDTH LEFT SQUARE BRACKET
+FF3C          ; disallowed_STD3_mapped ; 005C          # 1.1  FULLWIDTH REVERSE SOLIDUS
+FF3D          ; disallowed_STD3_mapped ; 005D          # 1.1  FULLWIDTH RIGHT SQUARE BRACKET
+FF3E          ; disallowed_STD3_mapped ; 005E          # 1.1  FULLWIDTH CIRCUMFLEX ACCENT
+FF3F          ; disallowed_STD3_mapped ; 005F          # 1.1  FULLWIDTH LOW LINE
+FF40          ; disallowed_STD3_mapped ; 0060          # 1.1  FULLWIDTH GRAVE ACCENT
+FF41          ; mapped                 ; 0061          # 1.1  FULLWIDTH LATIN SMALL LETTER A
+FF42          ; mapped                 ; 0062          # 1.1  FULLWIDTH LATIN SMALL LETTER B
+FF43          ; mapped                 ; 0063          # 1.1  FULLWIDTH LATIN SMALL LETTER C
+FF44          ; mapped                 ; 0064          # 1.1  FULLWIDTH LATIN SMALL LETTER D
+FF45          ; mapped                 ; 0065          # 1.1  FULLWIDTH LATIN SMALL LETTER E
+FF46          ; mapped                 ; 0066          # 1.1  FULLWIDTH LATIN SMALL LETTER F
+FF47          ; mapped                 ; 0067          # 1.1  FULLWIDTH LATIN SMALL LETTER G
+FF48          ; mapped                 ; 0068          # 1.1  FULLWIDTH LATIN SMALL LETTER H
+FF49          ; mapped                 ; 0069          # 1.1  FULLWIDTH LATIN SMALL LETTER I
+FF4A          ; mapped                 ; 006A          # 1.1  FULLWIDTH LATIN SMALL LETTER J
+FF4B          ; mapped                 ; 006B          # 1.1  FULLWIDTH LATIN SMALL LETTER K
+FF4C          ; mapped                 ; 006C          # 1.1  FULLWIDTH LATIN SMALL LETTER L
+FF4D          ; mapped                 ; 006D          # 1.1  FULLWIDTH LATIN SMALL LETTER M
+FF4E          ; mapped                 ; 006E          # 1.1  FULLWIDTH LATIN SMALL LETTER N
+FF4F          ; mapped                 ; 006F          # 1.1  FULLWIDTH LATIN SMALL LETTER O
+FF50          ; mapped                 ; 0070          # 1.1  FULLWIDTH LATIN SMALL LETTER P
+FF51          ; mapped                 ; 0071          # 1.1  FULLWIDTH LATIN SMALL LETTER Q
+FF52          ; mapped                 ; 0072          # 1.1  FULLWIDTH LATIN SMALL LETTER R
+FF53          ; mapped                 ; 0073          # 1.1  FULLWIDTH LATIN SMALL LETTER S
+FF54          ; mapped                 ; 0074          # 1.1  FULLWIDTH LATIN SMALL LETTER T
+FF55          ; mapped                 ; 0075          # 1.1  FULLWIDTH LATIN SMALL LETTER U
+FF56          ; mapped                 ; 0076          # 1.1  FULLWIDTH LATIN SMALL LETTER V
+FF57          ; mapped                 ; 0077          # 1.1  FULLWIDTH LATIN SMALL LETTER W
+FF58          ; mapped                 ; 0078          # 1.1  FULLWIDTH LATIN SMALL LETTER X
+FF59          ; mapped                 ; 0079          # 1.1  FULLWIDTH LATIN SMALL LETTER Y
+FF5A          ; mapped                 ; 007A          # 1.1  FULLWIDTH LATIN SMALL LETTER Z
+FF5B          ; disallowed_STD3_mapped ; 007B          # 1.1  FULLWIDTH LEFT CURLY BRACKET
+FF5C          ; disallowed_STD3_mapped ; 007C          # 1.1  FULLWIDTH VERTICAL LINE
+FF5D          ; disallowed_STD3_mapped ; 007D          # 1.1  FULLWIDTH RIGHT CURLY BRACKET
+FF5E          ; disallowed_STD3_mapped ; 007E          # 1.1  FULLWIDTH TILDE
+FF5F          ; mapped                 ; 2985          # 3.2  FULLWIDTH LEFT WHITE PARENTHESIS
+FF60          ; mapped                 ; 2986          # 3.2  FULLWIDTH RIGHT WHITE PARENTHESIS
+FF61          ; mapped                 ; 002E          # 1.1  HALFWIDTH IDEOGRAPHIC FULL STOP
+FF62          ; mapped                 ; 300C          # 1.1  HALFWIDTH LEFT CORNER BRACKET
+FF63          ; mapped                 ; 300D          # 1.1  HALFWIDTH RIGHT CORNER BRACKET
+FF64          ; mapped                 ; 3001          # 1.1  HALFWIDTH IDEOGRAPHIC COMMA
+FF65          ; mapped                 ; 30FB          # 1.1  HALFWIDTH KATAKANA MIDDLE DOT
+FF66          ; mapped                 ; 30F2          # 1.1  HALFWIDTH KATAKANA LETTER WO
+FF67          ; mapped                 ; 30A1          # 1.1  HALFWIDTH KATAKANA LETTER SMALL A
+FF68          ; mapped                 ; 30A3          # 1.1  HALFWIDTH KATAKANA LETTER SMALL I
+FF69          ; mapped                 ; 30A5          # 1.1  HALFWIDTH KATAKANA LETTER SMALL U
+FF6A          ; mapped                 ; 30A7          # 1.1  HALFWIDTH KATAKANA LETTER SMALL E
+FF6B          ; mapped                 ; 30A9          # 1.1  HALFWIDTH KATAKANA LETTER SMALL O
+FF6C          ; mapped                 ; 30E3          # 1.1  HALFWIDTH KATAKANA LETTER SMALL YA
+FF6D          ; mapped                 ; 30E5          # 1.1  HALFWIDTH KATAKANA LETTER SMALL YU
+FF6E          ; mapped                 ; 30E7          # 1.1  HALFWIDTH KATAKANA LETTER SMALL YO
+FF6F          ; mapped                 ; 30C3          # 1.1  HALFWIDTH KATAKANA LETTER SMALL TU
+FF70          ; mapped                 ; 30FC          # 1.1  HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
+FF71          ; mapped                 ; 30A2          # 1.1  HALFWIDTH KATAKANA LETTER A
+FF72          ; mapped                 ; 30A4          # 1.1  HALFWIDTH KATAKANA LETTER I
+FF73          ; mapped                 ; 30A6          # 1.1  HALFWIDTH KATAKANA LETTER U
+FF74          ; mapped                 ; 30A8          # 1.1  HALFWIDTH KATAKANA LETTER E
+FF75          ; mapped                 ; 30AA          # 1.1  HALFWIDTH KATAKANA LETTER O
+FF76          ; mapped                 ; 30AB          # 1.1  HALFWIDTH KATAKANA LETTER KA
+FF77          ; mapped                 ; 30AD          # 1.1  HALFWIDTH KATAKANA LETTER KI
+FF78          ; mapped                 ; 30AF          # 1.1  HALFWIDTH KATAKANA LETTER KU
+FF79          ; mapped                 ; 30B1          # 1.1  HALFWIDTH KATAKANA LETTER KE
+FF7A          ; mapped                 ; 30B3          # 1.1  HALFWIDTH KATAKANA LETTER KO
+FF7B          ; mapped                 ; 30B5          # 1.1  HALFWIDTH KATAKANA LETTER SA
+FF7C          ; mapped                 ; 30B7          # 1.1  HALFWIDTH KATAKANA LETTER SI
+FF7D          ; mapped                 ; 30B9          # 1.1  HALFWIDTH KATAKANA LETTER SU
+FF7E          ; mapped                 ; 30BB          # 1.1  HALFWIDTH KATAKANA LETTER SE
+FF7F          ; mapped                 ; 30BD          # 1.1  HALFWIDTH KATAKANA LETTER SO
+FF80          ; mapped                 ; 30BF          # 1.1  HALFWIDTH KATAKANA LETTER TA
+FF81          ; mapped                 ; 30C1          # 1.1  HALFWIDTH KATAKANA LETTER TI
+FF82          ; mapped                 ; 30C4          # 1.1  HALFWIDTH KATAKANA LETTER TU
+FF83          ; mapped                 ; 30C6          # 1.1  HALFWIDTH KATAKANA LETTER TE
+FF84          ; mapped                 ; 30C8          # 1.1  HALFWIDTH KATAKANA LETTER TO
+FF85          ; mapped                 ; 30CA          # 1.1  HALFWIDTH KATAKANA LETTER NA
+FF86          ; mapped                 ; 30CB          # 1.1  HALFWIDTH KATAKANA LETTER NI
+FF87          ; mapped                 ; 30CC          # 1.1  HALFWIDTH KATAKANA LETTER NU
+FF88          ; mapped                 ; 30CD          # 1.1  HALFWIDTH KATAKANA LETTER NE
+FF89          ; mapped                 ; 30CE          # 1.1  HALFWIDTH KATAKANA LETTER NO
+FF8A          ; mapped                 ; 30CF          # 1.1  HALFWIDTH KATAKANA LETTER HA
+FF8B          ; mapped                 ; 30D2          # 1.1  HALFWIDTH KATAKANA LETTER HI
+FF8C          ; mapped                 ; 30D5          # 1.1  HALFWIDTH KATAKANA LETTER HU
+FF8D          ; mapped                 ; 30D8          # 1.1  HALFWIDTH KATAKANA LETTER HE
+FF8E          ; mapped                 ; 30DB          # 1.1  HALFWIDTH KATAKANA LETTER HO
+FF8F          ; mapped                 ; 30DE          # 1.1  HALFWIDTH KATAKANA LETTER MA
+FF90          ; mapped                 ; 30DF          # 1.1  HALFWIDTH KATAKANA LETTER MI
+FF91          ; mapped                 ; 30E0          # 1.1  HALFWIDTH KATAKANA LETTER MU
+FF92          ; mapped                 ; 30E1          # 1.1  HALFWIDTH KATAKANA LETTER ME
+FF93          ; mapped                 ; 30E2          # 1.1  HALFWIDTH KATAKANA LETTER MO
+FF94          ; mapped                 ; 30E4          # 1.1  HALFWIDTH KATAKANA LETTER YA
+FF95          ; mapped                 ; 30E6          # 1.1  HALFWIDTH KATAKANA LETTER YU
+FF96          ; mapped                 ; 30E8          # 1.1  HALFWIDTH KATAKANA LETTER YO
+FF97          ; mapped                 ; 30E9          # 1.1  HALFWIDTH KATAKANA LETTER RA
+FF98          ; mapped                 ; 30EA          # 1.1  HALFWIDTH KATAKANA LETTER RI
+FF99          ; mapped                 ; 30EB          # 1.1  HALFWIDTH KATAKANA LETTER RU
+FF9A          ; mapped                 ; 30EC          # 1.1  HALFWIDTH KATAKANA LETTER RE
+FF9B          ; mapped                 ; 30ED          # 1.1  HALFWIDTH KATAKANA LETTER RO
+FF9C          ; mapped                 ; 30EF          # 1.1  HALFWIDTH KATAKANA LETTER WA
+FF9D          ; mapped                 ; 30F3          # 1.1  HALFWIDTH KATAKANA LETTER N
+FF9E          ; mapped                 ; 3099          # 1.1  HALFWIDTH KATAKANA VOICED SOUND MARK
+FF9F          ; mapped                 ; 309A          # 1.1  HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+FFA0          ; disallowed                             # 1.1  HALFWIDTH HANGUL FILLER
+FFA1          ; mapped                 ; 1100          # 1.1  HALFWIDTH HANGUL LETTER KIYEOK
+FFA2          ; mapped                 ; 1101          # 1.1  HALFWIDTH HANGUL LETTER SSANGKIYEOK
+FFA3          ; mapped                 ; 11AA          # 1.1  HALFWIDTH HANGUL LETTER KIYEOK-SIOS
+FFA4          ; mapped                 ; 1102          # 1.1  HALFWIDTH HANGUL LETTER NIEUN
+FFA5          ; mapped                 ; 11AC          # 1.1  HALFWIDTH HANGUL LETTER NIEUN-CIEUC
+FFA6          ; mapped                 ; 11AD          # 1.1  HALFWIDTH HANGUL LETTER NIEUN-HIEUH
+FFA7          ; mapped                 ; 1103          # 1.1  HALFWIDTH HANGUL LETTER TIKEUT
+FFA8          ; mapped                 ; 1104          # 1.1  HALFWIDTH HANGUL LETTER SSANGTIKEUT
+FFA9          ; mapped                 ; 1105          # 1.1  HALFWIDTH HANGUL LETTER RIEUL
+FFAA          ; mapped                 ; 11B0          # 1.1  HALFWIDTH HANGUL LETTER RIEUL-KIYEOK
+FFAB          ; mapped                 ; 11B1          # 1.1  HALFWIDTH HANGUL LETTER RIEUL-MIEUM
+FFAC          ; mapped                 ; 11B2          # 1.1  HALFWIDTH HANGUL LETTER RIEUL-PIEUP
+FFAD          ; mapped                 ; 11B3          # 1.1  HALFWIDTH HANGUL LETTER RIEUL-SIOS
+FFAE          ; mapped                 ; 11B4          # 1.1  HALFWIDTH HANGUL LETTER RIEUL-THIEUTH
+FFAF          ; mapped                 ; 11B5          # 1.1  HALFWIDTH HANGUL LETTER RIEUL-PHIEUPH
+FFB0          ; mapped                 ; 111A          # 1.1  HALFWIDTH HANGUL LETTER RIEUL-HIEUH
+FFB1          ; mapped                 ; 1106          # 1.1  HALFWIDTH HANGUL LETTER MIEUM
+FFB2          ; mapped                 ; 1107          # 1.1  HALFWIDTH HANGUL LETTER PIEUP
+FFB3          ; mapped                 ; 1108          # 1.1  HALFWIDTH HANGUL LETTER SSANGPIEUP
+FFB4          ; mapped                 ; 1121          # 1.1  HALFWIDTH HANGUL LETTER PIEUP-SIOS
+FFB5          ; mapped                 ; 1109          # 1.1  HALFWIDTH HANGUL LETTER SIOS
+FFB6          ; mapped                 ; 110A          # 1.1  HALFWIDTH HANGUL LETTER SSANGSIOS
+FFB7          ; mapped                 ; 110B          # 1.1  HALFWIDTH HANGUL LETTER IEUNG
+FFB8          ; mapped                 ; 110C          # 1.1  HALFWIDTH HANGUL LETTER CIEUC
+FFB9          ; mapped                 ; 110D          # 1.1  HALFWIDTH HANGUL LETTER SSANGCIEUC
+FFBA          ; mapped                 ; 110E          # 1.1  HALFWIDTH HANGUL LETTER CHIEUCH
+FFBB          ; mapped                 ; 110F          # 1.1  HALFWIDTH HANGUL LETTER KHIEUKH
+FFBC          ; mapped                 ; 1110          # 1.1  HALFWIDTH HANGUL LETTER THIEUTH
+FFBD          ; mapped                 ; 1111          # 1.1  HALFWIDTH HANGUL LETTER PHIEUPH
+FFBE          ; mapped                 ; 1112          # 1.1  HALFWIDTH HANGUL LETTER HIEUH
+FFBF..FFC1    ; disallowed                             # NA   <reserved-FFBF>..<reserved-FFC1>
+FFC2          ; mapped                 ; 1161          # 1.1  HALFWIDTH HANGUL LETTER A
+FFC3          ; mapped                 ; 1162          # 1.1  HALFWIDTH HANGUL LETTER AE
+FFC4          ; mapped                 ; 1163          # 1.1  HALFWIDTH HANGUL LETTER YA
+FFC5          ; mapped                 ; 1164          # 1.1  HALFWIDTH HANGUL LETTER YAE
+FFC6          ; mapped                 ; 1165          # 1.1  HALFWIDTH HANGUL LETTER EO
+FFC7          ; mapped                 ; 1166          # 1.1  HALFWIDTH HANGUL LETTER E
+FFC8..FFC9    ; disallowed                             # NA   <reserved-FFC8>..<reserved-FFC9>
+FFCA          ; mapped                 ; 1167          # 1.1  HALFWIDTH HANGUL LETTER YEO
+FFCB          ; mapped                 ; 1168          # 1.1  HALFWIDTH HANGUL LETTER YE
+FFCC          ; mapped                 ; 1169          # 1.1  HALFWIDTH HANGUL LETTER O
+FFCD          ; mapped                 ; 116A          # 1.1  HALFWIDTH HANGUL LETTER WA
+FFCE          ; mapped                 ; 116B          # 1.1  HALFWIDTH HANGUL LETTER WAE
+FFCF          ; mapped                 ; 116C          # 1.1  HALFWIDTH HANGUL LETTER OE
+FFD0..FFD1    ; disallowed                             # NA   <reserved-FFD0>..<reserved-FFD1>
+FFD2          ; mapped                 ; 116D          # 1.1  HALFWIDTH HANGUL LETTER YO
+FFD3          ; mapped                 ; 116E          # 1.1  HALFWIDTH HANGUL LETTER U
+FFD4          ; mapped                 ; 116F          # 1.1  HALFWIDTH HANGUL LETTER WEO
+FFD5          ; mapped                 ; 1170          # 1.1  HALFWIDTH HANGUL LETTER WE
+FFD6          ; mapped                 ; 1171          # 1.1  HALFWIDTH HANGUL LETTER WI
+FFD7          ; mapped                 ; 1172          # 1.1  HALFWIDTH HANGUL LETTER YU
+FFD8..FFD9    ; disallowed                             # NA   <reserved-FFD8>..<reserved-FFD9>
+FFDA          ; mapped                 ; 1173          # 1.1  HALFWIDTH HANGUL LETTER EU
+FFDB          ; mapped                 ; 1174          # 1.1  HALFWIDTH HANGUL LETTER YI
+FFDC          ; mapped                 ; 1175          # 1.1  HALFWIDTH HANGUL LETTER I
+FFDD..FFDF    ; disallowed                             # NA   <reserved-FFDD>..<reserved-FFDF>
+FFE0          ; mapped                 ; 00A2          # 1.1  FULLWIDTH CENT SIGN
+FFE1          ; mapped                 ; 00A3          # 1.1  FULLWIDTH POUND SIGN
+FFE2          ; mapped                 ; 00AC          # 1.1  FULLWIDTH NOT SIGN
+FFE3          ; disallowed_STD3_mapped ; 0020 0304     # 1.1  FULLWIDTH MACRON
+FFE4          ; mapped                 ; 00A6          # 1.1  FULLWIDTH BROKEN BAR
+FFE5          ; mapped                 ; 00A5          # 1.1  FULLWIDTH YEN SIGN
+FFE6          ; mapped                 ; 20A9          # 1.1  FULLWIDTH WON SIGN
+FFE7          ; disallowed                             # NA   <reserved-FFE7>
+FFE8          ; mapped                 ; 2502          # 1.1  HALFWIDTH FORMS LIGHT VERTICAL
+FFE9          ; mapped                 ; 2190          # 1.1  HALFWIDTH LEFTWARDS ARROW
+FFEA          ; mapped                 ; 2191          # 1.1  HALFWIDTH UPWARDS ARROW
+FFEB          ; mapped                 ; 2192          # 1.1  HALFWIDTH RIGHTWARDS ARROW
+FFEC          ; mapped                 ; 2193          # 1.1  HALFWIDTH DOWNWARDS ARROW
+FFED          ; mapped                 ; 25A0          # 1.1  HALFWIDTH BLACK SQUARE
+FFEE          ; mapped                 ; 25CB          # 1.1  HALFWIDTH WHITE CIRCLE
+FFEF..FFF8    ; disallowed                             # NA   <reserved-FFEF>..<reserved-FFF8>
+FFF9..FFFB    ; disallowed                             # 3.0  INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
+FFFC          ; disallowed                             # 2.1  OBJECT REPLACEMENT CHARACTER
+FFFD          ; disallowed                             # 1.1  REPLACEMENT CHARACTER
+FFFE..FFFF    ; disallowed                             # 1.1  <noncharacter-FFFE>..<noncharacter-FFFF>
+10000..1000B  ; valid                                  # 4.0  LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
+1000C         ; disallowed                             # NA   <reserved-1000C>
+1000D..10026  ; valid                                  # 4.0  LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
+10027         ; disallowed                             # NA   <reserved-10027>
+10028..1003A  ; valid                                  # 4.0  LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
+1003B         ; disallowed                             # NA   <reserved-1003B>
+1003C..1003D  ; valid                                  # 4.0  LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
+1003E         ; disallowed                             # NA   <reserved-1003E>
+1003F..1004D  ; valid                                  # 4.0  LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
+1004E..1004F  ; disallowed                             # NA   <reserved-1004E>..<reserved-1004F>
+10050..1005D  ; valid                                  # 4.0  LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
+1005E..1007F  ; disallowed                             # NA   <reserved-1005E>..<reserved-1007F>
+10080..100FA  ; valid                                  # 4.0  LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
+100FB..100FF  ; disallowed                             # NA   <reserved-100FB>..<reserved-100FF>
+10100..10102  ; valid                  ;      ; NV8    # 4.0  AEGEAN WORD SEPARATOR LINE..AEGEAN CHECK MARK
+10103..10106  ; disallowed                             # NA   <reserved-10103>..<reserved-10106>
+10107..10133  ; valid                  ;      ; NV8    # 4.0  AEGEAN NUMBER ONE..AEGEAN NUMBER NINETY THOUSAND
+10134..10136  ; disallowed                             # NA   <reserved-10134>..<reserved-10136>
+10137..1013F  ; valid                  ;      ; NV8    # 4.0  AEGEAN WEIGHT BASE UNIT..AEGEAN MEASURE THIRD SUBUNIT
+10140..1018A  ; valid                  ;      ; NV8    # 4.1  GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ZERO SIGN
+1018B..1018C  ; valid                  ;      ; NV8    # 7.0  GREEK ONE QUARTER SIGN..GREEK SINUSOID SIGN
+1018D..1018E  ; valid                  ;      ; NV8    # 9.0  GREEK INDICTION SIGN..NOMISMA SIGN
+1018F         ; disallowed                             # NA   <reserved-1018F>
+10190..1019B  ; valid                  ;      ; NV8    # 5.1  ROMAN SEXTANS SIGN..ROMAN CENTURIAL SIGN
+1019C         ; valid                  ;      ; NV8    # 13.0 ASCIA SYMBOL
+1019D..1019F  ; disallowed                             # NA   <reserved-1019D>..<reserved-1019F>
+101A0         ; valid                  ;      ; NV8    # 7.0  GREEK SYMBOL TAU RHO
+101A1..101CF  ; disallowed                             # NA   <reserved-101A1>..<reserved-101CF>
+101D0..101FC  ; valid                  ;      ; NV8    # 5.1  PHAISTOS DISC SIGN PEDESTRIAN..PHAISTOS DISC SIGN WAVY BAND
+101FD         ; valid                                  # 5.1  PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
+101FE..1027F  ; disallowed                             # NA   <reserved-101FE>..<reserved-1027F>
+10280..1029C  ; valid                                  # 5.1  LYCIAN LETTER A..LYCIAN LETTER X
+1029D..1029F  ; disallowed                             # NA   <reserved-1029D>..<reserved-1029F>
+102A0..102D0  ; valid                                  # 5.1  CARIAN LETTER A..CARIAN LETTER UUU3
+102D1..102DF  ; disallowed                             # NA   <reserved-102D1>..<reserved-102DF>
+102E0         ; valid                                  # 7.0  COPTIC EPACT THOUSANDS MARK
+102E1..102FB  ; valid                  ;      ; NV8    # 7.0  COPTIC EPACT DIGIT ONE..COPTIC EPACT NUMBER NINE HUNDRED
+102FC..102FF  ; disallowed                             # NA   <reserved-102FC>..<reserved-102FF>
+10300..1031E  ; valid                                  # 3.1  OLD ITALIC LETTER A..OLD ITALIC LETTER UU
+1031F         ; valid                                  # 7.0  OLD ITALIC LETTER ESS
+10320..10323  ; valid                  ;      ; NV8    # 3.1  OLD ITALIC NUMERAL ONE..OLD ITALIC NUMERAL FIFTY
+10324..1032C  ; disallowed                             # NA   <reserved-10324>..<reserved-1032C>
+1032D..1032F  ; valid                                  # 10.0 OLD ITALIC LETTER YE..OLD ITALIC LETTER SOUTHERN TSE
+10330..10340  ; valid                                  # 3.1  GOTHIC LETTER AHSA..GOTHIC LETTER PAIRTHRA
+10341         ; valid                  ;      ; NV8    # 3.1  GOTHIC LETTER NINETY
+10342..10349  ; valid                                  # 3.1  GOTHIC LETTER RAIDA..GOTHIC LETTER OTHAL
+1034A         ; valid                  ;      ; NV8    # 3.1  GOTHIC LETTER NINE HUNDRED
+1034B..1034F  ; disallowed                             # NA   <reserved-1034B>..<reserved-1034F>
+10350..1037A  ; valid                                  # 7.0  OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
+1037B..1037F  ; disallowed                             # NA   <reserved-1037B>..<reserved-1037F>
+10380..1039D  ; valid                                  # 4.0  UGARITIC LETTER ALPA..UGARITIC LETTER SSU
+1039E         ; disallowed                             # NA   <reserved-1039E>
+1039F         ; valid                  ;      ; NV8    # 4.0  UGARITIC WORD DIVIDER
+103A0..103C3  ; valid                                  # 4.1  OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
+103C4..103C7  ; disallowed                             # NA   <reserved-103C4>..<reserved-103C7>
+103C8..103CF  ; valid                                  # 4.1  OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
+103D0..103D5  ; valid                  ;      ; NV8    # 4.1  OLD PERSIAN WORD DIVIDER..OLD PERSIAN NUMBER HUNDRED
+103D6..103FF  ; disallowed                             # NA   <reserved-103D6>..<reserved-103FF>
+10400         ; mapped                 ; 10428         # 3.1  DESERET CAPITAL LETTER LONG I
+10401         ; mapped                 ; 10429         # 3.1  DESERET CAPITAL LETTER LONG E
+10402         ; mapped                 ; 1042A         # 3.1  DESERET CAPITAL LETTER LONG A
+10403         ; mapped                 ; 1042B         # 3.1  DESERET CAPITAL LETTER LONG AH
+10404         ; mapped                 ; 1042C         # 3.1  DESERET CAPITAL LETTER LONG O
+10405         ; mapped                 ; 1042D         # 3.1  DESERET CAPITAL LETTER LONG OO
+10406         ; mapped                 ; 1042E         # 3.1  DESERET CAPITAL LETTER SHORT I
+10407         ; mapped                 ; 1042F         # 3.1  DESERET CAPITAL LETTER SHORT E
+10408         ; mapped                 ; 10430         # 3.1  DESERET CAPITAL LETTER SHORT A
+10409         ; mapped                 ; 10431         # 3.1  DESERET CAPITAL LETTER SHORT AH
+1040A         ; mapped                 ; 10432         # 3.1  DESERET CAPITAL LETTER SHORT O
+1040B         ; mapped                 ; 10433         # 3.1  DESERET CAPITAL LETTER SHORT OO
+1040C         ; mapped                 ; 10434         # 3.1  DESERET CAPITAL LETTER AY
+1040D         ; mapped                 ; 10435         # 3.1  DESERET CAPITAL LETTER OW
+1040E         ; mapped                 ; 10436         # 3.1  DESERET CAPITAL LETTER WU
+1040F         ; mapped                 ; 10437         # 3.1  DESERET CAPITAL LETTER YEE
+10410         ; mapped                 ; 10438         # 3.1  DESERET CAPITAL LETTER H
+10411         ; mapped                 ; 10439         # 3.1  DESERET CAPITAL LETTER PEE
+10412         ; mapped                 ; 1043A         # 3.1  DESERET CAPITAL LETTER BEE
+10413         ; mapped                 ; 1043B         # 3.1  DESERET CAPITAL LETTER TEE
+10414         ; mapped                 ; 1043C         # 3.1  DESERET CAPITAL LETTER DEE
+10415         ; mapped                 ; 1043D         # 3.1  DESERET CAPITAL LETTER CHEE
+10416         ; mapped                 ; 1043E         # 3.1  DESERET CAPITAL LETTER JEE
+10417         ; mapped                 ; 1043F         # 3.1  DESERET CAPITAL LETTER KAY
+10418         ; mapped                 ; 10440         # 3.1  DESERET CAPITAL LETTER GAY
+10419         ; mapped                 ; 10441         # 3.1  DESERET CAPITAL LETTER EF
+1041A         ; mapped                 ; 10442         # 3.1  DESERET CAPITAL LETTER VEE
+1041B         ; mapped                 ; 10443         # 3.1  DESERET CAPITAL LETTER ETH
+1041C         ; mapped                 ; 10444         # 3.1  DESERET CAPITAL LETTER THEE
+1041D         ; mapped                 ; 10445         # 3.1  DESERET CAPITAL LETTER ES
+1041E         ; mapped                 ; 10446         # 3.1  DESERET CAPITAL LETTER ZEE
+1041F         ; mapped                 ; 10447         # 3.1  DESERET CAPITAL LETTER ESH
+10420         ; mapped                 ; 10448         # 3.1  DESERET CAPITAL LETTER ZHEE
+10421         ; mapped                 ; 10449         # 3.1  DESERET CAPITAL LETTER ER
+10422         ; mapped                 ; 1044A         # 3.1  DESERET CAPITAL LETTER EL
+10423         ; mapped                 ; 1044B         # 3.1  DESERET CAPITAL LETTER EM
+10424         ; mapped                 ; 1044C         # 3.1  DESERET CAPITAL LETTER EN
+10425         ; mapped                 ; 1044D         # 3.1  DESERET CAPITAL LETTER ENG
+10426         ; mapped                 ; 1044E         # 4.0  DESERET CAPITAL LETTER OI
+10427         ; mapped                 ; 1044F         # 4.0  DESERET CAPITAL LETTER EW
+10428..1044D  ; valid                                  # 3.1  DESERET SMALL LETTER LONG I..DESERET SMALL LETTER ENG
+1044E..1049D  ; valid                                  # 4.0  DESERET SMALL LETTER OI..OSMANYA LETTER OO
+1049E..1049F  ; disallowed                             # NA   <reserved-1049E>..<reserved-1049F>
+104A0..104A9  ; valid                                  # 4.0  OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
+104AA..104AF  ; disallowed                             # NA   <reserved-104AA>..<reserved-104AF>
+104B0         ; mapped                 ; 104D8         # 9.0  OSAGE CAPITAL LETTER A
+104B1         ; mapped                 ; 104D9         # 9.0  OSAGE CAPITAL LETTER AI
+104B2         ; mapped                 ; 104DA         # 9.0  OSAGE CAPITAL LETTER AIN
+104B3         ; mapped                 ; 104DB         # 9.0  OSAGE CAPITAL LETTER AH
+104B4         ; mapped                 ; 104DC         # 9.0  OSAGE CAPITAL LETTER BRA
+104B5         ; mapped                 ; 104DD         # 9.0  OSAGE CAPITAL LETTER CHA
+104B6         ; mapped                 ; 104DE         # 9.0  OSAGE CAPITAL LETTER EHCHA
+104B7         ; mapped                 ; 104DF         # 9.0  OSAGE CAPITAL LETTER E
+104B8         ; mapped                 ; 104E0         # 9.0  OSAGE CAPITAL LETTER EIN
+104B9         ; mapped                 ; 104E1         # 9.0  OSAGE CAPITAL LETTER HA
+104BA         ; mapped                 ; 104E2         # 9.0  OSAGE CAPITAL LETTER HYA
+104BB         ; mapped                 ; 104E3         # 9.0  OSAGE CAPITAL LETTER I
+104BC         ; mapped                 ; 104E4         # 9.0  OSAGE CAPITAL LETTER KA
+104BD         ; mapped                 ; 104E5         # 9.0  OSAGE CAPITAL LETTER EHKA
+104BE         ; mapped                 ; 104E6         # 9.0  OSAGE CAPITAL LETTER KYA
+104BF         ; mapped                 ; 104E7         # 9.0  OSAGE CAPITAL LETTER LA
+104C0         ; mapped                 ; 104E8         # 9.0  OSAGE CAPITAL LETTER MA
+104C1         ; mapped                 ; 104E9         # 9.0  OSAGE CAPITAL LETTER NA
+104C2         ; mapped                 ; 104EA         # 9.0  OSAGE CAPITAL LETTER O
+104C3         ; mapped                 ; 104EB         # 9.0  OSAGE CAPITAL LETTER OIN
+104C4         ; mapped                 ; 104EC         # 9.0  OSAGE CAPITAL LETTER PA
+104C5         ; mapped                 ; 104ED         # 9.0  OSAGE CAPITAL LETTER EHPA
+104C6         ; mapped                 ; 104EE         # 9.0  OSAGE CAPITAL LETTER SA
+104C7         ; mapped                 ; 104EF         # 9.0  OSAGE CAPITAL LETTER SHA
+104C8         ; mapped                 ; 104F0         # 9.0  OSAGE CAPITAL LETTER TA
+104C9         ; mapped                 ; 104F1         # 9.0  OSAGE CAPITAL LETTER EHTA
+104CA         ; mapped                 ; 104F2         # 9.0  OSAGE CAPITAL LETTER TSA
+104CB         ; mapped                 ; 104F3         # 9.0  OSAGE CAPITAL LETTER EHTSA
+104CC         ; mapped                 ; 104F4         # 9.0  OSAGE CAPITAL LETTER TSHA
+104CD         ; mapped                 ; 104F5         # 9.0  OSAGE CAPITAL LETTER DHA
+104CE         ; mapped                 ; 104F6         # 9.0  OSAGE CAPITAL LETTER U
+104CF         ; mapped                 ; 104F7         # 9.0  OSAGE CAPITAL LETTER WA
+104D0         ; mapped                 ; 104F8         # 9.0  OSAGE CAPITAL LETTER KHA
+104D1         ; mapped                 ; 104F9         # 9.0  OSAGE CAPITAL LETTER GHA
+104D2         ; mapped                 ; 104FA         # 9.0  OSAGE CAPITAL LETTER ZA
+104D3         ; mapped                 ; 104FB         # 9.0  OSAGE CAPITAL LETTER ZHA
+104D4..104D7  ; disallowed                             # NA   <reserved-104D4>..<reserved-104D7>
+104D8..104FB  ; valid                                  # 9.0  OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
+104FC..104FF  ; disallowed                             # NA   <reserved-104FC>..<reserved-104FF>
+10500..10527  ; valid                                  # 7.0  ELBASAN LETTER A..ELBASAN LETTER KHE
+10528..1052F  ; disallowed                             # NA   <reserved-10528>..<reserved-1052F>
+10530..10563  ; valid                                  # 7.0  CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
+10564..1056E  ; disallowed                             # NA   <reserved-10564>..<reserved-1056E>
+1056F         ; valid                  ;      ; NV8    # 7.0  CAUCASIAN ALBANIAN CITATION MARK
+10570         ; mapped                 ; 10597         # 14.0 VITHKUQI CAPITAL LETTER A
+10571         ; mapped                 ; 10598         # 14.0 VITHKUQI CAPITAL LETTER BBE
+10572         ; mapped                 ; 10599         # 14.0 VITHKUQI CAPITAL LETTER BE
+10573         ; mapped                 ; 1059A         # 14.0 VITHKUQI CAPITAL LETTER CE
+10574         ; mapped                 ; 1059B         # 14.0 VITHKUQI CAPITAL LETTER CHE
+10575         ; mapped                 ; 1059C         # 14.0 VITHKUQI CAPITAL LETTER DE
+10576         ; mapped                 ; 1059D         # 14.0 VITHKUQI CAPITAL LETTER DHE
+10577         ; mapped                 ; 1059E         # 14.0 VITHKUQI CAPITAL LETTER EI
+10578         ; mapped                 ; 1059F         # 14.0 VITHKUQI CAPITAL LETTER E
+10579         ; mapped                 ; 105A0         # 14.0 VITHKUQI CAPITAL LETTER FE
+1057A         ; mapped                 ; 105A1         # 14.0 VITHKUQI CAPITAL LETTER GA
+1057B         ; disallowed                             # NA   <reserved-1057B>
+1057C         ; mapped                 ; 105A3         # 14.0 VITHKUQI CAPITAL LETTER HA
+1057D         ; mapped                 ; 105A4         # 14.0 VITHKUQI CAPITAL LETTER HHA
+1057E         ; mapped                 ; 105A5         # 14.0 VITHKUQI CAPITAL LETTER I
+1057F         ; mapped                 ; 105A6         # 14.0 VITHKUQI CAPITAL LETTER IJE
+10580         ; mapped                 ; 105A7         # 14.0 VITHKUQI CAPITAL LETTER JE
+10581         ; mapped                 ; 105A8         # 14.0 VITHKUQI CAPITAL LETTER KA
+10582         ; mapped                 ; 105A9         # 14.0 VITHKUQI CAPITAL LETTER LA
+10583         ; mapped                 ; 105AA         # 14.0 VITHKUQI CAPITAL LETTER LLA
+10584         ; mapped                 ; 105AB         # 14.0 VITHKUQI CAPITAL LETTER ME
+10585         ; mapped                 ; 105AC         # 14.0 VITHKUQI CAPITAL LETTER NE
+10586         ; mapped                 ; 105AD         # 14.0 VITHKUQI CAPITAL LETTER NJE
+10587         ; mapped                 ; 105AE         # 14.0 VITHKUQI CAPITAL LETTER O
+10588         ; mapped                 ; 105AF         # 14.0 VITHKUQI CAPITAL LETTER PE
+10589         ; mapped                 ; 105B0         # 14.0 VITHKUQI CAPITAL LETTER QA
+1058A         ; mapped                 ; 105B1         # 14.0 VITHKUQI CAPITAL LETTER RE
+1058B         ; disallowed                             # NA   <reserved-1058B>
+1058C         ; mapped                 ; 105B3         # 14.0 VITHKUQI CAPITAL LETTER SE
+1058D         ; mapped                 ; 105B4         # 14.0 VITHKUQI CAPITAL LETTER SHE
+1058E         ; mapped                 ; 105B5         # 14.0 VITHKUQI CAPITAL LETTER TE
+1058F         ; mapped                 ; 105B6         # 14.0 VITHKUQI CAPITAL LETTER THE
+10590         ; mapped                 ; 105B7         # 14.0 VITHKUQI CAPITAL LETTER U
+10591         ; mapped                 ; 105B8         # 14.0 VITHKUQI CAPITAL LETTER VE
+10592         ; mapped                 ; 105B9         # 14.0 VITHKUQI CAPITAL LETTER XE
+10593         ; disallowed                             # NA   <reserved-10593>
+10594         ; mapped                 ; 105BB         # 14.0 VITHKUQI CAPITAL LETTER Y
+10595         ; mapped                 ; 105BC         # 14.0 VITHKUQI CAPITAL LETTER ZE
+10596         ; disallowed                             # NA   <reserved-10596>
+10597..105A1  ; valid                                  # 14.0 VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
+105A2         ; disallowed                             # NA   <reserved-105A2>
+105A3..105B1  ; valid                                  # 14.0 VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
+105B2         ; disallowed                             # NA   <reserved-105B2>
+105B3..105B9  ; valid                                  # 14.0 VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
+105BA         ; disallowed                             # NA   <reserved-105BA>
+105BB..105BC  ; valid                                  # 14.0 VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
+105BD..105FF  ; disallowed                             # NA   <reserved-105BD>..<reserved-105FF>
+10600..10736  ; valid                                  # 7.0  LINEAR A SIGN AB001..LINEAR A SIGN A664
+10737..1073F  ; disallowed                             # NA   <reserved-10737>..<reserved-1073F>
+10740..10755  ; valid                                  # 7.0  LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
+10756..1075F  ; disallowed                             # NA   <reserved-10756>..<reserved-1075F>
+10760..10767  ; valid                                  # 7.0  LINEAR A SIGN A800..LINEAR A SIGN A807
+10768..1077F  ; disallowed                             # NA   <reserved-10768>..<reserved-1077F>
+10780         ; valid                                  # 14.0 MODIFIER LETTER SMALL CAPITAL AA
+10781         ; mapped                 ; 02D0          # 14.0 MODIFIER LETTER SUPERSCRIPT TRIANGULAR COLON
+10782         ; mapped                 ; 02D1          # 14.0 MODIFIER LETTER SUPERSCRIPT HALF TRIANGULAR COLON
+10783         ; mapped                 ; 00E6          # 14.0 MODIFIER LETTER SMALL AE
+10784         ; mapped                 ; 0299          # 14.0 MODIFIER LETTER SMALL CAPITAL B
+10785         ; mapped                 ; 0253          # 14.0 MODIFIER LETTER SMALL B WITH HOOK
+10786         ; disallowed                             # NA   <reserved-10786>
+10787         ; mapped                 ; 02A3          # 14.0 MODIFIER LETTER SMALL DZ DIGRAPH
+10788         ; mapped                 ; AB66          # 14.0 MODIFIER LETTER SMALL DZ DIGRAPH WITH RETROFLEX HOOK
+10789         ; mapped                 ; 02A5          # 14.0 MODIFIER LETTER SMALL DZ DIGRAPH WITH CURL
+1078A         ; mapped                 ; 02A4          # 14.0 MODIFIER LETTER SMALL DEZH DIGRAPH
+1078B         ; mapped                 ; 0256          # 14.0 MODIFIER LETTER SMALL D WITH TAIL
+1078C         ; mapped                 ; 0257          # 14.0 MODIFIER LETTER SMALL D WITH HOOK
+1078D         ; mapped                 ; 1D91          # 14.0 MODIFIER LETTER SMALL D WITH HOOK AND TAIL
+1078E         ; mapped                 ; 0258          # 14.0 MODIFIER LETTER SMALL REVERSED E
+1078F         ; mapped                 ; 025E          # 14.0 MODIFIER LETTER SMALL CLOSED REVERSED OPEN E
+10790         ; mapped                 ; 02A9          # 14.0 MODIFIER LETTER SMALL FENG DIGRAPH
+10791         ; mapped                 ; 0264          # 14.0 MODIFIER LETTER SMALL RAMS HORN
+10792         ; mapped                 ; 0262          # 14.0 MODIFIER LETTER SMALL CAPITAL G
+10793         ; mapped                 ; 0260          # 14.0 MODIFIER LETTER SMALL G WITH HOOK
+10794         ; mapped                 ; 029B          # 14.0 MODIFIER LETTER SMALL CAPITAL G WITH HOOK
+10795         ; mapped                 ; 0127          # 14.0 MODIFIER LETTER SMALL H WITH STROKE
+10796         ; mapped                 ; 029C          # 14.0 MODIFIER LETTER SMALL CAPITAL H
+10797         ; mapped                 ; 0267          # 14.0 MODIFIER LETTER SMALL HENG WITH HOOK
+10798         ; mapped                 ; 0284          # 14.0 MODIFIER LETTER SMALL DOTLESS J WITH STROKE AND HOOK
+10799         ; mapped                 ; 02AA          # 14.0 MODIFIER LETTER SMALL LS DIGRAPH
+1079A         ; mapped                 ; 02AB          # 14.0 MODIFIER LETTER SMALL LZ DIGRAPH
+1079B         ; mapped                 ; 026C          # 14.0 MODIFIER LETTER SMALL L WITH BELT
+1079C         ; mapped                 ; 1DF04         # 14.0 MODIFIER LETTER SMALL CAPITAL L WITH BELT
+1079D         ; mapped                 ; A78E          # 14.0 MODIFIER LETTER SMALL L WITH RETROFLEX HOOK AND BELT
+1079E         ; mapped                 ; 026E          # 14.0 MODIFIER LETTER SMALL LEZH
+1079F         ; mapped                 ; 1DF05         # 14.0 MODIFIER LETTER SMALL LEZH WITH RETROFLEX HOOK
+107A0         ; mapped                 ; 028E          # 14.0 MODIFIER LETTER SMALL TURNED Y
+107A1         ; mapped                 ; 1DF06         # 14.0 MODIFIER LETTER SMALL TURNED Y WITH BELT
+107A2         ; mapped                 ; 00F8          # 14.0 MODIFIER LETTER SMALL O WITH STROKE
+107A3         ; mapped                 ; 0276          # 14.0 MODIFIER LETTER SMALL CAPITAL OE
+107A4         ; mapped                 ; 0277          # 14.0 MODIFIER LETTER SMALL CLOSED OMEGA
+107A5         ; mapped                 ; 0071          # 14.0 MODIFIER LETTER SMALL Q
+107A6         ; mapped                 ; 027A          # 14.0 MODIFIER LETTER SMALL TURNED R WITH LONG LEG
+107A7         ; mapped                 ; 1DF08         # 14.0 MODIFIER LETTER SMALL TURNED R WITH LONG LEG AND RETROFLEX HOOK
+107A8         ; mapped                 ; 027D          # 14.0 MODIFIER LETTER SMALL R WITH TAIL
+107A9         ; mapped                 ; 027E          # 14.0 MODIFIER LETTER SMALL R WITH FISHHOOK
+107AA         ; mapped                 ; 0280          # 14.0 MODIFIER LETTER SMALL CAPITAL R
+107AB         ; mapped                 ; 02A8          # 14.0 MODIFIER LETTER SMALL TC DIGRAPH WITH CURL
+107AC         ; mapped                 ; 02A6          # 14.0 MODIFIER LETTER SMALL TS DIGRAPH
+107AD         ; mapped                 ; AB67          # 14.0 MODIFIER LETTER SMALL TS DIGRAPH WITH RETROFLEX HOOK
+107AE         ; mapped                 ; 02A7          # 14.0 MODIFIER LETTER SMALL TESH DIGRAPH
+107AF         ; mapped                 ; 0288          # 14.0 MODIFIER LETTER SMALL T WITH RETROFLEX HOOK
+107B0         ; mapped                 ; 2C71          # 14.0 MODIFIER LETTER SMALL V WITH RIGHT HOOK
+107B1         ; disallowed                             # NA   <reserved-107B1>
+107B2         ; mapped                 ; 028F          # 14.0 MODIFIER LETTER SMALL CAPITAL Y
+107B3         ; mapped                 ; 02A1          # 14.0 MODIFIER LETTER GLOTTAL STOP WITH STROKE
+107B4         ; mapped                 ; 02A2          # 14.0 MODIFIER LETTER REVERSED GLOTTAL STOP WITH STROKE
+107B5         ; mapped                 ; 0298          # 14.0 MODIFIER LETTER BILABIAL CLICK
+107B6         ; mapped                 ; 01C0          # 14.0 MODIFIER LETTER DENTAL CLICK
+107B7         ; mapped                 ; 01C1          # 14.0 MODIFIER LETTER LATERAL CLICK
+107B8         ; mapped                 ; 01C2          # 14.0 MODIFIER LETTER ALVEOLAR CLICK
+107B9         ; mapped                 ; 1DF0A         # 14.0 MODIFIER LETTER RETROFLEX CLICK WITH RETROFLEX HOOK
+107BA         ; mapped                 ; 1DF1E         # 14.0 MODIFIER LETTER SMALL S WITH CURL
+107BB..107FF  ; disallowed                             # NA   <reserved-107BB>..<reserved-107FF>
+10800..10805  ; valid                                  # 4.0  CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
+10806..10807  ; disallowed                             # NA   <reserved-10806>..<reserved-10807>
+10808         ; valid                                  # 4.0  CYPRIOT SYLLABLE JO
+10809         ; disallowed                             # NA   <reserved-10809>
+1080A..10835  ; valid                                  # 4.0  CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
+10836         ; disallowed                             # NA   <reserved-10836>
+10837..10838  ; valid                                  # 4.0  CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
+10839..1083B  ; disallowed                             # NA   <reserved-10839>..<reserved-1083B>
+1083C         ; valid                                  # 4.0  CYPRIOT SYLLABLE ZA
+1083D..1083E  ; disallowed                             # NA   <reserved-1083D>..<reserved-1083E>
+1083F         ; valid                                  # 4.0  CYPRIOT SYLLABLE ZO
+10840..10855  ; valid                                  # 5.2  IMPERIAL ARAMAIC LETTER ALEPH..IMPERIAL ARAMAIC LETTER TAW
+10856         ; disallowed                             # NA   <reserved-10856>
+10857..1085F  ; valid                  ;      ; NV8    # 5.2  IMPERIAL ARAMAIC SECTION SIGN..IMPERIAL ARAMAIC NUMBER TEN THOUSAND
+10860..10876  ; valid                                  # 7.0  PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
+10877..1087F  ; valid                  ;      ; NV8    # 7.0  PALMYRENE LEFT-POINTING FLEURON..PALMYRENE NUMBER TWENTY
+10880..1089E  ; valid                                  # 7.0  NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
+1089F..108A6  ; disallowed                             # NA   <reserved-1089F>..<reserved-108A6>
+108A7..108AF  ; valid                  ;      ; NV8    # 7.0  NABATAEAN NUMBER ONE..NABATAEAN NUMBER ONE HUNDRED
+108B0..108DF  ; disallowed                             # NA   <reserved-108B0>..<reserved-108DF>
+108E0..108F2  ; valid                                  # 8.0  HATRAN LETTER ALEPH..HATRAN LETTER QOPH
+108F3         ; disallowed                             # NA   <reserved-108F3>
+108F4..108F5  ; valid                                  # 8.0  HATRAN LETTER SHIN..HATRAN LETTER TAW
+108F6..108FA  ; disallowed                             # NA   <reserved-108F6>..<reserved-108FA>
+108FB..108FF  ; valid                  ;      ; NV8    # 8.0  HATRAN NUMBER ONE..HATRAN NUMBER ONE HUNDRED
+10900..10915  ; valid                                  # 5.0  PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
+10916..10919  ; valid                  ;      ; NV8    # 5.0  PHOENICIAN NUMBER ONE..PHOENICIAN NUMBER ONE HUNDRED
+1091A..1091B  ; valid                  ;      ; NV8    # 5.2  PHOENICIAN NUMBER TWO..PHOENICIAN NUMBER THREE
+1091C..1091E  ; disallowed                             # NA   <reserved-1091C>..<reserved-1091E>
+1091F         ; valid                  ;      ; NV8    # 5.0  PHOENICIAN WORD SEPARATOR
+10920..10939  ; valid                                  # 5.1  LYDIAN LETTER A..LYDIAN LETTER C
+1093A..1093E  ; disallowed                             # NA   <reserved-1093A>..<reserved-1093E>
+1093F         ; valid                  ;      ; NV8    # 5.1  LYDIAN TRIANGULAR MARK
+10940..1097F  ; disallowed                             # NA   <reserved-10940>..<reserved-1097F>
+10980..109B7  ; valid                                  # 6.1  MEROITIC HIEROGLYPHIC LETTER A..MEROITIC CURSIVE LETTER DA
+109B8..109BB  ; disallowed                             # NA   <reserved-109B8>..<reserved-109BB>
+109BC..109BD  ; valid                  ;      ; NV8    # 8.0  MEROITIC CURSIVE FRACTION ELEVEN TWELFTHS..MEROITIC CURSIVE FRACTION ONE HALF
+109BE..109BF  ; valid                                  # 6.1  MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
+109C0..109CF  ; valid                  ;      ; NV8    # 8.0  MEROITIC CURSIVE NUMBER ONE..MEROITIC CURSIVE NUMBER SEVENTY
+109D0..109D1  ; disallowed                             # NA   <reserved-109D0>..<reserved-109D1>
+109D2..109FF  ; valid                  ;      ; NV8    # 8.0  MEROITIC CURSIVE NUMBER ONE HUNDRED..MEROITIC CURSIVE FRACTION TEN TWELFTHS
+10A00..10A03  ; valid                                  # 4.1  KHAROSHTHI LETTER A..KHAROSHTHI VOWEL SIGN VOCALIC R
+10A04         ; disallowed                             # NA   <reserved-10A04>
+10A05..10A06  ; valid                                  # 4.1  KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
+10A07..10A0B  ; disallowed                             # NA   <reserved-10A07>..<reserved-10A0B>
+10A0C..10A13  ; valid                                  # 4.1  KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI LETTER GHA
+10A14         ; disallowed                             # NA   <reserved-10A14>
+10A15..10A17  ; valid                                  # 4.1  KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
+10A18         ; disallowed                             # NA   <reserved-10A18>
+10A19..10A33  ; valid                                  # 4.1  KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER TTTHA
+10A34..10A35  ; valid                                  # 11.0 KHAROSHTHI LETTER TTTA..KHAROSHTHI LETTER VHA
+10A36..10A37  ; disallowed                             # NA   <reserved-10A36>..<reserved-10A37>
+10A38..10A3A  ; valid                                  # 4.1  KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
+10A3B..10A3E  ; disallowed                             # NA   <reserved-10A3B>..<reserved-10A3E>
+10A3F         ; valid                                  # 4.1  KHAROSHTHI VIRAMA
+10A40..10A47  ; valid                  ;      ; NV8    # 4.1  KHAROSHTHI DIGIT ONE..KHAROSHTHI NUMBER ONE THOUSAND
+10A48         ; valid                  ;      ; NV8    # 11.0 KHAROSHTHI FRACTION ONE HALF
+10A49..10A4F  ; disallowed                             # NA   <reserved-10A49>..<reserved-10A4F>
+10A50..10A58  ; valid                  ;      ; NV8    # 4.1  KHAROSHTHI PUNCTUATION DOT..KHAROSHTHI PUNCTUATION LINES
+10A59..10A5F  ; disallowed                             # NA   <reserved-10A59>..<reserved-10A5F>
+10A60..10A7C  ; valid                                  # 5.2  OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
+10A7D..10A7F  ; valid                  ;      ; NV8    # 5.2  OLD SOUTH ARABIAN NUMBER ONE..OLD SOUTH ARABIAN NUMERIC INDICATOR
+10A80..10A9C  ; valid                                  # 7.0  OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
+10A9D..10A9F  ; valid                  ;      ; NV8    # 7.0  OLD NORTH ARABIAN NUMBER ONE..OLD NORTH ARABIAN NUMBER TWENTY
+10AA0..10ABF  ; disallowed                             # NA   <reserved-10AA0>..<reserved-10ABF>
+10AC0..10AC7  ; valid                                  # 7.0  MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
+10AC8         ; valid                  ;      ; NV8    # 7.0  MANICHAEAN SIGN UD
+10AC9..10AE6  ; valid                                  # 7.0  MANICHAEAN LETTER ZAYIN..MANICHAEAN ABBREVIATION MARK BELOW
+10AE7..10AEA  ; disallowed                             # NA   <reserved-10AE7>..<reserved-10AEA>
+10AEB..10AF6  ; valid                  ;      ; NV8    # 7.0  MANICHAEAN NUMBER ONE..MANICHAEAN PUNCTUATION LINE FILLER
+10AF7..10AFF  ; disallowed                             # NA   <reserved-10AF7>..<reserved-10AFF>
+10B00..10B35  ; valid                                  # 5.2  AVESTAN LETTER A..AVESTAN LETTER HE
+10B36..10B38  ; disallowed                             # NA   <reserved-10B36>..<reserved-10B38>
+10B39..10B3F  ; valid                  ;      ; NV8    # 5.2  AVESTAN ABBREVIATION MARK..LARGE ONE RING OVER TWO RINGS PUNCTUATION
+10B40..10B55  ; valid                                  # 5.2  INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
+10B56..10B57  ; disallowed                             # NA   <reserved-10B56>..<reserved-10B57>
+10B58..10B5F  ; valid                  ;      ; NV8    # 5.2  INSCRIPTIONAL PARTHIAN NUMBER ONE..INSCRIPTIONAL PARTHIAN NUMBER ONE THOUSAND
+10B60..10B72  ; valid                                  # 5.2  INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
+10B73..10B77  ; disallowed                             # NA   <reserved-10B73>..<reserved-10B77>
+10B78..10B7F  ; valid                  ;      ; NV8    # 5.2  INSCRIPTIONAL PAHLAVI NUMBER ONE..INSCRIPTIONAL PAHLAVI NUMBER ONE THOUSAND
+10B80..10B91  ; valid                                  # 7.0  PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
+10B92..10B98  ; disallowed                             # NA   <reserved-10B92>..<reserved-10B98>
+10B99..10B9C  ; valid                  ;      ; NV8    # 7.0  PSALTER PAHLAVI SECTION MARK..PSALTER PAHLAVI FOUR DOTS WITH DOT
+10B9D..10BA8  ; disallowed                             # NA   <reserved-10B9D>..<reserved-10BA8>
+10BA9..10BAF  ; valid                  ;      ; NV8    # 7.0  PSALTER PAHLAVI NUMBER ONE..PSALTER PAHLAVI NUMBER ONE HUNDRED
+10BB0..10BFF  ; disallowed                             # NA   <reserved-10BB0>..<reserved-10BFF>
+10C00..10C48  ; valid                                  # 5.2  OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
+10C49..10C7F  ; disallowed                             # NA   <reserved-10C49>..<reserved-10C7F>
+10C80         ; mapped                 ; 10CC0         # 8.0  OLD HUNGARIAN CAPITAL LETTER A
+10C81         ; mapped                 ; 10CC1         # 8.0  OLD HUNGARIAN CAPITAL LETTER AA
+10C82         ; mapped                 ; 10CC2         # 8.0  OLD HUNGARIAN CAPITAL LETTER EB
+10C83         ; mapped                 ; 10CC3         # 8.0  OLD HUNGARIAN CAPITAL LETTER AMB
+10C84         ; mapped                 ; 10CC4         # 8.0  OLD HUNGARIAN CAPITAL LETTER EC
+10C85         ; mapped                 ; 10CC5         # 8.0  OLD HUNGARIAN CAPITAL LETTER ENC
+10C86         ; mapped                 ; 10CC6         # 8.0  OLD HUNGARIAN CAPITAL LETTER ECS
+10C87         ; mapped                 ; 10CC7         # 8.0  OLD HUNGARIAN CAPITAL LETTER ED
+10C88         ; mapped                 ; 10CC8         # 8.0  OLD HUNGARIAN CAPITAL LETTER AND
+10C89         ; mapped                 ; 10CC9         # 8.0  OLD HUNGARIAN CAPITAL LETTER E
+10C8A         ; mapped                 ; 10CCA         # 8.0  OLD HUNGARIAN CAPITAL LETTER CLOSE E
+10C8B         ; mapped                 ; 10CCB         # 8.0  OLD HUNGARIAN CAPITAL LETTER EE
+10C8C         ; mapped                 ; 10CCC         # 8.0  OLD HUNGARIAN CAPITAL LETTER EF
+10C8D         ; mapped                 ; 10CCD         # 8.0  OLD HUNGARIAN CAPITAL LETTER EG
+10C8E         ; mapped                 ; 10CCE         # 8.0  OLD HUNGARIAN CAPITAL LETTER EGY
+10C8F         ; mapped                 ; 10CCF         # 8.0  OLD HUNGARIAN CAPITAL LETTER EH
+10C90         ; mapped                 ; 10CD0         # 8.0  OLD HUNGARIAN CAPITAL LETTER I
+10C91         ; mapped                 ; 10CD1         # 8.0  OLD HUNGARIAN CAPITAL LETTER II
+10C92         ; mapped                 ; 10CD2         # 8.0  OLD HUNGARIAN CAPITAL LETTER EJ
+10C93         ; mapped                 ; 10CD3         # 8.0  OLD HUNGARIAN CAPITAL LETTER EK
+10C94         ; mapped                 ; 10CD4         # 8.0  OLD HUNGARIAN CAPITAL LETTER AK
+10C95         ; mapped                 ; 10CD5         # 8.0  OLD HUNGARIAN CAPITAL LETTER UNK
+10C96         ; mapped                 ; 10CD6         # 8.0  OLD HUNGARIAN CAPITAL LETTER EL
+10C97         ; mapped                 ; 10CD7         # 8.0  OLD HUNGARIAN CAPITAL LETTER ELY
+10C98         ; mapped                 ; 10CD8         # 8.0  OLD HUNGARIAN CAPITAL LETTER EM
+10C99         ; mapped                 ; 10CD9         # 8.0  OLD HUNGARIAN CAPITAL LETTER EN
+10C9A         ; mapped                 ; 10CDA         # 8.0  OLD HUNGARIAN CAPITAL LETTER ENY
+10C9B         ; mapped                 ; 10CDB         # 8.0  OLD HUNGARIAN CAPITAL LETTER O
+10C9C         ; mapped                 ; 10CDC         # 8.0  OLD HUNGARIAN CAPITAL LETTER OO
+10C9D         ; mapped                 ; 10CDD         # 8.0  OLD HUNGARIAN CAPITAL LETTER NIKOLSBURG OE
+10C9E         ; mapped                 ; 10CDE         # 8.0  OLD HUNGARIAN CAPITAL LETTER RUDIMENTA OE
+10C9F         ; mapped                 ; 10CDF         # 8.0  OLD HUNGARIAN CAPITAL LETTER OEE
+10CA0         ; mapped                 ; 10CE0         # 8.0  OLD HUNGARIAN CAPITAL LETTER EP
+10CA1         ; mapped                 ; 10CE1         # 8.0  OLD HUNGARIAN CAPITAL LETTER EMP
+10CA2         ; mapped                 ; 10CE2         # 8.0  OLD HUNGARIAN CAPITAL LETTER ER
+10CA3         ; mapped                 ; 10CE3         # 8.0  OLD HUNGARIAN CAPITAL LETTER SHORT ER
+10CA4         ; mapped                 ; 10CE4         # 8.0  OLD HUNGARIAN CAPITAL LETTER ES
+10CA5         ; mapped                 ; 10CE5         # 8.0  OLD HUNGARIAN CAPITAL LETTER ESZ
+10CA6         ; mapped                 ; 10CE6         # 8.0  OLD HUNGARIAN CAPITAL LETTER ET
+10CA7         ; mapped                 ; 10CE7         # 8.0  OLD HUNGARIAN CAPITAL LETTER ENT
+10CA8         ; mapped                 ; 10CE8         # 8.0  OLD HUNGARIAN CAPITAL LETTER ETY
+10CA9         ; mapped                 ; 10CE9         # 8.0  OLD HUNGARIAN CAPITAL LETTER ECH
+10CAA         ; mapped                 ; 10CEA         # 8.0  OLD HUNGARIAN CAPITAL LETTER U
+10CAB         ; mapped                 ; 10CEB         # 8.0  OLD HUNGARIAN CAPITAL LETTER UU
+10CAC         ; mapped                 ; 10CEC         # 8.0  OLD HUNGARIAN CAPITAL LETTER NIKOLSBURG UE
+10CAD         ; mapped                 ; 10CED         # 8.0  OLD HUNGARIAN CAPITAL LETTER RUDIMENTA UE
+10CAE         ; mapped                 ; 10CEE         # 8.0  OLD HUNGARIAN CAPITAL LETTER EV
+10CAF         ; mapped                 ; 10CEF         # 8.0  OLD HUNGARIAN CAPITAL LETTER EZ
+10CB0         ; mapped                 ; 10CF0         # 8.0  OLD HUNGARIAN CAPITAL LETTER EZS
+10CB1         ; mapped                 ; 10CF1         # 8.0  OLD HUNGARIAN CAPITAL LETTER ENT-SHAPED SIGN
+10CB2         ; mapped                 ; 10CF2         # 8.0  OLD HUNGARIAN CAPITAL LETTER US
+10CB3..10CBF  ; disallowed                             # NA   <reserved-10CB3>..<reserved-10CBF>
+10CC0..10CF2  ; valid                                  # 8.0  OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
+10CF3..10CF9  ; disallowed                             # NA   <reserved-10CF3>..<reserved-10CF9>
+10CFA..10CFF  ; valid                  ;      ; NV8    # 8.0  OLD HUNGARIAN NUMBER ONE..OLD HUNGARIAN NUMBER ONE THOUSAND
+10D00..10D27  ; valid                                  # 11.0 HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA SIGN TASSI
+10D28..10D2F  ; disallowed                             # NA   <reserved-10D28>..<reserved-10D2F>
+10D30..10D39  ; valid                                  # 11.0 HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
+10D3A..10E5F  ; disallowed                             # NA   <reserved-10D3A>..<reserved-10E5F>
+10E60..10E7E  ; valid                  ;      ; NV8    # 5.2  RUMI DIGIT ONE..RUMI FRACTION TWO THIRDS
+10E7F         ; disallowed                             # NA   <reserved-10E7F>
+10E80..10EA9  ; valid                                  # 13.0 YEZIDI LETTER ELIF..YEZIDI LETTER ET
+10EAA         ; disallowed                             # NA   <reserved-10EAA>
+10EAB..10EAC  ; valid                                  # 13.0 YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
+10EAD         ; valid                  ;      ; NV8    # 13.0 YEZIDI HYPHENATION MARK
+10EAE..10EAF  ; disallowed                             # NA   <reserved-10EAE>..<reserved-10EAF>
+10EB0..10EB1  ; valid                                  # 13.0 YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
+10EB2..10EFC  ; disallowed                             # NA   <reserved-10EB2>..<reserved-10EFC>
+10EFD..10EFF  ; valid                                  # 15.0 ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
+10F00..10F1C  ; valid                                  # 11.0 OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
+10F1D..10F26  ; valid                  ;      ; NV8    # 11.0 OLD SOGDIAN NUMBER ONE..OLD SOGDIAN FRACTION ONE HALF
+10F27         ; valid                                  # 11.0 OLD SOGDIAN LIGATURE AYIN-DALETH
+10F28..10F2F  ; disallowed                             # NA   <reserved-10F28>..<reserved-10F2F>
+10F30..10F50  ; valid                                  # 11.0 SOGDIAN LETTER ALEPH..SOGDIAN COMBINING STROKE BELOW
+10F51..10F59  ; valid                  ;      ; NV8    # 11.0 SOGDIAN NUMBER ONE..SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
+10F5A..10F6F  ; disallowed                             # NA   <reserved-10F5A>..<reserved-10F6F>
+10F70..10F85  ; valid                                  # 14.0 OLD UYGHUR LETTER ALEPH..OLD UYGHUR COMBINING TWO DOTS BELOW
+10F86..10F89  ; valid                  ;      ; NV8    # 14.0 OLD UYGHUR PUNCTUATION BAR..OLD UYGHUR PUNCTUATION FOUR DOTS
+10F8A..10FAF  ; disallowed                             # NA   <reserved-10F8A>..<reserved-10FAF>
+10FB0..10FC4  ; valid                                  # 13.0 CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
+10FC5..10FCB  ; valid                  ;      ; NV8    # 13.0 CHORASMIAN NUMBER ONE..CHORASMIAN NUMBER ONE HUNDRED
+10FCC..10FDF  ; disallowed                             # NA   <reserved-10FCC>..<reserved-10FDF>
+10FE0..10FF6  ; valid                                  # 12.0 ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
+10FF7..10FFF  ; disallowed                             # NA   <reserved-10FF7>..<reserved-10FFF>
+11000..11046  ; valid                                  # 6.0  BRAHMI SIGN CANDRABINDU..BRAHMI VIRAMA
+11047..1104D  ; valid                  ;      ; NV8    # 6.0  BRAHMI DANDA..BRAHMI PUNCTUATION LOTUS
+1104E..11051  ; disallowed                             # NA   <reserved-1104E>..<reserved-11051>
+11052..11065  ; valid                  ;      ; NV8    # 6.0  BRAHMI NUMBER ONE..BRAHMI NUMBER ONE THOUSAND
+11066..1106F  ; valid                                  # 6.0  BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
+11070..11075  ; valid                                  # 14.0 BRAHMI SIGN OLD TAMIL VIRAMA..BRAHMI LETTER OLD TAMIL LLA
+11076..1107E  ; disallowed                             # NA   <reserved-11076>..<reserved-1107E>
+1107F         ; valid                                  # 7.0  BRAHMI NUMBER JOINER
+11080..110BA  ; valid                                  # 5.2  KAITHI SIGN CANDRABINDU..KAITHI SIGN NUKTA
+110BB..110BC  ; valid                  ;      ; NV8    # 5.2  KAITHI ABBREVIATION SIGN..KAITHI ENUMERATION SIGN
+110BD         ; disallowed                             # 5.2  KAITHI NUMBER SIGN
+110BE..110C1  ; valid                  ;      ; NV8    # 5.2  KAITHI SECTION MARK..KAITHI DOUBLE DANDA
+110C2         ; valid                                  # 14.0 KAITHI VOWEL SIGN VOCALIC R
+110C3..110CC  ; disallowed                             # NA   <reserved-110C3>..<reserved-110CC>
+110CD         ; disallowed                             # 11.0 KAITHI NUMBER SIGN ABOVE
+110CE..110CF  ; disallowed                             # NA   <reserved-110CE>..<reserved-110CF>
+110D0..110E8  ; valid                                  # 6.1  SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
+110E9..110EF  ; disallowed                             # NA   <reserved-110E9>..<reserved-110EF>
+110F0..110F9  ; valid                                  # 6.1  SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
+110FA..110FF  ; disallowed                             # NA   <reserved-110FA>..<reserved-110FF>
+11100..11134  ; valid                                  # 6.1  CHAKMA SIGN CANDRABINDU..CHAKMA MAAYYAA
+11135         ; disallowed                             # NA   <reserved-11135>
+11136..1113F  ; valid                                  # 6.1  CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
+11140..11143  ; valid                  ;      ; NV8    # 6.1  CHAKMA SECTION MARK..CHAKMA QUESTION MARK
+11144..11146  ; valid                                  # 11.0 CHAKMA LETTER LHAA..CHAKMA VOWEL SIGN EI
+11147         ; valid                                  # 13.0 CHAKMA LETTER VAA
+11148..1114F  ; disallowed                             # NA   <reserved-11148>..<reserved-1114F>
+11150..11173  ; valid                                  # 7.0  MAHAJANI LETTER A..MAHAJANI SIGN NUKTA
+11174..11175  ; valid                  ;      ; NV8    # 7.0  MAHAJANI ABBREVIATION SIGN..MAHAJANI SECTION MARK
+11176         ; valid                                  # 7.0  MAHAJANI LIGATURE SHRI
+11177..1117F  ; disallowed                             # NA   <reserved-11177>..<reserved-1117F>
+11180..111C4  ; valid                                  # 6.1  SHARADA SIGN CANDRABINDU..SHARADA OM
+111C5..111C8  ; valid                  ;      ; NV8    # 6.1  SHARADA DANDA..SHARADA SEPARATOR
+111C9..111CC  ; valid                                  # 8.0  SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
+111CD         ; valid                  ;      ; NV8    # 7.0  SHARADA SUTRA MARK
+111CE..111CF  ; valid                                  # 13.0 SHARADA VOWEL SIGN PRISHTHAMATRA E..SHARADA SIGN INVERTED CANDRABINDU
+111D0..111D9  ; valid                                  # 6.1  SHARADA DIGIT ZERO..SHARADA DIGIT NINE
+111DA         ; valid                                  # 7.0  SHARADA EKAM
+111DB         ; valid                  ;      ; NV8    # 8.0  SHARADA SIGN SIDDHAM
+111DC         ; valid                                  # 8.0  SHARADA HEADSTROKE
+111DD..111DF  ; valid                  ;      ; NV8    # 8.0  SHARADA CONTINUATION SIGN..SHARADA SECTION MARK-2
+111E0         ; disallowed                             # NA   <reserved-111E0>
+111E1..111F4  ; valid                  ;      ; NV8    # 7.0  SINHALA ARCHAIC DIGIT ONE..SINHALA ARCHAIC NUMBER ONE THOUSAND
+111F5..111FF  ; disallowed                             # NA   <reserved-111F5>..<reserved-111FF>
+11200..11211  ; valid                                  # 7.0  KHOJKI LETTER A..KHOJKI LETTER JJA
+11212         ; disallowed                             # NA   <reserved-11212>
+11213..11237  ; valid                                  # 7.0  KHOJKI LETTER NYA..KHOJKI SIGN SHADDA
+11238..1123D  ; valid                  ;      ; NV8    # 7.0  KHOJKI DANDA..KHOJKI ABBREVIATION SIGN
+1123E         ; valid                                  # 9.0  KHOJKI SIGN SUKUN
+1123F..11241  ; valid                                  # 15.0 KHOJKI LETTER QA..KHOJKI VOWEL SIGN VOCALIC R
+11242..1127F  ; disallowed                             # NA   <reserved-11242>..<reserved-1127F>
+11280..11286  ; valid                                  # 8.0  MULTANI LETTER A..MULTANI LETTER GA
+11287         ; disallowed                             # NA   <reserved-11287>
+11288         ; valid                                  # 8.0  MULTANI LETTER GHA
+11289         ; disallowed                             # NA   <reserved-11289>
+1128A..1128D  ; valid                                  # 8.0  MULTANI LETTER CA..MULTANI LETTER JJA
+1128E         ; disallowed                             # NA   <reserved-1128E>
+1128F..1129D  ; valid                                  # 8.0  MULTANI LETTER NYA..MULTANI LETTER BA
+1129E         ; disallowed                             # NA   <reserved-1129E>
+1129F..112A8  ; valid                                  # 8.0  MULTANI LETTER BHA..MULTANI LETTER RHA
+112A9         ; valid                  ;      ; NV8    # 8.0  MULTANI SECTION MARK
+112AA..112AF  ; disallowed                             # NA   <reserved-112AA>..<reserved-112AF>
+112B0..112EA  ; valid                                  # 7.0  KHUDAWADI LETTER A..KHUDAWADI SIGN VIRAMA
+112EB..112EF  ; disallowed                             # NA   <reserved-112EB>..<reserved-112EF>
+112F0..112F9  ; valid                                  # 7.0  KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
+112FA..112FF  ; disallowed                             # NA   <reserved-112FA>..<reserved-112FF>
+11300         ; valid                                  # 8.0  GRANTHA SIGN COMBINING ANUSVARA ABOVE
+11301..11303  ; valid                                  # 7.0  GRANTHA SIGN CANDRABINDU..GRANTHA SIGN VISARGA
+11304         ; disallowed                             # NA   <reserved-11304>
+11305..1130C  ; valid                                  # 7.0  GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
+1130D..1130E  ; disallowed                             # NA   <reserved-1130D>..<reserved-1130E>
+1130F..11310  ; valid                                  # 7.0  GRANTHA LETTER EE..GRANTHA LETTER AI
+11311..11312  ; disallowed                             # NA   <reserved-11311>..<reserved-11312>
+11313..11328  ; valid                                  # 7.0  GRANTHA LETTER OO..GRANTHA LETTER NA
+11329         ; disallowed                             # NA   <reserved-11329>
+1132A..11330  ; valid                                  # 7.0  GRANTHA LETTER PA..GRANTHA LETTER RA
+11331         ; disallowed                             # NA   <reserved-11331>
+11332..11333  ; valid                                  # 7.0  GRANTHA LETTER LA..GRANTHA LETTER LLA
+11334         ; disallowed                             # NA   <reserved-11334>
+11335..11339  ; valid                                  # 7.0  GRANTHA LETTER VA..GRANTHA LETTER HA
+1133A         ; disallowed                             # NA   <reserved-1133A>
+1133B         ; valid                                  # 11.0 COMBINING BINDU BELOW
+1133C..11344  ; valid                                  # 7.0  GRANTHA SIGN NUKTA..GRANTHA VOWEL SIGN VOCALIC RR
+11345..11346  ; disallowed                             # NA   <reserved-11345>..<reserved-11346>
+11347..11348  ; valid                                  # 7.0  GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
+11349..1134A  ; disallowed                             # NA   <reserved-11349>..<reserved-1134A>
+1134B..1134D  ; valid                                  # 7.0  GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
+1134E..1134F  ; disallowed                             # NA   <reserved-1134E>..<reserved-1134F>
+11350         ; valid                                  # 8.0  GRANTHA OM
+11351..11356  ; disallowed                             # NA   <reserved-11351>..<reserved-11356>
+11357         ; valid                                  # 7.0  GRANTHA AU LENGTH MARK
+11358..1135C  ; disallowed                             # NA   <reserved-11358>..<reserved-1135C>
+1135D..11363  ; valid                                  # 7.0  GRANTHA SIGN PLUTA..GRANTHA VOWEL SIGN VOCALIC LL
+11364..11365  ; disallowed                             # NA   <reserved-11364>..<reserved-11365>
+11366..1136C  ; valid                                  # 7.0  COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
+1136D..1136F  ; disallowed                             # NA   <reserved-1136D>..<reserved-1136F>
+11370..11374  ; valid                                  # 7.0  COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
+11375..113FF  ; disallowed                             # NA   <reserved-11375>..<reserved-113FF>
+11400..1144A  ; valid                                  # 9.0  NEWA LETTER A..NEWA SIDDHI
+1144B..1144F  ; valid                  ;      ; NV8    # 9.0  NEWA DANDA..NEWA ABBREVIATION SIGN
+11450..11459  ; valid                                  # 9.0  NEWA DIGIT ZERO..NEWA DIGIT NINE
+1145A         ; valid                  ;      ; NV8    # 13.0 NEWA DOUBLE COMMA
+1145B         ; valid                  ;      ; NV8    # 9.0  NEWA PLACEHOLDER MARK
+1145C         ; disallowed                             # NA   <reserved-1145C>
+1145D         ; valid                  ;      ; NV8    # 9.0  NEWA INSERTION SIGN
+1145E         ; valid                                  # 11.0 NEWA SANDHI MARK
+1145F         ; valid                                  # 12.0 NEWA LETTER VEDIC ANUSVARA
+11460..11461  ; valid                                  # 13.0 NEWA SIGN JIHVAMULIYA..NEWA SIGN UPADHMANIYA
+11462..1147F  ; disallowed                             # NA   <reserved-11462>..<reserved-1147F>
+11480..114C5  ; valid                                  # 7.0  TIRHUTA ANJI..TIRHUTA GVANG
+114C6         ; valid                  ;      ; NV8    # 7.0  TIRHUTA ABBREVIATION SIGN
+114C7         ; valid                                  # 7.0  TIRHUTA OM
+114C8..114CF  ; disallowed                             # NA   <reserved-114C8>..<reserved-114CF>
+114D0..114D9  ; valid                                  # 7.0  TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
+114DA..1157F  ; disallowed                             # NA   <reserved-114DA>..<reserved-1157F>
+11580..115B5  ; valid                                  # 7.0  SIDDHAM LETTER A..SIDDHAM VOWEL SIGN VOCALIC RR
+115B6..115B7  ; disallowed                             # NA   <reserved-115B6>..<reserved-115B7>
+115B8..115C0  ; valid                                  # 7.0  SIDDHAM VOWEL SIGN E..SIDDHAM SIGN NUKTA
+115C1..115C9  ; valid                  ;      ; NV8    # 7.0  SIDDHAM SIGN SIDDHAM..SIDDHAM END OF TEXT MARK
+115CA..115D7  ; valid                  ;      ; NV8    # 8.0  SIDDHAM SECTION MARK WITH TRIDENT AND U-SHAPED ORNAMENTS..SIDDHAM SECTION MARK WITH CIRCLES AND FOUR ENCLOSURES
+115D8..115DD  ; valid                                  # 8.0  SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM VOWEL SIGN ALTERNATE UU
+115DE..115FF  ; disallowed                             # NA   <reserved-115DE>..<reserved-115FF>
+11600..11640  ; valid                                  # 7.0  MODI LETTER A..MODI SIGN ARDHACANDRA
+11641..11643  ; valid                  ;      ; NV8    # 7.0  MODI DANDA..MODI ABBREVIATION SIGN
+11644         ; valid                                  # 7.0  MODI SIGN HUVA
+11645..1164F  ; disallowed                             # NA   <reserved-11645>..<reserved-1164F>
+11650..11659  ; valid                                  # 7.0  MODI DIGIT ZERO..MODI DIGIT NINE
+1165A..1165F  ; disallowed                             # NA   <reserved-1165A>..<reserved-1165F>
+11660..1166C  ; valid                  ;      ; NV8    # 9.0  MONGOLIAN BIRGA WITH ORNAMENT..MONGOLIAN TURNED SWIRL BIRGA WITH DOUBLE ORNAMENT
+1166D..1167F  ; disallowed                             # NA   <reserved-1166D>..<reserved-1167F>
+11680..116B7  ; valid                                  # 6.1  TAKRI LETTER A..TAKRI SIGN NUKTA
+116B8         ; valid                                  # 12.0 TAKRI LETTER ARCHAIC KHA
+116B9         ; valid                  ;      ; NV8    # 14.0 TAKRI ABBREVIATION SIGN
+116BA..116BF  ; disallowed                             # NA   <reserved-116BA>..<reserved-116BF>
+116C0..116C9  ; valid                                  # 6.1  TAKRI DIGIT ZERO..TAKRI DIGIT NINE
+116CA..116FF  ; disallowed                             # NA   <reserved-116CA>..<reserved-116FF>
+11700..11719  ; valid                                  # 8.0  AHOM LETTER KA..AHOM LETTER JHA
+1171A         ; valid                                  # 11.0 AHOM LETTER ALTERNATE BA
+1171B..1171C  ; disallowed                             # NA   <reserved-1171B>..<reserved-1171C>
+1171D..1172B  ; valid                                  # 8.0  AHOM CONSONANT SIGN MEDIAL LA..AHOM SIGN KILLER
+1172C..1172F  ; disallowed                             # NA   <reserved-1172C>..<reserved-1172F>
+11730..11739  ; valid                                  # 8.0  AHOM DIGIT ZERO..AHOM DIGIT NINE
+1173A..1173F  ; valid                  ;      ; NV8    # 8.0  AHOM NUMBER TEN..AHOM SYMBOL VI
+11740..11746  ; valid                                  # 14.0 AHOM LETTER CA..AHOM LETTER LLA
+11747..117FF  ; disallowed                             # NA   <reserved-11747>..<reserved-117FF>
+11800..1183A  ; valid                                  # 11.0 DOGRA LETTER A..DOGRA SIGN NUKTA
+1183B         ; valid                  ;      ; NV8    # 11.0 DOGRA ABBREVIATION SIGN
+1183C..1189F  ; disallowed                             # NA   <reserved-1183C>..<reserved-1189F>
+118A0         ; mapped                 ; 118C0         # 7.0  WARANG CITI CAPITAL LETTER NGAA
+118A1         ; mapped                 ; 118C1         # 7.0  WARANG CITI CAPITAL LETTER A
+118A2         ; mapped                 ; 118C2         # 7.0  WARANG CITI CAPITAL LETTER WI
+118A3         ; mapped                 ; 118C3         # 7.0  WARANG CITI CAPITAL LETTER YU
+118A4         ; mapped                 ; 118C4         # 7.0  WARANG CITI CAPITAL LETTER YA
+118A5         ; mapped                 ; 118C5         # 7.0  WARANG CITI CAPITAL LETTER YO
+118A6         ; mapped                 ; 118C6         # 7.0  WARANG CITI CAPITAL LETTER II
+118A7         ; mapped                 ; 118C7         # 7.0  WARANG CITI CAPITAL LETTER UU
+118A8         ; mapped                 ; 118C8         # 7.0  WARANG CITI CAPITAL LETTER E
+118A9         ; mapped                 ; 118C9         # 7.0  WARANG CITI CAPITAL LETTER O
+118AA         ; mapped                 ; 118CA         # 7.0  WARANG CITI CAPITAL LETTER ANG
+118AB         ; mapped                 ; 118CB         # 7.0  WARANG CITI CAPITAL LETTER GA
+118AC         ; mapped                 ; 118CC         # 7.0  WARANG CITI CAPITAL LETTER KO
+118AD         ; mapped                 ; 118CD         # 7.0  WARANG CITI CAPITAL LETTER ENY
+118AE         ; mapped                 ; 118CE         # 7.0  WARANG CITI CAPITAL LETTER YUJ
+118AF         ; mapped                 ; 118CF         # 7.0  WARANG CITI CAPITAL LETTER UC
+118B0         ; mapped                 ; 118D0         # 7.0  WARANG CITI CAPITAL LETTER ENN
+118B1         ; mapped                 ; 118D1         # 7.0  WARANG CITI CAPITAL LETTER ODD
+118B2         ; mapped                 ; 118D2         # 7.0  WARANG CITI CAPITAL LETTER TTE
+118B3         ; mapped                 ; 118D3         # 7.0  WARANG CITI CAPITAL LETTER NUNG
+118B4         ; mapped                 ; 118D4         # 7.0  WARANG CITI CAPITAL LETTER DA
+118B5         ; mapped                 ; 118D5         # 7.0  WARANG CITI CAPITAL LETTER AT
+118B6         ; mapped                 ; 118D6         # 7.0  WARANG CITI CAPITAL LETTER AM
+118B7         ; mapped                 ; 118D7         # 7.0  WARANG CITI CAPITAL LETTER BU
+118B8         ; mapped                 ; 118D8         # 7.0  WARANG CITI CAPITAL LETTER PU
+118B9         ; mapped                 ; 118D9         # 7.0  WARANG CITI CAPITAL LETTER HIYO
+118BA         ; mapped                 ; 118DA         # 7.0  WARANG CITI CAPITAL LETTER HOLO
+118BB         ; mapped                 ; 118DB         # 7.0  WARANG CITI CAPITAL LETTER HORR
+118BC         ; mapped                 ; 118DC         # 7.0  WARANG CITI CAPITAL LETTER HAR
+118BD         ; mapped                 ; 118DD         # 7.0  WARANG CITI CAPITAL LETTER SSUU
+118BE         ; mapped                 ; 118DE         # 7.0  WARANG CITI CAPITAL LETTER SII
+118BF         ; mapped                 ; 118DF         # 7.0  WARANG CITI CAPITAL LETTER VIYO
+118C0..118E9  ; valid                                  # 7.0  WARANG CITI SMALL LETTER NGAA..WARANG CITI DIGIT NINE
+118EA..118F2  ; valid                  ;      ; NV8    # 7.0  WARANG CITI NUMBER TEN..WARANG CITI NUMBER NINETY
+118F3..118FE  ; disallowed                             # NA   <reserved-118F3>..<reserved-118FE>
+118FF         ; valid                                  # 7.0  WARANG CITI OM
+11900..11906  ; valid                                  # 13.0 DIVES AKURU LETTER A..DIVES AKURU LETTER E
+11907..11908  ; disallowed                             # NA   <reserved-11907>..<reserved-11908>
+11909         ; valid                                  # 13.0 DIVES AKURU LETTER O
+1190A..1190B  ; disallowed                             # NA   <reserved-1190A>..<reserved-1190B>
+1190C..11913  ; valid                                  # 13.0 DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
+11914         ; disallowed                             # NA   <reserved-11914>
+11915..11916  ; valid                                  # 13.0 DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
+11917         ; disallowed                             # NA   <reserved-11917>
+11918..11935  ; valid                                  # 13.0 DIVES AKURU LETTER DDA..DIVES AKURU VOWEL SIGN E
+11936         ; disallowed                             # NA   <reserved-11936>
+11937..11938  ; valid                                  # 13.0 DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
+11939..1193A  ; disallowed                             # NA   <reserved-11939>..<reserved-1193A>
+1193B..11943  ; valid                                  # 13.0 DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN NUKTA
+11944..11946  ; valid                  ;      ; NV8    # 13.0 DIVES AKURU DOUBLE DANDA..DIVES AKURU END OF TEXT MARK
+11947..1194F  ; disallowed                             # NA   <reserved-11947>..<reserved-1194F>
+11950..11959  ; valid                                  # 13.0 DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
+1195A..1199F  ; disallowed                             # NA   <reserved-1195A>..<reserved-1199F>
+119A0..119A7  ; valid                                  # 12.0 NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
+119A8..119A9  ; disallowed                             # NA   <reserved-119A8>..<reserved-119A9>
+119AA..119D7  ; valid                                  # 12.0 NANDINAGARI LETTER E..NANDINAGARI VOWEL SIGN VOCALIC RR
+119D8..119D9  ; disallowed                             # NA   <reserved-119D8>..<reserved-119D9>
+119DA..119E1  ; valid                                  # 12.0 NANDINAGARI VOWEL SIGN E..NANDINAGARI SIGN AVAGRAHA
+119E2         ; valid                  ;      ; NV8    # 12.0 NANDINAGARI SIGN SIDDHAM
+119E3..119E4  ; valid                                  # 12.0 NANDINAGARI HEADSTROKE..NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
+119E5..119FF  ; disallowed                             # NA   <reserved-119E5>..<reserved-119FF>
+11A00..11A3E  ; valid                                  # 10.0 ZANABAZAR SQUARE LETTER A..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
+11A3F..11A46  ; valid                  ;      ; NV8    # 10.0 ZANABAZAR SQUARE INITIAL HEAD MARK..ZANABAZAR SQUARE CLOSING DOUBLE-LINED HEAD MARK
+11A47         ; valid                                  # 10.0 ZANABAZAR SQUARE SUBJOINER
+11A48..11A4F  ; disallowed                             # NA   <reserved-11A48>..<reserved-11A4F>
+11A50..11A83  ; valid                                  # 10.0 SOYOMBO LETTER A..SOYOMBO LETTER KSSA
+11A84..11A85  ; valid                                  # 12.0 SOYOMBO SIGN JIHVAMULIYA..SOYOMBO SIGN UPADHMANIYA
+11A86..11A99  ; valid                                  # 10.0 SOYOMBO CLUSTER-INITIAL LETTER RA..SOYOMBO SUBJOINER
+11A9A..11A9C  ; valid                  ;      ; NV8    # 10.0 SOYOMBO MARK TSHEG..SOYOMBO MARK DOUBLE SHAD
+11A9D         ; valid                                  # 11.0 SOYOMBO MARK PLUTA
+11A9E..11AA2  ; valid                  ;      ; NV8    # 10.0 SOYOMBO HEAD MARK WITH MOON AND SUN AND TRIPLE FLAME..SOYOMBO TERMINAL MARK-2
+11AA3..11AAF  ; disallowed                             # NA   <reserved-11AA3>..<reserved-11AAF>
+11AB0..11ABF  ; valid                                  # 14.0 CANADIAN SYLLABICS NATTILIK HI..CANADIAN SYLLABICS SPA
+11AC0..11AF8  ; valid                                  # 7.0  PAU CIN HAU LETTER PA..PAU CIN HAU GLOTTAL STOP FINAL
+11AF9..11AFF  ; disallowed                             # NA   <reserved-11AF9>..<reserved-11AFF>
+11B00..11B09  ; valid                  ;      ; NV8    # 15.0 DEVANAGARI HEAD MARK..DEVANAGARI SIGN MINDU
+11B0A..11BFF  ; disallowed                             # NA   <reserved-11B0A>..<reserved-11BFF>
+11C00..11C08  ; valid                                  # 9.0  BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
+11C09         ; disallowed                             # NA   <reserved-11C09>
+11C0A..11C36  ; valid                                  # 9.0  BHAIKSUKI LETTER E..BHAIKSUKI VOWEL SIGN VOCALIC L
+11C37         ; disallowed                             # NA   <reserved-11C37>
+11C38..11C40  ; valid                                  # 9.0  BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN AVAGRAHA
+11C41..11C45  ; valid                  ;      ; NV8    # 9.0  BHAIKSUKI DANDA..BHAIKSUKI GAP FILLER-2
+11C46..11C4F  ; disallowed                             # NA   <reserved-11C46>..<reserved-11C4F>
+11C50..11C59  ; valid                                  # 9.0  BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
+11C5A..11C6C  ; valid                  ;      ; NV8    # 9.0  BHAIKSUKI NUMBER ONE..BHAIKSUKI HUNDREDS UNIT MARK
+11C6D..11C6F  ; disallowed                             # NA   <reserved-11C6D>..<reserved-11C6F>
+11C70..11C71  ; valid                  ;      ; NV8    # 9.0  MARCHEN HEAD MARK..MARCHEN MARK SHAD
+11C72..11C8F  ; valid                                  # 9.0  MARCHEN LETTER KA..MARCHEN LETTER A
+11C90..11C91  ; disallowed                             # NA   <reserved-11C90>..<reserved-11C91>
+11C92..11CA7  ; valid                                  # 9.0  MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
+11CA8         ; disallowed                             # NA   <reserved-11CA8>
+11CA9..11CB6  ; valid                                  # 9.0  MARCHEN SUBJOINED LETTER YA..MARCHEN SIGN CANDRABINDU
+11CB7..11CFF  ; disallowed                             # NA   <reserved-11CB7>..<reserved-11CFF>
+11D00..11D06  ; valid                                  # 10.0 MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
+11D07         ; disallowed                             # NA   <reserved-11D07>
+11D08..11D09  ; valid                                  # 10.0 MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
+11D0A         ; disallowed                             # NA   <reserved-11D0A>
+11D0B..11D36  ; valid                                  # 10.0 MASARAM GONDI LETTER AU..MASARAM GONDI VOWEL SIGN VOCALIC R
+11D37..11D39  ; disallowed                             # NA   <reserved-11D37>..<reserved-11D39>
+11D3A         ; valid                                  # 10.0 MASARAM GONDI VOWEL SIGN E
+11D3B         ; disallowed                             # NA   <reserved-11D3B>
+11D3C..11D3D  ; valid                                  # 10.0 MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
+11D3E         ; disallowed                             # NA   <reserved-11D3E>
+11D3F..11D47  ; valid                                  # 10.0 MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI RA-KARA
+11D48..11D4F  ; disallowed                             # NA   <reserved-11D48>..<reserved-11D4F>
+11D50..11D59  ; valid                                  # 10.0 MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
+11D5A..11D5F  ; disallowed                             # NA   <reserved-11D5A>..<reserved-11D5F>
+11D60..11D65  ; valid                                  # 11.0 GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
+11D66         ; disallowed                             # NA   <reserved-11D66>
+11D67..11D68  ; valid                                  # 11.0 GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
+11D69         ; disallowed                             # NA   <reserved-11D69>
+11D6A..11D8E  ; valid                                  # 11.0 GUNJALA GONDI LETTER OO..GUNJALA GONDI VOWEL SIGN UU
+11D8F         ; disallowed                             # NA   <reserved-11D8F>
+11D90..11D91  ; valid                                  # 11.0 GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
+11D92         ; disallowed                             # NA   <reserved-11D92>
+11D93..11D98  ; valid                                  # 11.0 GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI OM
+11D99..11D9F  ; disallowed                             # NA   <reserved-11D99>..<reserved-11D9F>
+11DA0..11DA9  ; valid                                  # 11.0 GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
+11DAA..11EDF  ; disallowed                             # NA   <reserved-11DAA>..<reserved-11EDF>
+11EE0..11EF6  ; valid                                  # 11.0 MAKASAR LETTER KA..MAKASAR VOWEL SIGN O
+11EF7..11EF8  ; valid                  ;      ; NV8    # 11.0 MAKASAR PASSIMBANG..MAKASAR END OF SECTION
+11EF9..11EFF  ; disallowed                             # NA   <reserved-11EF9>..<reserved-11EFF>
+11F00..11F10  ; valid                                  # 15.0 KAWI SIGN CANDRABINDU..KAWI LETTER O
+11F11         ; disallowed                             # NA   <reserved-11F11>
+11F12..11F3A  ; valid                                  # 15.0 KAWI LETTER KA..KAWI VOWEL SIGN VOCALIC R
+11F3B..11F3D  ; disallowed                             # NA   <reserved-11F3B>..<reserved-11F3D>
+11F3E..11F42  ; valid                                  # 15.0 KAWI VOWEL SIGN E..KAWI CONJOINER
+11F43..11F4F  ; valid                  ;      ; NV8    # 15.0 KAWI DANDA..KAWI PUNCTUATION CLOSING SPIRAL
+11F50..11F59  ; valid                                  # 15.0 KAWI DIGIT ZERO..KAWI DIGIT NINE
+11F5A..11FAF  ; disallowed                             # NA   <reserved-11F5A>..<reserved-11FAF>
+11FB0         ; valid                                  # 13.0 LISU LETTER YHA
+11FB1..11FBF  ; disallowed                             # NA   <reserved-11FB1>..<reserved-11FBF>
+11FC0..11FF1  ; valid                  ;      ; NV8    # 12.0 TAMIL FRACTION ONE THREE-HUNDRED-AND-TWENTIETH..TAMIL SIGN VAKAIYARAA
+11FF2..11FFE  ; disallowed                             # NA   <reserved-11FF2>..<reserved-11FFE>
+11FFF         ; valid                  ;      ; NV8    # 12.0 TAMIL PUNCTUATION END OF TEXT
+12000..1236E  ; valid                                  # 5.0  CUNEIFORM SIGN A..CUNEIFORM SIGN ZUM
+1236F..12398  ; valid                                  # 7.0  CUNEIFORM SIGN KAP ELAMITE..CUNEIFORM SIGN UM TIMES ME
+12399         ; valid                                  # 8.0  CUNEIFORM SIGN U U
+1239A..123FF  ; disallowed                             # NA   <reserved-1239A>..<reserved-123FF>
+12400..12462  ; valid                  ;      ; NV8    # 5.0  CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN OLD ASSYRIAN ONE QUARTER
+12463..1246E  ; valid                  ;      ; NV8    # 7.0  CUNEIFORM NUMERIC SIGN ONE QUARTER GUR..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
+1246F         ; disallowed                             # NA   <reserved-1246F>
+12470..12473  ; valid                  ;      ; NV8    # 5.0  CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER..CUNEIFORM PUNCTUATION SIGN DIAGONAL TRICOLON
+12474         ; valid                  ;      ; NV8    # 7.0  CUNEIFORM PUNCTUATION SIGN DIAGONAL QUADCOLON
+12475..1247F  ; disallowed                             # NA   <reserved-12475>..<reserved-1247F>
+12480..12543  ; valid                                  # 8.0  CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
+12544..12F8F  ; disallowed                             # NA   <reserved-12544>..<reserved-12F8F>
+12F90..12FF0  ; valid                                  # 14.0 CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
+12FF1..12FF2  ; valid                  ;      ; NV8    # 14.0 CYPRO-MINOAN SIGN CM301..CYPRO-MINOAN SIGN CM302
+12FF3..12FFF  ; disallowed                             # NA   <reserved-12FF3>..<reserved-12FFF>
+13000..1342E  ; valid                                  # 5.2  EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH AA032
+1342F         ; valid                                  # 15.0 EGYPTIAN HIEROGLYPH V011D
+13430..13438  ; disallowed                             # 12.0 EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END SEGMENT
+13439..1343F  ; disallowed                             # 15.0 EGYPTIAN HIEROGLYPH INSERT AT MIDDLE..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
+13440..13455  ; valid                                  # 15.0 EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
+13456..143FF  ; disallowed                             # NA   <reserved-13456>..<reserved-143FF>
+14400..14646  ; valid                                  # 8.0  ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A530
+14647..167FF  ; disallowed                             # NA   <reserved-14647>..<reserved-167FF>
+16800..16A38  ; valid                                  # 6.0  BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
+16A39..16A3F  ; disallowed                             # NA   <reserved-16A39>..<reserved-16A3F>
+16A40..16A5E  ; valid                                  # 7.0  MRO LETTER TA..MRO LETTER TEK
+16A5F         ; disallowed                             # NA   <reserved-16A5F>
+16A60..16A69  ; valid                                  # 7.0  MRO DIGIT ZERO..MRO DIGIT NINE
+16A6A..16A6D  ; disallowed                             # NA   <reserved-16A6A>..<reserved-16A6D>
+16A6E..16A6F  ; valid                  ;      ; NV8    # 7.0  MRO DANDA..MRO DOUBLE DANDA
+16A70..16ABE  ; valid                                  # 14.0 TANGSA LETTER OZ..TANGSA LETTER ZA
+16ABF         ; disallowed                             # NA   <reserved-16ABF>
+16AC0..16AC9  ; valid                                  # 14.0 TANGSA DIGIT ZERO..TANGSA DIGIT NINE
+16ACA..16ACF  ; disallowed                             # NA   <reserved-16ACA>..<reserved-16ACF>
+16AD0..16AED  ; valid                                  # 7.0  BASSA VAH LETTER ENNI..BASSA VAH LETTER I
+16AEE..16AEF  ; disallowed                             # NA   <reserved-16AEE>..<reserved-16AEF>
+16AF0..16AF4  ; valid                                  # 7.0  BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
+16AF5         ; valid                  ;      ; NV8    # 7.0  BASSA VAH FULL STOP
+16AF6..16AFF  ; disallowed                             # NA   <reserved-16AF6>..<reserved-16AFF>
+16B00..16B36  ; valid                                  # 7.0  PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG MARK CIM TAUM
+16B37..16B3F  ; valid                  ;      ; NV8    # 7.0  PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN XYEEM FAIB
+16B40..16B43  ; valid                                  # 7.0  PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
+16B44..16B45  ; valid                  ;      ; NV8    # 7.0  PAHAWH HMONG SIGN XAUS..PAHAWH HMONG SIGN CIM TSOV ROG
+16B46..16B4F  ; disallowed                             # NA   <reserved-16B46>..<reserved-16B4F>
+16B50..16B59  ; valid                                  # 7.0  PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
+16B5A         ; disallowed                             # NA   <reserved-16B5A>
+16B5B..16B61  ; valid                  ;      ; NV8    # 7.0  PAHAWH HMONG NUMBER TENS..PAHAWH HMONG NUMBER TRILLIONS
+16B62         ; disallowed                             # NA   <reserved-16B62>
+16B63..16B77  ; valid                                  # 7.0  PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
+16B78..16B7C  ; disallowed                             # NA   <reserved-16B78>..<reserved-16B7C>
+16B7D..16B8F  ; valid                                  # 7.0  PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
+16B90..16E3F  ; disallowed                             # NA   <reserved-16B90>..<reserved-16E3F>
+16E40         ; mapped                 ; 16E60         # 11.0 MEDEFAIDRIN CAPITAL LETTER M
+16E41         ; mapped                 ; 16E61         # 11.0 MEDEFAIDRIN CAPITAL LETTER S
+16E42         ; mapped                 ; 16E62         # 11.0 MEDEFAIDRIN CAPITAL LETTER V
+16E43         ; mapped                 ; 16E63         # 11.0 MEDEFAIDRIN CAPITAL LETTER W
+16E44         ; mapped                 ; 16E64         # 11.0 MEDEFAIDRIN CAPITAL LETTER ATIU
+16E45         ; mapped                 ; 16E65         # 11.0 MEDEFAIDRIN CAPITAL LETTER Z
+16E46         ; mapped                 ; 16E66         # 11.0 MEDEFAIDRIN CAPITAL LETTER KP
+16E47         ; mapped                 ; 16E67         # 11.0 MEDEFAIDRIN CAPITAL LETTER P
+16E48         ; mapped                 ; 16E68         # 11.0 MEDEFAIDRIN CAPITAL LETTER T
+16E49         ; mapped                 ; 16E69         # 11.0 MEDEFAIDRIN CAPITAL LETTER G
+16E4A         ; mapped                 ; 16E6A         # 11.0 MEDEFAIDRIN CAPITAL LETTER F
+16E4B         ; mapped                 ; 16E6B         # 11.0 MEDEFAIDRIN CAPITAL LETTER I
+16E4C         ; mapped                 ; 16E6C         # 11.0 MEDEFAIDRIN CAPITAL LETTER K
+16E4D         ; mapped                 ; 16E6D         # 11.0 MEDEFAIDRIN CAPITAL LETTER A
+16E4E         ; mapped                 ; 16E6E         # 11.0 MEDEFAIDRIN CAPITAL LETTER J
+16E4F         ; mapped                 ; 16E6F         # 11.0 MEDEFAIDRIN CAPITAL LETTER E
+16E50         ; mapped                 ; 16E70         # 11.0 MEDEFAIDRIN CAPITAL LETTER B
+16E51         ; mapped                 ; 16E71         # 11.0 MEDEFAIDRIN CAPITAL LETTER C
+16E52         ; mapped                 ; 16E72         # 11.0 MEDEFAIDRIN CAPITAL LETTER U
+16E53         ; mapped                 ; 16E73         # 11.0 MEDEFAIDRIN CAPITAL LETTER YU
+16E54         ; mapped                 ; 16E74         # 11.0 MEDEFAIDRIN CAPITAL LETTER L
+16E55         ; mapped                 ; 16E75         # 11.0 MEDEFAIDRIN CAPITAL LETTER Q
+16E56         ; mapped                 ; 16E76         # 11.0 MEDEFAIDRIN CAPITAL LETTER HP
+16E57         ; mapped                 ; 16E77         # 11.0 MEDEFAIDRIN CAPITAL LETTER NY
+16E58         ; mapped                 ; 16E78         # 11.0 MEDEFAIDRIN CAPITAL LETTER X
+16E59         ; mapped                 ; 16E79         # 11.0 MEDEFAIDRIN CAPITAL LETTER D
+16E5A         ; mapped                 ; 16E7A         # 11.0 MEDEFAIDRIN CAPITAL LETTER OE
+16E5B         ; mapped                 ; 16E7B         # 11.0 MEDEFAIDRIN CAPITAL LETTER N
+16E5C         ; mapped                 ; 16E7C         # 11.0 MEDEFAIDRIN CAPITAL LETTER R
+16E5D         ; mapped                 ; 16E7D         # 11.0 MEDEFAIDRIN CAPITAL LETTER O
+16E5E         ; mapped                 ; 16E7E         # 11.0 MEDEFAIDRIN CAPITAL LETTER AI
+16E5F         ; mapped                 ; 16E7F         # 11.0 MEDEFAIDRIN CAPITAL LETTER Y
+16E60..16E7F  ; valid                                  # 11.0 MEDEFAIDRIN SMALL LETTER M..MEDEFAIDRIN SMALL LETTER Y
+16E80..16E9A  ; valid                  ;      ; NV8    # 11.0 MEDEFAIDRIN DIGIT ZERO..MEDEFAIDRIN EXCLAMATION OH
+16E9B..16EFF  ; disallowed                             # NA   <reserved-16E9B>..<reserved-16EFF>
+16F00..16F44  ; valid                                  # 6.1  MIAO LETTER PA..MIAO LETTER HHA
+16F45..16F4A  ; valid                                  # 12.0 MIAO LETTER BRI..MIAO LETTER RTE
+16F4B..16F4E  ; disallowed                             # NA   <reserved-16F4B>..<reserved-16F4E>
+16F4F         ; valid                                  # 12.0 MIAO SIGN CONSONANT MODIFIER BAR
+16F50..16F7E  ; valid                                  # 6.1  MIAO LETTER NASALIZATION..MIAO VOWEL SIGN NG
+16F7F..16F87  ; valid                                  # 12.0 MIAO VOWEL SIGN UOG..MIAO VOWEL SIGN UI
+16F88..16F8E  ; disallowed                             # NA   <reserved-16F88>..<reserved-16F8E>
+16F8F..16F9F  ; valid                                  # 6.1  MIAO TONE RIGHT..MIAO LETTER REFORMED TONE-8
+16FA0..16FDF  ; disallowed                             # NA   <reserved-16FA0>..<reserved-16FDF>
+16FE0         ; valid                                  # 9.0  TANGUT ITERATION MARK
+16FE1         ; valid                                  # 10.0 NUSHU ITERATION MARK
+16FE2         ; valid                  ;      ; NV8    # 12.0 OLD CHINESE HOOK MARK
+16FE3         ; valid                                  # 12.0 OLD CHINESE ITERATION MARK
+16FE4         ; valid                                  # 13.0 KHITAN SMALL SCRIPT FILLER
+16FE5..16FEF  ; disallowed                             # NA   <reserved-16FE5>..<reserved-16FEF>
+16FF0..16FF1  ; valid                                  # 13.0 VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
+16FF2..16FFF  ; disallowed                             # NA   <reserved-16FF2>..<reserved-16FFF>
+17000..187EC  ; valid                                  # 9.0  TANGUT IDEOGRAPH-17000..TANGUT IDEOGRAPH-187EC
+187ED..187F1  ; valid                                  # 11.0 TANGUT IDEOGRAPH-187ED..TANGUT IDEOGRAPH-187F1
+187F2..187F7  ; valid                                  # 12.0 TANGUT IDEOGRAPH-187F2..TANGUT IDEOGRAPH-187F7
+187F8..187FF  ; disallowed                             # NA   <reserved-187F8>..<reserved-187FF>
+18800..18AF2  ; valid                                  # 9.0  TANGUT COMPONENT-001..TANGUT COMPONENT-755
+18AF3..18CD5  ; valid                                  # 13.0 TANGUT COMPONENT-756..KHITAN SMALL SCRIPT CHARACTER-18CD5
+18CD6..18CFF  ; disallowed                             # NA   <reserved-18CD6>..<reserved-18CFF>
+18D00..18D08  ; valid                                  # 13.0 TANGUT IDEOGRAPH-18D00..TANGUT IDEOGRAPH-18D08
+18D09..1AFEF  ; disallowed                             # NA   <reserved-18D09>..<reserved-1AFEF>
+1AFF0..1AFF3  ; valid                                  # 14.0 KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
+1AFF4         ; disallowed                             # NA   <reserved-1AFF4>
+1AFF5..1AFFB  ; valid                                  # 14.0 KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
+1AFFC         ; disallowed                             # NA   <reserved-1AFFC>
+1AFFD..1AFFE  ; valid                                  # 14.0 KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
+1AFFF         ; disallowed                             # NA   <reserved-1AFFF>
+1B000..1B001  ; valid                                  # 6.0  KATAKANA LETTER ARCHAIC E..HIRAGANA LETTER ARCHAIC YE
+1B002..1B11E  ; valid                                  # 10.0 HENTAIGANA LETTER A-1..HENTAIGANA LETTER N-MU-MO-2
+1B11F..1B122  ; valid                                  # 14.0 HIRAGANA LETTER ARCHAIC WU..KATAKANA LETTER ARCHAIC WU
+1B123..1B131  ; disallowed                             # NA   <reserved-1B123>..<reserved-1B131>
+1B132         ; valid                                  # 15.0 HIRAGANA LETTER SMALL KO
+1B133..1B14F  ; disallowed                             # NA   <reserved-1B133>..<reserved-1B14F>
+1B150..1B152  ; valid                                  # 12.0 HIRAGANA LETTER SMALL WI..HIRAGANA LETTER SMALL WO
+1B153..1B154  ; disallowed                             # NA   <reserved-1B153>..<reserved-1B154>
+1B155         ; valid                                  # 15.0 KATAKANA LETTER SMALL KO
+1B156..1B163  ; disallowed                             # NA   <reserved-1B156>..<reserved-1B163>
+1B164..1B167  ; valid                                  # 12.0 KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
+1B168..1B16F  ; disallowed                             # NA   <reserved-1B168>..<reserved-1B16F>
+1B170..1B2FB  ; valid                                  # 10.0 NUSHU CHARACTER-1B170..NUSHU CHARACTER-1B2FB
+1B2FC..1BBFF  ; disallowed                             # NA   <reserved-1B2FC>..<reserved-1BBFF>
+1BC00..1BC6A  ; valid                                  # 7.0  DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
+1BC6B..1BC6F  ; disallowed                             # NA   <reserved-1BC6B>..<reserved-1BC6F>
+1BC70..1BC7C  ; valid                                  # 7.0  DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
+1BC7D..1BC7F  ; disallowed                             # NA   <reserved-1BC7D>..<reserved-1BC7F>
+1BC80..1BC88  ; valid                                  # 7.0  DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
+1BC89..1BC8F  ; disallowed                             # NA   <reserved-1BC89>..<reserved-1BC8F>
+1BC90..1BC99  ; valid                                  # 7.0  DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
+1BC9A..1BC9B  ; disallowed                             # NA   <reserved-1BC9A>..<reserved-1BC9B>
+1BC9C         ; valid                  ;      ; NV8    # 7.0  DUPLOYAN SIGN O WITH CROSS
+1BC9D..1BC9E  ; valid                                  # 7.0  DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
+1BC9F         ; valid                  ;      ; NV8    # 7.0  DUPLOYAN PUNCTUATION CHINOOK FULL STOP
+1BCA0..1BCA3  ; ignored                                # 7.0  SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
+1BCA4..1CEFF  ; disallowed                             # NA   <reserved-1BCA4>..<reserved-1CEFF>
+1CF00..1CF2D  ; valid                                  # 14.0 ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
+1CF2E..1CF2F  ; disallowed                             # NA   <reserved-1CF2E>..<reserved-1CF2F>
+1CF30..1CF46  ; valid                                  # 14.0 ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
+1CF47..1CF4F  ; disallowed                             # NA   <reserved-1CF47>..<reserved-1CF4F>
+1CF50..1CFC3  ; valid                  ;      ; NV8    # 14.0 ZNAMENNY NEUME KRYUK..ZNAMENNY NEUME PAUK
+1CFC4..1CFFF  ; disallowed                             # NA   <reserved-1CFC4>..<reserved-1CFFF>
+1D000..1D0F5  ; valid                  ;      ; NV8    # 3.1  BYZANTINE MUSICAL SYMBOL PSILI..BYZANTINE MUSICAL SYMBOL GORGON NEO KATO
+1D0F6..1D0FF  ; disallowed                             # NA   <reserved-1D0F6>..<reserved-1D0FF>
+1D100..1D126  ; valid                  ;      ; NV8    # 3.1  MUSICAL SYMBOL SINGLE BARLINE..MUSICAL SYMBOL DRUM CLEF-2
+1D127..1D128  ; disallowed                             # NA   <reserved-1D127>..<reserved-1D128>
+1D129         ; valid                  ;      ; NV8    # 5.1  MUSICAL SYMBOL MULTIPLE MEASURE REST
+1D12A..1D15D  ; valid                  ;      ; NV8    # 3.1  MUSICAL SYMBOL DOUBLE SHARP..MUSICAL SYMBOL WHOLE NOTE
+1D15E         ; mapped                 ; 1D157 1D165   # 3.1  MUSICAL SYMBOL HALF NOTE
+1D15F         ; mapped                 ; 1D158 1D165   # 3.1  MUSICAL SYMBOL QUARTER NOTE
+1D160         ; mapped                 ; 1D158 1D165 1D16E #3.1 MUSICAL SYMBOL EIGHTH NOTE
+1D161         ; mapped                 ; 1D158 1D165 1D16F #3.1 MUSICAL SYMBOL SIXTEENTH NOTE
+1D162         ; mapped                 ; 1D158 1D165 1D170 #3.1 MUSICAL SYMBOL THIRTY-SECOND NOTE
+1D163         ; mapped                 ; 1D158 1D165 1D171 #3.1 MUSICAL SYMBOL SIXTY-FOURTH NOTE
+1D164         ; mapped                 ; 1D158 1D165 1D172 #3.1 MUSICAL SYMBOL ONE HUNDRED TWENTY-EIGHTH NOTE
+1D165..1D172  ; valid                  ;      ; NV8    # 3.1  MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING FLAG-5
+1D173..1D17A  ; disallowed                             # 3.1  MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
+1D17B..1D1BA  ; valid                  ;      ; NV8    # 3.1  MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL SEMIBREVIS BLACK
+1D1BB         ; mapped                 ; 1D1B9 1D165   # 3.1  MUSICAL SYMBOL MINIMA
+1D1BC         ; mapped                 ; 1D1BA 1D165   # 3.1  MUSICAL SYMBOL MINIMA BLACK
+1D1BD         ; mapped                 ; 1D1B9 1D165 1D16E #3.1 MUSICAL SYMBOL SEMIMINIMA WHITE
+1D1BE         ; mapped                 ; 1D1BA 1D165 1D16E #3.1 MUSICAL SYMBOL SEMIMINIMA BLACK
+1D1BF         ; mapped                 ; 1D1B9 1D165 1D16F #3.1 MUSICAL SYMBOL FUSA WHITE
+1D1C0         ; mapped                 ; 1D1BA 1D165 1D16F #3.1 MUSICAL SYMBOL FUSA BLACK
+1D1C1..1D1DD  ; valid                  ;      ; NV8    # 3.1  MUSICAL SYMBOL LONGA PERFECTA REST..MUSICAL SYMBOL PES SUBPUNCTIS
+1D1DE..1D1E8  ; valid                  ;      ; NV8    # 8.0  MUSICAL SYMBOL KIEVAN C CLEF..MUSICAL SYMBOL KIEVAN FLAT SIGN
+1D1E9..1D1EA  ; valid                  ;      ; NV8    # 14.0 MUSICAL SYMBOL SORI..MUSICAL SYMBOL KORON
+1D1EB..1D1FF  ; disallowed                             # NA   <reserved-1D1EB>..<reserved-1D1FF>
+1D200..1D245  ; valid                  ;      ; NV8    # 4.1  GREEK VOCAL NOTATION SYMBOL-1..GREEK MUSICAL LEIMMA
+1D246..1D2BF  ; disallowed                             # NA   <reserved-1D246>..<reserved-1D2BF>
+1D2C0..1D2D3  ; valid                  ;      ; NV8    # 15.0 KAKTOVIK NUMERAL ZERO..KAKTOVIK NUMERAL NINETEEN
+1D2D4..1D2DF  ; disallowed                             # NA   <reserved-1D2D4>..<reserved-1D2DF>
+1D2E0..1D2F3  ; valid                  ;      ; NV8    # 11.0 MAYAN NUMERAL ZERO..MAYAN NUMERAL NINETEEN
+1D2F4..1D2FF  ; disallowed                             # NA   <reserved-1D2F4>..<reserved-1D2FF>
+1D300..1D356  ; valid                  ;      ; NV8    # 4.0  MONOGRAM FOR EARTH..TETRAGRAM FOR FOSTERING
+1D357..1D35F  ; disallowed                             # NA   <reserved-1D357>..<reserved-1D35F>
+1D360..1D371  ; valid                  ;      ; NV8    # 5.0  COUNTING ROD UNIT DIGIT ONE..COUNTING ROD TENS DIGIT NINE
+1D372..1D378  ; valid                  ;      ; NV8    # 11.0 IDEOGRAPHIC TALLY MARK ONE..TALLY MARK FIVE
+1D379..1D3FF  ; disallowed                             # NA   <reserved-1D379>..<reserved-1D3FF>
+1D400         ; mapped                 ; 0061          # 3.1  MATHEMATICAL BOLD CAPITAL A
+1D401         ; mapped                 ; 0062          # 3.1  MATHEMATICAL BOLD CAPITAL B
+1D402         ; mapped                 ; 0063          # 3.1  MATHEMATICAL BOLD CAPITAL C
+1D403         ; mapped                 ; 0064          # 3.1  MATHEMATICAL BOLD CAPITAL D
+1D404         ; mapped                 ; 0065          # 3.1  MATHEMATICAL BOLD CAPITAL E
+1D405         ; mapped                 ; 0066          # 3.1  MATHEMATICAL BOLD CAPITAL F
+1D406         ; mapped                 ; 0067          # 3.1  MATHEMATICAL BOLD CAPITAL G
+1D407         ; mapped                 ; 0068          # 3.1  MATHEMATICAL BOLD CAPITAL H
+1D408         ; mapped                 ; 0069          # 3.1  MATHEMATICAL BOLD CAPITAL I
+1D409         ; mapped                 ; 006A          # 3.1  MATHEMATICAL BOLD CAPITAL J
+1D40A         ; mapped                 ; 006B          # 3.1  MATHEMATICAL BOLD CAPITAL K
+1D40B         ; mapped                 ; 006C          # 3.1  MATHEMATICAL BOLD CAPITAL L
+1D40C         ; mapped                 ; 006D          # 3.1  MATHEMATICAL BOLD CAPITAL M
+1D40D         ; mapped                 ; 006E          # 3.1  MATHEMATICAL BOLD CAPITAL N
+1D40E         ; mapped                 ; 006F          # 3.1  MATHEMATICAL BOLD CAPITAL O
+1D40F         ; mapped                 ; 0070          # 3.1  MATHEMATICAL BOLD CAPITAL P
+1D410         ; mapped                 ; 0071          # 3.1  MATHEMATICAL BOLD CAPITAL Q
+1D411         ; mapped                 ; 0072          # 3.1  MATHEMATICAL BOLD CAPITAL R
+1D412         ; mapped                 ; 0073          # 3.1  MATHEMATICAL BOLD CAPITAL S
+1D413         ; mapped                 ; 0074          # 3.1  MATHEMATICAL BOLD CAPITAL T
+1D414         ; mapped                 ; 0075          # 3.1  MATHEMATICAL BOLD CAPITAL U
+1D415         ; mapped                 ; 0076          # 3.1  MATHEMATICAL BOLD CAPITAL V
+1D416         ; mapped                 ; 0077          # 3.1  MATHEMATICAL BOLD CAPITAL W
+1D417         ; mapped                 ; 0078          # 3.1  MATHEMATICAL BOLD CAPITAL X
+1D418         ; mapped                 ; 0079          # 3.1  MATHEMATICAL BOLD CAPITAL Y
+1D419         ; mapped                 ; 007A          # 3.1  MATHEMATICAL BOLD CAPITAL Z
+1D41A         ; mapped                 ; 0061          # 3.1  MATHEMATICAL BOLD SMALL A
+1D41B         ; mapped                 ; 0062          # 3.1  MATHEMATICAL BOLD SMALL B
+1D41C         ; mapped                 ; 0063          # 3.1  MATHEMATICAL BOLD SMALL C
+1D41D         ; mapped                 ; 0064          # 3.1  MATHEMATICAL BOLD SMALL D
+1D41E         ; mapped                 ; 0065          # 3.1  MATHEMATICAL BOLD SMALL E
+1D41F         ; mapped                 ; 0066          # 3.1  MATHEMATICAL BOLD SMALL F
+1D420         ; mapped                 ; 0067          # 3.1  MATHEMATICAL BOLD SMALL G
+1D421         ; mapped                 ; 0068          # 3.1  MATHEMATICAL BOLD SMALL H
+1D422         ; mapped                 ; 0069          # 3.1  MATHEMATICAL BOLD SMALL I
+1D423         ; mapped                 ; 006A          # 3.1  MATHEMATICAL BOLD SMALL J
+1D424         ; mapped                 ; 006B          # 3.1  MATHEMATICAL BOLD SMALL K
+1D425         ; mapped                 ; 006C          # 3.1  MATHEMATICAL BOLD SMALL L
+1D426         ; mapped                 ; 006D          # 3.1  MATHEMATICAL BOLD SMALL M
+1D427         ; mapped                 ; 006E          # 3.1  MATHEMATICAL BOLD SMALL N
+1D428         ; mapped                 ; 006F          # 3.1  MATHEMATICAL BOLD SMALL O
+1D429         ; mapped                 ; 0070          # 3.1  MATHEMATICAL BOLD SMALL P
+1D42A         ; mapped                 ; 0071          # 3.1  MATHEMATICAL BOLD SMALL Q
+1D42B         ; mapped                 ; 0072          # 3.1  MATHEMATICAL BOLD SMALL R
+1D42C         ; mapped                 ; 0073          # 3.1  MATHEMATICAL BOLD SMALL S
+1D42D         ; mapped                 ; 0074          # 3.1  MATHEMATICAL BOLD SMALL T
+1D42E         ; mapped                 ; 0075          # 3.1  MATHEMATICAL BOLD SMALL U
+1D42F         ; mapped                 ; 0076          # 3.1  MATHEMATICAL BOLD SMALL V
+1D430         ; mapped                 ; 0077          # 3.1  MATHEMATICAL BOLD SMALL W
+1D431         ; mapped                 ; 0078          # 3.1  MATHEMATICAL BOLD SMALL X
+1D432         ; mapped                 ; 0079          # 3.1  MATHEMATICAL BOLD SMALL Y
+1D433         ; mapped                 ; 007A          # 3.1  MATHEMATICAL BOLD SMALL Z
+1D434         ; mapped                 ; 0061          # 3.1  MATHEMATICAL ITALIC CAPITAL A
+1D435         ; mapped                 ; 0062          # 3.1  MATHEMATICAL ITALIC CAPITAL B
+1D436         ; mapped                 ; 0063          # 3.1  MATHEMATICAL ITALIC CAPITAL C
+1D437         ; mapped                 ; 0064          # 3.1  MATHEMATICAL ITALIC CAPITAL D
+1D438         ; mapped                 ; 0065          # 3.1  MATHEMATICAL ITALIC CAPITAL E
+1D439         ; mapped                 ; 0066          # 3.1  MATHEMATICAL ITALIC CAPITAL F
+1D43A         ; mapped                 ; 0067          # 3.1  MATHEMATICAL ITALIC CAPITAL G
+1D43B         ; mapped                 ; 0068          # 3.1  MATHEMATICAL ITALIC CAPITAL H
+1D43C         ; mapped                 ; 0069          # 3.1  MATHEMATICAL ITALIC CAPITAL I
+1D43D         ; mapped                 ; 006A          # 3.1  MATHEMATICAL ITALIC CAPITAL J
+1D43E         ; mapped                 ; 006B          # 3.1  MATHEMATICAL ITALIC CAPITAL K
+1D43F         ; mapped                 ; 006C          # 3.1  MATHEMATICAL ITALIC CAPITAL L
+1D440         ; mapped                 ; 006D          # 3.1  MATHEMATICAL ITALIC CAPITAL M
+1D441         ; mapped                 ; 006E          # 3.1  MATHEMATICAL ITALIC CAPITAL N
+1D442         ; mapped                 ; 006F          # 3.1  MATHEMATICAL ITALIC CAPITAL O
+1D443         ; mapped                 ; 0070          # 3.1  MATHEMATICAL ITALIC CAPITAL P
+1D444         ; mapped                 ; 0071          # 3.1  MATHEMATICAL ITALIC CAPITAL Q
+1D445         ; mapped                 ; 0072          # 3.1  MATHEMATICAL ITALIC CAPITAL R
+1D446         ; mapped                 ; 0073          # 3.1  MATHEMATICAL ITALIC CAPITAL S
+1D447         ; mapped                 ; 0074          # 3.1  MATHEMATICAL ITALIC CAPITAL T
+1D448         ; mapped                 ; 0075          # 3.1  MATHEMATICAL ITALIC CAPITAL U
+1D449         ; mapped                 ; 0076          # 3.1  MATHEMATICAL ITALIC CAPITAL V
+1D44A         ; mapped                 ; 0077          # 3.1  MATHEMATICAL ITALIC CAPITAL W
+1D44B         ; mapped                 ; 0078          # 3.1  MATHEMATICAL ITALIC CAPITAL X
+1D44C         ; mapped                 ; 0079          # 3.1  MATHEMATICAL ITALIC CAPITAL Y
+1D44D         ; mapped                 ; 007A          # 3.1  MATHEMATICAL ITALIC CAPITAL Z
+1D44E         ; mapped                 ; 0061          # 3.1  MATHEMATICAL ITALIC SMALL A
+1D44F         ; mapped                 ; 0062          # 3.1  MATHEMATICAL ITALIC SMALL B
+1D450         ; mapped                 ; 0063          # 3.1  MATHEMATICAL ITALIC SMALL C
+1D451         ; mapped                 ; 0064          # 3.1  MATHEMATICAL ITALIC SMALL D
+1D452         ; mapped                 ; 0065          # 3.1  MATHEMATICAL ITALIC SMALL E
+1D453         ; mapped                 ; 0066          # 3.1  MATHEMATICAL ITALIC SMALL F
+1D454         ; mapped                 ; 0067          # 3.1  MATHEMATICAL ITALIC SMALL G
+1D455         ; disallowed                             # NA   <reserved-1D455>
+1D456         ; mapped                 ; 0069          # 3.1  MATHEMATICAL ITALIC SMALL I
+1D457         ; mapped                 ; 006A          # 3.1  MATHEMATICAL ITALIC SMALL J
+1D458         ; mapped                 ; 006B          # 3.1  MATHEMATICAL ITALIC SMALL K
+1D459         ; mapped                 ; 006C          # 3.1  MATHEMATICAL ITALIC SMALL L
+1D45A         ; mapped                 ; 006D          # 3.1  MATHEMATICAL ITALIC SMALL M
+1D45B         ; mapped                 ; 006E          # 3.1  MATHEMATICAL ITALIC SMALL N
+1D45C         ; mapped                 ; 006F          # 3.1  MATHEMATICAL ITALIC SMALL O
+1D45D         ; mapped                 ; 0070          # 3.1  MATHEMATICAL ITALIC SMALL P
+1D45E         ; mapped                 ; 0071          # 3.1  MATHEMATICAL ITALIC SMALL Q
+1D45F         ; mapped                 ; 0072          # 3.1  MATHEMATICAL ITALIC SMALL R
+1D460         ; mapped                 ; 0073          # 3.1  MATHEMATICAL ITALIC SMALL S
+1D461         ; mapped                 ; 0074          # 3.1  MATHEMATICAL ITALIC SMALL T
+1D462         ; mapped                 ; 0075          # 3.1  MATHEMATICAL ITALIC SMALL U
+1D463         ; mapped                 ; 0076          # 3.1  MATHEMATICAL ITALIC SMALL V
+1D464         ; mapped                 ; 0077          # 3.1  MATHEMATICAL ITALIC SMALL W
+1D465         ; mapped                 ; 0078          # 3.1  MATHEMATICAL ITALIC SMALL X
+1D466         ; mapped                 ; 0079          # 3.1  MATHEMATICAL ITALIC SMALL Y
+1D467         ; mapped                 ; 007A          # 3.1  MATHEMATICAL ITALIC SMALL Z
+1D468         ; mapped                 ; 0061          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL A
+1D469         ; mapped                 ; 0062          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL B
+1D46A         ; mapped                 ; 0063          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL C
+1D46B         ; mapped                 ; 0064          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL D
+1D46C         ; mapped                 ; 0065          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL E
+1D46D         ; mapped                 ; 0066          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL F
+1D46E         ; mapped                 ; 0067          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL G
+1D46F         ; mapped                 ; 0068          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL H
+1D470         ; mapped                 ; 0069          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL I
+1D471         ; mapped                 ; 006A          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL J
+1D472         ; mapped                 ; 006B          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL K
+1D473         ; mapped                 ; 006C          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL L
+1D474         ; mapped                 ; 006D          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL M
+1D475         ; mapped                 ; 006E          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL N
+1D476         ; mapped                 ; 006F          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL O
+1D477         ; mapped                 ; 0070          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL P
+1D478         ; mapped                 ; 0071          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL Q
+1D479         ; mapped                 ; 0072          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL R
+1D47A         ; mapped                 ; 0073          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL S
+1D47B         ; mapped                 ; 0074          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL T
+1D47C         ; mapped                 ; 0075          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL U
+1D47D         ; mapped                 ; 0076          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL V
+1D47E         ; mapped                 ; 0077          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL W
+1D47F         ; mapped                 ; 0078          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL X
+1D480         ; mapped                 ; 0079          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL Y
+1D481         ; mapped                 ; 007A          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL Z
+1D482         ; mapped                 ; 0061          # 3.1  MATHEMATICAL BOLD ITALIC SMALL A
+1D483         ; mapped                 ; 0062          # 3.1  MATHEMATICAL BOLD ITALIC SMALL B
+1D484         ; mapped                 ; 0063          # 3.1  MATHEMATICAL BOLD ITALIC SMALL C
+1D485         ; mapped                 ; 0064          # 3.1  MATHEMATICAL BOLD ITALIC SMALL D
+1D486         ; mapped                 ; 0065          # 3.1  MATHEMATICAL BOLD ITALIC SMALL E
+1D487         ; mapped                 ; 0066          # 3.1  MATHEMATICAL BOLD ITALIC SMALL F
+1D488         ; mapped                 ; 0067          # 3.1  MATHEMATICAL BOLD ITALIC SMALL G
+1D489         ; mapped                 ; 0068          # 3.1  MATHEMATICAL BOLD ITALIC SMALL H
+1D48A         ; mapped                 ; 0069          # 3.1  MATHEMATICAL BOLD ITALIC SMALL I
+1D48B         ; mapped                 ; 006A          # 3.1  MATHEMATICAL BOLD ITALIC SMALL J
+1D48C         ; mapped                 ; 006B          # 3.1  MATHEMATICAL BOLD ITALIC SMALL K
+1D48D         ; mapped                 ; 006C          # 3.1  MATHEMATICAL BOLD ITALIC SMALL L
+1D48E         ; mapped                 ; 006D          # 3.1  MATHEMATICAL BOLD ITALIC SMALL M
+1D48F         ; mapped                 ; 006E          # 3.1  MATHEMATICAL BOLD ITALIC SMALL N
+1D490         ; mapped                 ; 006F          # 3.1  MATHEMATICAL BOLD ITALIC SMALL O
+1D491         ; mapped                 ; 0070          # 3.1  MATHEMATICAL BOLD ITALIC SMALL P
+1D492         ; mapped                 ; 0071          # 3.1  MATHEMATICAL BOLD ITALIC SMALL Q
+1D493         ; mapped                 ; 0072          # 3.1  MATHEMATICAL BOLD ITALIC SMALL R
+1D494         ; mapped                 ; 0073          # 3.1  MATHEMATICAL BOLD ITALIC SMALL S
+1D495         ; mapped                 ; 0074          # 3.1  MATHEMATICAL BOLD ITALIC SMALL T
+1D496         ; mapped                 ; 0075          # 3.1  MATHEMATICAL BOLD ITALIC SMALL U
+1D497         ; mapped                 ; 0076          # 3.1  MATHEMATICAL BOLD ITALIC SMALL V
+1D498         ; mapped                 ; 0077          # 3.1  MATHEMATICAL BOLD ITALIC SMALL W
+1D499         ; mapped                 ; 0078          # 3.1  MATHEMATICAL BOLD ITALIC SMALL X
+1D49A         ; mapped                 ; 0079          # 3.1  MATHEMATICAL BOLD ITALIC SMALL Y
+1D49B         ; mapped                 ; 007A          # 3.1  MATHEMATICAL BOLD ITALIC SMALL Z
+1D49C         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SCRIPT CAPITAL A
+1D49D         ; disallowed                             # NA   <reserved-1D49D>
+1D49E         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SCRIPT CAPITAL C
+1D49F         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SCRIPT CAPITAL D
+1D4A0..1D4A1  ; disallowed                             # NA   <reserved-1D4A0>..<reserved-1D4A1>
+1D4A2         ; mapped                 ; 0067          # 3.1  MATHEMATICAL SCRIPT CAPITAL G
+1D4A3..1D4A4  ; disallowed                             # NA   <reserved-1D4A3>..<reserved-1D4A4>
+1D4A5         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SCRIPT CAPITAL J
+1D4A6         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SCRIPT CAPITAL K
+1D4A7..1D4A8  ; disallowed                             # NA   <reserved-1D4A7>..<reserved-1D4A8>
+1D4A9         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SCRIPT CAPITAL N
+1D4AA         ; mapped                 ; 006F          # 3.1  MATHEMATICAL SCRIPT CAPITAL O
+1D4AB         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SCRIPT CAPITAL P
+1D4AC         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SCRIPT CAPITAL Q
+1D4AD         ; disallowed                             # NA   <reserved-1D4AD>
+1D4AE         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SCRIPT CAPITAL S
+1D4AF         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SCRIPT CAPITAL T
+1D4B0         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SCRIPT CAPITAL U
+1D4B1         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SCRIPT CAPITAL V
+1D4B2         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SCRIPT CAPITAL W
+1D4B3         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SCRIPT CAPITAL X
+1D4B4         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SCRIPT CAPITAL Y
+1D4B5         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SCRIPT CAPITAL Z
+1D4B6         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SCRIPT SMALL A
+1D4B7         ; mapped                 ; 0062          # 3.1  MATHEMATICAL SCRIPT SMALL B
+1D4B8         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SCRIPT SMALL C
+1D4B9         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SCRIPT SMALL D
+1D4BA         ; disallowed                             # NA   <reserved-1D4BA>
+1D4BB         ; mapped                 ; 0066          # 3.1  MATHEMATICAL SCRIPT SMALL F
+1D4BC         ; disallowed                             # NA   <reserved-1D4BC>
+1D4BD         ; mapped                 ; 0068          # 3.1  MATHEMATICAL SCRIPT SMALL H
+1D4BE         ; mapped                 ; 0069          # 3.1  MATHEMATICAL SCRIPT SMALL I
+1D4BF         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SCRIPT SMALL J
+1D4C0         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SCRIPT SMALL K
+1D4C1         ; mapped                 ; 006C          # 4.0  MATHEMATICAL SCRIPT SMALL L
+1D4C2         ; mapped                 ; 006D          # 3.1  MATHEMATICAL SCRIPT SMALL M
+1D4C3         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SCRIPT SMALL N
+1D4C4         ; disallowed                             # NA   <reserved-1D4C4>
+1D4C5         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SCRIPT SMALL P
+1D4C6         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SCRIPT SMALL Q
+1D4C7         ; mapped                 ; 0072          # 3.1  MATHEMATICAL SCRIPT SMALL R
+1D4C8         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SCRIPT SMALL S
+1D4C9         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SCRIPT SMALL T
+1D4CA         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SCRIPT SMALL U
+1D4CB         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SCRIPT SMALL V
+1D4CC         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SCRIPT SMALL W
+1D4CD         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SCRIPT SMALL X
+1D4CE         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SCRIPT SMALL Y
+1D4CF         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SCRIPT SMALL Z
+1D4D0         ; mapped                 ; 0061          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL A
+1D4D1         ; mapped                 ; 0062          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL B
+1D4D2         ; mapped                 ; 0063          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL C
+1D4D3         ; mapped                 ; 0064          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL D
+1D4D4         ; mapped                 ; 0065          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL E
+1D4D5         ; mapped                 ; 0066          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL F
+1D4D6         ; mapped                 ; 0067          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL G
+1D4D7         ; mapped                 ; 0068          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL H
+1D4D8         ; mapped                 ; 0069          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL I
+1D4D9         ; mapped                 ; 006A          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL J
+1D4DA         ; mapped                 ; 006B          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL K
+1D4DB         ; mapped                 ; 006C          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL L
+1D4DC         ; mapped                 ; 006D          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL M
+1D4DD         ; mapped                 ; 006E          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL N
+1D4DE         ; mapped                 ; 006F          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL O
+1D4DF         ; mapped                 ; 0070          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL P
+1D4E0         ; mapped                 ; 0071          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL Q
+1D4E1         ; mapped                 ; 0072          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL R
+1D4E2         ; mapped                 ; 0073          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL S
+1D4E3         ; mapped                 ; 0074          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL T
+1D4E4         ; mapped                 ; 0075          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL U
+1D4E5         ; mapped                 ; 0076          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL V
+1D4E6         ; mapped                 ; 0077          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL W
+1D4E7         ; mapped                 ; 0078          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL X
+1D4E8         ; mapped                 ; 0079          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL Y
+1D4E9         ; mapped                 ; 007A          # 3.1  MATHEMATICAL BOLD SCRIPT CAPITAL Z
+1D4EA         ; mapped                 ; 0061          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL A
+1D4EB         ; mapped                 ; 0062          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL B
+1D4EC         ; mapped                 ; 0063          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL C
+1D4ED         ; mapped                 ; 0064          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL D
+1D4EE         ; mapped                 ; 0065          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL E
+1D4EF         ; mapped                 ; 0066          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL F
+1D4F0         ; mapped                 ; 0067          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL G
+1D4F1         ; mapped                 ; 0068          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL H
+1D4F2         ; mapped                 ; 0069          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL I
+1D4F3         ; mapped                 ; 006A          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL J
+1D4F4         ; mapped                 ; 006B          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL K
+1D4F5         ; mapped                 ; 006C          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL L
+1D4F6         ; mapped                 ; 006D          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL M
+1D4F7         ; mapped                 ; 006E          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL N
+1D4F8         ; mapped                 ; 006F          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL O
+1D4F9         ; mapped                 ; 0070          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL P
+1D4FA         ; mapped                 ; 0071          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL Q
+1D4FB         ; mapped                 ; 0072          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL R
+1D4FC         ; mapped                 ; 0073          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL S
+1D4FD         ; mapped                 ; 0074          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL T
+1D4FE         ; mapped                 ; 0075          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL U
+1D4FF         ; mapped                 ; 0076          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL V
+1D500         ; mapped                 ; 0077          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL W
+1D501         ; mapped                 ; 0078          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL X
+1D502         ; mapped                 ; 0079          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL Y
+1D503         ; mapped                 ; 007A          # 3.1  MATHEMATICAL BOLD SCRIPT SMALL Z
+1D504         ; mapped                 ; 0061          # 3.1  MATHEMATICAL FRAKTUR CAPITAL A
+1D505         ; mapped                 ; 0062          # 3.1  MATHEMATICAL FRAKTUR CAPITAL B
+1D506         ; disallowed                             # NA   <reserved-1D506>
+1D507         ; mapped                 ; 0064          # 3.1  MATHEMATICAL FRAKTUR CAPITAL D
+1D508         ; mapped                 ; 0065          # 3.1  MATHEMATICAL FRAKTUR CAPITAL E
+1D509         ; mapped                 ; 0066          # 3.1  MATHEMATICAL FRAKTUR CAPITAL F
+1D50A         ; mapped                 ; 0067          # 3.1  MATHEMATICAL FRAKTUR CAPITAL G
+1D50B..1D50C  ; disallowed                             # NA   <reserved-1D50B>..<reserved-1D50C>
+1D50D         ; mapped                 ; 006A          # 3.1  MATHEMATICAL FRAKTUR CAPITAL J
+1D50E         ; mapped                 ; 006B          # 3.1  MATHEMATICAL FRAKTUR CAPITAL K
+1D50F         ; mapped                 ; 006C          # 3.1  MATHEMATICAL FRAKTUR CAPITAL L
+1D510         ; mapped                 ; 006D          # 3.1  MATHEMATICAL FRAKTUR CAPITAL M
+1D511         ; mapped                 ; 006E          # 3.1  MATHEMATICAL FRAKTUR CAPITAL N
+1D512         ; mapped                 ; 006F          # 3.1  MATHEMATICAL FRAKTUR CAPITAL O
+1D513         ; mapped                 ; 0070          # 3.1  MATHEMATICAL FRAKTUR CAPITAL P
+1D514         ; mapped                 ; 0071          # 3.1  MATHEMATICAL FRAKTUR CAPITAL Q
+1D515         ; disallowed                             # NA   <reserved-1D515>
+1D516         ; mapped                 ; 0073          # 3.1  MATHEMATICAL FRAKTUR CAPITAL S
+1D517         ; mapped                 ; 0074          # 3.1  MATHEMATICAL FRAKTUR CAPITAL T
+1D518         ; mapped                 ; 0075          # 3.1  MATHEMATICAL FRAKTUR CAPITAL U
+1D519         ; mapped                 ; 0076          # 3.1  MATHEMATICAL FRAKTUR CAPITAL V
+1D51A         ; mapped                 ; 0077          # 3.1  MATHEMATICAL FRAKTUR CAPITAL W
+1D51B         ; mapped                 ; 0078          # 3.1  MATHEMATICAL FRAKTUR CAPITAL X
+1D51C         ; mapped                 ; 0079          # 3.1  MATHEMATICAL FRAKTUR CAPITAL Y
+1D51D         ; disallowed                             # NA   <reserved-1D51D>
+1D51E         ; mapped                 ; 0061          # 3.1  MATHEMATICAL FRAKTUR SMALL A
+1D51F         ; mapped                 ; 0062          # 3.1  MATHEMATICAL FRAKTUR SMALL B
+1D520         ; mapped                 ; 0063          # 3.1  MATHEMATICAL FRAKTUR SMALL C
+1D521         ; mapped                 ; 0064          # 3.1  MATHEMATICAL FRAKTUR SMALL D
+1D522         ; mapped                 ; 0065          # 3.1  MATHEMATICAL FRAKTUR SMALL E
+1D523         ; mapped                 ; 0066          # 3.1  MATHEMATICAL FRAKTUR SMALL F
+1D524         ; mapped                 ; 0067          # 3.1  MATHEMATICAL FRAKTUR SMALL G
+1D525         ; mapped                 ; 0068          # 3.1  MATHEMATICAL FRAKTUR SMALL H
+1D526         ; mapped                 ; 0069          # 3.1  MATHEMATICAL FRAKTUR SMALL I
+1D527         ; mapped                 ; 006A          # 3.1  MATHEMATICAL FRAKTUR SMALL J
+1D528         ; mapped                 ; 006B          # 3.1  MATHEMATICAL FRAKTUR SMALL K
+1D529         ; mapped                 ; 006C          # 3.1  MATHEMATICAL FRAKTUR SMALL L
+1D52A         ; mapped                 ; 006D          # 3.1  MATHEMATICAL FRAKTUR SMALL M
+1D52B         ; mapped                 ; 006E          # 3.1  MATHEMATICAL FRAKTUR SMALL N
+1D52C         ; mapped                 ; 006F          # 3.1  MATHEMATICAL FRAKTUR SMALL O
+1D52D         ; mapped                 ; 0070          # 3.1  MATHEMATICAL FRAKTUR SMALL P
+1D52E         ; mapped                 ; 0071          # 3.1  MATHEMATICAL FRAKTUR SMALL Q
+1D52F         ; mapped                 ; 0072          # 3.1  MATHEMATICAL FRAKTUR SMALL R
+1D530         ; mapped                 ; 0073          # 3.1  MATHEMATICAL FRAKTUR SMALL S
+1D531         ; mapped                 ; 0074          # 3.1  MATHEMATICAL FRAKTUR SMALL T
+1D532         ; mapped                 ; 0075          # 3.1  MATHEMATICAL FRAKTUR SMALL U
+1D533         ; mapped                 ; 0076          # 3.1  MATHEMATICAL FRAKTUR SMALL V
+1D534         ; mapped                 ; 0077          # 3.1  MATHEMATICAL FRAKTUR SMALL W
+1D535         ; mapped                 ; 0078          # 3.1  MATHEMATICAL FRAKTUR SMALL X
+1D536         ; mapped                 ; 0079          # 3.1  MATHEMATICAL FRAKTUR SMALL Y
+1D537         ; mapped                 ; 007A          # 3.1  MATHEMATICAL FRAKTUR SMALL Z
+1D538         ; mapped                 ; 0061          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL A
+1D539         ; mapped                 ; 0062          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL B
+1D53A         ; disallowed                             # NA   <reserved-1D53A>
+1D53B         ; mapped                 ; 0064          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL D
+1D53C         ; mapped                 ; 0065          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL E
+1D53D         ; mapped                 ; 0066          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL F
+1D53E         ; mapped                 ; 0067          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL G
+1D53F         ; disallowed                             # NA   <reserved-1D53F>
+1D540         ; mapped                 ; 0069          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL I
+1D541         ; mapped                 ; 006A          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL J
+1D542         ; mapped                 ; 006B          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL K
+1D543         ; mapped                 ; 006C          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL L
+1D544         ; mapped                 ; 006D          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL M
+1D545         ; disallowed                             # NA   <reserved-1D545>
+1D546         ; mapped                 ; 006F          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL O
+1D547..1D549  ; disallowed                             # NA   <reserved-1D547>..<reserved-1D549>
+1D54A         ; mapped                 ; 0073          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL S
+1D54B         ; mapped                 ; 0074          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL T
+1D54C         ; mapped                 ; 0075          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL U
+1D54D         ; mapped                 ; 0076          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL V
+1D54E         ; mapped                 ; 0077          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL W
+1D54F         ; mapped                 ; 0078          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL X
+1D550         ; mapped                 ; 0079          # 3.1  MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
+1D551         ; disallowed                             # NA   <reserved-1D551>
+1D552         ; mapped                 ; 0061          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL A
+1D553         ; mapped                 ; 0062          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL B
+1D554         ; mapped                 ; 0063          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL C
+1D555         ; mapped                 ; 0064          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL D
+1D556         ; mapped                 ; 0065          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL E
+1D557         ; mapped                 ; 0066          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL F
+1D558         ; mapped                 ; 0067          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL G
+1D559         ; mapped                 ; 0068          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL H
+1D55A         ; mapped                 ; 0069          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL I
+1D55B         ; mapped                 ; 006A          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL J
+1D55C         ; mapped                 ; 006B          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL K
+1D55D         ; mapped                 ; 006C          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL L
+1D55E         ; mapped                 ; 006D          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL M
+1D55F         ; mapped                 ; 006E          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL N
+1D560         ; mapped                 ; 006F          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL O
+1D561         ; mapped                 ; 0070          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL P
+1D562         ; mapped                 ; 0071          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL Q
+1D563         ; mapped                 ; 0072          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL R
+1D564         ; mapped                 ; 0073          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL S
+1D565         ; mapped                 ; 0074          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL T
+1D566         ; mapped                 ; 0075          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL U
+1D567         ; mapped                 ; 0076          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL V
+1D568         ; mapped                 ; 0077          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL W
+1D569         ; mapped                 ; 0078          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL X
+1D56A         ; mapped                 ; 0079          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL Y
+1D56B         ; mapped                 ; 007A          # 3.1  MATHEMATICAL DOUBLE-STRUCK SMALL Z
+1D56C         ; mapped                 ; 0061          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL A
+1D56D         ; mapped                 ; 0062          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL B
+1D56E         ; mapped                 ; 0063          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL C
+1D56F         ; mapped                 ; 0064          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL D
+1D570         ; mapped                 ; 0065          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL E
+1D571         ; mapped                 ; 0066          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL F
+1D572         ; mapped                 ; 0067          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL G
+1D573         ; mapped                 ; 0068          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL H
+1D574         ; mapped                 ; 0069          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL I
+1D575         ; mapped                 ; 006A          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL J
+1D576         ; mapped                 ; 006B          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL K
+1D577         ; mapped                 ; 006C          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL L
+1D578         ; mapped                 ; 006D          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL M
+1D579         ; mapped                 ; 006E          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL N
+1D57A         ; mapped                 ; 006F          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL O
+1D57B         ; mapped                 ; 0070          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL P
+1D57C         ; mapped                 ; 0071          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL Q
+1D57D         ; mapped                 ; 0072          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL R
+1D57E         ; mapped                 ; 0073          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL S
+1D57F         ; mapped                 ; 0074          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL T
+1D580         ; mapped                 ; 0075          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL U
+1D581         ; mapped                 ; 0076          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL V
+1D582         ; mapped                 ; 0077          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL W
+1D583         ; mapped                 ; 0078          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL X
+1D584         ; mapped                 ; 0079          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL Y
+1D585         ; mapped                 ; 007A          # 3.1  MATHEMATICAL BOLD FRAKTUR CAPITAL Z
+1D586         ; mapped                 ; 0061          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL A
+1D587         ; mapped                 ; 0062          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL B
+1D588         ; mapped                 ; 0063          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL C
+1D589         ; mapped                 ; 0064          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL D
+1D58A         ; mapped                 ; 0065          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL E
+1D58B         ; mapped                 ; 0066          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL F
+1D58C         ; mapped                 ; 0067          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL G
+1D58D         ; mapped                 ; 0068          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL H
+1D58E         ; mapped                 ; 0069          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL I
+1D58F         ; mapped                 ; 006A          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL J
+1D590         ; mapped                 ; 006B          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL K
+1D591         ; mapped                 ; 006C          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL L
+1D592         ; mapped                 ; 006D          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL M
+1D593         ; mapped                 ; 006E          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL N
+1D594         ; mapped                 ; 006F          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL O
+1D595         ; mapped                 ; 0070          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL P
+1D596         ; mapped                 ; 0071          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL Q
+1D597         ; mapped                 ; 0072          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL R
+1D598         ; mapped                 ; 0073          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL S
+1D599         ; mapped                 ; 0074          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL T
+1D59A         ; mapped                 ; 0075          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL U
+1D59B         ; mapped                 ; 0076          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL V
+1D59C         ; mapped                 ; 0077          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL W
+1D59D         ; mapped                 ; 0078          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL X
+1D59E         ; mapped                 ; 0079          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL Y
+1D59F         ; mapped                 ; 007A          # 3.1  MATHEMATICAL BOLD FRAKTUR SMALL Z
+1D5A0         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL A
+1D5A1         ; mapped                 ; 0062          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL B
+1D5A2         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL C
+1D5A3         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL D
+1D5A4         ; mapped                 ; 0065          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL E
+1D5A5         ; mapped                 ; 0066          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL F
+1D5A6         ; mapped                 ; 0067          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL G
+1D5A7         ; mapped                 ; 0068          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL H
+1D5A8         ; mapped                 ; 0069          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL I
+1D5A9         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL J
+1D5AA         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL K
+1D5AB         ; mapped                 ; 006C          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL L
+1D5AC         ; mapped                 ; 006D          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL M
+1D5AD         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL N
+1D5AE         ; mapped                 ; 006F          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL O
+1D5AF         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL P
+1D5B0         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL Q
+1D5B1         ; mapped                 ; 0072          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL R
+1D5B2         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL S
+1D5B3         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL T
+1D5B4         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL U
+1D5B5         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL V
+1D5B6         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL W
+1D5B7         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL X
+1D5B8         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL Y
+1D5B9         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SANS-SERIF CAPITAL Z
+1D5BA         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SANS-SERIF SMALL A
+1D5BB         ; mapped                 ; 0062          # 3.1  MATHEMATICAL SANS-SERIF SMALL B
+1D5BC         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SANS-SERIF SMALL C
+1D5BD         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SANS-SERIF SMALL D
+1D5BE         ; mapped                 ; 0065          # 3.1  MATHEMATICAL SANS-SERIF SMALL E
+1D5BF         ; mapped                 ; 0066          # 3.1  MATHEMATICAL SANS-SERIF SMALL F
+1D5C0         ; mapped                 ; 0067          # 3.1  MATHEMATICAL SANS-SERIF SMALL G
+1D5C1         ; mapped                 ; 0068          # 3.1  MATHEMATICAL SANS-SERIF SMALL H
+1D5C2         ; mapped                 ; 0069          # 3.1  MATHEMATICAL SANS-SERIF SMALL I
+1D5C3         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SANS-SERIF SMALL J
+1D5C4         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SANS-SERIF SMALL K
+1D5C5         ; mapped                 ; 006C          # 3.1  MATHEMATICAL SANS-SERIF SMALL L
+1D5C6         ; mapped                 ; 006D          # 3.1  MATHEMATICAL SANS-SERIF SMALL M
+1D5C7         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SANS-SERIF SMALL N
+1D5C8         ; mapped                 ; 006F          # 3.1  MATHEMATICAL SANS-SERIF SMALL O
+1D5C9         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SANS-SERIF SMALL P
+1D5CA         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SANS-SERIF SMALL Q
+1D5CB         ; mapped                 ; 0072          # 3.1  MATHEMATICAL SANS-SERIF SMALL R
+1D5CC         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SANS-SERIF SMALL S
+1D5CD         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SANS-SERIF SMALL T
+1D5CE         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SANS-SERIF SMALL U
+1D5CF         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SANS-SERIF SMALL V
+1D5D0         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SANS-SERIF SMALL W
+1D5D1         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SANS-SERIF SMALL X
+1D5D2         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SANS-SERIF SMALL Y
+1D5D3         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SANS-SERIF SMALL Z
+1D5D4         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL A
+1D5D5         ; mapped                 ; 0062          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL B
+1D5D6         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL C
+1D5D7         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL D
+1D5D8         ; mapped                 ; 0065          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL E
+1D5D9         ; mapped                 ; 0066          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL F
+1D5DA         ; mapped                 ; 0067          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL G
+1D5DB         ; mapped                 ; 0068          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL H
+1D5DC         ; mapped                 ; 0069          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL I
+1D5DD         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL J
+1D5DE         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL K
+1D5DF         ; mapped                 ; 006C          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL L
+1D5E0         ; mapped                 ; 006D          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL M
+1D5E1         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL N
+1D5E2         ; mapped                 ; 006F          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL O
+1D5E3         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL P
+1D5E4         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL Q
+1D5E5         ; mapped                 ; 0072          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL R
+1D5E6         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL S
+1D5E7         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL T
+1D5E8         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL U
+1D5E9         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL V
+1D5EA         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL W
+1D5EB         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL X
+1D5EC         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL Y
+1D5ED         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL Z
+1D5EE         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL A
+1D5EF         ; mapped                 ; 0062          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL B
+1D5F0         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL C
+1D5F1         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL D
+1D5F2         ; mapped                 ; 0065          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL E
+1D5F3         ; mapped                 ; 0066          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL F
+1D5F4         ; mapped                 ; 0067          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL G
+1D5F5         ; mapped                 ; 0068          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL H
+1D5F6         ; mapped                 ; 0069          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL I
+1D5F7         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL J
+1D5F8         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL K
+1D5F9         ; mapped                 ; 006C          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL L
+1D5FA         ; mapped                 ; 006D          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL M
+1D5FB         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL N
+1D5FC         ; mapped                 ; 006F          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL O
+1D5FD         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL P
+1D5FE         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL Q
+1D5FF         ; mapped                 ; 0072          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL R
+1D600         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL S
+1D601         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL T
+1D602         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL U
+1D603         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL V
+1D604         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL W
+1D605         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL X
+1D606         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL Y
+1D607         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL Z
+1D608         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL A
+1D609         ; mapped                 ; 0062          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL B
+1D60A         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL C
+1D60B         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL D
+1D60C         ; mapped                 ; 0065          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL E
+1D60D         ; mapped                 ; 0066          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL F
+1D60E         ; mapped                 ; 0067          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL G
+1D60F         ; mapped                 ; 0068          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL H
+1D610         ; mapped                 ; 0069          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL I
+1D611         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL J
+1D612         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL K
+1D613         ; mapped                 ; 006C          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL L
+1D614         ; mapped                 ; 006D          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL M
+1D615         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL N
+1D616         ; mapped                 ; 006F          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL O
+1D617         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL P
+1D618         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL Q
+1D619         ; mapped                 ; 0072          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL R
+1D61A         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL S
+1D61B         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL T
+1D61C         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL U
+1D61D         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL V
+1D61E         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL W
+1D61F         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL X
+1D620         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL Y
+1D621         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SANS-SERIF ITALIC CAPITAL Z
+1D622         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL A
+1D623         ; mapped                 ; 0062          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL B
+1D624         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL C
+1D625         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL D
+1D626         ; mapped                 ; 0065          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL E
+1D627         ; mapped                 ; 0066          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL F
+1D628         ; mapped                 ; 0067          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL G
+1D629         ; mapped                 ; 0068          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL H
+1D62A         ; mapped                 ; 0069          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL I
+1D62B         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL J
+1D62C         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL K
+1D62D         ; mapped                 ; 006C          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL L
+1D62E         ; mapped                 ; 006D          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL M
+1D62F         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL N
+1D630         ; mapped                 ; 006F          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL O
+1D631         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL P
+1D632         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL Q
+1D633         ; mapped                 ; 0072          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL R
+1D634         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL S
+1D635         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL T
+1D636         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL U
+1D637         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL V
+1D638         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL W
+1D639         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL X
+1D63A         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL Y
+1D63B         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SANS-SERIF ITALIC SMALL Z
+1D63C         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL A
+1D63D         ; mapped                 ; 0062          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL B
+1D63E         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL C
+1D63F         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL D
+1D640         ; mapped                 ; 0065          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL E
+1D641         ; mapped                 ; 0066          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL F
+1D642         ; mapped                 ; 0067          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL G
+1D643         ; mapped                 ; 0068          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL H
+1D644         ; mapped                 ; 0069          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL I
+1D645         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL J
+1D646         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL K
+1D647         ; mapped                 ; 006C          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL L
+1D648         ; mapped                 ; 006D          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL M
+1D649         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL N
+1D64A         ; mapped                 ; 006F          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL O
+1D64B         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL P
+1D64C         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL Q
+1D64D         ; mapped                 ; 0072          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL R
+1D64E         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL S
+1D64F         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL T
+1D650         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL U
+1D651         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL V
+1D652         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL W
+1D653         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL X
+1D654         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL Y
+1D655         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL Z
+1D656         ; mapped                 ; 0061          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL A
+1D657         ; mapped                 ; 0062          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL B
+1D658         ; mapped                 ; 0063          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL C
+1D659         ; mapped                 ; 0064          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL D
+1D65A         ; mapped                 ; 0065          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL E
+1D65B         ; mapped                 ; 0066          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL F
+1D65C         ; mapped                 ; 0067          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL G
+1D65D         ; mapped                 ; 0068          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL H
+1D65E         ; mapped                 ; 0069          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL I
+1D65F         ; mapped                 ; 006A          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL J
+1D660         ; mapped                 ; 006B          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL K
+1D661         ; mapped                 ; 006C          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL L
+1D662         ; mapped                 ; 006D          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL M
+1D663         ; mapped                 ; 006E          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL N
+1D664         ; mapped                 ; 006F          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL O
+1D665         ; mapped                 ; 0070          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL P
+1D666         ; mapped                 ; 0071          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL Q
+1D667         ; mapped                 ; 0072          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL R
+1D668         ; mapped                 ; 0073          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL S
+1D669         ; mapped                 ; 0074          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL T
+1D66A         ; mapped                 ; 0075          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL U
+1D66B         ; mapped                 ; 0076          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL V
+1D66C         ; mapped                 ; 0077          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL W
+1D66D         ; mapped                 ; 0078          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL X
+1D66E         ; mapped                 ; 0079          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL Y
+1D66F         ; mapped                 ; 007A          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL Z
+1D670         ; mapped                 ; 0061          # 3.1  MATHEMATICAL MONOSPACE CAPITAL A
+1D671         ; mapped                 ; 0062          # 3.1  MATHEMATICAL MONOSPACE CAPITAL B
+1D672         ; mapped                 ; 0063          # 3.1  MATHEMATICAL MONOSPACE CAPITAL C
+1D673         ; mapped                 ; 0064          # 3.1  MATHEMATICAL MONOSPACE CAPITAL D
+1D674         ; mapped                 ; 0065          # 3.1  MATHEMATICAL MONOSPACE CAPITAL E
+1D675         ; mapped                 ; 0066          # 3.1  MATHEMATICAL MONOSPACE CAPITAL F
+1D676         ; mapped                 ; 0067          # 3.1  MATHEMATICAL MONOSPACE CAPITAL G
+1D677         ; mapped                 ; 0068          # 3.1  MATHEMATICAL MONOSPACE CAPITAL H
+1D678         ; mapped                 ; 0069          # 3.1  MATHEMATICAL MONOSPACE CAPITAL I
+1D679         ; mapped                 ; 006A          # 3.1  MATHEMATICAL MONOSPACE CAPITAL J
+1D67A         ; mapped                 ; 006B          # 3.1  MATHEMATICAL MONOSPACE CAPITAL K
+1D67B         ; mapped                 ; 006C          # 3.1  MATHEMATICAL MONOSPACE CAPITAL L
+1D67C         ; mapped                 ; 006D          # 3.1  MATHEMATICAL MONOSPACE CAPITAL M
+1D67D         ; mapped                 ; 006E          # 3.1  MATHEMATICAL MONOSPACE CAPITAL N
+1D67E         ; mapped                 ; 006F          # 3.1  MATHEMATICAL MONOSPACE CAPITAL O
+1D67F         ; mapped                 ; 0070          # 3.1  MATHEMATICAL MONOSPACE CAPITAL P
+1D680         ; mapped                 ; 0071          # 3.1  MATHEMATICAL MONOSPACE CAPITAL Q
+1D681         ; mapped                 ; 0072          # 3.1  MATHEMATICAL MONOSPACE CAPITAL R
+1D682         ; mapped                 ; 0073          # 3.1  MATHEMATICAL MONOSPACE CAPITAL S
+1D683         ; mapped                 ; 0074          # 3.1  MATHEMATICAL MONOSPACE CAPITAL T
+1D684         ; mapped                 ; 0075          # 3.1  MATHEMATICAL MONOSPACE CAPITAL U
+1D685         ; mapped                 ; 0076          # 3.1  MATHEMATICAL MONOSPACE CAPITAL V
+1D686         ; mapped                 ; 0077          # 3.1  MATHEMATICAL MONOSPACE CAPITAL W
+1D687         ; mapped                 ; 0078          # 3.1  MATHEMATICAL MONOSPACE CAPITAL X
+1D688         ; mapped                 ; 0079          # 3.1  MATHEMATICAL MONOSPACE CAPITAL Y
+1D689         ; mapped                 ; 007A          # 3.1  MATHEMATICAL MONOSPACE CAPITAL Z
+1D68A         ; mapped                 ; 0061          # 3.1  MATHEMATICAL MONOSPACE SMALL A
+1D68B         ; mapped                 ; 0062          # 3.1  MATHEMATICAL MONOSPACE SMALL B
+1D68C         ; mapped                 ; 0063          # 3.1  MATHEMATICAL MONOSPACE SMALL C
+1D68D         ; mapped                 ; 0064          # 3.1  MATHEMATICAL MONOSPACE SMALL D
+1D68E         ; mapped                 ; 0065          # 3.1  MATHEMATICAL MONOSPACE SMALL E
+1D68F         ; mapped                 ; 0066          # 3.1  MATHEMATICAL MONOSPACE SMALL F
+1D690         ; mapped                 ; 0067          # 3.1  MATHEMATICAL MONOSPACE SMALL G
+1D691         ; mapped                 ; 0068          # 3.1  MATHEMATICAL MONOSPACE SMALL H
+1D692         ; mapped                 ; 0069          # 3.1  MATHEMATICAL MONOSPACE SMALL I
+1D693         ; mapped                 ; 006A          # 3.1  MATHEMATICAL MONOSPACE SMALL J
+1D694         ; mapped                 ; 006B          # 3.1  MATHEMATICAL MONOSPACE SMALL K
+1D695         ; mapped                 ; 006C          # 3.1  MATHEMATICAL MONOSPACE SMALL L
+1D696         ; mapped                 ; 006D          # 3.1  MATHEMATICAL MONOSPACE SMALL M
+1D697         ; mapped                 ; 006E          # 3.1  MATHEMATICAL MONOSPACE SMALL N
+1D698         ; mapped                 ; 006F          # 3.1  MATHEMATICAL MONOSPACE SMALL O
+1D699         ; mapped                 ; 0070          # 3.1  MATHEMATICAL MONOSPACE SMALL P
+1D69A         ; mapped                 ; 0071          # 3.1  MATHEMATICAL MONOSPACE SMALL Q
+1D69B         ; mapped                 ; 0072          # 3.1  MATHEMATICAL MONOSPACE SMALL R
+1D69C         ; mapped                 ; 0073          # 3.1  MATHEMATICAL MONOSPACE SMALL S
+1D69D         ; mapped                 ; 0074          # 3.1  MATHEMATICAL MONOSPACE SMALL T
+1D69E         ; mapped                 ; 0075          # 3.1  MATHEMATICAL MONOSPACE SMALL U
+1D69F         ; mapped                 ; 0076          # 3.1  MATHEMATICAL MONOSPACE SMALL V
+1D6A0         ; mapped                 ; 0077          # 3.1  MATHEMATICAL MONOSPACE SMALL W
+1D6A1         ; mapped                 ; 0078          # 3.1  MATHEMATICAL MONOSPACE SMALL X
+1D6A2         ; mapped                 ; 0079          # 3.1  MATHEMATICAL MONOSPACE SMALL Y
+1D6A3         ; mapped                 ; 007A          # 3.1  MATHEMATICAL MONOSPACE SMALL Z
+1D6A4         ; mapped                 ; 0131          # 4.1  MATHEMATICAL ITALIC SMALL DOTLESS I
+1D6A5         ; mapped                 ; 0237          # 4.1  MATHEMATICAL ITALIC SMALL DOTLESS J
+1D6A6..1D6A7  ; disallowed                             # NA   <reserved-1D6A6>..<reserved-1D6A7>
+1D6A8         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL BOLD CAPITAL ALPHA
+1D6A9         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL BOLD CAPITAL BETA
+1D6AA         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL BOLD CAPITAL GAMMA
+1D6AB         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL BOLD CAPITAL DELTA
+1D6AC         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL BOLD CAPITAL EPSILON
+1D6AD         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL BOLD CAPITAL ZETA
+1D6AE         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL BOLD CAPITAL ETA
+1D6AF         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL BOLD CAPITAL THETA
+1D6B0         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL BOLD CAPITAL IOTA
+1D6B1         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL BOLD CAPITAL KAPPA
+1D6B2         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL BOLD CAPITAL LAMDA
+1D6B3         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL BOLD CAPITAL MU
+1D6B4         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL BOLD CAPITAL NU
+1D6B5         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL BOLD CAPITAL XI
+1D6B6         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL BOLD CAPITAL OMICRON
+1D6B7         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL BOLD CAPITAL PI
+1D6B8         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL BOLD CAPITAL RHO
+1D6B9         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL BOLD CAPITAL THETA SYMBOL
+1D6BA         ; mapped                 ; 03C3          # 3.1  MATHEMATICAL BOLD CAPITAL SIGMA
+1D6BB         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL BOLD CAPITAL TAU
+1D6BC         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL BOLD CAPITAL UPSILON
+1D6BD         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL BOLD CAPITAL PHI
+1D6BE         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL BOLD CAPITAL CHI
+1D6BF         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL BOLD CAPITAL PSI
+1D6C0         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL BOLD CAPITAL OMEGA
+1D6C1         ; mapped                 ; 2207          # 3.1  MATHEMATICAL BOLD NABLA
+1D6C2         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL BOLD SMALL ALPHA
+1D6C3         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL BOLD SMALL BETA
+1D6C4         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL BOLD SMALL GAMMA
+1D6C5         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL BOLD SMALL DELTA
+1D6C6         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL BOLD SMALL EPSILON
+1D6C7         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL BOLD SMALL ZETA
+1D6C8         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL BOLD SMALL ETA
+1D6C9         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL BOLD SMALL THETA
+1D6CA         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL BOLD SMALL IOTA
+1D6CB         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL BOLD SMALL KAPPA
+1D6CC         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL BOLD SMALL LAMDA
+1D6CD         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL BOLD SMALL MU
+1D6CE         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL BOLD SMALL NU
+1D6CF         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL BOLD SMALL XI
+1D6D0         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL BOLD SMALL OMICRON
+1D6D1         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL BOLD SMALL PI
+1D6D2         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL BOLD SMALL RHO
+1D6D3..1D6D4  ; mapped                 ; 03C3          # 3.1  MATHEMATICAL BOLD SMALL FINAL SIGMA..MATHEMATICAL BOLD SMALL SIGMA
+1D6D5         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL BOLD SMALL TAU
+1D6D6         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL BOLD SMALL UPSILON
+1D6D7         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL BOLD SMALL PHI
+1D6D8         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL BOLD SMALL CHI
+1D6D9         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL BOLD SMALL PSI
+1D6DA         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL BOLD SMALL OMEGA
+1D6DB         ; mapped                 ; 2202          # 3.1  MATHEMATICAL BOLD PARTIAL DIFFERENTIAL
+1D6DC         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL BOLD EPSILON SYMBOL
+1D6DD         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL BOLD THETA SYMBOL
+1D6DE         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL BOLD KAPPA SYMBOL
+1D6DF         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL BOLD PHI SYMBOL
+1D6E0         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL BOLD RHO SYMBOL
+1D6E1         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL BOLD PI SYMBOL
+1D6E2         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL ITALIC CAPITAL ALPHA
+1D6E3         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL ITALIC CAPITAL BETA
+1D6E4         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL ITALIC CAPITAL GAMMA
+1D6E5         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL ITALIC CAPITAL DELTA
+1D6E6         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL ITALIC CAPITAL EPSILON
+1D6E7         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL ITALIC CAPITAL ZETA
+1D6E8         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL ITALIC CAPITAL ETA
+1D6E9         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL ITALIC CAPITAL THETA
+1D6EA         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL ITALIC CAPITAL IOTA
+1D6EB         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL ITALIC CAPITAL KAPPA
+1D6EC         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL ITALIC CAPITAL LAMDA
+1D6ED         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL ITALIC CAPITAL MU
+1D6EE         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL ITALIC CAPITAL NU
+1D6EF         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL ITALIC CAPITAL XI
+1D6F0         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL ITALIC CAPITAL OMICRON
+1D6F1         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL ITALIC CAPITAL PI
+1D6F2         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL ITALIC CAPITAL RHO
+1D6F3         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL ITALIC CAPITAL THETA SYMBOL
+1D6F4         ; mapped                 ; 03C3          # 3.1  MATHEMATICAL ITALIC CAPITAL SIGMA
+1D6F5         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL ITALIC CAPITAL TAU
+1D6F6         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL ITALIC CAPITAL UPSILON
+1D6F7         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL ITALIC CAPITAL PHI
+1D6F8         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL ITALIC CAPITAL CHI
+1D6F9         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL ITALIC CAPITAL PSI
+1D6FA         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL ITALIC CAPITAL OMEGA
+1D6FB         ; mapped                 ; 2207          # 3.1  MATHEMATICAL ITALIC NABLA
+1D6FC         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL ITALIC SMALL ALPHA
+1D6FD         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL ITALIC SMALL BETA
+1D6FE         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL ITALIC SMALL GAMMA
+1D6FF         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL ITALIC SMALL DELTA
+1D700         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL ITALIC SMALL EPSILON
+1D701         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL ITALIC SMALL ZETA
+1D702         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL ITALIC SMALL ETA
+1D703         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL ITALIC SMALL THETA
+1D704         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL ITALIC SMALL IOTA
+1D705         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL ITALIC SMALL KAPPA
+1D706         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL ITALIC SMALL LAMDA
+1D707         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL ITALIC SMALL MU
+1D708         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL ITALIC SMALL NU
+1D709         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL ITALIC SMALL XI
+1D70A         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL ITALIC SMALL OMICRON
+1D70B         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL ITALIC SMALL PI
+1D70C         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL ITALIC SMALL RHO
+1D70D..1D70E  ; mapped                 ; 03C3          # 3.1  MATHEMATICAL ITALIC SMALL FINAL SIGMA..MATHEMATICAL ITALIC SMALL SIGMA
+1D70F         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL ITALIC SMALL TAU
+1D710         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL ITALIC SMALL UPSILON
+1D711         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL ITALIC SMALL PHI
+1D712         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL ITALIC SMALL CHI
+1D713         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL ITALIC SMALL PSI
+1D714         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL ITALIC SMALL OMEGA
+1D715         ; mapped                 ; 2202          # 3.1  MATHEMATICAL ITALIC PARTIAL DIFFERENTIAL
+1D716         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL ITALIC EPSILON SYMBOL
+1D717         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL ITALIC THETA SYMBOL
+1D718         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL ITALIC KAPPA SYMBOL
+1D719         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL ITALIC PHI SYMBOL
+1D71A         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL ITALIC RHO SYMBOL
+1D71B         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL ITALIC PI SYMBOL
+1D71C         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL ALPHA
+1D71D         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL BETA
+1D71E         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL GAMMA
+1D71F         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL DELTA
+1D720         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL EPSILON
+1D721         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL ZETA
+1D722         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL ETA
+1D723         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL THETA
+1D724         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL IOTA
+1D725         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL KAPPA
+1D726         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL LAMDA
+1D727         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL MU
+1D728         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL NU
+1D729         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL XI
+1D72A         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL OMICRON
+1D72B         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL PI
+1D72C         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL RHO
+1D72D         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL THETA SYMBOL
+1D72E         ; mapped                 ; 03C3          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL SIGMA
+1D72F         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL TAU
+1D730         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL UPSILON
+1D731         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL PHI
+1D732         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL CHI
+1D733         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL PSI
+1D734         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL BOLD ITALIC CAPITAL OMEGA
+1D735         ; mapped                 ; 2207          # 3.1  MATHEMATICAL BOLD ITALIC NABLA
+1D736         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL BOLD ITALIC SMALL ALPHA
+1D737         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL BOLD ITALIC SMALL BETA
+1D738         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL BOLD ITALIC SMALL GAMMA
+1D739         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL BOLD ITALIC SMALL DELTA
+1D73A         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL BOLD ITALIC SMALL EPSILON
+1D73B         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL BOLD ITALIC SMALL ZETA
+1D73C         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL BOLD ITALIC SMALL ETA
+1D73D         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL BOLD ITALIC SMALL THETA
+1D73E         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL BOLD ITALIC SMALL IOTA
+1D73F         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL BOLD ITALIC SMALL KAPPA
+1D740         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL BOLD ITALIC SMALL LAMDA
+1D741         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL BOLD ITALIC SMALL MU
+1D742         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL BOLD ITALIC SMALL NU
+1D743         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL BOLD ITALIC SMALL XI
+1D744         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL BOLD ITALIC SMALL OMICRON
+1D745         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL BOLD ITALIC SMALL PI
+1D746         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL BOLD ITALIC SMALL RHO
+1D747..1D748  ; mapped                 ; 03C3          # 3.1  MATHEMATICAL BOLD ITALIC SMALL FINAL SIGMA..MATHEMATICAL BOLD ITALIC SMALL SIGMA
+1D749         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL BOLD ITALIC SMALL TAU
+1D74A         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL BOLD ITALIC SMALL UPSILON
+1D74B         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL BOLD ITALIC SMALL PHI
+1D74C         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL BOLD ITALIC SMALL CHI
+1D74D         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL BOLD ITALIC SMALL PSI
+1D74E         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL BOLD ITALIC SMALL OMEGA
+1D74F         ; mapped                 ; 2202          # 3.1  MATHEMATICAL BOLD ITALIC PARTIAL DIFFERENTIAL
+1D750         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL BOLD ITALIC EPSILON SYMBOL
+1D751         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL BOLD ITALIC THETA SYMBOL
+1D752         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL BOLD ITALIC KAPPA SYMBOL
+1D753         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL BOLD ITALIC PHI SYMBOL
+1D754         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL BOLD ITALIC RHO SYMBOL
+1D755         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL BOLD ITALIC PI SYMBOL
+1D756         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL ALPHA
+1D757         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL BETA
+1D758         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL GAMMA
+1D759         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL DELTA
+1D75A         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL EPSILON
+1D75B         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL ZETA
+1D75C         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL ETA
+1D75D         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL THETA
+1D75E         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL IOTA
+1D75F         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL KAPPA
+1D760         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL LAMDA
+1D761         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL MU
+1D762         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL NU
+1D763         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL XI
+1D764         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL OMICRON
+1D765         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL PI
+1D766         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL RHO
+1D767         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL THETA SYMBOL
+1D768         ; mapped                 ; 03C3          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL SIGMA
+1D769         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL TAU
+1D76A         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL UPSILON
+1D76B         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL PHI
+1D76C         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL CHI
+1D76D         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL PSI
+1D76E         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL SANS-SERIF BOLD CAPITAL OMEGA
+1D76F         ; mapped                 ; 2207          # 3.1  MATHEMATICAL SANS-SERIF BOLD NABLA
+1D770         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA
+1D771         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL BETA
+1D772         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL GAMMA
+1D773         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL DELTA
+1D774         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL EPSILON
+1D775         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL ZETA
+1D776         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL ETA
+1D777         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL THETA
+1D778         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL IOTA
+1D779         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL KAPPA
+1D77A         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL LAMDA
+1D77B         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL MU
+1D77C         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL NU
+1D77D         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL XI
+1D77E         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL OMICRON
+1D77F         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL PI
+1D780         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL RHO
+1D781..1D782  ; mapped                 ; 03C3          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL FINAL SIGMA..MATHEMATICAL SANS-SERIF BOLD SMALL SIGMA
+1D783         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL TAU
+1D784         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL UPSILON
+1D785         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL PHI
+1D786         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL CHI
+1D787         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL PSI
+1D788         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL SANS-SERIF BOLD SMALL OMEGA
+1D789         ; mapped                 ; 2202          # 3.1  MATHEMATICAL SANS-SERIF BOLD PARTIAL DIFFERENTIAL
+1D78A         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL SANS-SERIF BOLD EPSILON SYMBOL
+1D78B         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL SANS-SERIF BOLD THETA SYMBOL
+1D78C         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL SANS-SERIF BOLD KAPPA SYMBOL
+1D78D         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL SANS-SERIF BOLD PHI SYMBOL
+1D78E         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL SANS-SERIF BOLD RHO SYMBOL
+1D78F         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL SANS-SERIF BOLD PI SYMBOL
+1D790         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL ALPHA
+1D791         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL BETA
+1D792         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL GAMMA
+1D793         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL DELTA
+1D794         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL EPSILON
+1D795         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL ZETA
+1D796         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL ETA
+1D797         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL THETA
+1D798         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL IOTA
+1D799         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL KAPPA
+1D79A         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL LAMDA
+1D79B         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL MU
+1D79C         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL NU
+1D79D         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL XI
+1D79E         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMICRON
+1D79F         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL PI
+1D7A0         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL RHO
+1D7A1         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL THETA SYMBOL
+1D7A2         ; mapped                 ; 03C3          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL SIGMA
+1D7A3         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL TAU
+1D7A4         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL UPSILON
+1D7A5         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL PHI
+1D7A6         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL CHI
+1D7A7         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL PSI
+1D7A8         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMEGA
+1D7A9         ; mapped                 ; 2207          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC NABLA
+1D7AA         ; mapped                 ; 03B1          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA
+1D7AB         ; mapped                 ; 03B2          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL BETA
+1D7AC         ; mapped                 ; 03B3          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL GAMMA
+1D7AD         ; mapped                 ; 03B4          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL DELTA
+1D7AE         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL EPSILON
+1D7AF         ; mapped                 ; 03B6          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ZETA
+1D7B0         ; mapped                 ; 03B7          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ETA
+1D7B1         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL THETA
+1D7B2         ; mapped                 ; 03B9          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL IOTA
+1D7B3         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL KAPPA
+1D7B4         ; mapped                 ; 03BB          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL LAMDA
+1D7B5         ; mapped                 ; 03BC          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL MU
+1D7B6         ; mapped                 ; 03BD          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL NU
+1D7B7         ; mapped                 ; 03BE          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL XI
+1D7B8         ; mapped                 ; 03BF          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMICRON
+1D7B9         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL PI
+1D7BA         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL RHO
+1D7BB..1D7BC  ; mapped                 ; 03C3          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL FINAL SIGMA..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL SIGMA
+1D7BD         ; mapped                 ; 03C4          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL TAU
+1D7BE         ; mapped                 ; 03C5          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL UPSILON
+1D7BF         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL PHI
+1D7C0         ; mapped                 ; 03C7          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL CHI
+1D7C1         ; mapped                 ; 03C8          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL PSI
+1D7C2         ; mapped                 ; 03C9          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMEGA
+1D7C3         ; mapped                 ; 2202          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC PARTIAL DIFFERENTIAL
+1D7C4         ; mapped                 ; 03B5          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC EPSILON SYMBOL
+1D7C5         ; mapped                 ; 03B8          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC THETA SYMBOL
+1D7C6         ; mapped                 ; 03BA          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC KAPPA SYMBOL
+1D7C7         ; mapped                 ; 03C6          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC PHI SYMBOL
+1D7C8         ; mapped                 ; 03C1          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC RHO SYMBOL
+1D7C9         ; mapped                 ; 03C0          # 3.1  MATHEMATICAL SANS-SERIF BOLD ITALIC PI SYMBOL
+1D7CA..1D7CB  ; mapped                 ; 03DD          # 5.0  MATHEMATICAL BOLD CAPITAL DIGAMMA..MATHEMATICAL BOLD SMALL DIGAMMA
+1D7CC..1D7CD  ; disallowed                             # NA   <reserved-1D7CC>..<reserved-1D7CD>
+1D7CE         ; mapped                 ; 0030          # 3.1  MATHEMATICAL BOLD DIGIT ZERO
+1D7CF         ; mapped                 ; 0031          # 3.1  MATHEMATICAL BOLD DIGIT ONE
+1D7D0         ; mapped                 ; 0032          # 3.1  MATHEMATICAL BOLD DIGIT TWO
+1D7D1         ; mapped                 ; 0033          # 3.1  MATHEMATICAL BOLD DIGIT THREE
+1D7D2         ; mapped                 ; 0034          # 3.1  MATHEMATICAL BOLD DIGIT FOUR
+1D7D3         ; mapped                 ; 0035          # 3.1  MATHEMATICAL BOLD DIGIT FIVE
+1D7D4         ; mapped                 ; 0036          # 3.1  MATHEMATICAL BOLD DIGIT SIX
+1D7D5         ; mapped                 ; 0037          # 3.1  MATHEMATICAL BOLD DIGIT SEVEN
+1D7D6         ; mapped                 ; 0038          # 3.1  MATHEMATICAL BOLD DIGIT EIGHT
+1D7D7         ; mapped                 ; 0039          # 3.1  MATHEMATICAL BOLD DIGIT NINE
+1D7D8         ; mapped                 ; 0030          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT ZERO
+1D7D9         ; mapped                 ; 0031          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT ONE
+1D7DA         ; mapped                 ; 0032          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT TWO
+1D7DB         ; mapped                 ; 0033          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT THREE
+1D7DC         ; mapped                 ; 0034          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT FOUR
+1D7DD         ; mapped                 ; 0035          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT FIVE
+1D7DE         ; mapped                 ; 0036          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT SIX
+1D7DF         ; mapped                 ; 0037          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT SEVEN
+1D7E0         ; mapped                 ; 0038          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT EIGHT
+1D7E1         ; mapped                 ; 0039          # 3.1  MATHEMATICAL DOUBLE-STRUCK DIGIT NINE
+1D7E2         ; mapped                 ; 0030          # 3.1  MATHEMATICAL SANS-SERIF DIGIT ZERO
+1D7E3         ; mapped                 ; 0031          # 3.1  MATHEMATICAL SANS-SERIF DIGIT ONE
+1D7E4         ; mapped                 ; 0032          # 3.1  MATHEMATICAL SANS-SERIF DIGIT TWO
+1D7E5         ; mapped                 ; 0033          # 3.1  MATHEMATICAL SANS-SERIF DIGIT THREE
+1D7E6         ; mapped                 ; 0034          # 3.1  MATHEMATICAL SANS-SERIF DIGIT FOUR
+1D7E7         ; mapped                 ; 0035          # 3.1  MATHEMATICAL SANS-SERIF DIGIT FIVE
+1D7E8         ; mapped                 ; 0036          # 3.1  MATHEMATICAL SANS-SERIF DIGIT SIX
+1D7E9         ; mapped                 ; 0037          # 3.1  MATHEMATICAL SANS-SERIF DIGIT SEVEN
+1D7EA         ; mapped                 ; 0038          # 3.1  MATHEMATICAL SANS-SERIF DIGIT EIGHT
+1D7EB         ; mapped                 ; 0039          # 3.1  MATHEMATICAL SANS-SERIF DIGIT NINE
+1D7EC         ; mapped                 ; 0030          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT ZERO
+1D7ED         ; mapped                 ; 0031          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT ONE
+1D7EE         ; mapped                 ; 0032          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT TWO
+1D7EF         ; mapped                 ; 0033          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT THREE
+1D7F0         ; mapped                 ; 0034          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT FOUR
+1D7F1         ; mapped                 ; 0035          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT FIVE
+1D7F2         ; mapped                 ; 0036          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT SIX
+1D7F3         ; mapped                 ; 0037          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT SEVEN
+1D7F4         ; mapped                 ; 0038          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT EIGHT
+1D7F5         ; mapped                 ; 0039          # 3.1  MATHEMATICAL SANS-SERIF BOLD DIGIT NINE
+1D7F6         ; mapped                 ; 0030          # 3.1  MATHEMATICAL MONOSPACE DIGIT ZERO
+1D7F7         ; mapped                 ; 0031          # 3.1  MATHEMATICAL MONOSPACE DIGIT ONE
+1D7F8         ; mapped                 ; 0032          # 3.1  MATHEMATICAL MONOSPACE DIGIT TWO
+1D7F9         ; mapped                 ; 0033          # 3.1  MATHEMATICAL MONOSPACE DIGIT THREE
+1D7FA         ; mapped                 ; 0034          # 3.1  MATHEMATICAL MONOSPACE DIGIT FOUR
+1D7FB         ; mapped                 ; 0035          # 3.1  MATHEMATICAL MONOSPACE DIGIT FIVE
+1D7FC         ; mapped                 ; 0036          # 3.1  MATHEMATICAL MONOSPACE DIGIT SIX
+1D7FD         ; mapped                 ; 0037          # 3.1  MATHEMATICAL MONOSPACE DIGIT SEVEN
+1D7FE         ; mapped                 ; 0038          # 3.1  MATHEMATICAL MONOSPACE DIGIT EIGHT
+1D7FF         ; mapped                 ; 0039          # 3.1  MATHEMATICAL MONOSPACE DIGIT NINE
+1D800..1D9FF  ; valid                  ;      ; NV8    # 8.0  SIGNWRITING HAND-FIST INDEX..SIGNWRITING HEAD
+1DA00..1DA36  ; valid                                  # 8.0  SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
+1DA37..1DA3A  ; valid                  ;      ; NV8    # 8.0  SIGNWRITING AIR BLOW SMALL ROTATIONS..SIGNWRITING BREATH EXHALE
+1DA3B..1DA6C  ; valid                                  # 8.0  SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
+1DA6D..1DA74  ; valid                  ;      ; NV8    # 8.0  SIGNWRITING SHOULDER HIP SPINE..SIGNWRITING TORSO-FLOORPLANE TWISTING
+1DA75         ; valid                                  # 8.0  SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
+1DA76..1DA83  ; valid                  ;      ; NV8    # 8.0  SIGNWRITING LIMB COMBINATION..SIGNWRITING LOCATION DEPTH
+1DA84         ; valid                                  # 8.0  SIGNWRITING LOCATION HEAD NECK
+1DA85..1DA8B  ; valid                  ;      ; NV8    # 8.0  SIGNWRITING LOCATION TORSO..SIGNWRITING PARENTHESIS
+1DA8C..1DA9A  ; disallowed                             # NA   <reserved-1DA8C>..<reserved-1DA9A>
+1DA9B..1DA9F  ; valid                                  # 8.0  SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
+1DAA0         ; disallowed                             # NA   <reserved-1DAA0>
+1DAA1..1DAAF  ; valid                                  # 8.0  SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
+1DAB0..1DEFF  ; disallowed                             # NA   <reserved-1DAB0>..<reserved-1DEFF>
+1DF00..1DF1E  ; valid                                  # 14.0 LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER S WITH CURL
+1DF1F..1DF24  ; disallowed                             # NA   <reserved-1DF1F>..<reserved-1DF24>
+1DF25..1DF2A  ; valid                                  # 15.0 LATIN SMALL LETTER D WITH MID-HEIGHT LEFT HOOK..LATIN SMALL LETTER T WITH MID-HEIGHT LEFT HOOK
+1DF2B..1DFFF  ; disallowed                             # NA   <reserved-1DF2B>..<reserved-1DFFF>
+1E000..1E006  ; valid                                  # 9.0  COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
+1E007         ; disallowed                             # NA   <reserved-1E007>
+1E008..1E018  ; valid                                  # 9.0  COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
+1E019..1E01A  ; disallowed                             # NA   <reserved-1E019>..<reserved-1E01A>
+1E01B..1E021  ; valid                                  # 9.0  COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
+1E022         ; disallowed                             # NA   <reserved-1E022>
+1E023..1E024  ; valid                                  # 9.0  COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
+1E025         ; disallowed                             # NA   <reserved-1E025>
+1E026..1E02A  ; valid                                  # 9.0  COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
+1E02B..1E02F  ; disallowed                             # NA   <reserved-1E02B>..<reserved-1E02F>
+1E030         ; mapped                 ; 0430          # 15.0 MODIFIER LETTER CYRILLIC SMALL A
+1E031         ; mapped                 ; 0431          # 15.0 MODIFIER LETTER CYRILLIC SMALL BE
+1E032         ; mapped                 ; 0432          # 15.0 MODIFIER LETTER CYRILLIC SMALL VE
+1E033         ; mapped                 ; 0433          # 15.0 MODIFIER LETTER CYRILLIC SMALL GHE
+1E034         ; mapped                 ; 0434          # 15.0 MODIFIER LETTER CYRILLIC SMALL DE
+1E035         ; mapped                 ; 0435          # 15.0 MODIFIER LETTER CYRILLIC SMALL IE
+1E036         ; mapped                 ; 0436          # 15.0 MODIFIER LETTER CYRILLIC SMALL ZHE
+1E037         ; mapped                 ; 0437          # 15.0 MODIFIER LETTER CYRILLIC SMALL ZE
+1E038         ; mapped                 ; 0438          # 15.0 MODIFIER LETTER CYRILLIC SMALL I
+1E039         ; mapped                 ; 043A          # 15.0 MODIFIER LETTER CYRILLIC SMALL KA
+1E03A         ; mapped                 ; 043B          # 15.0 MODIFIER LETTER CYRILLIC SMALL EL
+1E03B         ; mapped                 ; 043C          # 15.0 MODIFIER LETTER CYRILLIC SMALL EM
+1E03C         ; mapped                 ; 043E          # 15.0 MODIFIER LETTER CYRILLIC SMALL O
+1E03D         ; mapped                 ; 043F          # 15.0 MODIFIER LETTER CYRILLIC SMALL PE
+1E03E         ; mapped                 ; 0440          # 15.0 MODIFIER LETTER CYRILLIC SMALL ER
+1E03F         ; mapped                 ; 0441          # 15.0 MODIFIER LETTER CYRILLIC SMALL ES
+1E040         ; mapped                 ; 0442          # 15.0 MODIFIER LETTER CYRILLIC SMALL TE
+1E041         ; mapped                 ; 0443          # 15.0 MODIFIER LETTER CYRILLIC SMALL U
+1E042         ; mapped                 ; 0444          # 15.0 MODIFIER LETTER CYRILLIC SMALL EF
+1E043         ; mapped                 ; 0445          # 15.0 MODIFIER LETTER CYRILLIC SMALL HA
+1E044         ; mapped                 ; 0446          # 15.0 MODIFIER LETTER CYRILLIC SMALL TSE
+1E045         ; mapped                 ; 0447          # 15.0 MODIFIER LETTER CYRILLIC SMALL CHE
+1E046         ; mapped                 ; 0448          # 15.0 MODIFIER LETTER CYRILLIC SMALL SHA
+1E047         ; mapped                 ; 044B          # 15.0 MODIFIER LETTER CYRILLIC SMALL YERU
+1E048         ; mapped                 ; 044D          # 15.0 MODIFIER LETTER CYRILLIC SMALL E
+1E049         ; mapped                 ; 044E          # 15.0 MODIFIER LETTER CYRILLIC SMALL YU
+1E04A         ; mapped                 ; A689          # 15.0 MODIFIER LETTER CYRILLIC SMALL DZZE
+1E04B         ; mapped                 ; 04D9          # 15.0 MODIFIER LETTER CYRILLIC SMALL SCHWA
+1E04C         ; mapped                 ; 0456          # 15.0 MODIFIER LETTER CYRILLIC SMALL BYELORUSSIAN-UKRAINIAN I
+1E04D         ; mapped                 ; 0458          # 15.0 MODIFIER LETTER CYRILLIC SMALL JE
+1E04E         ; mapped                 ; 04E9          # 15.0 MODIFIER LETTER CYRILLIC SMALL BARRED O
+1E04F         ; mapped                 ; 04AF          # 15.0 MODIFIER LETTER CYRILLIC SMALL STRAIGHT U
+1E050         ; mapped                 ; 04CF          # 15.0 MODIFIER LETTER CYRILLIC SMALL PALOCHKA
+1E051         ; mapped                 ; 0430          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER A
+1E052         ; mapped                 ; 0431          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER BE
+1E053         ; mapped                 ; 0432          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER VE
+1E054         ; mapped                 ; 0433          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER GHE
+1E055         ; mapped                 ; 0434          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER DE
+1E056         ; mapped                 ; 0435          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER IE
+1E057         ; mapped                 ; 0436          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER ZHE
+1E058         ; mapped                 ; 0437          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER ZE
+1E059         ; mapped                 ; 0438          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER I
+1E05A         ; mapped                 ; 043A          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER KA
+1E05B         ; mapped                 ; 043B          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER EL
+1E05C         ; mapped                 ; 043E          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER O
+1E05D         ; mapped                 ; 043F          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER PE
+1E05E         ; mapped                 ; 0441          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER ES
+1E05F         ; mapped                 ; 0443          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER U
+1E060         ; mapped                 ; 0444          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER EF
+1E061         ; mapped                 ; 0445          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER HA
+1E062         ; mapped                 ; 0446          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER TSE
+1E063         ; mapped                 ; 0447          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER CHE
+1E064         ; mapped                 ; 0448          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER SHA
+1E065         ; mapped                 ; 044A          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER HARD SIGN
+1E066         ; mapped                 ; 044B          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER YERU
+1E067         ; mapped                 ; 0491          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER GHE WITH UPTURN
+1E068         ; mapped                 ; 0456          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+1E069         ; mapped                 ; 0455          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER DZE
+1E06A         ; mapped                 ; 045F          # 15.0 CYRILLIC SUBSCRIPT SMALL LETTER DZHE
+1E06B         ; mapped                 ; 04AB          # 15.0 MODIFIER LETTER CYRILLIC SMALL ES WITH DESCENDER
+1E06C         ; mapped                 ; A651          # 15.0 MODIFIER LETTER CYRILLIC SMALL YERU WITH BACK YER
+1E06D         ; mapped                 ; 04B1          # 15.0 MODIFIER LETTER CYRILLIC SMALL STRAIGHT U WITH STROKE
+1E06E..1E08E  ; disallowed                             # NA   <reserved-1E06E>..<reserved-1E08E>
+1E08F         ; valid                                  # 15.0 COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+1E090..1E0FF  ; disallowed                             # NA   <reserved-1E090>..<reserved-1E0FF>
+1E100..1E12C  ; valid                                  # 12.0 NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
+1E12D..1E12F  ; disallowed                             # NA   <reserved-1E12D>..<reserved-1E12F>
+1E130..1E13D  ; valid                                  # 12.0 NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
+1E13E..1E13F  ; disallowed                             # NA   <reserved-1E13E>..<reserved-1E13F>
+1E140..1E149  ; valid                                  # 12.0 NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
+1E14A..1E14D  ; disallowed                             # NA   <reserved-1E14A>..<reserved-1E14D>
+1E14E         ; valid                                  # 12.0 NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
+1E14F         ; valid                  ;      ; NV8    # 12.0 NYIAKENG PUACHUE HMONG CIRCLED CA
+1E150..1E28F  ; disallowed                             # NA   <reserved-1E150>..<reserved-1E28F>
+1E290..1E2AE  ; valid                                  # 14.0 TOTO LETTER PA..TOTO SIGN RISING TONE
+1E2AF..1E2BF  ; disallowed                             # NA   <reserved-1E2AF>..<reserved-1E2BF>
+1E2C0..1E2F9  ; valid                                  # 12.0 WANCHO LETTER AA..WANCHO DIGIT NINE
+1E2FA..1E2FE  ; disallowed                             # NA   <reserved-1E2FA>..<reserved-1E2FE>
+1E2FF         ; valid                  ;      ; NV8    # 12.0 WANCHO NGUN SIGN
+1E300..1E4CF  ; disallowed                             # NA   <reserved-1E300>..<reserved-1E4CF>
+1E4D0..1E4F9  ; valid                                  # 15.0 NAG MUNDARI LETTER O..NAG MUNDARI DIGIT NINE
+1E4FA..1E7DF  ; disallowed                             # NA   <reserved-1E4FA>..<reserved-1E7DF>
+1E7E0..1E7E6  ; valid                                  # 14.0 ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
+1E7E7         ; disallowed                             # NA   <reserved-1E7E7>
+1E7E8..1E7EB  ; valid                                  # 14.0 ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
+1E7EC         ; disallowed                             # NA   <reserved-1E7EC>
+1E7ED..1E7EE  ; valid                                  # 14.0 ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
+1E7EF         ; disallowed                             # NA   <reserved-1E7EF>
+1E7F0..1E7FE  ; valid                                  # 14.0 ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
+1E7FF         ; disallowed                             # NA   <reserved-1E7FF>
+1E800..1E8C4  ; valid                                  # 7.0  MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
+1E8C5..1E8C6  ; disallowed                             # NA   <reserved-1E8C5>..<reserved-1E8C6>
+1E8C7..1E8CF  ; valid                  ;      ; NV8    # 7.0  MENDE KIKAKUI DIGIT ONE..MENDE KIKAKUI DIGIT NINE
+1E8D0..1E8D6  ; valid                                  # 7.0  MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
+1E8D7..1E8FF  ; disallowed                             # NA   <reserved-1E8D7>..<reserved-1E8FF>
+1E900         ; mapped                 ; 1E922         # 9.0  ADLAM CAPITAL LETTER ALIF
+1E901         ; mapped                 ; 1E923         # 9.0  ADLAM CAPITAL LETTER DAALI
+1E902         ; mapped                 ; 1E924         # 9.0  ADLAM CAPITAL LETTER LAAM
+1E903         ; mapped                 ; 1E925         # 9.0  ADLAM CAPITAL LETTER MIIM
+1E904         ; mapped                 ; 1E926         # 9.0  ADLAM CAPITAL LETTER BA
+1E905         ; mapped                 ; 1E927         # 9.0  ADLAM CAPITAL LETTER SINNYIIYHE
+1E906         ; mapped                 ; 1E928         # 9.0  ADLAM CAPITAL LETTER PE
+1E907         ; mapped                 ; 1E929         # 9.0  ADLAM CAPITAL LETTER BHE
+1E908         ; mapped                 ; 1E92A         # 9.0  ADLAM CAPITAL LETTER RA
+1E909         ; mapped                 ; 1E92B         # 9.0  ADLAM CAPITAL LETTER E
+1E90A         ; mapped                 ; 1E92C         # 9.0  ADLAM CAPITAL LETTER FA
+1E90B         ; mapped                 ; 1E92D         # 9.0  ADLAM CAPITAL LETTER I
+1E90C         ; mapped                 ; 1E92E         # 9.0  ADLAM CAPITAL LETTER O
+1E90D         ; mapped                 ; 1E92F         # 9.0  ADLAM CAPITAL LETTER DHA
+1E90E         ; mapped                 ; 1E930         # 9.0  ADLAM CAPITAL LETTER YHE
+1E90F         ; mapped                 ; 1E931         # 9.0  ADLAM CAPITAL LETTER WAW
+1E910         ; mapped                 ; 1E932         # 9.0  ADLAM CAPITAL LETTER NUN
+1E911         ; mapped                 ; 1E933         # 9.0  ADLAM CAPITAL LETTER KAF
+1E912         ; mapped                 ; 1E934         # 9.0  ADLAM CAPITAL LETTER YA
+1E913         ; mapped                 ; 1E935         # 9.0  ADLAM CAPITAL LETTER U
+1E914         ; mapped                 ; 1E936         # 9.0  ADLAM CAPITAL LETTER JIIM
+1E915         ; mapped                 ; 1E937         # 9.0  ADLAM CAPITAL LETTER CHI
+1E916         ; mapped                 ; 1E938         # 9.0  ADLAM CAPITAL LETTER HA
+1E917         ; mapped                 ; 1E939         # 9.0  ADLAM CAPITAL LETTER QAAF
+1E918         ; mapped                 ; 1E93A         # 9.0  ADLAM CAPITAL LETTER GA
+1E919         ; mapped                 ; 1E93B         # 9.0  ADLAM CAPITAL LETTER NYA
+1E91A         ; mapped                 ; 1E93C         # 9.0  ADLAM CAPITAL LETTER TU
+1E91B         ; mapped                 ; 1E93D         # 9.0  ADLAM CAPITAL LETTER NHA
+1E91C         ; mapped                 ; 1E93E         # 9.0  ADLAM CAPITAL LETTER VA
+1E91D         ; mapped                 ; 1E93F         # 9.0  ADLAM CAPITAL LETTER KHA
+1E91E         ; mapped                 ; 1E940         # 9.0  ADLAM CAPITAL LETTER GBE
+1E91F         ; mapped                 ; 1E941         # 9.0  ADLAM CAPITAL LETTER ZAL
+1E920         ; mapped                 ; 1E942         # 9.0  ADLAM CAPITAL LETTER KPO
+1E921         ; mapped                 ; 1E943         # 9.0  ADLAM CAPITAL LETTER SHA
+1E922..1E94A  ; valid                                  # 9.0  ADLAM SMALL LETTER ALIF..ADLAM NUKTA
+1E94B         ; valid                                  # 12.0 ADLAM NASALIZATION MARK
+1E94C..1E94F  ; disallowed                             # NA   <reserved-1E94C>..<reserved-1E94F>
+1E950..1E959  ; valid                                  # 9.0  ADLAM DIGIT ZERO..ADLAM DIGIT NINE
+1E95A..1E95D  ; disallowed                             # NA   <reserved-1E95A>..<reserved-1E95D>
+1E95E..1E95F  ; valid                  ;      ; NV8    # 9.0  ADLAM INITIAL EXCLAMATION MARK..ADLAM INITIAL QUESTION MARK
+1E960..1EC70  ; disallowed                             # NA   <reserved-1E960>..<reserved-1EC70>
+1EC71..1ECB4  ; valid                  ;      ; NV8    # 11.0 INDIC SIYAQ NUMBER ONE..INDIC SIYAQ ALTERNATE LAKH MARK
+1ECB5..1ED00  ; disallowed                             # NA   <reserved-1ECB5>..<reserved-1ED00>
+1ED01..1ED3D  ; valid                  ;      ; NV8    # 12.0 OTTOMAN SIYAQ NUMBER ONE..OTTOMAN SIYAQ FRACTION ONE SIXTH
+1ED3E..1EDFF  ; disallowed                             # NA   <reserved-1ED3E>..<reserved-1EDFF>
+1EE00         ; mapped                 ; 0627          # 6.1  ARABIC MATHEMATICAL ALEF
+1EE01         ; mapped                 ; 0628          # 6.1  ARABIC MATHEMATICAL BEH
+1EE02         ; mapped                 ; 062C          # 6.1  ARABIC MATHEMATICAL JEEM
+1EE03         ; mapped                 ; 062F          # 6.1  ARABIC MATHEMATICAL DAL
+1EE04         ; disallowed                             # NA   <reserved-1EE04>
+1EE05         ; mapped                 ; 0648          # 6.1  ARABIC MATHEMATICAL WAW
+1EE06         ; mapped                 ; 0632          # 6.1  ARABIC MATHEMATICAL ZAIN
+1EE07         ; mapped                 ; 062D          # 6.1  ARABIC MATHEMATICAL HAH
+1EE08         ; mapped                 ; 0637          # 6.1  ARABIC MATHEMATICAL TAH
+1EE09         ; mapped                 ; 064A          # 6.1  ARABIC MATHEMATICAL YEH
+1EE0A         ; mapped                 ; 0643          # 6.1  ARABIC MATHEMATICAL KAF
+1EE0B         ; mapped                 ; 0644          # 6.1  ARABIC MATHEMATICAL LAM
+1EE0C         ; mapped                 ; 0645          # 6.1  ARABIC MATHEMATICAL MEEM
+1EE0D         ; mapped                 ; 0646          # 6.1  ARABIC MATHEMATICAL NOON
+1EE0E         ; mapped                 ; 0633          # 6.1  ARABIC MATHEMATICAL SEEN
+1EE0F         ; mapped                 ; 0639          # 6.1  ARABIC MATHEMATICAL AIN
+1EE10         ; mapped                 ; 0641          # 6.1  ARABIC MATHEMATICAL FEH
+1EE11         ; mapped                 ; 0635          # 6.1  ARABIC MATHEMATICAL SAD
+1EE12         ; mapped                 ; 0642          # 6.1  ARABIC MATHEMATICAL QAF
+1EE13         ; mapped                 ; 0631          # 6.1  ARABIC MATHEMATICAL REH
+1EE14         ; mapped                 ; 0634          # 6.1  ARABIC MATHEMATICAL SHEEN
+1EE15         ; mapped                 ; 062A          # 6.1  ARABIC MATHEMATICAL TEH
+1EE16         ; mapped                 ; 062B          # 6.1  ARABIC MATHEMATICAL THEH
+1EE17         ; mapped                 ; 062E          # 6.1  ARABIC MATHEMATICAL KHAH
+1EE18         ; mapped                 ; 0630          # 6.1  ARABIC MATHEMATICAL THAL
+1EE19         ; mapped                 ; 0636          # 6.1  ARABIC MATHEMATICAL DAD
+1EE1A         ; mapped                 ; 0638          # 6.1  ARABIC MATHEMATICAL ZAH
+1EE1B         ; mapped                 ; 063A          # 6.1  ARABIC MATHEMATICAL GHAIN
+1EE1C         ; mapped                 ; 066E          # 6.1  ARABIC MATHEMATICAL DOTLESS BEH
+1EE1D         ; mapped                 ; 06BA          # 6.1  ARABIC MATHEMATICAL DOTLESS NOON
+1EE1E         ; mapped                 ; 06A1          # 6.1  ARABIC MATHEMATICAL DOTLESS FEH
+1EE1F         ; mapped                 ; 066F          # 6.1  ARABIC MATHEMATICAL DOTLESS QAF
+1EE20         ; disallowed                             # NA   <reserved-1EE20>
+1EE21         ; mapped                 ; 0628          # 6.1  ARABIC MATHEMATICAL INITIAL BEH
+1EE22         ; mapped                 ; 062C          # 6.1  ARABIC MATHEMATICAL INITIAL JEEM
+1EE23         ; disallowed                             # NA   <reserved-1EE23>
+1EE24         ; mapped                 ; 0647          # 6.1  ARABIC MATHEMATICAL INITIAL HEH
+1EE25..1EE26  ; disallowed                             # NA   <reserved-1EE25>..<reserved-1EE26>
+1EE27         ; mapped                 ; 062D          # 6.1  ARABIC MATHEMATICAL INITIAL HAH
+1EE28         ; disallowed                             # NA   <reserved-1EE28>
+1EE29         ; mapped                 ; 064A          # 6.1  ARABIC MATHEMATICAL INITIAL YEH
+1EE2A         ; mapped                 ; 0643          # 6.1  ARABIC MATHEMATICAL INITIAL KAF
+1EE2B         ; mapped                 ; 0644          # 6.1  ARABIC MATHEMATICAL INITIAL LAM
+1EE2C         ; mapped                 ; 0645          # 6.1  ARABIC MATHEMATICAL INITIAL MEEM
+1EE2D         ; mapped                 ; 0646          # 6.1  ARABIC MATHEMATICAL INITIAL NOON
+1EE2E         ; mapped                 ; 0633          # 6.1  ARABIC MATHEMATICAL INITIAL SEEN
+1EE2F         ; mapped                 ; 0639          # 6.1  ARABIC MATHEMATICAL INITIAL AIN
+1EE30         ; mapped                 ; 0641          # 6.1  ARABIC MATHEMATICAL INITIAL FEH
+1EE31         ; mapped                 ; 0635          # 6.1  ARABIC MATHEMATICAL INITIAL SAD
+1EE32         ; mapped                 ; 0642          # 6.1  ARABIC MATHEMATICAL INITIAL QAF
+1EE33         ; disallowed                             # NA   <reserved-1EE33>
+1EE34         ; mapped                 ; 0634          # 6.1  ARABIC MATHEMATICAL INITIAL SHEEN
+1EE35         ; mapped                 ; 062A          # 6.1  ARABIC MATHEMATICAL INITIAL TEH
+1EE36         ; mapped                 ; 062B          # 6.1  ARABIC MATHEMATICAL INITIAL THEH
+1EE37         ; mapped                 ; 062E          # 6.1  ARABIC MATHEMATICAL INITIAL KHAH
+1EE38         ; disallowed                             # NA   <reserved-1EE38>
+1EE39         ; mapped                 ; 0636          # 6.1  ARABIC MATHEMATICAL INITIAL DAD
+1EE3A         ; disallowed                             # NA   <reserved-1EE3A>
+1EE3B         ; mapped                 ; 063A          # 6.1  ARABIC MATHEMATICAL INITIAL GHAIN
+1EE3C..1EE41  ; disallowed                             # NA   <reserved-1EE3C>..<reserved-1EE41>
+1EE42         ; mapped                 ; 062C          # 6.1  ARABIC MATHEMATICAL TAILED JEEM
+1EE43..1EE46  ; disallowed                             # NA   <reserved-1EE43>..<reserved-1EE46>
+1EE47         ; mapped                 ; 062D          # 6.1  ARABIC MATHEMATICAL TAILED HAH
+1EE48         ; disallowed                             # NA   <reserved-1EE48>
+1EE49         ; mapped                 ; 064A          # 6.1  ARABIC MATHEMATICAL TAILED YEH
+1EE4A         ; disallowed                             # NA   <reserved-1EE4A>
+1EE4B         ; mapped                 ; 0644          # 6.1  ARABIC MATHEMATICAL TAILED LAM
+1EE4C         ; disallowed                             # NA   <reserved-1EE4C>
+1EE4D         ; mapped                 ; 0646          # 6.1  ARABIC MATHEMATICAL TAILED NOON
+1EE4E         ; mapped                 ; 0633          # 6.1  ARABIC MATHEMATICAL TAILED SEEN
+1EE4F         ; mapped                 ; 0639          # 6.1  ARABIC MATHEMATICAL TAILED AIN
+1EE50         ; disallowed                             # NA   <reserved-1EE50>
+1EE51         ; mapped                 ; 0635          # 6.1  ARABIC MATHEMATICAL TAILED SAD
+1EE52         ; mapped                 ; 0642          # 6.1  ARABIC MATHEMATICAL TAILED QAF
+1EE53         ; disallowed                             # NA   <reserved-1EE53>
+1EE54         ; mapped                 ; 0634          # 6.1  ARABIC MATHEMATICAL TAILED SHEEN
+1EE55..1EE56  ; disallowed                             # NA   <reserved-1EE55>..<reserved-1EE56>
+1EE57         ; mapped                 ; 062E          # 6.1  ARABIC MATHEMATICAL TAILED KHAH
+1EE58         ; disallowed                             # NA   <reserved-1EE58>
+1EE59         ; mapped                 ; 0636          # 6.1  ARABIC MATHEMATICAL TAILED DAD
+1EE5A         ; disallowed                             # NA   <reserved-1EE5A>
+1EE5B         ; mapped                 ; 063A          # 6.1  ARABIC MATHEMATICAL TAILED GHAIN
+1EE5C         ; disallowed                             # NA   <reserved-1EE5C>
+1EE5D         ; mapped                 ; 06BA          # 6.1  ARABIC MATHEMATICAL TAILED DOTLESS NOON
+1EE5E         ; disallowed                             # NA   <reserved-1EE5E>
+1EE5F         ; mapped                 ; 066F          # 6.1  ARABIC MATHEMATICAL TAILED DOTLESS QAF
+1EE60         ; disallowed                             # NA   <reserved-1EE60>
+1EE61         ; mapped                 ; 0628          # 6.1  ARABIC MATHEMATICAL STRETCHED BEH
+1EE62         ; mapped                 ; 062C          # 6.1  ARABIC MATHEMATICAL STRETCHED JEEM
+1EE63         ; disallowed                             # NA   <reserved-1EE63>
+1EE64         ; mapped                 ; 0647          # 6.1  ARABIC MATHEMATICAL STRETCHED HEH
+1EE65..1EE66  ; disallowed                             # NA   <reserved-1EE65>..<reserved-1EE66>
+1EE67         ; mapped                 ; 062D          # 6.1  ARABIC MATHEMATICAL STRETCHED HAH
+1EE68         ; mapped                 ; 0637          # 6.1  ARABIC MATHEMATICAL STRETCHED TAH
+1EE69         ; mapped                 ; 064A          # 6.1  ARABIC MATHEMATICAL STRETCHED YEH
+1EE6A         ; mapped                 ; 0643          # 6.1  ARABIC MATHEMATICAL STRETCHED KAF
+1EE6B         ; disallowed                             # NA   <reserved-1EE6B>
+1EE6C         ; mapped                 ; 0645          # 6.1  ARABIC MATHEMATICAL STRETCHED MEEM
+1EE6D         ; mapped                 ; 0646          # 6.1  ARABIC MATHEMATICAL STRETCHED NOON
+1EE6E         ; mapped                 ; 0633          # 6.1  ARABIC MATHEMATICAL STRETCHED SEEN
+1EE6F         ; mapped                 ; 0639          # 6.1  ARABIC MATHEMATICAL STRETCHED AIN
+1EE70         ; mapped                 ; 0641          # 6.1  ARABIC MATHEMATICAL STRETCHED FEH
+1EE71         ; mapped                 ; 0635          # 6.1  ARABIC MATHEMATICAL STRETCHED SAD
+1EE72         ; mapped                 ; 0642          # 6.1  ARABIC MATHEMATICAL STRETCHED QAF
+1EE73         ; disallowed                             # NA   <reserved-1EE73>
+1EE74         ; mapped                 ; 0634          # 6.1  ARABIC MATHEMATICAL STRETCHED SHEEN
+1EE75         ; mapped                 ; 062A          # 6.1  ARABIC MATHEMATICAL STRETCHED TEH
+1EE76         ; mapped                 ; 062B          # 6.1  ARABIC MATHEMATICAL STRETCHED THEH
+1EE77         ; mapped                 ; 062E          # 6.1  ARABIC MATHEMATICAL STRETCHED KHAH
+1EE78         ; disallowed                             # NA   <reserved-1EE78>
+1EE79         ; mapped                 ; 0636          # 6.1  ARABIC MATHEMATICAL STRETCHED DAD
+1EE7A         ; mapped                 ; 0638          # 6.1  ARABIC MATHEMATICAL STRETCHED ZAH
+1EE7B         ; mapped                 ; 063A          # 6.1  ARABIC MATHEMATICAL STRETCHED GHAIN
+1EE7C         ; mapped                 ; 066E          # 6.1  ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
+1EE7D         ; disallowed                             # NA   <reserved-1EE7D>
+1EE7E         ; mapped                 ; 06A1          # 6.1  ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
+1EE7F         ; disallowed                             # NA   <reserved-1EE7F>
+1EE80         ; mapped                 ; 0627          # 6.1  ARABIC MATHEMATICAL LOOPED ALEF
+1EE81         ; mapped                 ; 0628          # 6.1  ARABIC MATHEMATICAL LOOPED BEH
+1EE82         ; mapped                 ; 062C          # 6.1  ARABIC MATHEMATICAL LOOPED JEEM
+1EE83         ; mapped                 ; 062F          # 6.1  ARABIC MATHEMATICAL LOOPED DAL
+1EE84         ; mapped                 ; 0647          # 6.1  ARABIC MATHEMATICAL LOOPED HEH
+1EE85         ; mapped                 ; 0648          # 6.1  ARABIC MATHEMATICAL LOOPED WAW
+1EE86         ; mapped                 ; 0632          # 6.1  ARABIC MATHEMATICAL LOOPED ZAIN
+1EE87         ; mapped                 ; 062D          # 6.1  ARABIC MATHEMATICAL LOOPED HAH
+1EE88         ; mapped                 ; 0637          # 6.1  ARABIC MATHEMATICAL LOOPED TAH
+1EE89         ; mapped                 ; 064A          # 6.1  ARABIC MATHEMATICAL LOOPED YEH
+1EE8A         ; disallowed                             # NA   <reserved-1EE8A>
+1EE8B         ; mapped                 ; 0644          # 6.1  ARABIC MATHEMATICAL LOOPED LAM
+1EE8C         ; mapped                 ; 0645          # 6.1  ARABIC MATHEMATICAL LOOPED MEEM
+1EE8D         ; mapped                 ; 0646          # 6.1  ARABIC MATHEMATICAL LOOPED NOON
+1EE8E         ; mapped                 ; 0633          # 6.1  ARABIC MATHEMATICAL LOOPED SEEN
+1EE8F         ; mapped                 ; 0639          # 6.1  ARABIC MATHEMATICAL LOOPED AIN
+1EE90         ; mapped                 ; 0641          # 6.1  ARABIC MATHEMATICAL LOOPED FEH
+1EE91         ; mapped                 ; 0635          # 6.1  ARABIC MATHEMATICAL LOOPED SAD
+1EE92         ; mapped                 ; 0642          # 6.1  ARABIC MATHEMATICAL LOOPED QAF
+1EE93         ; mapped                 ; 0631          # 6.1  ARABIC MATHEMATICAL LOOPED REH
+1EE94         ; mapped                 ; 0634          # 6.1  ARABIC MATHEMATICAL LOOPED SHEEN
+1EE95         ; mapped                 ; 062A          # 6.1  ARABIC MATHEMATICAL LOOPED TEH
+1EE96         ; mapped                 ; 062B          # 6.1  ARABIC MATHEMATICAL LOOPED THEH
+1EE97         ; mapped                 ; 062E          # 6.1  ARABIC MATHEMATICAL LOOPED KHAH
+1EE98         ; mapped                 ; 0630          # 6.1  ARABIC MATHEMATICAL LOOPED THAL
+1EE99         ; mapped                 ; 0636          # 6.1  ARABIC MATHEMATICAL LOOPED DAD
+1EE9A         ; mapped                 ; 0638          # 6.1  ARABIC MATHEMATICAL LOOPED ZAH
+1EE9B         ; mapped                 ; 063A          # 6.1  ARABIC MATHEMATICAL LOOPED GHAIN
+1EE9C..1EEA0  ; disallowed                             # NA   <reserved-1EE9C>..<reserved-1EEA0>
+1EEA1         ; mapped                 ; 0628          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK BEH
+1EEA2         ; mapped                 ; 062C          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK JEEM
+1EEA3         ; mapped                 ; 062F          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
+1EEA4         ; disallowed                             # NA   <reserved-1EEA4>
+1EEA5         ; mapped                 ; 0648          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK WAW
+1EEA6         ; mapped                 ; 0632          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK ZAIN
+1EEA7         ; mapped                 ; 062D          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK HAH
+1EEA8         ; mapped                 ; 0637          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK TAH
+1EEA9         ; mapped                 ; 064A          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
+1EEAA         ; disallowed                             # NA   <reserved-1EEAA>
+1EEAB         ; mapped                 ; 0644          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK LAM
+1EEAC         ; mapped                 ; 0645          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK MEEM
+1EEAD         ; mapped                 ; 0646          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK NOON
+1EEAE         ; mapped                 ; 0633          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK SEEN
+1EEAF         ; mapped                 ; 0639          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK AIN
+1EEB0         ; mapped                 ; 0641          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK FEH
+1EEB1         ; mapped                 ; 0635          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK SAD
+1EEB2         ; mapped                 ; 0642          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK QAF
+1EEB3         ; mapped                 ; 0631          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK REH
+1EEB4         ; mapped                 ; 0634          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK SHEEN
+1EEB5         ; mapped                 ; 062A          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK TEH
+1EEB6         ; mapped                 ; 062B          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK THEH
+1EEB7         ; mapped                 ; 062E          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK KHAH
+1EEB8         ; mapped                 ; 0630          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK THAL
+1EEB9         ; mapped                 ; 0636          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK DAD
+1EEBA         ; mapped                 ; 0638          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK ZAH
+1EEBB         ; mapped                 ; 063A          # 6.1  ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
+1EEBC..1EEEF  ; disallowed                             # NA   <reserved-1EEBC>..<reserved-1EEEF>
+1EEF0..1EEF1  ; valid                  ;      ; NV8    # 6.1  ARABIC MATHEMATICAL OPERATOR MEEM WITH HAH WITH TATWEEL..ARABIC MATHEMATICAL OPERATOR HAH WITH DAL
+1EEF2..1EFFF  ; disallowed                             # NA   <reserved-1EEF2>..<reserved-1EFFF>
+1F000..1F02B  ; valid                  ;      ; NV8    # 5.1  MAHJONG TILE EAST WIND..MAHJONG TILE BACK
+1F02C..1F02F  ; disallowed                             # NA   <reserved-1F02C>..<reserved-1F02F>
+1F030..1F093  ; valid                  ;      ; NV8    # 5.1  DOMINO TILE HORIZONTAL BACK..DOMINO TILE VERTICAL-06-06
+1F094..1F09F  ; disallowed                             # NA   <reserved-1F094>..<reserved-1F09F>
+1F0A0..1F0AE  ; valid                  ;      ; NV8    # 6.0  PLAYING CARD BACK..PLAYING CARD KING OF SPADES
+1F0AF..1F0B0  ; disallowed                             # NA   <reserved-1F0AF>..<reserved-1F0B0>
+1F0B1..1F0BE  ; valid                  ;      ; NV8    # 6.0  PLAYING CARD ACE OF HEARTS..PLAYING CARD KING OF HEARTS
+1F0BF         ; valid                  ;      ; NV8    # 7.0  PLAYING CARD RED JOKER
+1F0C0         ; disallowed                             # NA   <reserved-1F0C0>
+1F0C1..1F0CF  ; valid                  ;      ; NV8    # 6.0  PLAYING CARD ACE OF DIAMONDS..PLAYING CARD BLACK JOKER
+1F0D0         ; disallowed                             # NA   <reserved-1F0D0>
+1F0D1..1F0DF  ; valid                  ;      ; NV8    # 6.0  PLAYING CARD ACE OF CLUBS..PLAYING CARD WHITE JOKER
+1F0E0..1F0F5  ; valid                  ;      ; NV8    # 7.0  PLAYING CARD FOOL..PLAYING CARD TRUMP-21
+1F0F6..1F0FF  ; disallowed                             # NA   <reserved-1F0F6>..<reserved-1F0FF>
+1F100         ; disallowed                             # 5.2  DIGIT ZERO FULL STOP
+1F101         ; disallowed_STD3_mapped ; 0030 002C     # 5.2  DIGIT ZERO COMMA
+1F102         ; disallowed_STD3_mapped ; 0031 002C     # 5.2  DIGIT ONE COMMA
+1F103         ; disallowed_STD3_mapped ; 0032 002C     # 5.2  DIGIT TWO COMMA
+1F104         ; disallowed_STD3_mapped ; 0033 002C     # 5.2  DIGIT THREE COMMA
+1F105         ; disallowed_STD3_mapped ; 0034 002C     # 5.2  DIGIT FOUR COMMA
+1F106         ; disallowed_STD3_mapped ; 0035 002C     # 5.2  DIGIT FIVE COMMA
+1F107         ; disallowed_STD3_mapped ; 0036 002C     # 5.2  DIGIT SIX COMMA
+1F108         ; disallowed_STD3_mapped ; 0037 002C     # 5.2  DIGIT SEVEN COMMA
+1F109         ; disallowed_STD3_mapped ; 0038 002C     # 5.2  DIGIT EIGHT COMMA
+1F10A         ; disallowed_STD3_mapped ; 0039 002C     # 5.2  DIGIT NINE COMMA
+1F10B..1F10C  ; valid                  ;      ; NV8    # 7.0  DINGBAT CIRCLED SANS-SERIF DIGIT ZERO..DINGBAT NEGATIVE CIRCLED SANS-SERIF DIGIT ZERO
+1F10D..1F10F  ; valid                  ;      ; NV8    # 13.0 CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+1F110         ; disallowed_STD3_mapped ; 0028 0061 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER A
+1F111         ; disallowed_STD3_mapped ; 0028 0062 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER B
+1F112         ; disallowed_STD3_mapped ; 0028 0063 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER C
+1F113         ; disallowed_STD3_mapped ; 0028 0064 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER D
+1F114         ; disallowed_STD3_mapped ; 0028 0065 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER E
+1F115         ; disallowed_STD3_mapped ; 0028 0066 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER F
+1F116         ; disallowed_STD3_mapped ; 0028 0067 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER G
+1F117         ; disallowed_STD3_mapped ; 0028 0068 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER H
+1F118         ; disallowed_STD3_mapped ; 0028 0069 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER I
+1F119         ; disallowed_STD3_mapped ; 0028 006A 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER J
+1F11A         ; disallowed_STD3_mapped ; 0028 006B 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER K
+1F11B         ; disallowed_STD3_mapped ; 0028 006C 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER L
+1F11C         ; disallowed_STD3_mapped ; 0028 006D 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER M
+1F11D         ; disallowed_STD3_mapped ; 0028 006E 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER N
+1F11E         ; disallowed_STD3_mapped ; 0028 006F 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER O
+1F11F         ; disallowed_STD3_mapped ; 0028 0070 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER P
+1F120         ; disallowed_STD3_mapped ; 0028 0071 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER Q
+1F121         ; disallowed_STD3_mapped ; 0028 0072 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER R
+1F122         ; disallowed_STD3_mapped ; 0028 0073 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER S
+1F123         ; disallowed_STD3_mapped ; 0028 0074 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER T
+1F124         ; disallowed_STD3_mapped ; 0028 0075 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER U
+1F125         ; disallowed_STD3_mapped ; 0028 0076 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER V
+1F126         ; disallowed_STD3_mapped ; 0028 0077 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER W
+1F127         ; disallowed_STD3_mapped ; 0028 0078 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER X
+1F128         ; disallowed_STD3_mapped ; 0028 0079 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER Y
+1F129         ; disallowed_STD3_mapped ; 0028 007A 0029 #5.2  PARENTHESIZED LATIN CAPITAL LETTER Z
+1F12A         ; mapped                 ; 3014 0073 3015 #5.2  TORTOISE SHELL BRACKETED LATIN CAPITAL LETTER S
+1F12B         ; mapped                 ; 0063          # 5.2  CIRCLED ITALIC LATIN CAPITAL LETTER C
+1F12C         ; mapped                 ; 0072          # 5.2  CIRCLED ITALIC LATIN CAPITAL LETTER R
+1F12D         ; mapped                 ; 0063 0064     # 5.2  CIRCLED CD
+1F12E         ; mapped                 ; 0077 007A     # 5.2  CIRCLED WZ
+1F12F         ; valid                  ;      ; NV8    # 11.0 COPYLEFT SYMBOL
+1F130         ; mapped                 ; 0061          # 6.0  SQUARED LATIN CAPITAL LETTER A
+1F131         ; mapped                 ; 0062          # 5.2  SQUARED LATIN CAPITAL LETTER B
+1F132         ; mapped                 ; 0063          # 6.0  SQUARED LATIN CAPITAL LETTER C
+1F133         ; mapped                 ; 0064          # 6.0  SQUARED LATIN CAPITAL LETTER D
+1F134         ; mapped                 ; 0065          # 6.0  SQUARED LATIN CAPITAL LETTER E
+1F135         ; mapped                 ; 0066          # 6.0  SQUARED LATIN CAPITAL LETTER F
+1F136         ; mapped                 ; 0067          # 6.0  SQUARED LATIN CAPITAL LETTER G
+1F137         ; mapped                 ; 0068          # 6.0  SQUARED LATIN CAPITAL LETTER H
+1F138         ; mapped                 ; 0069          # 6.0  SQUARED LATIN CAPITAL LETTER I
+1F139         ; mapped                 ; 006A          # 6.0  SQUARED LATIN CAPITAL LETTER J
+1F13A         ; mapped                 ; 006B          # 6.0  SQUARED LATIN CAPITAL LETTER K
+1F13B         ; mapped                 ; 006C          # 6.0  SQUARED LATIN CAPITAL LETTER L
+1F13C         ; mapped                 ; 006D          # 6.0  SQUARED LATIN CAPITAL LETTER M
+1F13D         ; mapped                 ; 006E          # 5.2  SQUARED LATIN CAPITAL LETTER N
+1F13E         ; mapped                 ; 006F          # 6.0  SQUARED LATIN CAPITAL LETTER O
+1F13F         ; mapped                 ; 0070          # 5.2  SQUARED LATIN CAPITAL LETTER P
+1F140         ; mapped                 ; 0071          # 6.0  SQUARED LATIN CAPITAL LETTER Q
+1F141         ; mapped                 ; 0072          # 6.0  SQUARED LATIN CAPITAL LETTER R
+1F142         ; mapped                 ; 0073          # 5.2  SQUARED LATIN CAPITAL LETTER S
+1F143         ; mapped                 ; 0074          # 6.0  SQUARED LATIN CAPITAL LETTER T
+1F144         ; mapped                 ; 0075          # 6.0  SQUARED LATIN CAPITAL LETTER U
+1F145         ; mapped                 ; 0076          # 6.0  SQUARED LATIN CAPITAL LETTER V
+1F146         ; mapped                 ; 0077          # 5.2  SQUARED LATIN CAPITAL LETTER W
+1F147         ; mapped                 ; 0078          # 6.0  SQUARED LATIN CAPITAL LETTER X
+1F148         ; mapped                 ; 0079          # 6.0  SQUARED LATIN CAPITAL LETTER Y
+1F149         ; mapped                 ; 007A          # 6.0  SQUARED LATIN CAPITAL LETTER Z
+1F14A         ; mapped                 ; 0068 0076     # 5.2  SQUARED HV
+1F14B         ; mapped                 ; 006D 0076     # 5.2  SQUARED MV
+1F14C         ; mapped                 ; 0073 0064     # 5.2  SQUARED SD
+1F14D         ; mapped                 ; 0073 0073     # 5.2  SQUARED SS
+1F14E         ; mapped                 ; 0070 0070 0076 #5.2  SQUARED PPV
+1F14F         ; mapped                 ; 0077 0063     # 6.0  SQUARED WC
+1F150..1F156  ; valid                  ;      ; NV8    # 6.0  NEGATIVE CIRCLED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER G
+1F157         ; valid                  ;      ; NV8    # 5.2  NEGATIVE CIRCLED LATIN CAPITAL LETTER H
+1F158..1F15E  ; valid                  ;      ; NV8    # 6.0  NEGATIVE CIRCLED LATIN CAPITAL LETTER I..NEGATIVE CIRCLED LATIN CAPITAL LETTER O
+1F15F         ; valid                  ;      ; NV8    # 5.2  NEGATIVE CIRCLED LATIN CAPITAL LETTER P
+1F160..1F169  ; valid                  ;      ; NV8    # 6.0  NEGATIVE CIRCLED LATIN CAPITAL LETTER Q..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
+1F16A         ; mapped                 ; 006D 0063     # 6.1  RAISED MC SIGN
+1F16B         ; mapped                 ; 006D 0064     # 6.1  RAISED MD SIGN
+1F16C         ; mapped                 ; 006D 0072     # 12.0 RAISED MR SIGN
+1F16D..1F16F  ; valid                  ;      ; NV8    # 13.0 CIRCLED CC..CIRCLED HUMAN FIGURE
+1F170..1F178  ; valid                  ;      ; NV8    # 6.0  NEGATIVE SQUARED LATIN CAPITAL LETTER A..NEGATIVE SQUARED LATIN CAPITAL LETTER I
+1F179         ; valid                  ;      ; NV8    # 5.2  NEGATIVE SQUARED LATIN CAPITAL LETTER J
+1F17A         ; valid                  ;      ; NV8    # 6.0  NEGATIVE SQUARED LATIN CAPITAL LETTER K
+1F17B..1F17C  ; valid                  ;      ; NV8    # 5.2  NEGATIVE SQUARED LATIN CAPITAL LETTER L..NEGATIVE SQUARED LATIN CAPITAL LETTER M
+1F17D..1F17E  ; valid                  ;      ; NV8    # 6.0  NEGATIVE SQUARED LATIN CAPITAL LETTER N..NEGATIVE SQUARED LATIN CAPITAL LETTER O
+1F17F         ; valid                  ;      ; NV8    # 5.2  NEGATIVE SQUARED LATIN CAPITAL LETTER P
+1F180..1F189  ; valid                  ;      ; NV8    # 6.0  NEGATIVE SQUARED LATIN CAPITAL LETTER Q..NEGATIVE SQUARED LATIN CAPITAL LETTER Z
+1F18A..1F18D  ; valid                  ;      ; NV8    # 5.2  CROSSED NEGATIVE SQUARED LATIN CAPITAL LETTER P..NEGATIVE SQUARED SA
+1F18E..1F18F  ; valid                  ;      ; NV8    # 6.0  NEGATIVE SQUARED AB..NEGATIVE SQUARED WC
+1F190         ; mapped                 ; 0064 006A     # 5.2  SQUARE DJ
+1F191..1F19A  ; valid                  ;      ; NV8    # 6.0  SQUARED CL..SQUARED VS
+1F19B..1F1AC  ; valid                  ;      ; NV8    # 9.0  SQUARED THREE D..SQUARED VOD
+1F1AD         ; valid                  ;      ; NV8    # 13.0 MASK WORK SYMBOL
+1F1AE..1F1E5  ; disallowed                             # NA   <reserved-1F1AE>..<reserved-1F1E5>
+1F1E6..1F1FF  ; valid                  ;      ; NV8    # 6.0  REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
+1F200         ; mapped                 ; 307B 304B     # 5.2  SQUARE HIRAGANA HOKA
+1F201         ; mapped                 ; 30B3 30B3     # 6.0  SQUARED KATAKANA KOKO
+1F202         ; mapped                 ; 30B5          # 6.0  SQUARED KATAKANA SA
+1F203..1F20F  ; disallowed                             # NA   <reserved-1F203>..<reserved-1F20F>
+1F210         ; mapped                 ; 624B          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-624B
+1F211         ; mapped                 ; 5B57          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-5B57
+1F212         ; mapped                 ; 53CC          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-53CC
+1F213         ; mapped                 ; 30C7          # 5.2  SQUARED KATAKANA DE
+1F214         ; mapped                 ; 4E8C          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-4E8C
+1F215         ; mapped                 ; 591A          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-591A
+1F216         ; mapped                 ; 89E3          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-89E3
+1F217         ; mapped                 ; 5929          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-5929
+1F218         ; mapped                 ; 4EA4          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-4EA4
+1F219         ; mapped                 ; 6620          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-6620
+1F21A         ; mapped                 ; 7121          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-7121
+1F21B         ; mapped                 ; 6599          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-6599
+1F21C         ; mapped                 ; 524D          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-524D
+1F21D         ; mapped                 ; 5F8C          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-5F8C
+1F21E         ; mapped                 ; 518D          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-518D
+1F21F         ; mapped                 ; 65B0          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-65B0
+1F220         ; mapped                 ; 521D          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-521D
+1F221         ; mapped                 ; 7D42          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-7D42
+1F222         ; mapped                 ; 751F          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-751F
+1F223         ; mapped                 ; 8CA9          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-8CA9
+1F224         ; mapped                 ; 58F0          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-58F0
+1F225         ; mapped                 ; 5439          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-5439
+1F226         ; mapped                 ; 6F14          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-6F14
+1F227         ; mapped                 ; 6295          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-6295
+1F228         ; mapped                 ; 6355          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-6355
+1F229         ; mapped                 ; 4E00          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-4E00
+1F22A         ; mapped                 ; 4E09          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-4E09
+1F22B         ; mapped                 ; 904A          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-904A
+1F22C         ; mapped                 ; 5DE6          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-5DE6
+1F22D         ; mapped                 ; 4E2D          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-4E2D
+1F22E         ; mapped                 ; 53F3          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-53F3
+1F22F         ; mapped                 ; 6307          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-6307
+1F230         ; mapped                 ; 8D70          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-8D70
+1F231         ; mapped                 ; 6253          # 5.2  SQUARED CJK UNIFIED IDEOGRAPH-6253
+1F232         ; mapped                 ; 7981          # 6.0  SQUARED CJK UNIFIED IDEOGRAPH-7981
+1F233         ; mapped                 ; 7A7A          # 6.0  SQUARED CJK UNIFIED IDEOGRAPH-7A7A
+1F234         ; mapped                 ; 5408          # 6.0  SQUARED CJK UNIFIED IDEOGRAPH-5408
+1F235         ; mapped                 ; 6E80          # 6.0  SQUARED CJK UNIFIED IDEOGRAPH-6E80
+1F236         ; mapped                 ; 6709          # 6.0  SQUARED CJK UNIFIED IDEOGRAPH-6709
+1F237         ; mapped                 ; 6708          # 6.0  SQUARED CJK UNIFIED IDEOGRAPH-6708
+1F238         ; mapped                 ; 7533          # 6.0  SQUARED CJK UNIFIED IDEOGRAPH-7533
+1F239         ; mapped                 ; 5272          # 6.0  SQUARED CJK UNIFIED IDEOGRAPH-5272
+1F23A         ; mapped                 ; 55B6          # 6.0  SQUARED CJK UNIFIED IDEOGRAPH-55B6
+1F23B         ; mapped                 ; 914D          # 9.0  SQUARED CJK UNIFIED IDEOGRAPH-914D
+1F23C..1F23F  ; disallowed                             # NA   <reserved-1F23C>..<reserved-1F23F>
+1F240         ; mapped                 ; 3014 672C 3015 #5.2  TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-672C
+1F241         ; mapped                 ; 3014 4E09 3015 #5.2  TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-4E09
+1F242         ; mapped                 ; 3014 4E8C 3015 #5.2  TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-4E8C
+1F243         ; mapped                 ; 3014 5B89 3015 #5.2  TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-5B89
+1F244         ; mapped                 ; 3014 70B9 3015 #5.2  TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-70B9
+1F245         ; mapped                 ; 3014 6253 3015 #5.2  TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-6253
+1F246         ; mapped                 ; 3014 76D7 3015 #5.2  TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-76D7
+1F247         ; mapped                 ; 3014 52DD 3015 #5.2  TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-52DD
+1F248         ; mapped                 ; 3014 6557 3015 #5.2  TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-6557
+1F249..1F24F  ; disallowed                             # NA   <reserved-1F249>..<reserved-1F24F>
+1F250         ; mapped                 ; 5F97          # 6.0  CIRCLED IDEOGRAPH ADVANTAGE
+1F251         ; mapped                 ; 53EF          # 6.0  CIRCLED IDEOGRAPH ACCEPT
+1F252..1F25F  ; disallowed                             # NA   <reserved-1F252>..<reserved-1F25F>
+1F260..1F265  ; valid                  ;      ; NV8    # 10.0 ROUNDED SYMBOL FOR FU..ROUNDED SYMBOL FOR CAI
+1F266..1F2FF  ; disallowed                             # NA   <reserved-1F266>..<reserved-1F2FF>
+1F300..1F320  ; valid                  ;      ; NV8    # 6.0  CYCLONE..SHOOTING STAR
+1F321..1F32C  ; valid                  ;      ; NV8    # 7.0  THERMOMETER..WIND BLOWING FACE
+1F32D..1F32F  ; valid                  ;      ; NV8    # 8.0  HOT DOG..BURRITO
+1F330..1F335  ; valid                  ;      ; NV8    # 6.0  CHESTNUT..CACTUS
+1F336         ; valid                  ;      ; NV8    # 7.0  HOT PEPPER
+1F337..1F37C  ; valid                  ;      ; NV8    # 6.0  TULIP..BABY BOTTLE
+1F37D         ; valid                  ;      ; NV8    # 7.0  FORK AND KNIFE WITH PLATE
+1F37E..1F37F  ; valid                  ;      ; NV8    # 8.0  BOTTLE WITH POPPING CORK..POPCORN
+1F380..1F393  ; valid                  ;      ; NV8    # 6.0  RIBBON..GRADUATION CAP
+1F394..1F39F  ; valid                  ;      ; NV8    # 7.0  HEART WITH TIP ON THE LEFT..ADMISSION TICKETS
+1F3A0..1F3C4  ; valid                  ;      ; NV8    # 6.0  CAROUSEL HORSE..SURFER
+1F3C5         ; valid                  ;      ; NV8    # 7.0  SPORTS MEDAL
+1F3C6..1F3CA  ; valid                  ;      ; NV8    # 6.0  TROPHY..SWIMMER
+1F3CB..1F3CE  ; valid                  ;      ; NV8    # 7.0  WEIGHT LIFTER..RACING CAR
+1F3CF..1F3D3  ; valid                  ;      ; NV8    # 8.0  CRICKET BAT AND BALL..TABLE TENNIS PADDLE AND BALL
+1F3D4..1F3DF  ; valid                  ;      ; NV8    # 7.0  SNOW CAPPED MOUNTAIN..STADIUM
+1F3E0..1F3F0  ; valid                  ;      ; NV8    # 6.0  HOUSE BUILDING..EUROPEAN CASTLE
+1F3F1..1F3F7  ; valid                  ;      ; NV8    # 7.0  WHITE PENNANT..LABEL
+1F3F8..1F3FF  ; valid                  ;      ; NV8    # 8.0  BADMINTON RACQUET AND SHUTTLECOCK..EMOJI MODIFIER FITZPATRICK TYPE-6
+1F400..1F43E  ; valid                  ;      ; NV8    # 6.0  RAT..PAW PRINTS
+1F43F         ; valid                  ;      ; NV8    # 7.0  CHIPMUNK
+1F440         ; valid                  ;      ; NV8    # 6.0  EYES
+1F441         ; valid                  ;      ; NV8    # 7.0  EYE
+1F442..1F4F7  ; valid                  ;      ; NV8    # 6.0  EAR..CAMERA
+1F4F8         ; valid                  ;      ; NV8    # 7.0  CAMERA WITH FLASH
+1F4F9..1F4FC  ; valid                  ;      ; NV8    # 6.0  VIDEO CAMERA..VIDEOCASSETTE
+1F4FD..1F4FE  ; valid                  ;      ; NV8    # 7.0  FILM PROJECTOR..PORTABLE STEREO
+1F4FF         ; valid                  ;      ; NV8    # 8.0  PRAYER BEADS
+1F500..1F53D  ; valid                  ;      ; NV8    # 6.0  TWISTED RIGHTWARDS ARROWS..DOWN-POINTING SMALL RED TRIANGLE
+1F53E..1F53F  ; valid                  ;      ; NV8    # 7.0  LOWER RIGHT SHADOWED WHITE CIRCLE..UPPER RIGHT SHADOWED WHITE CIRCLE
+1F540..1F543  ; valid                  ;      ; NV8    # 6.1  CIRCLED CROSS POMMEE..NOTCHED LEFT SEMICIRCLE WITH THREE DOTS
+1F544..1F54A  ; valid                  ;      ; NV8    # 7.0  NOTCHED RIGHT SEMICIRCLE WITH THREE DOTS..DOVE OF PEACE
+1F54B..1F54F  ; valid                  ;      ; NV8    # 8.0  KAABA..BOWL OF HYGIEIA
+1F550..1F567  ; valid                  ;      ; NV8    # 6.0  CLOCK FACE ONE OCLOCK..CLOCK FACE TWELVE-THIRTY
+1F568..1F579  ; valid                  ;      ; NV8    # 7.0  RIGHT SPEAKER..JOYSTICK
+1F57A         ; valid                  ;      ; NV8    # 9.0  MAN DANCING
+1F57B..1F5A3  ; valid                  ;      ; NV8    # 7.0  LEFT HAND TELEPHONE RECEIVER..BLACK DOWN POINTING BACKHAND INDEX
+1F5A4         ; valid                  ;      ; NV8    # 9.0  BLACK HEART
+1F5A5..1F5FA  ; valid                  ;      ; NV8    # 7.0  DESKTOP COMPUTER..WORLD MAP
+1F5FB..1F5FF  ; valid                  ;      ; NV8    # 6.0  MOUNT FUJI..MOYAI
+1F600         ; valid                  ;      ; NV8    # 6.1  GRINNING FACE
+1F601..1F610  ; valid                  ;      ; NV8    # 6.0  GRINNING FACE WITH SMILING EYES..NEUTRAL FACE
+1F611         ; valid                  ;      ; NV8    # 6.1  EXPRESSIONLESS FACE
+1F612..1F614  ; valid                  ;      ; NV8    # 6.0  UNAMUSED FACE..PENSIVE FACE
+1F615         ; valid                  ;      ; NV8    # 6.1  CONFUSED FACE
+1F616         ; valid                  ;      ; NV8    # 6.0  CONFOUNDED FACE
+1F617         ; valid                  ;      ; NV8    # 6.1  KISSING FACE
+1F618         ; valid                  ;      ; NV8    # 6.0  FACE THROWING A KISS
+1F619         ; valid                  ;      ; NV8    # 6.1  KISSING FACE WITH SMILING EYES
+1F61A         ; valid                  ;      ; NV8    # 6.0  KISSING FACE WITH CLOSED EYES
+1F61B         ; valid                  ;      ; NV8    # 6.1  FACE WITH STUCK-OUT TONGUE
+1F61C..1F61E  ; valid                  ;      ; NV8    # 6.0  FACE WITH STUCK-OUT TONGUE AND WINKING EYE..DISAPPOINTED FACE
+1F61F         ; valid                  ;      ; NV8    # 6.1  WORRIED FACE
+1F620..1F625  ; valid                  ;      ; NV8    # 6.0  ANGRY FACE..DISAPPOINTED BUT RELIEVED FACE
+1F626..1F627  ; valid                  ;      ; NV8    # 6.1  FROWNING FACE WITH OPEN MOUTH..ANGUISHED FACE
+1F628..1F62B  ; valid                  ;      ; NV8    # 6.0  FEARFUL FACE..TIRED FACE
+1F62C         ; valid                  ;      ; NV8    # 6.1  GRIMACING FACE
+1F62D         ; valid                  ;      ; NV8    # 6.0  LOUDLY CRYING FACE
+1F62E..1F62F  ; valid                  ;      ; NV8    # 6.1  FACE WITH OPEN MOUTH..HUSHED FACE
+1F630..1F633  ; valid                  ;      ; NV8    # 6.0  FACE WITH OPEN MOUTH AND COLD SWEAT..FLUSHED FACE
+1F634         ; valid                  ;      ; NV8    # 6.1  SLEEPING FACE
+1F635..1F640  ; valid                  ;      ; NV8    # 6.0  DIZZY FACE..WEARY CAT FACE
+1F641..1F642  ; valid                  ;      ; NV8    # 7.0  SLIGHTLY FROWNING FACE..SLIGHTLY SMILING FACE
+1F643..1F644  ; valid                  ;      ; NV8    # 8.0  UPSIDE-DOWN FACE..FACE WITH ROLLING EYES
+1F645..1F64F  ; valid                  ;      ; NV8    # 6.0  FACE WITH NO GOOD GESTURE..PERSON WITH FOLDED HANDS
+1F650..1F67F  ; valid                  ;      ; NV8    # 7.0  NORTH WEST POINTING LEAF..REVERSE CHECKER BOARD
+1F680..1F6C5  ; valid                  ;      ; NV8    # 6.0  ROCKET..LEFT LUGGAGE
+1F6C6..1F6CF  ; valid                  ;      ; NV8    # 7.0  TRIANGLE WITH ROUNDED CORNERS..BED
+1F6D0         ; valid                  ;      ; NV8    # 8.0  PLACE OF WORSHIP
+1F6D1..1F6D2  ; valid                  ;      ; NV8    # 9.0  OCTAGONAL SIGN..SHOPPING TROLLEY
+1F6D3..1F6D4  ; valid                  ;      ; NV8    # 10.0 STUPA..PAGODA
+1F6D5         ; valid                  ;      ; NV8    # 12.0 HINDU TEMPLE
+1F6D6..1F6D7  ; valid                  ;      ; NV8    # 13.0 HUT..ELEVATOR
+1F6D8..1F6DB  ; disallowed                             # NA   <reserved-1F6D8>..<reserved-1F6DB>
+1F6DC         ; valid                  ;      ; NV8    # 15.0 WIRELESS
+1F6DD..1F6DF  ; valid                  ;      ; NV8    # 14.0 PLAYGROUND SLIDE..RING BUOY
+1F6E0..1F6EC  ; valid                  ;      ; NV8    # 7.0  HAMMER AND WRENCH..AIRPLANE ARRIVING
+1F6ED..1F6EF  ; disallowed                             # NA   <reserved-1F6ED>..<reserved-1F6EF>
+1F6F0..1F6F3  ; valid                  ;      ; NV8    # 7.0  SATELLITE..PASSENGER SHIP
+1F6F4..1F6F6  ; valid                  ;      ; NV8    # 9.0  SCOOTER..CANOE
+1F6F7..1F6F8  ; valid                  ;      ; NV8    # 10.0 SLED..FLYING SAUCER
+1F6F9         ; valid                  ;      ; NV8    # 11.0 SKATEBOARD
+1F6FA         ; valid                  ;      ; NV8    # 12.0 AUTO RICKSHAW
+1F6FB..1F6FC  ; valid                  ;      ; NV8    # 13.0 PICKUP TRUCK..ROLLER SKATE
+1F6FD..1F6FF  ; disallowed                             # NA   <reserved-1F6FD>..<reserved-1F6FF>
+1F700..1F773  ; valid                  ;      ; NV8    # 6.0  ALCHEMICAL SYMBOL FOR QUINTESSENCE..ALCHEMICAL SYMBOL FOR HALF OUNCE
+1F774..1F776  ; valid                  ;      ; NV8    # 15.0 LOT OF FORTUNE..LUNAR ECLIPSE
+1F777..1F77A  ; disallowed                             # NA   <reserved-1F777>..<reserved-1F77A>
+1F77B..1F77F  ; valid                  ;      ; NV8    # 15.0 HAUMEA..ORCUS
+1F780..1F7D4  ; valid                  ;      ; NV8    # 7.0  BLACK LEFT-POINTING ISOSCELES RIGHT TRIANGLE..HEAVY TWELVE POINTED PINWHEEL STAR
+1F7D5..1F7D8  ; valid                  ;      ; NV8    # 11.0 CIRCLED TRIANGLE..NEGATIVE CIRCLED SQUARE
+1F7D9         ; valid                  ;      ; NV8    # 15.0 NINE POINTED WHITE STAR
+1F7DA..1F7DF  ; disallowed                             # NA   <reserved-1F7DA>..<reserved-1F7DF>
+1F7E0..1F7EB  ; valid                  ;      ; NV8    # 12.0 LARGE ORANGE CIRCLE..LARGE BROWN SQUARE
+1F7EC..1F7EF  ; disallowed                             # NA   <reserved-1F7EC>..<reserved-1F7EF>
+1F7F0         ; valid                  ;      ; NV8    # 14.0 HEAVY EQUALS SIGN
+1F7F1..1F7FF  ; disallowed                             # NA   <reserved-1F7F1>..<reserved-1F7FF>
+1F800..1F80B  ; valid                  ;      ; NV8    # 7.0  LEFTWARDS ARROW WITH SMALL TRIANGLE ARROWHEAD..DOWNWARDS ARROW WITH LARGE TRIANGLE ARROWHEAD
+1F80C..1F80F  ; disallowed                             # NA   <reserved-1F80C>..<reserved-1F80F>
+1F810..1F847  ; valid                  ;      ; NV8    # 7.0  LEFTWARDS ARROW WITH SMALL EQUILATERAL ARROWHEAD..DOWNWARDS HEAVY ARROW
+1F848..1F84F  ; disallowed                             # NA   <reserved-1F848>..<reserved-1F84F>
+1F850..1F859  ; valid                  ;      ; NV8    # 7.0  LEFTWARDS SANS-SERIF ARROW..UP DOWN SANS-SERIF ARROW
+1F85A..1F85F  ; disallowed                             # NA   <reserved-1F85A>..<reserved-1F85F>
+1F860..1F887  ; valid                  ;      ; NV8    # 7.0  WIDE-HEADED LEFTWARDS LIGHT BARB ARROW..WIDE-HEADED SOUTH WEST VERY HEAVY BARB ARROW
+1F888..1F88F  ; disallowed                             # NA   <reserved-1F888>..<reserved-1F88F>
+1F890..1F8AD  ; valid                  ;      ; NV8    # 7.0  LEFTWARDS TRIANGLE ARROWHEAD..WHITE ARROW SHAFT WIDTH TWO THIRDS
+1F8AE..1F8AF  ; disallowed                             # NA   <reserved-1F8AE>..<reserved-1F8AF>
+1F8B0..1F8B1  ; valid                  ;      ; NV8    # 13.0 ARROW POINTING UPWARDS THEN NORTH WEST..ARROW POINTING RIGHTWARDS THEN CURVING SOUTH WEST
+1F8B2..1F8FF  ; disallowed                             # NA   <reserved-1F8B2>..<reserved-1F8FF>
+1F900..1F90B  ; valid                  ;      ; NV8    # 10.0 CIRCLED CROSS FORMEE WITH FOUR DOTS..DOWNWARD FACING NOTCHED HOOK WITH DOT
+1F90C         ; valid                  ;      ; NV8    # 13.0 PINCHED FINGERS
+1F90D..1F90F  ; valid                  ;      ; NV8    # 12.0 WHITE HEART..PINCHING HAND
+1F910..1F918  ; valid                  ;      ; NV8    # 8.0  ZIPPER-MOUTH FACE..SIGN OF THE HORNS
+1F919..1F91E  ; valid                  ;      ; NV8    # 9.0  CALL ME HAND..HAND WITH INDEX AND MIDDLE FINGERS CROSSED
+1F91F         ; valid                  ;      ; NV8    # 10.0 I LOVE YOU HAND SIGN
+1F920..1F927  ; valid                  ;      ; NV8    # 9.0  FACE WITH COWBOY HAT..SNEEZING FACE
+1F928..1F92F  ; valid                  ;      ; NV8    # 10.0 FACE WITH ONE EYEBROW RAISED..SHOCKED FACE WITH EXPLODING HEAD
+1F930         ; valid                  ;      ; NV8    # 9.0  PREGNANT WOMAN
+1F931..1F932  ; valid                  ;      ; NV8    # 10.0 BREAST-FEEDING..PALMS UP TOGETHER
+1F933..1F93E  ; valid                  ;      ; NV8    # 9.0  SELFIE..HANDBALL
+1F93F         ; valid                  ;      ; NV8    # 12.0 DIVING MASK
+1F940..1F94B  ; valid                  ;      ; NV8    # 9.0  WILTED FLOWER..MARTIAL ARTS UNIFORM
+1F94C         ; valid                  ;      ; NV8    # 10.0 CURLING STONE
+1F94D..1F94F  ; valid                  ;      ; NV8    # 11.0 LACROSSE STICK AND BALL..FLYING DISC
+1F950..1F95E  ; valid                  ;      ; NV8    # 9.0  CROISSANT..PANCAKES
+1F95F..1F96B  ; valid                  ;      ; NV8    # 10.0 DUMPLING..CANNED FOOD
+1F96C..1F970  ; valid                  ;      ; NV8    # 11.0 LEAFY GREEN..SMILING FACE WITH SMILING EYES AND THREE HEARTS
+1F971         ; valid                  ;      ; NV8    # 12.0 YAWNING FACE
+1F972         ; valid                  ;      ; NV8    # 13.0 SMILING FACE WITH TEAR
+1F973..1F976  ; valid                  ;      ; NV8    # 11.0 FACE WITH PARTY HORN AND PARTY HAT..FREEZING FACE
+1F977..1F978  ; valid                  ;      ; NV8    # 13.0 NINJA..DISGUISED FACE
+1F979         ; valid                  ;      ; NV8    # 14.0 FACE HOLDING BACK TEARS
+1F97A         ; valid                  ;      ; NV8    # 11.0 FACE WITH PLEADING EYES
+1F97B         ; valid                  ;      ; NV8    # 12.0 SARI
+1F97C..1F97F  ; valid                  ;      ; NV8    # 11.0 LAB COAT..FLAT SHOE
+1F980..1F984  ; valid                  ;      ; NV8    # 8.0  CRAB..UNICORN FACE
+1F985..1F991  ; valid                  ;      ; NV8    # 9.0  EAGLE..SQUID
+1F992..1F997  ; valid                  ;      ; NV8    # 10.0 GIRAFFE FACE..CRICKET
+1F998..1F9A2  ; valid                  ;      ; NV8    # 11.0 KANGAROO..SWAN
+1F9A3..1F9A4  ; valid                  ;      ; NV8    # 13.0 MAMMOTH..DODO
+1F9A5..1F9AA  ; valid                  ;      ; NV8    # 12.0 SLOTH..OYSTER
+1F9AB..1F9AD  ; valid                  ;      ; NV8    # 13.0 BEAVER..SEAL
+1F9AE..1F9AF  ; valid                  ;      ; NV8    # 12.0 GUIDE DOG..PROBING CANE
+1F9B0..1F9B9  ; valid                  ;      ; NV8    # 11.0 EMOJI COMPONENT RED HAIR..SUPERVILLAIN
+1F9BA..1F9BF  ; valid                  ;      ; NV8    # 12.0 SAFETY VEST..MECHANICAL LEG
+1F9C0         ; valid                  ;      ; NV8    # 8.0  CHEESE WEDGE
+1F9C1..1F9C2  ; valid                  ;      ; NV8    # 11.0 CUPCAKE..SALT SHAKER
+1F9C3..1F9CA  ; valid                  ;      ; NV8    # 12.0 BEVERAGE BOX..ICE CUBE
+1F9CB         ; valid                  ;      ; NV8    # 13.0 BUBBLE TEA
+1F9CC         ; valid                  ;      ; NV8    # 14.0 TROLL
+1F9CD..1F9CF  ; valid                  ;      ; NV8    # 12.0 STANDING PERSON..DEAF PERSON
+1F9D0..1F9E6  ; valid                  ;      ; NV8    # 10.0 FACE WITH MONOCLE..SOCKS
+1F9E7..1F9FF  ; valid                  ;      ; NV8    # 11.0 RED GIFT ENVELOPE..NAZAR AMULET
+1FA00..1FA53  ; valid                  ;      ; NV8    # 12.0 NEUTRAL CHESS KING..BLACK CHESS KNIGHT-BISHOP
+1FA54..1FA5F  ; disallowed                             # NA   <reserved-1FA54>..<reserved-1FA5F>
+1FA60..1FA6D  ; valid                  ;      ; NV8    # 11.0 XIANGQI RED GENERAL..XIANGQI BLACK SOLDIER
+1FA6E..1FA6F  ; disallowed                             # NA   <reserved-1FA6E>..<reserved-1FA6F>
+1FA70..1FA73  ; valid                  ;      ; NV8    # 12.0 BALLET SHOES..SHORTS
+1FA74         ; valid                  ;      ; NV8    # 13.0 THONG SANDAL
+1FA75..1FA77  ; valid                  ;      ; NV8    # 15.0 LIGHT BLUE HEART..PINK HEART
+1FA78..1FA7A  ; valid                  ;      ; NV8    # 12.0 DROP OF BLOOD..STETHOSCOPE
+1FA7B..1FA7C  ; valid                  ;      ; NV8    # 14.0 X-RAY..CRUTCH
+1FA7D..1FA7F  ; disallowed                             # NA   <reserved-1FA7D>..<reserved-1FA7F>
+1FA80..1FA82  ; valid                  ;      ; NV8    # 12.0 YO-YO..PARACHUTE
+1FA83..1FA86  ; valid                  ;      ; NV8    # 13.0 BOOMERANG..NESTING DOLLS
+1FA87..1FA88  ; valid                  ;      ; NV8    # 15.0 MARACAS..FLUTE
+1FA89..1FA8F  ; disallowed                             # NA   <reserved-1FA89>..<reserved-1FA8F>
+1FA90..1FA95  ; valid                  ;      ; NV8    # 12.0 RINGED PLANET..BANJO
+1FA96..1FAA8  ; valid                  ;      ; NV8    # 13.0 MILITARY HELMET..ROCK
+1FAA9..1FAAC  ; valid                  ;      ; NV8    # 14.0 MIRROR BALL..HAMSA
+1FAAD..1FAAF  ; valid                  ;      ; NV8    # 15.0 FOLDING HAND FAN..KHANDA
+1FAB0..1FAB6  ; valid                  ;      ; NV8    # 13.0 FLY..FEATHER
+1FAB7..1FABA  ; valid                  ;      ; NV8    # 14.0 LOTUS..NEST WITH EGGS
+1FABB..1FABD  ; valid                  ;      ; NV8    # 15.0 HYACINTH..WING
+1FABE         ; disallowed                             # NA   <reserved-1FABE>
+1FABF         ; valid                  ;      ; NV8    # 15.0 GOOSE
+1FAC0..1FAC2  ; valid                  ;      ; NV8    # 13.0 ANATOMICAL HEART..PEOPLE HUGGING
+1FAC3..1FAC5  ; valid                  ;      ; NV8    # 14.0 PREGNANT MAN..PERSON WITH CROWN
+1FAC6..1FACD  ; disallowed                             # NA   <reserved-1FAC6>..<reserved-1FACD>
+1FACE..1FACF  ; valid                  ;      ; NV8    # 15.0 MOOSE..DONKEY
+1FAD0..1FAD6  ; valid                  ;      ; NV8    # 13.0 BLUEBERRIES..TEAPOT
+1FAD7..1FAD9  ; valid                  ;      ; NV8    # 14.0 POURING LIQUID..JAR
+1FADA..1FADB  ; valid                  ;      ; NV8    # 15.0 GINGER ROOT..PEA POD
+1FADC..1FADF  ; disallowed                             # NA   <reserved-1FADC>..<reserved-1FADF>
+1FAE0..1FAE7  ; valid                  ;      ; NV8    # 14.0 MELTING FACE..BUBBLES
+1FAE8         ; valid                  ;      ; NV8    # 15.0 SHAKING FACE
+1FAE9..1FAEF  ; disallowed                             # NA   <reserved-1FAE9>..<reserved-1FAEF>
+1FAF0..1FAF6  ; valid                  ;      ; NV8    # 14.0 HAND WITH INDEX FINGER AND THUMB CROSSED..HEART HANDS
+1FAF7..1FAF8  ; valid                  ;      ; NV8    # 15.0 LEFTWARDS PUSHING HAND..RIGHTWARDS PUSHING HAND
+1FAF9..1FAFF  ; disallowed                             # NA   <reserved-1FAF9>..<reserved-1FAFF>
+1FB00..1FB92  ; valid                  ;      ; NV8    # 13.0 BLOCK SEXTANT-1..UPPER HALF INVERSE MEDIUM SHADE AND LOWER HALF BLOCK
+1FB93         ; disallowed                             # NA   <reserved-1FB93>
+1FB94..1FBCA  ; valid                  ;      ; NV8    # 13.0 LEFT HALF INVERSE MEDIUM SHADE AND RIGHT HALF BLOCK..WHITE UP-POINTING CHEVRON
+1FBCB..1FBEF  ; disallowed                             # NA   <reserved-1FBCB>..<reserved-1FBEF>
+1FBF0         ; mapped                 ; 0030          # 13.0 SEGMENTED DIGIT ZERO
+1FBF1         ; mapped                 ; 0031          # 13.0 SEGMENTED DIGIT ONE
+1FBF2         ; mapped                 ; 0032          # 13.0 SEGMENTED DIGIT TWO
+1FBF3         ; mapped                 ; 0033          # 13.0 SEGMENTED DIGIT THREE
+1FBF4         ; mapped                 ; 0034          # 13.0 SEGMENTED DIGIT FOUR
+1FBF5         ; mapped                 ; 0035          # 13.0 SEGMENTED DIGIT FIVE
+1FBF6         ; mapped                 ; 0036          # 13.0 SEGMENTED DIGIT SIX
+1FBF7         ; mapped                 ; 0037          # 13.0 SEGMENTED DIGIT SEVEN
+1FBF8         ; mapped                 ; 0038          # 13.0 SEGMENTED DIGIT EIGHT
+1FBF9         ; mapped                 ; 0039          # 13.0 SEGMENTED DIGIT NINE
+1FBFA..1FFFD  ; disallowed                             # NA   <reserved-1FBFA>..<reserved-1FFFD>
+1FFFE..1FFFF  ; disallowed                             # 2.0  <noncharacter-1FFFE>..<noncharacter-1FFFF>
+20000..2A6D6  ; valid                                  # 3.1  CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6D6
+2A6D7..2A6DD  ; valid                                  # 13.0 CJK UNIFIED IDEOGRAPH-2A6D7..CJK UNIFIED IDEOGRAPH-2A6DD
+2A6DE..2A6DF  ; valid                                  # 14.0 CJK UNIFIED IDEOGRAPH-2A6DE..CJK UNIFIED IDEOGRAPH-2A6DF
+2A6E0..2A6FF  ; disallowed                             # NA   <reserved-2A6E0>..<reserved-2A6FF>
+2A700..2B734  ; valid                                  # 5.2  CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B734
+2B735..2B738  ; valid                                  # 14.0 CJK UNIFIED IDEOGRAPH-2B735..CJK UNIFIED IDEOGRAPH-2B738
+2B739         ; valid                                  # 15.0 CJK UNIFIED IDEOGRAPH-2B739
+2B73A..2B73F  ; disallowed                             # NA   <reserved-2B73A>..<reserved-2B73F>
+2B740..2B81D  ; valid                                  # 6.0  CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
+2B81E..2B81F  ; disallowed                             # NA   <reserved-2B81E>..<reserved-2B81F>
+2B820..2CEA1  ; valid                                  # 8.0  CJK UNIFIED IDEOGRAPH-2B820..CJK UNIFIED IDEOGRAPH-2CEA1
+2CEA2..2CEAF  ; disallowed                             # NA   <reserved-2CEA2>..<reserved-2CEAF>
+2CEB0..2EBE0  ; valid                                  # 10.0 CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
+2EBE1..2F7FF  ; disallowed                             # NA   <reserved-2EBE1>..<reserved-2F7FF>
+2F800         ; mapped                 ; 4E3D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F800
+2F801         ; mapped                 ; 4E38          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F801
+2F802         ; mapped                 ; 4E41          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F802
+2F803         ; mapped                 ; 20122         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F803
+2F804         ; mapped                 ; 4F60          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F804
+2F805         ; mapped                 ; 4FAE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F805
+2F806         ; mapped                 ; 4FBB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F806
+2F807         ; mapped                 ; 5002          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F807
+2F808         ; mapped                 ; 507A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F808
+2F809         ; mapped                 ; 5099          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F809
+2F80A         ; mapped                 ; 50E7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F80A
+2F80B         ; mapped                 ; 50CF          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F80B
+2F80C         ; mapped                 ; 349E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F80C
+2F80D         ; mapped                 ; 2063A         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F80D
+2F80E         ; mapped                 ; 514D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F80E
+2F80F         ; mapped                 ; 5154          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F80F
+2F810         ; mapped                 ; 5164          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F810
+2F811         ; mapped                 ; 5177          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F811
+2F812         ; mapped                 ; 2051C         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F812
+2F813         ; mapped                 ; 34B9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F813
+2F814         ; mapped                 ; 5167          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F814
+2F815         ; mapped                 ; 518D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F815
+2F816         ; mapped                 ; 2054B         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F816
+2F817         ; mapped                 ; 5197          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F817
+2F818         ; mapped                 ; 51A4          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F818
+2F819         ; mapped                 ; 4ECC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F819
+2F81A         ; mapped                 ; 51AC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F81A
+2F81B         ; mapped                 ; 51B5          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F81B
+2F81C         ; mapped                 ; 291DF         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F81C
+2F81D         ; mapped                 ; 51F5          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F81D
+2F81E         ; mapped                 ; 5203          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F81E
+2F81F         ; mapped                 ; 34DF          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F81F
+2F820         ; mapped                 ; 523B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F820
+2F821         ; mapped                 ; 5246          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F821
+2F822         ; mapped                 ; 5272          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F822
+2F823         ; mapped                 ; 5277          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F823
+2F824         ; mapped                 ; 3515          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F824
+2F825         ; mapped                 ; 52C7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F825
+2F826         ; mapped                 ; 52C9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F826
+2F827         ; mapped                 ; 52E4          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F827
+2F828         ; mapped                 ; 52FA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F828
+2F829         ; mapped                 ; 5305          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F829
+2F82A         ; mapped                 ; 5306          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F82A
+2F82B         ; mapped                 ; 5317          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F82B
+2F82C         ; mapped                 ; 5349          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F82C
+2F82D         ; mapped                 ; 5351          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F82D
+2F82E         ; mapped                 ; 535A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F82E
+2F82F         ; mapped                 ; 5373          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F82F
+2F830         ; mapped                 ; 537D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F830
+2F831..2F833  ; mapped                 ; 537F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F831..CJK COMPATIBILITY IDEOGRAPH-2F833
+2F834         ; mapped                 ; 20A2C         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F834
+2F835         ; mapped                 ; 7070          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F835
+2F836         ; mapped                 ; 53CA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F836
+2F837         ; mapped                 ; 53DF          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F837
+2F838         ; mapped                 ; 20B63         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F838
+2F839         ; mapped                 ; 53EB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F839
+2F83A         ; mapped                 ; 53F1          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F83A
+2F83B         ; mapped                 ; 5406          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F83B
+2F83C         ; mapped                 ; 549E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F83C
+2F83D         ; mapped                 ; 5438          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F83D
+2F83E         ; mapped                 ; 5448          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F83E
+2F83F         ; mapped                 ; 5468          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F83F
+2F840         ; mapped                 ; 54A2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F840
+2F841         ; mapped                 ; 54F6          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F841
+2F842         ; mapped                 ; 5510          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F842
+2F843         ; mapped                 ; 5553          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F843
+2F844         ; mapped                 ; 5563          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F844
+2F845..2F846  ; mapped                 ; 5584          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F845..CJK COMPATIBILITY IDEOGRAPH-2F846
+2F847         ; mapped                 ; 5599          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F847
+2F848         ; mapped                 ; 55AB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F848
+2F849         ; mapped                 ; 55B3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F849
+2F84A         ; mapped                 ; 55C2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F84A
+2F84B         ; mapped                 ; 5716          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F84B
+2F84C         ; mapped                 ; 5606          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F84C
+2F84D         ; mapped                 ; 5717          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F84D
+2F84E         ; mapped                 ; 5651          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F84E
+2F84F         ; mapped                 ; 5674          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F84F
+2F850         ; mapped                 ; 5207          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F850
+2F851         ; mapped                 ; 58EE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F851
+2F852         ; mapped                 ; 57CE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F852
+2F853         ; mapped                 ; 57F4          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F853
+2F854         ; mapped                 ; 580D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F854
+2F855         ; mapped                 ; 578B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F855
+2F856         ; mapped                 ; 5832          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F856
+2F857         ; mapped                 ; 5831          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F857
+2F858         ; mapped                 ; 58AC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F858
+2F859         ; mapped                 ; 214E4         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F859
+2F85A         ; mapped                 ; 58F2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F85A
+2F85B         ; mapped                 ; 58F7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F85B
+2F85C         ; mapped                 ; 5906          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F85C
+2F85D         ; mapped                 ; 591A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F85D
+2F85E         ; mapped                 ; 5922          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F85E
+2F85F         ; mapped                 ; 5962          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F85F
+2F860         ; mapped                 ; 216A8         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F860
+2F861         ; mapped                 ; 216EA         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F861
+2F862         ; mapped                 ; 59EC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F862
+2F863         ; mapped                 ; 5A1B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F863
+2F864         ; mapped                 ; 5A27          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F864
+2F865         ; mapped                 ; 59D8          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F865
+2F866         ; mapped                 ; 5A66          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F866
+2F867         ; mapped                 ; 36EE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F867
+2F868         ; disallowed                             # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F868
+2F869         ; mapped                 ; 5B08          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F869
+2F86A..2F86B  ; mapped                 ; 5B3E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F86A..CJK COMPATIBILITY IDEOGRAPH-2F86B
+2F86C         ; mapped                 ; 219C8         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F86C
+2F86D         ; mapped                 ; 5BC3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F86D
+2F86E         ; mapped                 ; 5BD8          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F86E
+2F86F         ; mapped                 ; 5BE7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F86F
+2F870         ; mapped                 ; 5BF3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F870
+2F871         ; mapped                 ; 21B18         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F871
+2F872         ; mapped                 ; 5BFF          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F872
+2F873         ; mapped                 ; 5C06          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F873
+2F874         ; disallowed                             # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F874
+2F875         ; mapped                 ; 5C22          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F875
+2F876         ; mapped                 ; 3781          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F876
+2F877         ; mapped                 ; 5C60          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F877
+2F878         ; mapped                 ; 5C6E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F878
+2F879         ; mapped                 ; 5CC0          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F879
+2F87A         ; mapped                 ; 5C8D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F87A
+2F87B         ; mapped                 ; 21DE4         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F87B
+2F87C         ; mapped                 ; 5D43          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F87C
+2F87D         ; mapped                 ; 21DE6         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F87D
+2F87E         ; mapped                 ; 5D6E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F87E
+2F87F         ; mapped                 ; 5D6B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F87F
+2F880         ; mapped                 ; 5D7C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F880
+2F881         ; mapped                 ; 5DE1          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F881
+2F882         ; mapped                 ; 5DE2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F882
+2F883         ; mapped                 ; 382F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F883
+2F884         ; mapped                 ; 5DFD          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F884
+2F885         ; mapped                 ; 5E28          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F885
+2F886         ; mapped                 ; 5E3D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F886
+2F887         ; mapped                 ; 5E69          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F887
+2F888         ; mapped                 ; 3862          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F888
+2F889         ; mapped                 ; 22183         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F889
+2F88A         ; mapped                 ; 387C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F88A
+2F88B         ; mapped                 ; 5EB0          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F88B
+2F88C         ; mapped                 ; 5EB3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F88C
+2F88D         ; mapped                 ; 5EB6          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F88D
+2F88E         ; mapped                 ; 5ECA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F88E
+2F88F         ; mapped                 ; 2A392         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F88F
+2F890         ; mapped                 ; 5EFE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F890
+2F891..2F892  ; mapped                 ; 22331         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F891..CJK COMPATIBILITY IDEOGRAPH-2F892
+2F893         ; mapped                 ; 8201          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F893
+2F894..2F895  ; mapped                 ; 5F22          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F894..CJK COMPATIBILITY IDEOGRAPH-2F895
+2F896         ; mapped                 ; 38C7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F896
+2F897         ; mapped                 ; 232B8         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F897
+2F898         ; mapped                 ; 261DA         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F898
+2F899         ; mapped                 ; 5F62          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F899
+2F89A         ; mapped                 ; 5F6B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F89A
+2F89B         ; mapped                 ; 38E3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F89B
+2F89C         ; mapped                 ; 5F9A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F89C
+2F89D         ; mapped                 ; 5FCD          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F89D
+2F89E         ; mapped                 ; 5FD7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F89E
+2F89F         ; mapped                 ; 5FF9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F89F
+2F8A0         ; mapped                 ; 6081          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A0
+2F8A1         ; mapped                 ; 393A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A1
+2F8A2         ; mapped                 ; 391C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A2
+2F8A3         ; mapped                 ; 6094          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A3
+2F8A4         ; mapped                 ; 226D4         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A4
+2F8A5         ; mapped                 ; 60C7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A5
+2F8A6         ; mapped                 ; 6148          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A6
+2F8A7         ; mapped                 ; 614C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A7
+2F8A8         ; mapped                 ; 614E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A8
+2F8A9         ; mapped                 ; 614C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8A9
+2F8AA         ; mapped                 ; 617A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8AA
+2F8AB         ; mapped                 ; 618E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8AB
+2F8AC         ; mapped                 ; 61B2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8AC
+2F8AD         ; mapped                 ; 61A4          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8AD
+2F8AE         ; mapped                 ; 61AF          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8AE
+2F8AF         ; mapped                 ; 61DE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8AF
+2F8B0         ; mapped                 ; 61F2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B0
+2F8B1         ; mapped                 ; 61F6          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B1
+2F8B2         ; mapped                 ; 6210          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B2
+2F8B3         ; mapped                 ; 621B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B3
+2F8B4         ; mapped                 ; 625D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B4
+2F8B5         ; mapped                 ; 62B1          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B5
+2F8B6         ; mapped                 ; 62D4          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B6
+2F8B7         ; mapped                 ; 6350          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B7
+2F8B8         ; mapped                 ; 22B0C         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B8
+2F8B9         ; mapped                 ; 633D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8B9
+2F8BA         ; mapped                 ; 62FC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8BA
+2F8BB         ; mapped                 ; 6368          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8BB
+2F8BC         ; mapped                 ; 6383          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8BC
+2F8BD         ; mapped                 ; 63E4          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8BD
+2F8BE         ; mapped                 ; 22BF1         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8BE
+2F8BF         ; mapped                 ; 6422          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8BF
+2F8C0         ; mapped                 ; 63C5          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C0
+2F8C1         ; mapped                 ; 63A9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C1
+2F8C2         ; mapped                 ; 3A2E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C2
+2F8C3         ; mapped                 ; 6469          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C3
+2F8C4         ; mapped                 ; 647E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C4
+2F8C5         ; mapped                 ; 649D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C5
+2F8C6         ; mapped                 ; 6477          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C6
+2F8C7         ; mapped                 ; 3A6C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C7
+2F8C8         ; mapped                 ; 654F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C8
+2F8C9         ; mapped                 ; 656C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8C9
+2F8CA         ; mapped                 ; 2300A         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8CA
+2F8CB         ; mapped                 ; 65E3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8CB
+2F8CC         ; mapped                 ; 66F8          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8CC
+2F8CD         ; mapped                 ; 6649          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8CD
+2F8CE         ; mapped                 ; 3B19          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8CE
+2F8CF         ; mapped                 ; 6691          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8CF
+2F8D0         ; mapped                 ; 3B08          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D0
+2F8D1         ; mapped                 ; 3AE4          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D1
+2F8D2         ; mapped                 ; 5192          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D2
+2F8D3         ; mapped                 ; 5195          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D3
+2F8D4         ; mapped                 ; 6700          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D4
+2F8D5         ; mapped                 ; 669C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D5
+2F8D6         ; mapped                 ; 80AD          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D6
+2F8D7         ; mapped                 ; 43D9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D7
+2F8D8         ; mapped                 ; 6717          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D8
+2F8D9         ; mapped                 ; 671B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8D9
+2F8DA         ; mapped                 ; 6721          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8DA
+2F8DB         ; mapped                 ; 675E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8DB
+2F8DC         ; mapped                 ; 6753          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8DC
+2F8DD         ; mapped                 ; 233C3         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8DD
+2F8DE         ; mapped                 ; 3B49          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8DE
+2F8DF         ; mapped                 ; 67FA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8DF
+2F8E0         ; mapped                 ; 6785          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E0
+2F8E1         ; mapped                 ; 6852          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E1
+2F8E2         ; mapped                 ; 6885          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E2
+2F8E3         ; mapped                 ; 2346D         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E3
+2F8E4         ; mapped                 ; 688E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E4
+2F8E5         ; mapped                 ; 681F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E5
+2F8E6         ; mapped                 ; 6914          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E6
+2F8E7         ; mapped                 ; 3B9D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E7
+2F8E8         ; mapped                 ; 6942          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E8
+2F8E9         ; mapped                 ; 69A3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8E9
+2F8EA         ; mapped                 ; 69EA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8EA
+2F8EB         ; mapped                 ; 6AA8          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8EB
+2F8EC         ; mapped                 ; 236A3         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8EC
+2F8ED         ; mapped                 ; 6ADB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8ED
+2F8EE         ; mapped                 ; 3C18          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8EE
+2F8EF         ; mapped                 ; 6B21          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8EF
+2F8F0         ; mapped                 ; 238A7         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F0
+2F8F1         ; mapped                 ; 6B54          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F1
+2F8F2         ; mapped                 ; 3C4E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F2
+2F8F3         ; mapped                 ; 6B72          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F3
+2F8F4         ; mapped                 ; 6B9F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F4
+2F8F5         ; mapped                 ; 6BBA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F5
+2F8F6         ; mapped                 ; 6BBB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F6
+2F8F7         ; mapped                 ; 23A8D         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F7
+2F8F8         ; mapped                 ; 21D0B         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F8
+2F8F9         ; mapped                 ; 23AFA         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8F9
+2F8FA         ; mapped                 ; 6C4E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8FA
+2F8FB         ; mapped                 ; 23CBC         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8FB
+2F8FC         ; mapped                 ; 6CBF          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8FC
+2F8FD         ; mapped                 ; 6CCD          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8FD
+2F8FE         ; mapped                 ; 6C67          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8FE
+2F8FF         ; mapped                 ; 6D16          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F8FF
+2F900         ; mapped                 ; 6D3E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F900
+2F901         ; mapped                 ; 6D77          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F901
+2F902         ; mapped                 ; 6D41          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F902
+2F903         ; mapped                 ; 6D69          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F903
+2F904         ; mapped                 ; 6D78          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F904
+2F905         ; mapped                 ; 6D85          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F905
+2F906         ; mapped                 ; 23D1E         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F906
+2F907         ; mapped                 ; 6D34          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F907
+2F908         ; mapped                 ; 6E2F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F908
+2F909         ; mapped                 ; 6E6E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F909
+2F90A         ; mapped                 ; 3D33          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F90A
+2F90B         ; mapped                 ; 6ECB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F90B
+2F90C         ; mapped                 ; 6EC7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F90C
+2F90D         ; mapped                 ; 23ED1         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F90D
+2F90E         ; mapped                 ; 6DF9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F90E
+2F90F         ; mapped                 ; 6F6E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F90F
+2F910         ; mapped                 ; 23F5E         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F910
+2F911         ; mapped                 ; 23F8E         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F911
+2F912         ; mapped                 ; 6FC6          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F912
+2F913         ; mapped                 ; 7039          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F913
+2F914         ; mapped                 ; 701E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F914
+2F915         ; mapped                 ; 701B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F915
+2F916         ; mapped                 ; 3D96          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F916
+2F917         ; mapped                 ; 704A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F917
+2F918         ; mapped                 ; 707D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F918
+2F919         ; mapped                 ; 7077          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F919
+2F91A         ; mapped                 ; 70AD          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F91A
+2F91B         ; mapped                 ; 20525         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F91B
+2F91C         ; mapped                 ; 7145          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F91C
+2F91D         ; mapped                 ; 24263         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F91D
+2F91E         ; mapped                 ; 719C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F91E
+2F91F         ; disallowed                             # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F91F
+2F920         ; mapped                 ; 7228          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F920
+2F921         ; mapped                 ; 7235          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F921
+2F922         ; mapped                 ; 7250          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F922
+2F923         ; mapped                 ; 24608         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F923
+2F924         ; mapped                 ; 7280          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F924
+2F925         ; mapped                 ; 7295          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F925
+2F926         ; mapped                 ; 24735         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F926
+2F927         ; mapped                 ; 24814         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F927
+2F928         ; mapped                 ; 737A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F928
+2F929         ; mapped                 ; 738B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F929
+2F92A         ; mapped                 ; 3EAC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F92A
+2F92B         ; mapped                 ; 73A5          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F92B
+2F92C..2F92D  ; mapped                 ; 3EB8          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F92C..CJK COMPATIBILITY IDEOGRAPH-2F92D
+2F92E         ; mapped                 ; 7447          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F92E
+2F92F         ; mapped                 ; 745C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F92F
+2F930         ; mapped                 ; 7471          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F930
+2F931         ; mapped                 ; 7485          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F931
+2F932         ; mapped                 ; 74CA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F932
+2F933         ; mapped                 ; 3F1B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F933
+2F934         ; mapped                 ; 7524          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F934
+2F935         ; mapped                 ; 24C36         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F935
+2F936         ; mapped                 ; 753E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F936
+2F937         ; mapped                 ; 24C92         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F937
+2F938         ; mapped                 ; 7570          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F938
+2F939         ; mapped                 ; 2219F         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F939
+2F93A         ; mapped                 ; 7610          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F93A
+2F93B         ; mapped                 ; 24FA1         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F93B
+2F93C         ; mapped                 ; 24FB8         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F93C
+2F93D         ; mapped                 ; 25044         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F93D
+2F93E         ; mapped                 ; 3FFC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F93E
+2F93F         ; mapped                 ; 4008          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F93F
+2F940         ; mapped                 ; 76F4          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F940
+2F941         ; mapped                 ; 250F3         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F941
+2F942         ; mapped                 ; 250F2         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F942
+2F943         ; mapped                 ; 25119         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F943
+2F944         ; mapped                 ; 25133         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F944
+2F945         ; mapped                 ; 771E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F945
+2F946..2F947  ; mapped                 ; 771F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F946..CJK COMPATIBILITY IDEOGRAPH-2F947
+2F948         ; mapped                 ; 774A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F948
+2F949         ; mapped                 ; 4039          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F949
+2F94A         ; mapped                 ; 778B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F94A
+2F94B         ; mapped                 ; 4046          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F94B
+2F94C         ; mapped                 ; 4096          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F94C
+2F94D         ; mapped                 ; 2541D         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F94D
+2F94E         ; mapped                 ; 784E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F94E
+2F94F         ; mapped                 ; 788C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F94F
+2F950         ; mapped                 ; 78CC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F950
+2F951         ; mapped                 ; 40E3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F951
+2F952         ; mapped                 ; 25626         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F952
+2F953         ; mapped                 ; 7956          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F953
+2F954         ; mapped                 ; 2569A         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F954
+2F955         ; mapped                 ; 256C5         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F955
+2F956         ; mapped                 ; 798F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F956
+2F957         ; mapped                 ; 79EB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F957
+2F958         ; mapped                 ; 412F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F958
+2F959         ; mapped                 ; 7A40          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F959
+2F95A         ; mapped                 ; 7A4A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F95A
+2F95B         ; mapped                 ; 7A4F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F95B
+2F95C         ; mapped                 ; 2597C         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F95C
+2F95D..2F95E  ; mapped                 ; 25AA7         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F95D..CJK COMPATIBILITY IDEOGRAPH-2F95E
+2F95F         ; disallowed                             # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F95F
+2F960         ; mapped                 ; 4202          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F960
+2F961         ; mapped                 ; 25BAB         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F961
+2F962         ; mapped                 ; 7BC6          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F962
+2F963         ; mapped                 ; 7BC9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F963
+2F964         ; mapped                 ; 4227          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F964
+2F965         ; mapped                 ; 25C80         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F965
+2F966         ; mapped                 ; 7CD2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F966
+2F967         ; mapped                 ; 42A0          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F967
+2F968         ; mapped                 ; 7CE8          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F968
+2F969         ; mapped                 ; 7CE3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F969
+2F96A         ; mapped                 ; 7D00          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F96A
+2F96B         ; mapped                 ; 25F86         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F96B
+2F96C         ; mapped                 ; 7D63          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F96C
+2F96D         ; mapped                 ; 4301          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F96D
+2F96E         ; mapped                 ; 7DC7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F96E
+2F96F         ; mapped                 ; 7E02          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F96F
+2F970         ; mapped                 ; 7E45          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F970
+2F971         ; mapped                 ; 4334          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F971
+2F972         ; mapped                 ; 26228         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F972
+2F973         ; mapped                 ; 26247         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F973
+2F974         ; mapped                 ; 4359          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F974
+2F975         ; mapped                 ; 262D9         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F975
+2F976         ; mapped                 ; 7F7A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F976
+2F977         ; mapped                 ; 2633E         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F977
+2F978         ; mapped                 ; 7F95          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F978
+2F979         ; mapped                 ; 7FFA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F979
+2F97A         ; mapped                 ; 8005          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F97A
+2F97B         ; mapped                 ; 264DA         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F97B
+2F97C         ; mapped                 ; 26523         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F97C
+2F97D         ; mapped                 ; 8060          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F97D
+2F97E         ; mapped                 ; 265A8         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F97E
+2F97F         ; mapped                 ; 8070          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F97F
+2F980         ; mapped                 ; 2335F         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F980
+2F981         ; mapped                 ; 43D5          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F981
+2F982         ; mapped                 ; 80B2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F982
+2F983         ; mapped                 ; 8103          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F983
+2F984         ; mapped                 ; 440B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F984
+2F985         ; mapped                 ; 813E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F985
+2F986         ; mapped                 ; 5AB5          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F986
+2F987         ; mapped                 ; 267A7         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F987
+2F988         ; mapped                 ; 267B5         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F988
+2F989         ; mapped                 ; 23393         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F989
+2F98A         ; mapped                 ; 2339C         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F98A
+2F98B         ; mapped                 ; 8201          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F98B
+2F98C         ; mapped                 ; 8204          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F98C
+2F98D         ; mapped                 ; 8F9E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F98D
+2F98E         ; mapped                 ; 446B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F98E
+2F98F         ; mapped                 ; 8291          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F98F
+2F990         ; mapped                 ; 828B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F990
+2F991         ; mapped                 ; 829D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F991
+2F992         ; mapped                 ; 52B3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F992
+2F993         ; mapped                 ; 82B1          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F993
+2F994         ; mapped                 ; 82B3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F994
+2F995         ; mapped                 ; 82BD          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F995
+2F996         ; mapped                 ; 82E6          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F996
+2F997         ; mapped                 ; 26B3C         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F997
+2F998         ; mapped                 ; 82E5          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F998
+2F999         ; mapped                 ; 831D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F999
+2F99A         ; mapped                 ; 8363          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F99A
+2F99B         ; mapped                 ; 83AD          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F99B
+2F99C         ; mapped                 ; 8323          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F99C
+2F99D         ; mapped                 ; 83BD          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F99D
+2F99E         ; mapped                 ; 83E7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F99E
+2F99F         ; mapped                 ; 8457          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F99F
+2F9A0         ; mapped                 ; 8353          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A0
+2F9A1         ; mapped                 ; 83CA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A1
+2F9A2         ; mapped                 ; 83CC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A2
+2F9A3         ; mapped                 ; 83DC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A3
+2F9A4         ; mapped                 ; 26C36         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A4
+2F9A5         ; mapped                 ; 26D6B         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A5
+2F9A6         ; mapped                 ; 26CD5         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A6
+2F9A7         ; mapped                 ; 452B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A7
+2F9A8         ; mapped                 ; 84F1          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A8
+2F9A9         ; mapped                 ; 84F3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9A9
+2F9AA         ; mapped                 ; 8516          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9AA
+2F9AB         ; mapped                 ; 273CA         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9AB
+2F9AC         ; mapped                 ; 8564          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9AC
+2F9AD         ; mapped                 ; 26F2C         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9AD
+2F9AE         ; mapped                 ; 455D          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9AE
+2F9AF         ; mapped                 ; 4561          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9AF
+2F9B0         ; mapped                 ; 26FB1         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B0
+2F9B1         ; mapped                 ; 270D2         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B1
+2F9B2         ; mapped                 ; 456B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B2
+2F9B3         ; mapped                 ; 8650          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B3
+2F9B4         ; mapped                 ; 865C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B4
+2F9B5         ; mapped                 ; 8667          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B5
+2F9B6         ; mapped                 ; 8669          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B6
+2F9B7         ; mapped                 ; 86A9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B7
+2F9B8         ; mapped                 ; 8688          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B8
+2F9B9         ; mapped                 ; 870E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9B9
+2F9BA         ; mapped                 ; 86E2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9BA
+2F9BB         ; mapped                 ; 8779          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9BB
+2F9BC         ; mapped                 ; 8728          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9BC
+2F9BD         ; mapped                 ; 876B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9BD
+2F9BE         ; mapped                 ; 8786          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9BE
+2F9BF         ; disallowed                             # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9BF
+2F9C0         ; mapped                 ; 87E1          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C0
+2F9C1         ; mapped                 ; 8801          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C1
+2F9C2         ; mapped                 ; 45F9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C2
+2F9C3         ; mapped                 ; 8860          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C3
+2F9C4         ; mapped                 ; 8863          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C4
+2F9C5         ; mapped                 ; 27667         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C5
+2F9C6         ; mapped                 ; 88D7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C6
+2F9C7         ; mapped                 ; 88DE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C7
+2F9C8         ; mapped                 ; 4635          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C8
+2F9C9         ; mapped                 ; 88FA          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9C9
+2F9CA         ; mapped                 ; 34BB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9CA
+2F9CB         ; mapped                 ; 278AE         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9CB
+2F9CC         ; mapped                 ; 27966         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9CC
+2F9CD         ; mapped                 ; 46BE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9CD
+2F9CE         ; mapped                 ; 46C7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9CE
+2F9CF         ; mapped                 ; 8AA0          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9CF
+2F9D0         ; mapped                 ; 8AED          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D0
+2F9D1         ; mapped                 ; 8B8A          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D1
+2F9D2         ; mapped                 ; 8C55          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D2
+2F9D3         ; mapped                 ; 27CA8         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D3
+2F9D4         ; mapped                 ; 8CAB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D4
+2F9D5         ; mapped                 ; 8CC1          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D5
+2F9D6         ; mapped                 ; 8D1B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D6
+2F9D7         ; mapped                 ; 8D77          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D7
+2F9D8         ; mapped                 ; 27F2F         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D8
+2F9D9         ; mapped                 ; 20804         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9D9
+2F9DA         ; mapped                 ; 8DCB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9DA
+2F9DB         ; mapped                 ; 8DBC          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9DB
+2F9DC         ; mapped                 ; 8DF0          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9DC
+2F9DD         ; mapped                 ; 208DE         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9DD
+2F9DE         ; mapped                 ; 8ED4          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9DE
+2F9DF         ; mapped                 ; 8F38          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9DF
+2F9E0         ; mapped                 ; 285D2         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E0
+2F9E1         ; mapped                 ; 285ED         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E1
+2F9E2         ; mapped                 ; 9094          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E2
+2F9E3         ; mapped                 ; 90F1          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E3
+2F9E4         ; mapped                 ; 9111          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E4
+2F9E5         ; mapped                 ; 2872E         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E5
+2F9E6         ; mapped                 ; 911B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E6
+2F9E7         ; mapped                 ; 9238          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E7
+2F9E8         ; mapped                 ; 92D7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E8
+2F9E9         ; mapped                 ; 92D8          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9E9
+2F9EA         ; mapped                 ; 927C          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9EA
+2F9EB         ; mapped                 ; 93F9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9EB
+2F9EC         ; mapped                 ; 9415          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9EC
+2F9ED         ; mapped                 ; 28BFA         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9ED
+2F9EE         ; mapped                 ; 958B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9EE
+2F9EF         ; mapped                 ; 4995          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9EF
+2F9F0         ; mapped                 ; 95B7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F0
+2F9F1         ; mapped                 ; 28D77         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F1
+2F9F2         ; mapped                 ; 49E6          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F2
+2F9F3         ; mapped                 ; 96C3          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F3
+2F9F4         ; mapped                 ; 5DB2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F4
+2F9F5         ; mapped                 ; 9723          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F5
+2F9F6         ; mapped                 ; 29145         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F6
+2F9F7         ; mapped                 ; 2921A         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F7
+2F9F8         ; mapped                 ; 4A6E          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F8
+2F9F9         ; mapped                 ; 4A76          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9F9
+2F9FA         ; mapped                 ; 97E0          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9FA
+2F9FB         ; mapped                 ; 2940A         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9FB
+2F9FC         ; mapped                 ; 4AB2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9FC
+2F9FD         ; mapped                 ; 29496         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9FD
+2F9FE..2F9FF  ; mapped                 ; 980B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2F9FE..CJK COMPATIBILITY IDEOGRAPH-2F9FF
+2FA00         ; mapped                 ; 9829          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA00
+2FA01         ; mapped                 ; 295B6         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA01
+2FA02         ; mapped                 ; 98E2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA02
+2FA03         ; mapped                 ; 4B33          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA03
+2FA04         ; mapped                 ; 9929          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA04
+2FA05         ; mapped                 ; 99A7          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA05
+2FA06         ; mapped                 ; 99C2          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA06
+2FA07         ; mapped                 ; 99FE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA07
+2FA08         ; mapped                 ; 4BCE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA08
+2FA09         ; mapped                 ; 29B30         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA09
+2FA0A         ; mapped                 ; 9B12          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA0A
+2FA0B         ; mapped                 ; 9C40          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA0B
+2FA0C         ; mapped                 ; 9CFD          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA0C
+2FA0D         ; mapped                 ; 4CCE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA0D
+2FA0E         ; mapped                 ; 4CED          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA0E
+2FA0F         ; mapped                 ; 9D67          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA0F
+2FA10         ; mapped                 ; 2A0CE         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA10
+2FA11         ; mapped                 ; 4CF8          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA11
+2FA12         ; mapped                 ; 2A105         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA12
+2FA13         ; mapped                 ; 2A20E         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA13
+2FA14         ; mapped                 ; 2A291         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA14
+2FA15         ; mapped                 ; 9EBB          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA15
+2FA16         ; mapped                 ; 4D56          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA16
+2FA17         ; mapped                 ; 9EF9          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA17
+2FA18         ; mapped                 ; 9EFE          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA18
+2FA19         ; mapped                 ; 9F05          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA19
+2FA1A         ; mapped                 ; 9F0F          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA1A
+2FA1B         ; mapped                 ; 9F16          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA1B
+2FA1C         ; mapped                 ; 9F3B          # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA1C
+2FA1D         ; mapped                 ; 2A600         # 3.1  CJK COMPATIBILITY IDEOGRAPH-2FA1D
+2FA1E..2FFFD  ; disallowed                             # NA   <reserved-2FA1E>..<reserved-2FFFD>
+2FFFE..2FFFF  ; disallowed                             # 2.0  <noncharacter-2FFFE>..<noncharacter-2FFFF>
+30000..3134A  ; valid                                  # 13.0 CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
+3134B..3134F  ; disallowed                             # NA   <reserved-3134B>..<reserved-3134F>
+31350..323AF  ; valid                                  # 15.0 CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
+323B0..3FFFD  ; disallowed                             # NA   <reserved-323B0>..<reserved-3FFFD>
+3FFFE..3FFFF  ; disallowed                             # 2.0  <noncharacter-3FFFE>..<noncharacter-3FFFF>
+40000..4FFFD  ; disallowed                             # NA   <reserved-40000>..<reserved-4FFFD>
+4FFFE..4FFFF  ; disallowed                             # 2.0  <noncharacter-4FFFE>..<noncharacter-4FFFF>
+50000..5FFFD  ; disallowed                             # NA   <reserved-50000>..<reserved-5FFFD>
+5FFFE..5FFFF  ; disallowed                             # 2.0  <noncharacter-5FFFE>..<noncharacter-5FFFF>
+60000..6FFFD  ; disallowed                             # NA   <reserved-60000>..<reserved-6FFFD>
+6FFFE..6FFFF  ; disallowed                             # 2.0  <noncharacter-6FFFE>..<noncharacter-6FFFF>
+70000..7FFFD  ; disallowed                             # NA   <reserved-70000>..<reserved-7FFFD>
+7FFFE..7FFFF  ; disallowed                             # 2.0  <noncharacter-7FFFE>..<noncharacter-7FFFF>
+80000..8FFFD  ; disallowed                             # NA   <reserved-80000>..<reserved-8FFFD>
+8FFFE..8FFFF  ; disallowed                             # 2.0  <noncharacter-8FFFE>..<noncharacter-8FFFF>
+90000..9FFFD  ; disallowed                             # NA   <reserved-90000>..<reserved-9FFFD>
+9FFFE..9FFFF  ; disallowed                             # 2.0  <noncharacter-9FFFE>..<noncharacter-9FFFF>
+A0000..AFFFD  ; disallowed                             # NA   <reserved-A0000>..<reserved-AFFFD>
+AFFFE..AFFFF  ; disallowed                             # 2.0  <noncharacter-AFFFE>..<noncharacter-AFFFF>
+B0000..BFFFD  ; disallowed                             # NA   <reserved-B0000>..<reserved-BFFFD>
+BFFFE..BFFFF  ; disallowed                             # 2.0  <noncharacter-BFFFE>..<noncharacter-BFFFF>
+C0000..CFFFD  ; disallowed                             # NA   <reserved-C0000>..<reserved-CFFFD>
+CFFFE..CFFFF  ; disallowed                             # 2.0  <noncharacter-CFFFE>..<noncharacter-CFFFF>
+D0000..DFFFD  ; disallowed                             # NA   <reserved-D0000>..<reserved-DFFFD>
+DFFFE..DFFFF  ; disallowed                             # 2.0  <noncharacter-DFFFE>..<noncharacter-DFFFF>
+E0000         ; disallowed                             # NA   <reserved-E0000>
+E0001         ; disallowed                             # 3.1  LANGUAGE TAG
+E0002..E001F  ; disallowed                             # NA   <reserved-E0002>..<reserved-E001F>
+E0020..E007F  ; disallowed                             # 3.1  TAG SPACE..CANCEL TAG
+E0080..E00FF  ; disallowed                             # NA   <reserved-E0080>..<reserved-E00FF>
+E0100..E01EF  ; ignored                                # 4.0  VARIATION SELECTOR-17..VARIATION SELECTOR-256
+E01F0..EFFFD  ; disallowed                             # NA   <reserved-E01F0>..<reserved-EFFFD>
+EFFFE..EFFFF  ; disallowed                             # 2.0  <noncharacter-EFFFE>..<noncharacter-EFFFF>
+F0000..FFFFD  ; disallowed                             # 2.0  <private-use-F0000>..<private-use-FFFFD>
+FFFFE..FFFFF  ; disallowed                             # 2.0  <noncharacter-FFFFE>..<noncharacter-FFFFF>
+100000..10FFFD; disallowed                             # 2.0  <private-use-100000>..<private-use-10FFFD>
+10FFFE..10FFFF; disallowed                             # 2.0  <noncharacter-10FFFE>..<noncharacter-10FFFF>
+
+# Total code points: 1114112
+


### PR DESCRIPTION
As described in UTS #46, https://www.unicode.org/reports/tr46

This is working towards OkHttp's own implementation of what IDN.toASCII() does on the JVM.