### PR TITLE
Fix a concurrency problem with web socket cleanup

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -281,6 +281,9 @@ class RealConnection(
       override fun close() {
         exchange.bodyComplete<IOException?>(-1L, responseDone = true, requestDone = true, e = null)
       }
+      override fun cancel() {
+        exchange.cancel()
+      }
     }
   }
 

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/WebSocketHttpTest.java
@@ -36,7 +36,6 @@ import mockwebserver3.RecordedRequest;
 import mockwebserver3.SocketPolicy;
 import mockwebserver3.SocketPolicy.KeepOpen;
 import mockwebserver3.SocketPolicy.NoResponse;
-import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 import okhttp3.OkHttpClientTestRule;
 import okhttp3.Protocol;
@@ -1088,10 +1087,10 @@ public final class WebSocketHttpTest {
     return webSocket;
   }
 
-  private void closeWebSockets(WebSocket webSocket, WebSocket server) {
+  private void closeWebSockets(WebSocket client, WebSocket server) {
     server.close(1001, "");
     clientListener.assertClosing(1001, "");
-    webSocket.close(1000, "");
+    client.close(1000, "");
     serverListener.assertClosing(1000, "");
     clientListener.assertClosed(1001, "");
     serverListener.assertClosed(1000, "");


### PR DESCRIPTION
We were seeing crashes in Deflater.deflate with a root cause of closing the deflater while it was in use.

The underlying problem is that web socket streams were closed when the web socket was canceled, but not by the thread that owned those streams.

This moves stream cleanup to always run on the owning thread:
 - writer cleanup happens on the task queue
 - reader cleanup happens after loopReader

This also introduces a new function, Streams.cancel() so a failed writer can break an active reader, and vise-versa. Previously we were using close() to do this job.

There's a lot of test changes but it's mostly in adding the TaskFaker facet to RealWebSocketTest. The test now runs with a fake clock, with the deterministic benefits that brings.

See also: https://github.com/square/okhttp/issues/6719