### PR TITLE
Evict connection pool a second time after tests

### DIFF
--- a/okhttp-testing-support/src/jvmMain/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/jvmMain/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -191,7 +191,9 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
       }
 
       assertEquals(0, connectionPool.connectionCount()) {
-        "Still ${connectionPool.connectionCount()} connections open"
+        val call = connectionPool.delegate.calls
+
+        "Still ${connectionPool.connectionCount()} connections open: $call"
       }
     }
   }

--- a/okhttp-testing-support/src/jvmMain/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/jvmMain/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -192,9 +192,7 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
 
       connectionPool.evictAll()
       assertEquals(0, connectionPool.connectionCount()) {
-        val calls = connectionPool.delegate.calls
-
-        "Still ${connectionPool.connectionCount()} connections open, calls: $calls"
+        "Still ${connectionPool.connectionCount()} connections open"
       }
     }
   }

--- a/okhttp-testing-support/src/jvmMain/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/jvmMain/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -190,10 +190,11 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
         println("After delay: " + connectionPool.connectionCount())
       }
 
+      connectionPool.evictAll()
       assertEquals(0, connectionPool.connectionCount()) {
-        val call = connectionPool.delegate.calls
+        val calls = connectionPool.delegate.calls
 
-        "Still ${connectionPool.connectionCount()} connections open: $call"
+        "Still ${connectionPool.connectionCount()} connections open, calls: $calls"
       }
     }
   }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -20,7 +20,6 @@ import java.net.Socket
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 import okhttp3.Address
-import okhttp3.Call
 import okhttp3.ConnectionListener
 import okhttp3.ConnectionPool
 import okhttp3.Route
@@ -276,11 +275,6 @@ class RealConnectionPool(
 
     return references.size
   }
-
-  val calls: List<Call>
-    get() {
-      return connections.flatMap { it.calls.mapNotNull { it.get() } }
-    }
 
   companion object {
     fun get(connectionPool: ConnectionPool): RealConnectionPool = connectionPool.delegate

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -20,6 +20,7 @@ import java.net.Socket
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 import okhttp3.Address
+import okhttp3.Call
 import okhttp3.ConnectionListener
 import okhttp3.ConnectionPool
 import okhttp3.Route
@@ -275,6 +276,11 @@ class RealConnectionPool(
 
     return references.size
   }
+
+  val calls: List<Call>
+    get() {
+      return connections.flatMap { it.calls.mapNotNull { it.get() } }
+    }
 
   companion object {
     fun get(connectionPool: ConnectionPool): RealConnectionPool = connectionPool.delegate

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -909,11 +909,6 @@ public final class WebSocketHttpTest {
 
   /** https://github.com/square/okhttp/issues/7768 */
   @Test public void reconnectingToNonWebSocket() throws InterruptedException {
-    // Async test is problematic
-    client = this.client.newBuilder()
-            .connectionPool(new ConnectionPool())
-            .build();
-
     for (int i = 0; i < 30; i++) {
       webServer.enqueue(new MockResponse.Builder()
         .bodyDelay(100, TimeUnit.MILLISECONDS)
@@ -950,8 +945,6 @@ public final class WebSocketHttpTest {
     for (WebSocket webSocket: webSockets) {
       webSocket.cancel();
     }
-    client.dispatcher().cancelAll();
-    client.connectionPool().evictAll();
   }
 
   @Test public void compressedMessages() throws Exception {


### PR DESCRIPTION
Debugging flakyness introduced in https://github.com/square/okhttp/pull/7815