### PR TITLE
Making max message size for Websockets configurable

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -769,7 +769,8 @@ class MockWebServer : Closeable {
       random = SecureRandom(),
       pingIntervalMillis = 0,
       extensions = WebSocketExtensions.parse(webSocketResponse.headers),
-      minimumDeflateSize = 0L // Compress all messages if compression is enabled.
+      minimumDeflateSize = 0L, // Compress all messages if compression is enabled.
+      maxQueueSize = RealWebSocket.DEFAULT_MAX_QUEUE_SIZE
     )
     webSocketResponse.webSocketListener.onOpen(webSocket, fancyResponse)
     val name = "MockWebServer WebSocket ${request.path!!}"

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -925,6 +925,7 @@ public class okhttp3/OkHttpClient : okhttp3/Call$Factory, okhttp3/WebSocket$Fact
 	public final fun followSslRedirects ()Z
 	public final fun hostnameVerifier ()Ljavax/net/ssl/HostnameVerifier;
 	public final fun interceptors ()Ljava/util/List;
+	public final fun maxQueueSize ()J
 	public final fun minWebSocketMessageToCompress ()J
 	public final fun networkInterceptors ()Ljava/util/List;
 	public fun newBuilder ()Lokhttp3/OkHttpClient$Builder;
@@ -971,6 +972,7 @@ public final class okhttp3/OkHttpClient$Builder {
 	public final fun followSslRedirects (Z)Lokhttp3/OkHttpClient$Builder;
 	public final fun hostnameVerifier (Ljavax/net/ssl/HostnameVerifier;)Lokhttp3/OkHttpClient$Builder;
 	public final fun interceptors ()Ljava/util/List;
+	public final fun maxQueueSize (J)Lokhttp3/OkHttpClient$Builder;
 	public final fun minWebSocketMessageToCompress (J)Lokhttp3/OkHttpClient$Builder;
 	public final fun networkInterceptors ()Ljava/util/List;
 	public final fun pingInterval (JLjava/util/concurrent/TimeUnit;)Lokhttp3/OkHttpClient$Builder;

--- a/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
@@ -547,7 +547,7 @@ open class OkHttpClient internal constructor(
     internal var minWebSocketMessageToCompress = RealWebSocket.DEFAULT_MINIMUM_DEFLATE_SIZE
     internal var routeDatabase: RouteDatabase? = null
     internal var taskRunner: TaskRunner? = null
-    internal var maxQueueSize = RealWebSocket.DEFAULT_MAX_QUEUE_SIZE
+    internal var maxQueueSize: Long = RealWebSocket.DEFAULT_MAX_QUEUE_SIZE
 
     internal constructor(okHttpClient: OkHttpClient) : this() {
       this.dispatcher = okHttpClient.dispatcher

--- a/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
@@ -232,7 +232,8 @@ open class OkHttpClient internal constructor(
   val minWebSocketMessageToCompress: Long = builder.minWebSocketMessageToCompress
 
   /**
-   * Maximum outbound web socket message size (in bytes) that will be sent
+   * The maximum number of bytes to enqueue. Rather than enqueueing beyond this limit we tear down
+   * the web socket! It's possible that we're writing faster than the peer can read.
    */
   @get:JvmName("maxQueueSize")
   val maxQueueSize: Long = builder.maxQueueSize

--- a/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/OkHttpClient.kt
@@ -231,6 +231,12 @@ open class OkHttpClient internal constructor(
   @get:JvmName("minWebSocketMessageToCompress")
   val minWebSocketMessageToCompress: Long = builder.minWebSocketMessageToCompress
 
+  /**
+   * Maximum outbound web socket message size (in bytes) that will be sent
+   */
+  @get:JvmName("maxQueueSize")
+  val maxQueueSize: Long = builder.maxQueueSize
+
   internal val routeDatabase: RouteDatabase = builder.routeDatabase ?: RouteDatabase()
   internal val taskRunner: TaskRunner = builder.taskRunner ?: TaskRunner.INSTANCE
 
@@ -291,7 +297,8 @@ open class OkHttpClient internal constructor(
       random = Random(),
       pingIntervalMillis = pingIntervalMillis.toLong(),
       extensions = null, // Always null for clients.
-      minimumDeflateSize = minWebSocketMessageToCompress
+      minimumDeflateSize = minWebSocketMessageToCompress,
+      maxQueueSize = maxQueueSize
     )
     webSocket.connect(this)
     return webSocket
@@ -540,6 +547,7 @@ open class OkHttpClient internal constructor(
     internal var minWebSocketMessageToCompress = RealWebSocket.DEFAULT_MINIMUM_DEFLATE_SIZE
     internal var routeDatabase: RouteDatabase? = null
     internal var taskRunner: TaskRunner? = null
+    internal var maxQueueSize = RealWebSocket.DEFAULT_MAX_QUEUE_SIZE
 
     internal constructor(okHttpClient: OkHttpClient) : this() {
       this.dispatcher = okHttpClient.dispatcher
@@ -574,6 +582,7 @@ open class OkHttpClient internal constructor(
       this.minWebSocketMessageToCompress = okHttpClient.minWebSocketMessageToCompress
       this.routeDatabase = okHttpClient.routeDatabase
       this.taskRunner = okHttpClient.taskRunner
+      this.maxQueueSize = okHttpClient.maxQueueSize
     }
 
     /**
@@ -1205,6 +1214,14 @@ open class OkHttpClient internal constructor(
       }
 
       this.minWebSocketMessageToCompress = bytes
+    }
+
+    fun maxQueueSize(bytes: Long) = apply {
+      require(bytes >= 0) {
+        "maxQueueSize must be positive: $bytes"
+      }
+
+      this.maxQueueSize = bytes
     }
 
     fun build(): OkHttpClient = OkHttpClient(this)

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/RealWebSocket.kt
@@ -402,8 +402,8 @@ class RealWebSocket(
     if (failed || enqueuedClose) return false
 
     // If this frame overflows the buffer, reject it and close the web socket.
-    if (queueSize + data.size > MAX_QUEUE_SIZE) {
-      close(CLOSE_CLIENT_GOING_AWAY, null)
+    if (queueSize + data.size > DEFAULT_MAX_QUEUE_SIZE) {
+      close(CLOSE_CLIENT_GOING_AWAY, "Message to large to send safely, aborting...")
       return false
     }
 
@@ -632,7 +632,7 @@ class RealWebSocket(
      * The maximum number of bytes to enqueue. Rather than enqueueing beyond this limit we tear down
      * the web socket! It's possible that we're writing faster than the peer can read.
      */
-    private const val MAX_QUEUE_SIZE = 16L * 1024 * 1024 // 16 MiB.
+    private const val DEFAULT_MAX_QUEUE_SIZE = 16L * 1024 * 1024 // 16 MiB.
 
     /**
      * The maximum amount of time after the client calls [close] to wait for a graceful shutdown. If

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/RealWebSocket.kt
@@ -128,7 +128,6 @@ class RealWebSocket(
   /** True if we have sent a ping that is still awaiting a reply. */
   private var awaitingPong = false
 
-
   init {
     require("GET" == originalRequest.method) {
       "Request must be GET: ${originalRequest.method}"

--- a/okhttp/src/jvmTest/java/okhttp3/OkHttpClientTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/OkHttpClientTest.kt
@@ -420,6 +420,17 @@ class OkHttpClientTest {
       assertThat(expected.message)
         .isEqualTo("minWebSocketMessageToCompress must be positive: -1024")
     }
+
+    @Test fun maxQueueSizeNegative() {
+      val builder = OkHttpClient.Builder()
+      try {
+        builder.maxQueueSize(-1024)
+        fail<Any>()
+      } catch (expected: IllegalArgumentException) {
+        assertThat(expected.message)
+          .isEqualTo("maxQueueSize must be positive: -1024")
+      }
+    }
   }
 
   companion object {

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/RealWebSocketTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/RealWebSocketTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static okhttp3.internal.ws.RealWebSocket.DEFAULT_MAX_QUEUE_SIZE;
 import static okhttp3.internal.ws.RealWebSocket.DEFAULT_MINIMUM_DEFLATE_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
@@ -427,7 +428,7 @@ public final class RealWebSocketTest {
           .build();
       webSocket = new RealWebSocket(TaskRunner.INSTANCE, response.request(), listener, random,
           pingIntervalMillis, WebSocketExtensions.Companion.parse(responseHeaders),
-          DEFAULT_MINIMUM_DEFLATE_SIZE);
+          DEFAULT_MINIMUM_DEFLATE_SIZE,DEFAULT_MAX_QUEUE_SIZE);
       webSocket.initReaderAndWriter(name, this);
     }
 

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -1083,7 +1083,9 @@ public final class WebSocketHttpTest {
 
   private RealWebSocket newWebSocket(Request request) {
     RealWebSocket webSocket = new RealWebSocket(TaskRunner.INSTANCE, request, clientListener,
-        random, client.pingIntervalMillis(), null, 0L);
+        random, client.pingIntervalMillis(), null, 0L,
+      RealWebSocket.DEFAULT_MAX_QUEUE_SIZE);
+
     webSocket.connect(client);
     return webSocket;
   }

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -541,13 +541,13 @@ public final class WebSocketHttpTest {
     for (int i = 0; i < messageCount; i++) {
       serverListener.assertBinaryMessage(message);
     }
-    serverListener.assertClosing(1001, "");
+    serverListener.assertClosing(1001, "Message to large to send safely, aborting...");
 
     // When the server acknowledges the close the connection shuts down gracefully.
     server.close(1000, null);
     clientListener.assertClosing(1000, "");
     clientListener.assertClosed(1000, "");
-    serverListener.assertClosed(1001, "");
+    serverListener.assertClosed(1001, "Message to large to send safely, aborting...");
   }
 
   @Test public void closeReasonMaximumLength() {


### PR DESCRIPTION
Hi, in react-native, which uses okhttp for networking on android, there is a mismatch between the max message size that can be sent via websockets.

On iOS there is seemingly no limit to the size a message can have. On Android we have this hard cap to 16MiB

This PR will enable teams to override this default setting of 16MiB if they want to.

(Other libraries, such as [ws](https://github.com/websockets/ws/blob/master/doc/ws.md#class-websocketserver) also provide an API for defining the max message size. )