### PR TITLE
Add new method in Headers.kt to allow non ASCII chars in both header …

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/Headers.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Headers.kt
@@ -263,20 +263,11 @@ class Headers private constructor(
     }
 
     /**
-     * Add a header with the specified name and value. Does validation of header names, allowing
-     * non-ASCII values.
+     * Add a header with the specified name and value. Does not validate headers names and values, allowing
+     * non-ASCII characters.
      */
     fun addUnsafeNonAscii(name: String, value: String) = apply {
-      checkName(name)
       addLenient(name, value)
-    }
-
-    /**
-     * Add a header with the specified name and value. Doesn't validate neither header names or values,
-     * allowing non-ASCII characters in both.
-     */
-    fun addUnsafeNonAsciiNameOrValue(name: String, value: String) = apply {
-      addLenientNoTrim(name, value)
     }
 
     /**
@@ -329,15 +320,6 @@ class Headers private constructor(
     internal fun addLenient(name: String, value: String) = apply {
       namesAndValues.add(name)
       namesAndValues.add(value.trim())
-    }
-
-    /**
-     * Add a field with the specified value without any validation or value trimming. Only appropriate for headers
-     * from the remote peer or cache.
-     */
-    private fun addLenientNoTrim(name: String, value: String) = apply {
-      namesAndValues.add(name)
-      namesAndValues.add(value)
     }
 
     fun removeAll(name: String) = apply {

--- a/okhttp/src/main/kotlin/okhttp3/Headers.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Headers.kt
@@ -272,6 +272,14 @@ class Headers private constructor(
     }
 
     /**
+     * Add a header with the specified name and value. Doesn't validate neither header names or values,
+     * allowing non-ASCII characters in both.
+     */
+    fun addUnsafeNonAsciiNameOrValue(name: String, value: String) = apply {
+      addLenientNoTrim(name, value)
+    }
+
+    /**
      * Adds all headers from an existing collection.
      */
     fun addAll(headers: Headers) = apply {
@@ -321,6 +329,15 @@ class Headers private constructor(
     internal fun addLenient(name: String, value: String) = apply {
       namesAndValues.add(name)
       namesAndValues.add(value.trim())
+    }
+
+    /**
+     * Add a field with the specified value without any validation or value trimming. Only appropriate for headers
+     * from the remote peer or cache.
+     */
+    private fun addLenientNoTrim(name: String, value: String) = apply {
+      namesAndValues.add(name)
+      namesAndValues.add(value)
     }
 
     fun removeAll(name: String) = apply {

--- a/okhttp/src/test/java/okhttp3/HeadersTest.java
+++ b/okhttp/src/test/java/okhttp3/HeadersTest.java
@@ -129,16 +129,11 @@ public final class HeadersTest {
     }
   }
 
-  @Test public void addUnsafeNonAsciiRejectsUnicodeName() {
-    try {
-      new Headers.Builder()
-          .addUnsafeNonAscii("héader1", "value1")
-          .build();
-      fail("Should have complained about invalid value");
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected.getMessage()).isEqualTo(
-          "Unexpected char 0xe9 at 1 in header name: héader1");
-    }
+  @Test public void addUnsafeNonAsciiAcceptsUnicodeName() {
+    Headers headers = new Headers.Builder()
+        .addUnsafeNonAscii("héader1", "value1")
+        .build();
+    assertThat(headers.toString()).isEqualTo("héader1: value1\n");
   }
 
   @Test public void addUnsafeNonAsciiAcceptsUnicodeValue() {


### PR DESCRIPTION
I'm working on a fuzzing tool called CATS: https://github.com/Endava/cats that use okhttp as underlying http transport library. Multiple HTTP headers fuzzers will send different non-ASCII characters in both header names and values. Other fuzzers are prefixing/suffixing header values with spaces. The current `addUnsafeNonAscii()` doesn't allow non-ASCII in header values and also does trimming of values. This PR introduces an additional method that allows non-ASCII in both header names and values and doesn't do any value trimming.