### PR TITLE
Fix: Add explicit argument name in use lambda function in okhttp-coroutines/README.md

### DIFF
--- a/okhttp-coroutines/README.md
+++ b/okhttp-coroutines/README.md
@@ -6,7 +6,7 @@ Support for Kotlin clients using coroutines.
 ```kotlin
 val call = client.newCall(request)
 
-call.executeAsync().use {
+call.executeAsync().use { response ->
   withContext(Dispatchers.IO) {
     println(response.body?.string())
   }


### PR DESCRIPTION
Fix wrong syntax in okhttp-coroutines/README.md