### PR TITLE
Disable javadoc temporarily

### DIFF
--- a/mockwebserver-deprecated/build.gradle.kts
+++ b/mockwebserver-deprecated/build.gradle.kts
@@ -25,5 +25,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/mockwebserver-junit4/build.gradle.kts
+++ b/mockwebserver-junit4/build.gradle.kts
@@ -22,5 +22,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/mockwebserver-junit5/build.gradle.kts
+++ b/mockwebserver-junit5/build.gradle.kts
@@ -33,5 +33,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/mockwebserver/build.gradle.kts
+++ b/mockwebserver/build.gradle.kts
@@ -25,5 +25,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/okcurl/build.gradle.kts
+++ b/okcurl/build.gradle.kts
@@ -113,5 +113,5 @@ tasks.getByName("copyJvmJar").dependsOn(tasks.getByName("jvmJar"))
 tasks.getByName("nativeImage").dependsOn(copyJvmJar)
 
 mavenPublishing {
-  configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinMultiplatform(javadocJar = JavadocJar.Empty()))
 }

--- a/okhttp-brotli/build.gradle.kts
+++ b/okhttp-brotli/build.gradle.kts
@@ -26,5 +26,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/okhttp-coroutines/build.gradle.kts
+++ b/okhttp-coroutines/build.gradle.kts
@@ -102,6 +102,6 @@ project.applyOsgi(
 
 mavenPublishing {
   configure(
-    KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaGfm"))
+    KotlinMultiplatform(javadocJar = JavadocJar.Empty())
   )
 }

--- a/okhttp-dnsoverhttps/build.gradle.kts
+++ b/okhttp-dnsoverhttps/build.gradle.kts
@@ -28,5 +28,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/okhttp-logging-interceptor/build.gradle.kts
+++ b/okhttp-logging-interceptor/build.gradle.kts
@@ -28,5 +28,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/okhttp-sse/build.gradle.kts
+++ b/okhttp-sse/build.gradle.kts
@@ -27,5 +27,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/okhttp-tls/build.gradle.kts
+++ b/okhttp-tls/build.gradle.kts
@@ -33,5 +33,5 @@ animalsniffer {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/okhttp-urlconnection/build.gradle.kts
+++ b/okhttp-urlconnection/build.gradle.kts
@@ -28,5 +28,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinJvm(javadocJar = JavadocJar.Empty()))
 }

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -217,5 +217,5 @@ dependencies {
 }
 
 mavenPublishing {
-  configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaGfm")))
+  configure(KotlinMultiplatform(javadocJar = JavadocJar.Empty()))
 }


### PR DESCRIPTION
Failing currently https://github.com/square/okhttp/actions/runs/6198721220/job/16829730445

```
    Reason: Task ':logging-interceptor:dokkaJavadocJar' uses this output of task ':mockwebserver:dokkaGfm' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':mockwebserver:dokkaGfm' as an input of ':logging-interceptor:dokkaJavadocJar'.
      2. Declare an explicit dependency on ':mockwebserver:dokkaG
      3. 
```