### PR TITLE
Stop printing suppressed exceptions to stdout

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/Util.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/Util.kt
@@ -618,10 +618,6 @@ internal inline fun Any.assertThreadDoesntHoldLock() {
 }
 
 fun Exception.withSuppressed(suppressed: List<Exception>): Throwable = apply {
-  if (suppressed.size > 1) {
-    println(suppressed)
-  }
-
   for (e in suppressed) addSuppressed(e)
 }
 


### PR DESCRIPTION
I think this may have been left in from some println-debugging? Not sure.

Fixes #7851 