### PR TITLE
Fix: Staled cache response used when system time adjusted backward

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/cache/CacheStrategy.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/cache/CacheStrategy.kt
@@ -272,9 +272,9 @@ class CacheStrategy internal constructor(
         apparentReceivedAge
       }
 
-      val responseDuration = receivedResponseMillis - sentRequestMillis
-      val residentDuration = nowMillis - receivedResponseMillis
-      return maxOf(0, receivedAge + responseDuration + residentDuration)
+      val responseDuration = maxOf(0, receivedResponseMillis - sentRequestMillis)
+      val residentDuration = maxOf(0, nowMillis - receivedResponseMillis)
+      return receivedAge + responseDuration + residentDuration
     }
 
     /**

--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/cache/CacheStrategy.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/cache/CacheStrategy.kt
@@ -274,7 +274,7 @@ class CacheStrategy internal constructor(
 
       val responseDuration = receivedResponseMillis - sentRequestMillis
       val residentDuration = nowMillis - receivedResponseMillis
-      return receivedAge + responseDuration + residentDuration
+      return maxOf(0, receivedAge + responseDuration + residentDuration)
     }
 
     /**


### PR DESCRIPTION
OkHttp would incorrectly use a cached response for a second request if the server's first response did not contain caching headers, if the system time was adjusted backward between the two requests。