### PR TITLE
Don't infinite loop on self-terminating compressed websocket messages

### DIFF
--- a/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/MessageInflater.kt
+++ b/okhttp/src/jvmMain/kotlin/okhttp3/internal/ws/MessageInflater.kt
@@ -48,7 +48,7 @@ class MessageInflater(
     // Instead, we ensure that all bytes from source have been processed by inflater.
     do {
       inflaterSource.readOrInflate(buffer, Long.MAX_VALUE)
-    } while (inflater.bytesRead < totalBytesToRead)
+    } while (inflater.bytesRead < totalBytesToRead && !inflater.finished())
   }
 
   @Throws(IOException::class)

--- a/okhttp/src/jvmTest/java/okhttp3/internal/ws/MessageDeflaterInflaterTest.kt
+++ b/okhttp/src/jvmTest/java/okhttp3/internal/ws/MessageDeflaterInflaterTest.kt
@@ -32,6 +32,16 @@ internal class MessageDeflaterInflaterTest {
     assertThat(inflater.inflate(message)).isEqualTo("Hello inflation!".encodeUtf8())
   }
 
+  /**
+   * We had a bug where self-finishing inflater streams would infinite loop!
+   * https://github.com/square/okhttp/issues/8078
+   */
+  @Test fun `inflate returns finished before bytesRead reaches input length`() {
+    val inflater = MessageInflater(false)
+    val message = "53621260020000".decodeHex()
+    assertThat(inflater.inflate(message)).isEqualTo("22021002".decodeHex())
+  }
+
   @Test fun `deflate golden value`() {
     val deflater = MessageDeflater(false)
     val deflated = deflater.deflate("Hello deflate!".encodeUtf8())


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/8078