### PR TITLE
Suspend support in interceptors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,7 +139,7 @@ subprojects {
     }
   }
 
-  val platform = System.getProperty("okhttp.platform", "jdk9")
+  val platform = System.getProperty("okhttp.platform", "bouncycastle")
   val testJavaVersion = System.getProperty("test.java.version", "11").toInt()
 
   val testRuntimeOnly: Configuration by configurations.getting

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,7 +139,7 @@ subprojects {
     }
   }
 
-  val platform = System.getProperty("okhttp.platform", "bouncycastle")
+  val platform = System.getProperty("okhttp.platform", "jdk9")
   val testJavaVersion = System.getProperty("test.java.version", "11").toInt()
 
   val testRuntimeOnly: Configuration by configurations.getting

--- a/okhttp-coroutines/api/okhttp-coroutines.api
+++ b/okhttp-coroutines/api/okhttp-coroutines.api
@@ -2,3 +2,8 @@ public final class okhttp3/JvmCallExtensionsKt {
 	public static final fun executeAsync (Lokhttp3/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class okhttp3/SuspendingInterceptor : okhttp3/Interceptor {
+	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
+	public abstract fun interceptAsync (Lokhttp3/Interceptor$Chain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/okhttp-coroutines/src/jvmMain/kotlin/okhttp3/SuspendingInterceptor.kt
+++ b/okhttp-coroutines/src/jvmMain/kotlin/okhttp3/SuspendingInterceptor.kt
@@ -1,0 +1,11 @@
+package okhttp3;
+
+import kotlinx.coroutines.runBlocking
+
+abstract class SuspendingInterceptor: Interceptor {
+  override fun intercept(chain: Interceptor.Chain): Response = runBlocking {
+    interceptAsync(chain)
+  }
+
+  abstract suspend fun interceptAsync(chain: Interceptor.Chain): Response
+}

--- a/okhttp-coroutines/src/jvmMain/kotlin/okhttp3/SuspendingInterceptor.kt
+++ b/okhttp-coroutines/src/jvmMain/kotlin/okhttp3/SuspendingInterceptor.kt
@@ -2,10 +2,10 @@ package okhttp3;
 
 import kotlinx.coroutines.runBlocking
 
-abstract class SuspendingInterceptor: Interceptor {
+fun interface SuspendingInterceptor: Interceptor {
   override fun intercept(chain: Interceptor.Chain): Response = runBlocking {
     interceptAsync(chain)
   }
 
-  abstract suspend fun interceptAsync(chain: Interceptor.Chain): Response
+  suspend fun interceptAsync(chain: Interceptor.Chain): Response
 }

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -762,6 +762,7 @@ public abstract interface class okhttp3/Interceptor$Chain {
 	public abstract fun call ()Lokhttp3/Call;
 	public abstract fun connectTimeoutMillis ()I
 	public abstract fun connection ()Lokhttp3/Connection;
+	public abstract fun getCallFactory ()Lokhttp3/Call$Factory;
 	public abstract fun proceed (Lokhttp3/Request;)Lokhttp3/Response;
 	public abstract fun readTimeoutMillis ()I
 	public abstract fun request ()Lokhttp3/Request;

--- a/okhttp/src/jvmMain/kotlin/okhttp3/Interceptor.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Interceptor.kt
@@ -89,6 +89,8 @@ fun interface Interceptor {
 
     fun call(): Call
 
+    val callFactory: Call.Factory
+
     fun connectTimeoutMillis(): Int
 
     fun withConnectTimeout(timeout: Int, unit: TimeUnit): Chain

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -43,6 +43,7 @@ import okhttp3.internal.cache.CacheInterceptor
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.http.BridgeInterceptor
 import okhttp3.internal.http.CallServerInterceptor
+import okhttp3.internal.http.InterceptorCall
 import okhttp3.internal.http.RealInterceptorChain
 import okhttp3.internal.http.RetryAndFollowUpInterceptor
 import okhttp3.internal.platform.Platform
@@ -60,517 +61,540 @@ import okio.Timeout
  * canceling may break the entire connection.
  */
 class RealCall(
-  val client: OkHttpClient,
-  /** The application's original request unadulterated by redirects or auth headers. */
-  val originalRequest: Request,
-  val forWebSocket: Boolean
+    val client: OkHttpClient,
+    /** The application's original request unadulterated by redirects or auth headers. */
+    val originalRequest: Request,
+    val forWebSocket: Boolean
 ) : Call, Cloneable {
-  private val connectionPool: RealConnectionPool = client.connectionPool.delegate
+    private val connectionPool: RealConnectionPool = client.connectionPool.delegate
 
-  internal val eventListener: EventListener = client.eventListenerFactory.create(this)
+    internal val eventListener: EventListener = client.eventListenerFactory.create(this)
 
-  private val timeout = object : AsyncTimeout() {
-    override fun timedOut() {
-      cancel()
-    }
-  }.apply {
-    timeout(client.callTimeoutMillis.toLong(), MILLISECONDS)
-  }
-
-  private val executed = AtomicBoolean()
-
-  // These properties are only accessed by the thread executing the call.
-
-  /** Initialized in [callStart]. */
-  private var callStackTrace: Any? = null
-
-  /** Finds an exchange to send the next request and receive the next response. */
-  private var exchangeFinder: ExchangeFinder? = null
-
-  var connection: RealConnection? = null
-    private set
-  private var timeoutEarlyExit = false
-
-  /**
-   * This is the same value as [exchange], but scoped to the execution of the network interceptors.
-   * The [exchange] field is assigned to null when its streams end, which may be before or after the
-   * network interceptors return.
-   */
-  internal var interceptorScopedExchange: Exchange? = null
-    private set
-
-  // These properties are guarded by this. They are typically only accessed by the thread executing
-  // the call, but they may be accessed by other threads for duplex requests.
-
-  /** True if this call still has a request body open. */
-  private var requestBodyOpen = false
-
-  /** True if this call still has a response body open. */
-  private var responseBodyOpen = false
-
-  /** True if there are more exchanges expected for this call. */
-  private var expectMoreExchanges = true
-
-  // These properties are accessed by canceling threads. Any thread can cancel a call, and once it's
-  // canceled it's canceled forever.
-
-  @Volatile private var canceled = false
-  @Volatile private var exchange: Exchange? = null
-  internal val plansToCancel = CopyOnWriteArrayList<RoutePlanner.Plan>()
-
-  override fun timeout(): Timeout = timeout
-
-  @SuppressWarnings("CloneDoesntCallSuperClone") // We are a final type & this saves clearing state.
-  override fun clone(): Call = RealCall(client, originalRequest, forWebSocket)
-
-  override fun request(): Request = originalRequest
-
-  /**
-   * Immediately closes the socket connection if it's currently held. Use this to interrupt an
-   * in-flight request from any thread. It's the caller's responsibility to close the request body
-   * and response body streams; otherwise resources may be leaked.
-   *
-   * This method is safe to be called concurrently, but provides limited guarantees. If a transport
-   * layer connection has been established (such as a HTTP/2 stream) that is terminated. Otherwise
-   * if a socket connection is being established, that is terminated.
-   */
-  override fun cancel() {
-    if (canceled) return // Already canceled.
-
-    canceled = true
-    exchange?.cancel()
-    for (plan in plansToCancel) {
-      plan.cancel()
-    }
-
-    eventListener.canceled(this)
-  }
-
-  override fun isCanceled(): Boolean = canceled
-
-  override fun execute(): Response {
-    check(executed.compareAndSet(false, true)) { "Already Executed" }
-
-    timeout.enter()
-    callStart()
-    try {
-      client.dispatcher.executed(this)
-      return getResponseWithInterceptorChain()
-    } finally {
-      client.dispatcher.finished(this)
-    }
-  }
-
-  override fun enqueue(responseCallback: Callback) {
-    check(executed.compareAndSet(false, true)) { "Already Executed" }
-
-    callStart()
-    client.dispatcher.enqueue(AsyncCall(responseCallback))
-  }
-
-  override fun isExecuted(): Boolean = executed.get()
-
-  private fun callStart() {
-    this.callStackTrace = Platform.get().getStackTraceForCloseable("response.body().close()")
-    eventListener.callStart(this)
-  }
-
-  @Throws(IOException::class)
-  internal fun getResponseWithInterceptorChain(): Response {
-    // Build a full stack of interceptors.
-    val interceptors = mutableListOf<Interceptor>()
-    interceptors += client.interceptors
-    interceptors += RetryAndFollowUpInterceptor(client)
-    interceptors += BridgeInterceptor(client.cookieJar)
-    interceptors += CacheInterceptor(client.cache)
-    interceptors += ConnectInterceptor
-    if (!forWebSocket) {
-      interceptors += client.networkInterceptors
-    }
-    interceptors += CallServerInterceptor(forWebSocket)
-
-    val chain = RealInterceptorChain(
-      call = this,
-      interceptors = interceptors,
-      index = 0,
-      exchange = null,
-      request = originalRequest,
-      connectTimeoutMillis = client.connectTimeoutMillis,
-      readTimeoutMillis = client.readTimeoutMillis,
-      writeTimeoutMillis = client.writeTimeoutMillis
-    )
-
-    var calledNoMoreExchanges = false
-    try {
-      val response = chain.proceed(originalRequest)
-      if (isCanceled()) {
-        response.closeQuietly()
-        throw IOException("Canceled")
-      }
-      return response
-    } catch (e: IOException) {
-      calledNoMoreExchanges = true
-      throw noMoreExchanges(e) as Throwable
-    } finally {
-      if (!calledNoMoreExchanges) {
-        noMoreExchanges(null)
-      }
-    }
-  }
-
-  /**
-   * Prepare for a potential trip through all of this call's network interceptors. This prepares to
-   * find an exchange to carry the request.
-   *
-   * Note that an exchange will not be needed if the request is satisfied by the cache.
-   *
-   * @param newRoutePlanner true if this is not a retry and new routing can be performed.
-   */
-  fun enterNetworkInterceptorExchange(
-    request: Request,
-    newRoutePlanner: Boolean,
-    chain: RealInterceptorChain,
-  ) {
-    check(interceptorScopedExchange == null)
-
-    synchronized(this) {
-      check(!responseBodyOpen) {
-        "cannot make a new request because the previous response is still open: " +
-          "please call response.close()"
-      }
-      check(!requestBodyOpen)
-    }
-
-    if (newRoutePlanner) {
-      val routePlanner = RealRoutePlanner(
-        client,
-        createAddress(request.url),
-        this,
-        chain,
-        connectionListener = connectionPool.connectionListener
-      )
-      this.exchangeFinder = when {
-        client.fastFallback -> FastFallbackExchangeFinder(routePlanner, client.taskRunner)
-        else -> SequentialExchangeFinder(routePlanner)
-      }
-    }
-  }
-
-  /** Finds a new or pooled connection to carry a forthcoming request and response. */
-  internal fun initExchange(chain: RealInterceptorChain): Exchange {
-    synchronized(this) {
-      check(expectMoreExchanges) { "released" }
-      check(!responseBodyOpen)
-      check(!requestBodyOpen)
-    }
-
-    val exchangeFinder = this.exchangeFinder!!
-    val connection = exchangeFinder.find()
-    val codec = connection.newCodec(client, chain)
-    val result = Exchange(this, eventListener, exchangeFinder, codec)
-    this.interceptorScopedExchange = result
-    this.exchange = result
-    synchronized(this) {
-      this.requestBodyOpen = true
-      this.responseBodyOpen = true
-    }
-
-    if (canceled) throw IOException("Canceled")
-    return result
-  }
-
-  fun acquireConnectionNoEvents(connection: RealConnection) {
-    connection.assertThreadHoldsLock()
-
-    check(this.connection == null)
-    this.connection = connection
-    connection.calls.add(CallReference(this, callStackTrace))
-  }
-
-  /**
-   * Releases resources held with the request or response of [exchange]. This should be called when
-   * the request completes normally or when it fails due to an exception, in which case [e] should
-   * be non-null.
-   *
-   * If the exchange was canceled or timed out, this will wrap [e] in an exception that provides
-   * that additional context. Otherwise [e] is returned as-is.
-   */
-  internal fun <E : IOException?> messageDone(
-    exchange: Exchange,
-    requestDone: Boolean,
-    responseDone: Boolean,
-    e: E
-  ): E {
-    if (exchange != this.exchange) return e // This exchange was detached violently!
-
-    var bothStreamsDone = false
-    var callDone = false
-    synchronized(this) {
-      if (requestDone && requestBodyOpen || responseDone && responseBodyOpen) {
-        if (requestDone) requestBodyOpen = false
-        if (responseDone) responseBodyOpen = false
-        bothStreamsDone = !requestBodyOpen && !responseBodyOpen
-        callDone = !requestBodyOpen && !responseBodyOpen && !expectMoreExchanges
-      }
-    }
-
-    if (bothStreamsDone) {
-      this.exchange = null
-      this.connection?.incrementSuccessCount()
-    }
-
-    if (callDone) {
-      return callDone(e)
-    }
-
-    return e
-  }
-
-  internal fun noMoreExchanges(e: IOException?): IOException? {
-    var callDone = false
-    synchronized(this) {
-      if (expectMoreExchanges) {
-        expectMoreExchanges = false
-        callDone = !requestBodyOpen && !responseBodyOpen
-      }
-    }
-
-    if (callDone) {
-      return callDone(e)
-    }
-
-    return e
-  }
-
-  /**
-   * Complete this call. This should be called once these properties are all false:
-   * [requestBodyOpen], [responseBodyOpen], and [expectMoreExchanges].
-   *
-   * This will release the connection if it is still held.
-   *
-   * It will also notify the listener that the call completed; either successfully or
-   * unsuccessfully.
-   *
-   * If the call was canceled or timed out, this will wrap [e] in an exception that provides that
-   * additional context. Otherwise [e] is returned as-is.
-   */
-  private fun <E : IOException?> callDone(e: E): E {
-    assertThreadDoesntHoldLock()
-
-    val connection = this.connection
-    if (connection != null) {
-      connection.assertThreadDoesntHoldLock()
-      val toClose: Socket? = synchronized(connection) {
-        // Sets this.connection to null.
-        releaseConnectionNoEvents()
-      }
-      if (this.connection == null) {
-        toClose?.closeQuietly()
-        eventListener.connectionReleased(this, connection)
-        connection.connectionListener.connectionReleased(connection, this)
-        if (toClose != null) {
-          connection.connectionListener.connectionClosed(connection)
+    private val timeout = object : AsyncTimeout() {
+        override fun timedOut() {
+            cancel()
         }
-      } else {
-        check(toClose == null) // If we still have a connection we shouldn't be closing any sockets.
-      }
+    }.apply {
+        timeout(client.callTimeoutMillis.toLong(), MILLISECONDS)
     }
 
-    val result = timeoutExit(e)
-    if (e != null) {
-      eventListener.callFailed(this, result!!)
-    } else {
-      eventListener.callEnd(this)
-    }
-    return result
-  }
+    private val executed = AtomicBoolean()
 
-  /**
-   * Remove this call from the connection's list of allocations. Returns a socket that the caller
-   * should close.
-   */
-  internal fun releaseConnectionNoEvents(): Socket? {
-    val connection = this.connection!!
-    connection.assertThreadHoldsLock()
+    // These properties are only accessed by the thread executing the call.
 
-    val calls = connection.calls
-    val index = calls.indexOfFirst { it.get() == this@RealCall }
-    check(index != -1)
+    /** Initialized in [callStart]. */
+    private var callStackTrace: Any? = null
 
-    calls.removeAt(index)
-    this.connection = null
+    /** Finds an exchange to send the next request and receive the next response. */
+    private var exchangeFinder: ExchangeFinder? = null
 
-    if (calls.isEmpty()) {
-      connection.idleAtNs = System.nanoTime()
-      if (connectionPool.connectionBecameIdle(connection)) {
-        return connection.socket()
-      }
-    }
-
-    return null
-  }
-
-  private fun <E : IOException?> timeoutExit(cause: E): E {
-    if (timeoutEarlyExit) return cause
-    if (!timeout.exit()) return cause
-
-    val e = InterruptedIOException("timeout")
-    if (cause != null) e.initCause(cause)
-    @Suppress("UNCHECKED_CAST") // E is either IOException or IOException?
-    return e as E
-  }
-
-  /**
-   * Stops applying the timeout before the call is entirely complete. This is used for WebSockets
-   * and duplex calls where the timeout only applies to the initial setup.
-   */
-  fun timeoutEarlyExit() {
-    check(!timeoutEarlyExit)
-    timeoutEarlyExit = true
-    timeout.exit()
-  }
-
-  /**
-   * @param closeExchange true if the current exchange should be closed because it will not be used.
-   *     This is usually due to either an exception or a retry.
-   */
-  internal fun exitNetworkInterceptorExchange(closeExchange: Boolean) {
-    synchronized(this) {
-      check(expectMoreExchanges) { "released" }
-    }
-
-    if (closeExchange) {
-      exchange?.detachWithViolence()
-    }
-
-    interceptorScopedExchange = null
-  }
-
-  private fun createAddress(url: HttpUrl): Address {
-    var sslSocketFactory: SSLSocketFactory? = null
-    var hostnameVerifier: HostnameVerifier? = null
-    var certificatePinner: CertificatePinner? = null
-    if (url.isHttps) {
-      sslSocketFactory = client.sslSocketFactory
-      hostnameVerifier = client.hostnameVerifier
-      certificatePinner = client.certificatePinner
-    }
-
-    return Address(
-      uriHost = url.host,
-      uriPort = url.port,
-      dns = client.dns,
-      socketFactory = client.socketFactory,
-      sslSocketFactory = sslSocketFactory,
-      hostnameVerifier = hostnameVerifier,
-      certificatePinner = certificatePinner,
-      proxyAuthenticator = client.proxyAuthenticator,
-      proxy = client.proxy,
-      protocols = client.protocols,
-      connectionSpecs = client.connectionSpecs,
-      proxySelector = client.proxySelector
-    )
-  }
-
-  fun retryAfterFailure(): Boolean {
-    return exchange?.hasFailure == true &&
-      exchangeFinder!!.routePlanner.hasNext(exchange?.connection)
-  }
-
-  /**
-   * Returns a string that describes this call. Doesn't include a full URL as that might contain
-   * sensitive information.
-   */
-  private fun toLoggableString(): String {
-    return ((if (isCanceled()) "canceled " else "") +
-      (if (forWebSocket) "web socket" else "call") +
-      " to " + redactedUrl())
-  }
-
-  internal fun redactedUrl(): String = originalRequest.url.redact()
-
-  inner class AsyncCall(
-    private val responseCallback: Callback
-  ) : Runnable {
-    @Volatile var callsPerHost = AtomicInteger(0)
-      private set
-
-    fun reuseCallsPerHostFrom(other: AsyncCall) {
-      this.callsPerHost = other.callsPerHost
-    }
-
-    val host: String
-      get() = originalRequest.url.host
-
-    val request: Request
-      get() = originalRequest
-
-    val call: RealCall
-      get() = this@RealCall
+    var connection: RealConnection? = null
+        private set
+    private var timeoutEarlyExit = false
 
     /**
-     * Attempt to enqueue this async call on [executorService]. This will attempt to clean up
-     * if the executor has been shut down by reporting the call as failed.
+     * This is the same value as [exchange], but scoped to the execution of the network interceptors.
+     * The [exchange] field is assigned to null when its streams end, which may be before or after the
+     * network interceptors return.
      */
-    fun executeOn(executorService: ExecutorService) {
-      client.dispatcher.assertThreadDoesntHoldLock()
+    internal var interceptorScopedExchange: Exchange? = null
+        private set
 
-      var success = false
-      try {
-        executorService.execute(this)
-        success = true
-      } catch (e: RejectedExecutionException) {
-        failRejected(e)
-      } finally {
-        if (!success) {
-          client.dispatcher.finished(this) // This call is no longer running!
+    // These properties are guarded by this. They are typically only accessed by the thread executing
+    // the call, but they may be accessed by other threads for duplex requests.
+
+    /** True if this call still has a request body open. */
+    private var requestBodyOpen = false
+
+    /** True if this call still has a response body open. */
+    private var responseBodyOpen = false
+
+    /** True if there are more exchanges expected for this call. */
+    private var expectMoreExchanges = true
+
+    // These properties are accessed by canceling threads. Any thread can cancel a call, and once it's
+    // canceled it's canceled forever.
+
+    @Volatile
+    private var canceled = false
+    @Volatile
+    private var exchange: Exchange? = null
+    internal val plansToCancel = CopyOnWriteArrayList<RoutePlanner.Plan>()
+
+    override fun timeout(): Timeout = timeout
+
+    @SuppressWarnings("CloneDoesntCallSuperClone") // We are a final type & this saves clearing state.
+    override fun clone(): Call = RealCall(client, originalRequest, forWebSocket)
+
+    override fun request(): Request = originalRequest
+
+    /**
+     * Immediately closes the socket connection if it's currently held. Use this to interrupt an
+     * in-flight request from any thread. It's the caller's responsibility to close the request body
+     * and response body streams; otherwise resources may be leaked.
+     *
+     * This method is safe to be called concurrently, but provides limited guarantees. If a transport
+     * layer connection has been established (such as a HTTP/2 stream) that is terminated. Otherwise
+     * if a socket connection is being established, that is terminated.
+     */
+    override fun cancel() {
+        if (canceled) return // Already canceled.
+
+        canceled = true
+        exchange?.cancel()
+        for (plan in plansToCancel) {
+            plan.cancel()
         }
-      }
+
+        eventListener.canceled(this)
     }
 
-    internal fun failRejected(e: RejectedExecutionException? = null) {
-      val ioException = InterruptedIOException("executor rejected")
-      ioException.initCause(e)
-      noMoreExchanges(ioException)
-      responseCallback.onFailure(this@RealCall, ioException)
-    }
+    override fun isCanceled(): Boolean = canceled
 
-    override fun run() {
-      threadName("OkHttp ${redactedUrl()}") {
-        var signalledCallback = false
+    override fun execute(): Response {
+        check(executed.compareAndSet(false, true)) { "Already Executed" }
+
         timeout.enter()
+        callStart()
         try {
-          val response = getResponseWithInterceptorChain()
-          signalledCallback = true
-          responseCallback.onResponse(this@RealCall, response)
-        } catch (e: IOException) {
-          if (signalledCallback) {
-            // Do not signal the callback twice!
-            Platform.get().log("Callback failure for ${toLoggableString()}", Platform.INFO, e)
-          } else {
-            responseCallback.onFailure(this@RealCall, e)
-          }
-        } catch (t: Throwable) {
-          cancel()
-          if (!signalledCallback) {
-            val canceledException = IOException("canceled due to $t")
-            canceledException.addSuppressed(t)
-            responseCallback.onFailure(this@RealCall, canceledException)
-          }
-          throw t
+            client.dispatcher.executed(this)
+            return getResponseWithInterceptorChain()
         } finally {
-          client.dispatcher.finished(this)
+            client.dispatcher.finished(this)
         }
-      }
     }
-  }
 
-  internal class CallReference(
-    referent: RealCall,
+    override fun enqueue(responseCallback: Callback) {
+        if (isOnDispatcherThread()) {
+            InterceptorCall(this).enqueue(responseCallback)
+        } else {
+
+            check(executed.compareAndSet(false, true)) { "Already Executed" }
+
+            callStart()
+            client.dispatcher.enqueue(AsyncCall(responseCallback))
+        }
+    }
+
+    private fun isOnDispatcherThread(): Boolean = onCallThread.get()
+
+    override fun isExecuted(): Boolean = executed.get()
+
+    private fun callStart() {
+        this.callStackTrace = Platform.get().getStackTraceForCloseable("response.body().close()")
+        eventListener.callStart(this)
+    }
+
+    @Throws(IOException::class)
+    internal fun getResponseWithInterceptorChain(): Response {
+        // Build a full stack of interceptors.
+        val interceptors = mutableListOf<Interceptor>()
+        interceptors += client.interceptors
+        interceptors += RetryAndFollowUpInterceptor(client)
+        interceptors += BridgeInterceptor(client.cookieJar)
+        interceptors += CacheInterceptor(client.cache)
+        interceptors += ConnectInterceptor
+        if (!forWebSocket) {
+            interceptors += client.networkInterceptors
+        }
+        interceptors += CallServerInterceptor(forWebSocket)
+
+        val chain = RealInterceptorChain(
+            call = this,
+            interceptors = interceptors,
+            index = 0,
+            exchange = null,
+            request = originalRequest,
+            connectTimeoutMillis = client.connectTimeoutMillis,
+            readTimeoutMillis = client.readTimeoutMillis,
+            writeTimeoutMillis = client.writeTimeoutMillis
+        )
+
+        var calledNoMoreExchanges = false
+        try {
+            val response = chain.proceed(originalRequest)
+            if (isCanceled()) {
+                response.closeQuietly()
+                throw IOException("Canceled")
+            }
+            return response
+        } catch (e: IOException) {
+            calledNoMoreExchanges = true
+            throw noMoreExchanges(e) as Throwable
+        } finally {
+            if (!calledNoMoreExchanges) {
+                noMoreExchanges(null)
+            }
+        }
+    }
+
     /**
-     * Captures the stack trace at the time the Call is executed or enqueued. This is helpful for
-     * identifying the origin of connection leaks.
+     * Prepare for a potential trip through all of this call's network interceptors. This prepares to
+     * find an exchange to carry the request.
+     *
+     * Note that an exchange will not be needed if the request is satisfied by the cache.
+     *
+     * @param newRoutePlanner true if this is not a retry and new routing can be performed.
      */
-    val callStackTrace: Any?
-  ) : WeakReference<RealCall>(referent)
+    fun enterNetworkInterceptorExchange(
+        request: Request,
+        newRoutePlanner: Boolean,
+        chain: RealInterceptorChain,
+    ) {
+        check(interceptorScopedExchange == null)
+
+        synchronized(this) {
+            check(!responseBodyOpen) {
+                "cannot make a new request because the previous response is still open: " +
+                        "please call response.close()"
+            }
+            check(!requestBodyOpen)
+        }
+
+        if (newRoutePlanner) {
+            val routePlanner = RealRoutePlanner(
+                client,
+                createAddress(request.url),
+                this,
+                chain,
+                connectionListener = connectionPool.connectionListener
+            )
+            this.exchangeFinder = when {
+                client.fastFallback -> FastFallbackExchangeFinder(routePlanner, client.taskRunner)
+                else -> SequentialExchangeFinder(routePlanner)
+            }
+        }
+    }
+
+    /** Finds a new or pooled connection to carry a forthcoming request and response. */
+    internal fun initExchange(chain: RealInterceptorChain): Exchange {
+        synchronized(this) {
+            check(expectMoreExchanges) { "released" }
+            check(!responseBodyOpen)
+            check(!requestBodyOpen)
+        }
+
+        val exchangeFinder = this.exchangeFinder!!
+        val connection = exchangeFinder.find()
+        val codec = connection.newCodec(client, chain)
+        val result = Exchange(this, eventListener, exchangeFinder, codec)
+        this.interceptorScopedExchange = result
+        this.exchange = result
+        synchronized(this) {
+            this.requestBodyOpen = true
+            this.responseBodyOpen = true
+        }
+
+        if (canceled) throw IOException("Canceled")
+        return result
+    }
+
+    fun acquireConnectionNoEvents(connection: RealConnection) {
+        connection.assertThreadHoldsLock()
+
+        check(this.connection == null)
+        this.connection = connection
+        connection.calls.add(CallReference(this, callStackTrace))
+    }
+
+    /**
+     * Releases resources held with the request or response of [exchange]. This should be called when
+     * the request completes normally or when it fails due to an exception, in which case [e] should
+     * be non-null.
+     *
+     * If the exchange was canceled or timed out, this will wrap [e] in an exception that provides
+     * that additional context. Otherwise [e] is returned as-is.
+     */
+    internal fun <E : IOException?> messageDone(
+        exchange: Exchange,
+        requestDone: Boolean,
+        responseDone: Boolean,
+        e: E
+    ): E {
+        if (exchange != this.exchange) return e // This exchange was detached violently!
+
+        var bothStreamsDone = false
+        var callDone = false
+        synchronized(this) {
+            if (requestDone && requestBodyOpen || responseDone && responseBodyOpen) {
+                if (requestDone) requestBodyOpen = false
+                if (responseDone) responseBodyOpen = false
+                bothStreamsDone = !requestBodyOpen && !responseBodyOpen
+                callDone = !requestBodyOpen && !responseBodyOpen && !expectMoreExchanges
+            }
+        }
+
+        if (bothStreamsDone) {
+            this.exchange = null
+            this.connection?.incrementSuccessCount()
+        }
+
+        if (callDone) {
+            return callDone(e)
+        }
+
+        return e
+    }
+
+    internal fun noMoreExchanges(e: IOException?): IOException? {
+        var callDone = false
+        synchronized(this) {
+            if (expectMoreExchanges) {
+                expectMoreExchanges = false
+                callDone = !requestBodyOpen && !responseBodyOpen
+            }
+        }
+
+        if (callDone) {
+            return callDone(e)
+        }
+
+        return e
+    }
+
+    /**
+     * Complete this call. This should be called once these properties are all false:
+     * [requestBodyOpen], [responseBodyOpen], and [expectMoreExchanges].
+     *
+     * This will release the connection if it is still held.
+     *
+     * It will also notify the listener that the call completed; either successfully or
+     * unsuccessfully.
+     *
+     * If the call was canceled or timed out, this will wrap [e] in an exception that provides that
+     * additional context. Otherwise [e] is returned as-is.
+     */
+    private fun <E : IOException?> callDone(e: E): E {
+        assertThreadDoesntHoldLock()
+
+        val connection = this.connection
+        if (connection != null) {
+            connection.assertThreadDoesntHoldLock()
+            val toClose: Socket? = synchronized(connection) {
+                // Sets this.connection to null.
+                releaseConnectionNoEvents()
+            }
+            if (this.connection == null) {
+                toClose?.closeQuietly()
+                eventListener.connectionReleased(this, connection)
+                connection.connectionListener.connectionReleased(connection, this)
+                if (toClose != null) {
+                    connection.connectionListener.connectionClosed(connection)
+                }
+            } else {
+                check(toClose == null) // If we still have a connection we shouldn't be closing any sockets.
+            }
+        }
+
+        val result = timeoutExit(e)
+        if (e != null) {
+            eventListener.callFailed(this, result!!)
+        } else {
+            eventListener.callEnd(this)
+        }
+        return result
+    }
+
+    /**
+     * Remove this call from the connection's list of allocations. Returns a socket that the caller
+     * should close.
+     */
+    internal fun releaseConnectionNoEvents(): Socket? {
+        val connection = this.connection!!
+        connection.assertThreadHoldsLock()
+
+        val calls = connection.calls
+        val index = calls.indexOfFirst { it.get() == this@RealCall }
+        check(index != -1)
+
+        calls.removeAt(index)
+        this.connection = null
+
+        if (calls.isEmpty()) {
+            connection.idleAtNs = System.nanoTime()
+            if (connectionPool.connectionBecameIdle(connection)) {
+                return connection.socket()
+            }
+        }
+
+        return null
+    }
+
+    private fun <E : IOException?> timeoutExit(cause: E): E {
+        if (timeoutEarlyExit) return cause
+        if (!timeout.exit()) return cause
+
+        val e = InterruptedIOException("timeout")
+        if (cause != null) e.initCause(cause)
+        @Suppress("UNCHECKED_CAST") // E is either IOException or IOException?
+        return e as E
+    }
+
+    /**
+     * Stops applying the timeout before the call is entirely complete. This is used for WebSockets
+     * and duplex calls where the timeout only applies to the initial setup.
+     */
+    fun timeoutEarlyExit() {
+        check(!timeoutEarlyExit)
+        timeoutEarlyExit = true
+        timeout.exit()
+    }
+
+    /**
+     * @param closeExchange true if the current exchange should be closed because it will not be used.
+     *     This is usually due to either an exception or a retry.
+     */
+    internal fun exitNetworkInterceptorExchange(closeExchange: Boolean) {
+        synchronized(this) {
+            check(expectMoreExchanges) { "released" }
+        }
+
+        if (closeExchange) {
+            exchange?.detachWithViolence()
+        }
+
+        interceptorScopedExchange = null
+    }
+
+    private fun createAddress(url: HttpUrl): Address {
+        var sslSocketFactory: SSLSocketFactory? = null
+        var hostnameVerifier: HostnameVerifier? = null
+        var certificatePinner: CertificatePinner? = null
+        if (url.isHttps) {
+            sslSocketFactory = client.sslSocketFactory
+            hostnameVerifier = client.hostnameVerifier
+            certificatePinner = client.certificatePinner
+        }
+
+        return Address(
+            uriHost = url.host,
+            uriPort = url.port,
+            dns = client.dns,
+            socketFactory = client.socketFactory,
+            sslSocketFactory = sslSocketFactory,
+            hostnameVerifier = hostnameVerifier,
+            certificatePinner = certificatePinner,
+            proxyAuthenticator = client.proxyAuthenticator,
+            proxy = client.proxy,
+            protocols = client.protocols,
+            connectionSpecs = client.connectionSpecs,
+            proxySelector = client.proxySelector
+        )
+    }
+
+    fun retryAfterFailure(): Boolean {
+        return exchange?.hasFailure == true &&
+                exchangeFinder!!.routePlanner.hasNext(exchange?.connection)
+    }
+
+    /**
+     * Returns a string that describes this call. Doesn't include a full URL as that might contain
+     * sensitive information.
+     */
+    private fun toLoggableString(): String {
+        return ((if (isCanceled()) "canceled " else "") +
+                (if (forWebSocket) "web socket" else "call") +
+                " to " + redactedUrl())
+    }
+
+    internal fun redactedUrl(): String = originalRequest.url.redact()
+
+    inner class AsyncCall(
+        private val responseCallback: Callback
+    ) : Runnable {
+        @Volatile
+        var callsPerHost = AtomicInteger(0)
+            private set
+
+        fun reuseCallsPerHostFrom(other: AsyncCall) {
+            this.callsPerHost = other.callsPerHost
+        }
+
+        val host: String
+            get() = originalRequest.url.host
+
+        val request: Request
+            get() = originalRequest
+
+        val call: RealCall
+            get() = this@RealCall
+
+        /**
+         * Attempt to enqueue this async call on [executorService]. This will attempt to clean up
+         * if the executor has been shut down by reporting the call as failed.
+         */
+        fun executeOn(executorService: ExecutorService) {
+            client.dispatcher.assertThreadDoesntHoldLock()
+
+            var success = false
+            try {
+                executorService.execute {
+                    onCallThread.set(true)
+                    try {
+                        this.run()
+                    } finally {
+                        onCallThread.set(false)
+                    }
+                }
+                success = true
+            } catch (e: RejectedExecutionException) {
+                failRejected(e)
+            } finally {
+                if (!success) {
+                    client.dispatcher.finished(this) // This call is no longer running!
+                }
+            }
+        }
+
+        internal fun failRejected(e: RejectedExecutionException? = null) {
+            val ioException = InterruptedIOException("executor rejected")
+            ioException.initCause(e)
+            noMoreExchanges(ioException)
+            responseCallback.onFailure(this@RealCall, ioException)
+        }
+
+        override fun run() {
+            threadName("OkHttp ${redactedUrl()}") {
+                var signalledCallback = false
+                timeout.enter()
+                try {
+                    val response = getResponseWithInterceptorChain()
+                    signalledCallback = true
+                    responseCallback.onResponse(this@RealCall, response)
+                } catch (e: IOException) {
+                    if (signalledCallback) {
+                        // Do not signal the callback twice!
+                        Platform.get().log("Callback failure for ${toLoggableString()}", Platform.INFO, e)
+                    } else {
+                        responseCallback.onFailure(this@RealCall, e)
+                    }
+                } catch (t: Throwable) {
+                    cancel()
+                    if (!signalledCallback) {
+                        val canceledException = IOException("canceled due to $t")
+                        canceledException.addSuppressed(t)
+                        responseCallback.onFailure(this@RealCall, canceledException)
+                    }
+                    throw t
+                } finally {
+                    client.dispatcher.finished(this)
+                }
+            }
+        }
+    }
+
+    internal class CallReference(
+        referent: RealCall,
+        /**
+         * Captures the stack trace at the time the Call is executed or enqueued. This is helpful for
+         * identifying the origin of connection leaks.
+         */
+        val callStackTrace: Any?
+    ) : WeakReference<RealCall>(referent)
+
+    companion object {
+        val onCallThread = object : ThreadLocal<Boolean>() {
+            override fun initialValue(): Boolean = false
+        }
+    }
 }

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/InterceptorCallFactory.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/InterceptorCallFactory.kt
@@ -1,0 +1,25 @@
+package okhttp3.internal.http
+
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Request
+import okio.IOException
+
+class InterceptorCallFactory(val delegate: Call.Factory) : Call.Factory {
+  override fun newCall(request: Request): Call {
+   return InterceptorCall(delegate.newCall(request))
+  }
+}
+
+class InterceptorCall(val delegate: Call): Call by delegate  {
+
+  override fun enqueue(responseCallback: Callback) {
+    try {
+      responseCallback.onResponse(this, delegate.execute())
+    } catch (ioe: IOException) {
+      responseCallback.onFailure(this, ioe)
+    }
+  }
+
+  override fun clone(): Call = InterceptorCall(delegate.clone())
+}

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/InterceptorCallFactory.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/InterceptorCallFactory.kt
@@ -15,9 +15,9 @@ class InterceptorCall(val delegate: Call): Call by delegate  {
 
   override fun enqueue(responseCallback: Callback) {
     try {
-      responseCallback.onResponse(this, delegate.execute())
+      responseCallback.onResponse(delegate, delegate.execute())
     } catch (ioe: IOException) {
-      responseCallback.onFailure(this, ioe)
+      responseCallback.onFailure(delegate, ioe)
     }
   }
 

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RealInterceptorChain.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RealInterceptorChain.kt
@@ -58,6 +58,9 @@ class RealInterceptorChain(
 
   override fun connection(): Connection? = exchange?.connection
 
+  override val callFactory: Call.Factory
+    get() = InterceptorCallFactory(call.client)
+
   override fun connectTimeoutMillis(): Int = connectTimeoutMillis
 
   override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {

--- a/okhttp/src/jvmTest/java/okhttp3/KotlinSourceModernTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/KotlinSourceModernTest.kt
@@ -1175,6 +1175,8 @@ class KotlinSourceModernTest {
       override fun proceed(request: Request): Response = TODO()
       override fun connection(): Connection? = TODO()
       override fun call(): Call = TODO()
+      override val callFactory: Call.Factory
+        get() = TODO()
       override fun connectTimeoutMillis(): Int = TODO()
       override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = TODO()
       override fun readTimeoutMillis(): Int = TODO()


### PR DESCRIPTION
A quick riff on https://github.com/square/okhttp/issues/7904 to provoke discussion

Detection is by two mechanisms

1) Use a thread local set in AsyncCall.executeOn, if the interceptor strictly on the same thread, this works.  But not swapping dispatchers.
2) Use chain.callFactory which never actually enqueues.

We should look at what is possible on SuspendingInterceptor, if we say that this support relies on using it, and all frameworks (wire, retrofit) are suspending, then maybe we can carry some information  in the CoroutineContext to detect this, and pick it back up again in executeAsync?