### PR TITLE
Add flow control observability

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/http2/Http2FlowControlConnectionListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/http2/Http2FlowControlConnectionListener.kt
@@ -23,7 +23,12 @@ import okhttp3.internal.http2.flowcontrol.WindowCounter
  */
 class Http2FlowControlConnectionListener: ConnectionListener(), FlowControlListener {
   val start = System.currentTimeMillis()
-  override fun receivingFlowControlWindowChanged(streamId: Int, windowCounter: WindowCounter) {
-    println("${System.currentTimeMillis() - start},$streamId,${windowCounter.unacknowledged}")
+
+  override fun receivingStreamWindowChanged(streamId: Int, windowCounter: WindowCounter, bufferSize: Long) {
+    println("${System.currentTimeMillis() - start},$streamId,${windowCounter.unacknowledged},$bufferSize")
+  }
+
+  override fun receivingConnectionWindowChanged(windowCounter: WindowCounter) {
+    println("${System.currentTimeMillis() - start},0,${windowCounter.unacknowledged},")
   }
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/http2/Http2FlowControlConnectionListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/http2/Http2FlowControlConnectionListener.kt
@@ -1,0 +1,11 @@
+package okhttp3.internal.http2
+
+import okhttp3.ConnectionListener
+import okhttp3.internal.http2.flowcontrol.WindowCounter
+
+class Http2FlowControlConnectionListener: ConnectionListener(), FlowControlListener {
+  val start = System.currentTimeMillis()
+  override fun flowControlWindowChanged(streamId: Int, windowCounter: WindowCounter) {
+    println("${System.currentTimeMillis() - start},$streamId,${windowCounter.unacknowledged}")
+  }
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/http2/Http2FlowControlConnectionListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/http2/Http2FlowControlConnectionListener.kt
@@ -1,11 +1,29 @@
+/*
+ * Copyright (C) 2023 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okhttp3.internal.http2
 
 import okhttp3.ConnectionListener
 import okhttp3.internal.http2.flowcontrol.WindowCounter
 
+/**
+ * ConnectionListener that outputs CSV for flow control of client receiving streams.
+ */
 class Http2FlowControlConnectionListener: ConnectionListener(), FlowControlListener {
   val start = System.currentTimeMillis()
-  override fun flowControlWindowChanged(streamId: Int, windowCounter: WindowCounter) {
+  override fun receivingFlowControlWindowChanged(streamId: Int, windowCounter: WindowCounter) {
     println("${System.currentTimeMillis() - start},$streamId,${windowCounter.unacknowledged}")
   }
 }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -42,6 +42,7 @@ import okhttp3.internal.http.RealInterceptorChain
 import okhttp3.internal.http1.Http1ExchangeCodec
 import okhttp3.internal.http2.ConnectionShutdownException
 import okhttp3.internal.http2.ErrorCode
+import okhttp3.internal.http2.FlowControlListener
 import okhttp3.internal.http2.Http2Connection
 import okhttp3.internal.http2.Http2ExchangeCodec
 import okhttp3.internal.http2.Http2Stream
@@ -158,10 +159,12 @@ class RealConnection(
     val source = this.source!!
     val sink = this.sink!!
     socket.soTimeout = 0 // HTTP/2 connection timeouts are set per-stream.
+    val flowControlListener = connectionListener as? FlowControlListener ?: FlowControlListener.None
     val http2Connection = Http2Connection.Builder(client = true, taskRunner)
       .socket(socket, route.address.url.host, source, sink)
       .listener(this)
       .pingIntervalMillis(pingIntervalMillis)
+      .flowControlListener(flowControlListener)
       .build()
     this.http2Connection = http2Connection
     this.allocationLimit = Http2Connection.DEFAULT_SETTINGS.getMaxConcurrentStreams()

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/FlowControlListener.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/FlowControlListener.kt
@@ -1,12 +1,32 @@
+/*
+ * Copyright (C) 2023 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package okhttp3.internal.http2
 
 import okhttp3.internal.http2.flowcontrol.WindowCounter
 
 interface FlowControlListener {
-  fun flowControlWindowChanged(streamId: Int, windowCounter: WindowCounter)
+  /**
+   * Notification that the receiving flow control window has changed.
+   * [WindowCounter] generally carries the client view of total and acked bytes.
+   */
+  fun receivingFlowControlWindowChanged(streamId: Int, windowCounter: WindowCounter)
 
+  /** Noop implementation */
   object None: FlowControlListener {
-    override fun flowControlWindowChanged(streamId: Int, windowCounter: WindowCounter) {
+    override fun receivingFlowControlWindowChanged(streamId: Int, windowCounter: WindowCounter) {
     }
   }
 }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/FlowControlListener.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/FlowControlListener.kt
@@ -19,14 +19,23 @@ import okhttp3.internal.http2.flowcontrol.WindowCounter
 
 interface FlowControlListener {
   /**
-   * Notification that the receiving flow control window has changed.
+   * Notification that the receiving stream flow control window has changed.
    * [WindowCounter] generally carries the client view of total and acked bytes.
    */
-  fun receivingFlowControlWindowChanged(streamId: Int, windowCounter: WindowCounter)
+  fun receivingStreamWindowChanged(streamId: Int, windowCounter: WindowCounter, bufferSize: Long)
+
+  /**
+   * Notification that the receiving connection flow control window has changed.
+   * [WindowCounter] generally carries the client view of total and acked bytes.
+   */
+  fun receivingConnectionWindowChanged(windowCounter: WindowCounter)
 
   /** Noop implementation */
   object None: FlowControlListener {
-    override fun receivingFlowControlWindowChanged(streamId: Int, windowCounter: WindowCounter) {
+    override fun receivingStreamWindowChanged(streamId: Int, windowCounter: WindowCounter, bufferSize: Long) {
+    }
+
+    override fun receivingConnectionWindowChanged(windowCounter: WindowCounter) {
     }
   }
 }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/FlowControlListener.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/FlowControlListener.kt
@@ -1,0 +1,12 @@
+package okhttp3.internal.http2
+
+import okhttp3.internal.http2.flowcontrol.WindowCounter
+
+interface FlowControlListener {
+  fun flowControlWindowChanged(streamId: Int, windowCounter: WindowCounter)
+
+  object None: FlowControlListener {
+    override fun flowControlWindowChanged(streamId: Int, windowCounter: WindowCounter) {
+    }
+  }
+}

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Connection.kt
@@ -193,7 +193,7 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
       writeWindowUpdateLater(0, readBytesToAcknowledge)
       readBytes.increase(acknowledged = readBytesToAcknowledge)
     }
-    flowControlListener.flowControlWindowChanged(0, readBytes)
+    flowControlListener.receivingFlowControlWindowChanged(0, readBytes)
   }
 
   /**

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Connection.kt
@@ -193,7 +193,7 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
       writeWindowUpdateLater(0, readBytesToAcknowledge)
       readBytes.increase(acknowledged = readBytesToAcknowledge)
     }
-    flowControlListener.receivingFlowControlWindowChanged(0, readBytes)
+    flowControlListener.receivingConnectionWindowChanged(readBytes)
   }
 
   /**

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Connection.kt
@@ -187,11 +187,11 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
   }
 
   @Synchronized internal fun updateConnectionFlowControl(read: Long) {
-    readBytes.increase(total = read)
+    readBytes.update(total = read)
     val readBytesToAcknowledge = readBytes.unacknowledged
     if (readBytesToAcknowledge >= okHttpSettings.initialWindowSize / 2) {
       writeWindowUpdateLater(0, readBytesToAcknowledge)
-      readBytes.increase(acknowledged = readBytesToAcknowledge)
+      readBytes.update(acknowledged = readBytesToAcknowledge)
     }
     flowControlListener.receivingConnectionWindowChanged(readBytes)
   }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Connection.kt
@@ -27,6 +27,7 @@ import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.http2.ErrorCode.REFUSED_STREAM
 import okhttp3.internal.http2.Settings.Companion.DEFAULT_INITIAL_WINDOW_SIZE
+import okhttp3.internal.http2.flowcontrol.WindowCounter
 import okhttp3.internal.ignoreIoExceptions
 import okhttp3.internal.notifyAll
 import okhttp3.internal.okHttpName
@@ -105,6 +106,8 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
   /** Consider this connection to be unhealthy if a degraded pong isn't received by this time. */
   private var degradedPongDeadlineNs = 0L
 
+  internal val flowControlListener: FlowControlListener = builder.flowControlListener
+
   /** Settings we communicate to the peer. */
   val okHttpSettings = Settings().apply {
     // Flow control was designed more for servers, or proxies than edge clients. If we are a client,
@@ -121,13 +124,8 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
    */
   var peerSettings = DEFAULT_SETTINGS
 
-  /** The total number of bytes consumed by the application. */
-  var readBytesTotal = 0L
-    private set
-
-  /** The total number of bytes acknowledged by outgoing `WINDOW_UPDATE` frames. */
-  var readBytesAcknowledged = 0L
-    private set
+  /** The bytes consumed and acknowledged by the application. */
+  val readBytes: WindowCounter = WindowCounter(streamId = 0)
 
   /** The total number of bytes produced by the application. */
   var writeBytesTotal = 0L
@@ -172,11 +170,14 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
   /**
    * Returns the number of [open streams][Http2Stream.isOpen] on this connection.
    */
-  @Synchronized fun openStreamCount(): Int = streams.size
+  @Synchronized
+  fun openStreamCount(): Int = streams.size
 
-  @Synchronized fun getStream(id: Int): Http2Stream? = streams[id]
+  @Synchronized
+  fun getStream(id: Int): Http2Stream? = streams[id]
 
-  @Synchronized internal fun removeStream(streamId: Int): Http2Stream? {
+  @Synchronized
+  internal fun removeStream(streamId: Int): Http2Stream? {
     val stream = streams.remove(streamId)
 
     // The removed stream may be blocked on a connection-wide window update.
@@ -186,12 +187,13 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
   }
 
   @Synchronized internal fun updateConnectionFlowControl(read: Long) {
-    readBytesTotal += read
-    val readBytesToAcknowledge = readBytesTotal - readBytesAcknowledged
+    readBytes.increase(total = read)
+    val readBytesToAcknowledge = readBytes.unacknowledged
     if (readBytesToAcknowledge >= okHttpSettings.initialWindowSize / 2) {
       writeWindowUpdateLater(0, readBytesToAcknowledge)
-      readBytesAcknowledged += readBytesToAcknowledge
+      readBytes.increase(acknowledged = readBytesToAcknowledge)
     }
+    flowControlListener.flowControlWindowChanged(0, readBytes)
   }
 
   /**
@@ -568,6 +570,7 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
     internal var listener = Listener.REFUSE_INCOMING_STREAMS
     internal var pushObserver = PushObserver.CANCEL
     internal var pingIntervalMillis: Int = 0
+    internal var flowControlListener: FlowControlListener = FlowControlListener.None
 
     @Throws(IOException::class) @JvmOverloads
     fun socket(
@@ -595,6 +598,10 @@ class Http2Connection internal constructor(builder: Builder) : Closeable {
 
     fun pingIntervalMillis(pingIntervalMillis: Int) = apply {
       this.pingIntervalMillis = pingIntervalMillis
+    }
+
+    fun flowControlListener(flowControlListener: FlowControlListener) = apply {
+      this.flowControlListener = flowControlListener
     }
 
     fun build(): Http2Connection {

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
@@ -382,7 +382,7 @@ class Http2Stream internal constructor(
             } else if (readBuffer.size > 0L) {
               // Prepare to read bytes. Start by moving them to the caller's buffer.
               readBytesDelivered = readBuffer.read(sink, minOf(byteCount, readBuffer.size))
-              readBytes.increase(total = readBytesDelivered)
+              readBytes.update(total = readBytesDelivered)
 
               val unacknowledgedBytesRead = readBytes.unacknowledged
               if (errorExceptionToDeliver == null &&
@@ -390,9 +390,8 @@ class Http2Stream internal constructor(
                 // Flow control: notify the peer that we're ready for more data! Only send a
                 // WINDOW_UPDATE if the stream isn't in error.
                 connection.writeWindowUpdateLater(id, unacknowledgedBytesRead)
-                readBytes.increase(acknowledged = unacknowledgedBytesRead)
+                readBytes.update(acknowledged = unacknowledgedBytesRead)
               }
-              connection.flowControlListener.receivingStreamWindowChanged(id, readBytes, readBuffer.size)
             } else if (!finished && errorExceptionToDeliver == null) {
               // Nothing to do. Wait until that changes then try again.
               waitForIo()
@@ -404,6 +403,7 @@ class Http2Stream internal constructor(
             }
           }
         }
+        connection.flowControlListener.receivingStreamWindowChanged(id, readBytes, readBuffer.size)
 
         // 2. Do it outside of the synchronized block and timeout.
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
@@ -392,7 +392,7 @@ class Http2Stream internal constructor(
                 connection.writeWindowUpdateLater(id, unacknowledgedBytesRead)
                 readBytes.increase(acknowledged = unacknowledgedBytesRead)
               }
-              connection.flowControlListener.receivingFlowControlWindowChanged(id, readBytes)
+              connection.flowControlListener.receivingStreamWindowChanged(id, readBytes, readBuffer.size)
             } else if (!finished && errorExceptionToDeliver == null) {
               // Nothing to do. Wait until that changes then try again.
               waitForIo()
@@ -491,6 +491,7 @@ class Http2Stream internal constructor(
           updateConnectionFlowControl(bytesDiscarded)
         }
       }
+      connection.flowControlListener.receivingStreamWindowChanged(id, readBytes, readBuffer.size)
     }
 
     override fun timeout(): Timeout = readTimeout

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
@@ -392,7 +392,7 @@ class Http2Stream internal constructor(
                 connection.writeWindowUpdateLater(id, unacknowledgedBytesRead)
                 readBytes.increase(acknowledged = unacknowledgedBytesRead)
               }
-              connection.flowControlListener.flowControlWindowChanged(id, readBytes)
+              connection.flowControlListener.receivingFlowControlWindowChanged(id, readBytes)
             } else if (!finished && errorExceptionToDeliver == null) {
               // Nothing to do. Wait until that changes then try again.
               waitForIo()

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
@@ -23,6 +23,7 @@ import java.util.ArrayDeque
 import okhttp3.Headers
 import okhttp3.internal.EMPTY_HEADERS
 import okhttp3.internal.assertThreadDoesntHoldLock
+import okhttp3.internal.http2.flowcontrol.WindowCounter
 import okhttp3.internal.notifyAll
 import okhttp3.internal.toHeaderList
 import okhttp3.internal.wait
@@ -45,13 +46,8 @@ class Http2Stream internal constructor(
   // Internal state is guarded by this. No long-running or potentially blocking operations are
   // performed while the lock is held.
 
-  /** The total number of bytes consumed by the application. */
-  var readBytesTotal = 0L
-    internal set
-
-  /** The total number of bytes acknowledged by outgoing `WINDOW_UPDATE` frames. */
-  var readBytesAcknowledged = 0L
-    internal set
+  /** The bytes consumed and acknowledged by the stream. */
+  val readBytes: WindowCounter = WindowCounter(id)
 
   /** The total number of bytes produced by the application. */
   var writeBytesTotal = 0L
@@ -386,16 +382,17 @@ class Http2Stream internal constructor(
             } else if (readBuffer.size > 0L) {
               // Prepare to read bytes. Start by moving them to the caller's buffer.
               readBytesDelivered = readBuffer.read(sink, minOf(byteCount, readBuffer.size))
-              readBytesTotal += readBytesDelivered
+              readBytes.increase(total = readBytesDelivered)
 
-              val unacknowledgedBytesRead = readBytesTotal - readBytesAcknowledged
+              val unacknowledgedBytesRead = readBytes.unacknowledged
               if (errorExceptionToDeliver == null &&
                   unacknowledgedBytesRead >= connection.okHttpSettings.initialWindowSize / 2) {
                 // Flow control: notify the peer that we're ready for more data! Only send a
                 // WINDOW_UPDATE if the stream isn't in error.
                 connection.writeWindowUpdateLater(id, unacknowledgedBytesRead)
-                readBytesAcknowledged = readBytesTotal
+                readBytes.increase(acknowledged = unacknowledgedBytesRead)
               }
+              connection.flowControlListener.flowControlWindowChanged(id, readBytes)
             } else if (!finished && errorExceptionToDeliver == null) {
               // Nothing to do. Wait until that changes then try again.
               waitForIo()

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/flowcontrol/WindowCounter.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/flowcontrol/WindowCounter.kt
@@ -1,34 +1,28 @@
 package okhttp3.internal.http2.flowcontrol
 
-import java.util.concurrent.atomic.AtomicLong
-
 class WindowCounter(
   val streamId: Int
 ) {
   /** The total number of bytes consumed. */
-  private val _total: AtomicLong = AtomicLong(0)
+  var total: Long = 0L
+    private set
 
   /** The total number of bytes acknowledged by outgoing `WINDOW_UPDATE` frames. */
-  private val _acknowledged: AtomicLong = AtomicLong(0)
-
-  val total: Long
-    get() = _total.get()
-
-  val acknowledged: Long
-    get() = _acknowledged.get()
+  var acknowledged: Long = 0L
+    private set
 
   val unacknowledged: Long
-    @Synchronized get() = _total.get() - _acknowledged.get()
+    @Synchronized get() = total - acknowledged
 
   @Synchronized
-  fun increase(total: Long = 0, acknowledged: Long = 0) {
+  fun update(total: Long = 0, acknowledged: Long = 0) {
     check(total >= 0)
     check(acknowledged >= 0)
 
-    this._total.addAndGet(total)
-    this._acknowledged.addAndGet(acknowledged)
+    this.total += total
+    this.acknowledged += acknowledged
 
-    check(this._acknowledged.get() <= this._total.get())
+    check(this.acknowledged <= this.total)
   }
 
   override fun toString(): String {

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/flowcontrol/WindowCounter.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/flowcontrol/WindowCounter.kt
@@ -1,0 +1,37 @@
+package okhttp3.internal.http2.flowcontrol
+
+import java.util.concurrent.atomic.AtomicLong
+
+class WindowCounter(
+  val streamId: Int
+) {
+  /** The total number of bytes consumed. */
+  private val _total: AtomicLong = AtomicLong(0)
+
+  /** The total number of bytes acknowledged by outgoing `WINDOW_UPDATE` frames. */
+  private val _acknowledged: AtomicLong = AtomicLong(0)
+
+  val total: Long
+    get() = _total.get()
+
+  val acknowledged: Long
+    get() = _acknowledged.get()
+
+  val unacknowledged: Long
+    @Synchronized get() = _total.get() - _acknowledged.get()
+
+  @Synchronized
+  fun increase(total: Long = 0, acknowledged: Long = 0) {
+    check(total >= 0)
+    check(acknowledged >= 0)
+
+    this._total.addAndGet(total)
+    this._acknowledged.addAndGet(acknowledged)
+
+    check(this._acknowledged.get() <= this._total.get())
+  }
+
+  override fun toString(): String {
+    return "WindowCounter(streamId=$streamId, total=$total, acknowledged=$acknowledged, unacknowledged=$unacknowledged)"
+  }
+}

--- a/okhttp/src/jvmTest/java/okhttp3/internal/http2/Http2ConnectionTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/http2/Http2ConnectionTest.kt
@@ -206,8 +206,8 @@ class Http2ConnectionTest {
     assertThat(frame2.type).isEqualTo(Http2.TYPE_RST_STREAM)
     val frame3 = peer.takeFrame()
     assertThat(frame3.type).isEqualTo(Http2.TYPE_RST_STREAM)
-    assertThat(connection.readBytesAcknowledged).isEqualTo(0L)
-    assertThat(connection.readBytesTotal).isEqualTo(2048L)
+    assertThat(connection.readBytes.acknowledged).isEqualTo(0L)
+    assertThat(connection.readBytes.total).isEqualTo(2048L)
   }
 
   @Test fun receiveGoAwayHttp2() {
@@ -285,8 +285,8 @@ class Http2ConnectionTest {
     val connection = connect(peer)
     connection.okHttpSettings[Settings.INITIAL_WINDOW_SIZE] = windowSize
     val stream = connection.newStream(headerEntries("b", "banana"), false)
-    assertThat(stream.readBytesAcknowledged).isEqualTo(0L)
-    assertThat(stream.readBytesTotal).isEqualTo(0L)
+    assertThat(stream.readBytes.acknowledged).isEqualTo(0L)
+    assertThat(stream.readBytes.total).isEqualTo(0L)
     assertThat(stream.takeHeaders()).isEqualTo(headersOf("a", "android"))
     val source = stream.getSource()
     val buffer = Buffer()
@@ -1744,8 +1744,8 @@ class Http2ConnectionTest {
     val connection = connect(peer)
     connection.okHttpSettings[Settings.INITIAL_WINDOW_SIZE] = windowSize
     val stream = connection.newStream(headerEntries("b", "banana"), false)
-    assertThat(stream.readBytesAcknowledged).isEqualTo(0L)
-    assertThat(stream.readBytesTotal).isEqualTo(0L)
+    assertThat(stream.readBytes.acknowledged).isEqualTo(0L)
+    assertThat(stream.readBytes.total).isEqualTo(0L)
     assertThat(stream.takeHeaders()).isEqualTo(headersOf("a", "android"))
     val source = stream.getSource()
     val buffer = Buffer()


### PR DESCRIPTION
Add an internal API for receiving HTTP/2 flow control information, definitely not complete.

This shows

Connection - unacked on connection - this is not true in the first, as connection doesn't bump until consumed via a stream
3 - The unacked on stream 3 (the stalled request)
3-buffer - The data sitting inside the Buffer to be read
5 & 5-buffer - same as 3.

<img width="611" alt="image" src="https://user-images.githubusercontent.com/231923/236888341-904cf71b-e568-401e-940d-d461236207b9.png">


As an example used before and after this fix https://github.com/square/okhttp/pull/7801/files

<img width="611" alt="image" src="https://user-images.githubusercontent.com/231923/236889135-85346240-7601-48a8-b554-db8e6e903943.png">
