### PR TITLE
Avoid infinite wait on bad response handling.

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt
@@ -264,12 +264,12 @@ class Http2Stream internal constructor(
       if (this.errorCode != null) {
         return false
       }
-      if (source.finished && sink.finished) {
-        return false
-      }
       this.errorCode = errorCode
       this.errorException = errorException
       notifyAll()
+      if (source.finished && sink.finished) {
+        return false
+      }
     }
     connection.removeStream(id)
     return true
@@ -491,7 +491,7 @@ class Http2Stream internal constructor(
       // But delay updating the stream flow control until that stream has been
       // consumed
       updateConnectionFlowControl(byteCount)
-      
+
       // Notify that buffer size changed
       connection.flowControlListener.receivingStreamWindowChanged(id, readBytes, readBuffer.size)
     }


### PR DESCRIPTION
From https://github.com/square/okhttp/pull/7938

Avoid hanging on takeHeaders (incorrect 103 handling) when response body is empty.

If we mess up our logic (103 and so on), we call closeInternal on the stream from the timeout, but only if if source.isFinished() is false.  For an empty body, this will be true, so the next waitForIo, would wait indefinitely.