### PR TITLE
Fix JDK 8 test

### DIFF
--- a/okhttp/src/jvmTest/java/okhttp3/CacheTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/CacheTest.java
@@ -364,7 +364,7 @@ public final class CacheTest {
     Path cacheEntry = fileSystem.allPaths().stream()
             .filter((e) -> e.name().endsWith(".0"))
             .findFirst()
-            .orElseThrow();
+            .orElseThrow(NoSuchElementException::new);
     corruptCertificate(cacheEntry);
 
     Response response2 = client.newCall(request).execute(); // Not Cached!


### PR DESCRIPTION
```
CacheTest[jvm] > secureResponseCachingWithCorruption()[jvm] FAILED
    java.lang.NoSuchMethodError: java.util.Optional.orElseThrow()Ljava/lang/Object;
        at okhttp3.CacheTest.secureResponseCachingWithCorruption(CacheTest.java:367)
```