### PR TITLE
Handle certificate corruption

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/Cache.kt
@@ -629,7 +629,8 @@ class Cache internal constructor(
         for (i in 0 until length) {
           val line = source.readUtf8LineStrict()
           val bytes = Buffer()
-          bytes.write(line.decodeBase64()!!)
+          val certificateBytes = line.decodeBase64() ?: throw IOException("Corrupt certificate in cache entry")
+          bytes.write(certificateBytes)
           result.add(certificateFactory.generateCertificate(bytes.inputStream()))
         }
         return result


### PR DESCRIPTION
Avoid NPE and throw IOException

#fixes https://github.com/square/okhttp/issues/7978