### PR TITLE
Even more assertk

### DIFF
--- a/okhttp-testing-support/src/test/kotlin/okhttp3/OkHttpClientTestRuleTest.kt
+++ b/okhttp-testing-support/src/test/kotlin/okhttp3/OkHttpClientTestRuleTest.kt
@@ -15,7 +15,8 @@
  */
 package okhttp3
 
-import org.assertj.core.api.Assertions.assertThat
+import assertk.assertThat
+import assertk.assertions.hasMessage
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -46,7 +47,7 @@ class OkHttpClientTestRuleTest {
       fail("")
     } catch (expected: AssertionError) {
       assertThat(expected).hasMessage("uncaught exception thrown during test")
-      assertThat(expected.cause).hasMessage("boom!")
+      assertThat(expected.cause!!).hasMessage("boom!")
     }
   }
 }

--- a/okhttp-tls/src/test/java/okhttp3/tls/HandshakeCertificatesTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/HandshakeCertificatesTest.kt
@@ -15,6 +15,9 @@
  */
 package okhttp3.tls
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.matchesPredicate
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.ServerSocket
@@ -30,7 +33,6 @@ import okhttp3.Handshake.Companion.handshake
 import okhttp3.internal.closeQuietly
 import okhttp3.testing.PlatformRule
 import okio.ByteString.Companion.toByteString
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -133,7 +135,9 @@ class HandshakeCertificatesTest {
       .toSet()
 
     // It's safe to assume all platforms will have a major Internet certificate issuer.
-    assertThat(names).anyMatch { it.matches(Regex("[A-Z]+=Entrust.*")) }
+    assertThat(names).matchesPredicate { strings ->
+      strings.any { it.matches(Regex("[A-Z]+=Entrust.*")) }
+    }
   }
 
   private fun startTlsServer(): InetSocketAddress {

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerCertificatesTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerCertificatesTest.kt
@@ -15,6 +15,11 @@
  */
 package okhttp3.tls.internal.der
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import java.math.BigInteger
 import java.security.KeyFactory
 import java.security.spec.PKCS8EncodedKeySpec
@@ -36,7 +41,6 @@ import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class DerCertificatesTest {

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
@@ -15,6 +15,12 @@
  */
 package okhttp3.tls.internal.der
 
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import java.math.BigInteger
 import java.net.InetAddress
 import java.net.ProtocolException
@@ -31,7 +37,6 @@ import okio.Buffer
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail

--- a/okhttp/src/test/java/okhttp3/AddressTest.kt
+++ b/okhttp/src/test/java/okhttp3/AddressTest.kt
@@ -15,9 +15,11 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
 import java.net.Proxy
 import okhttp3.internal.http.RecordingProxySelector
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 

--- a/okhttp/src/test/java/okhttp3/BouncyCastleTest.kt
+++ b/okhttp/src/test/java/okhttp3/BouncyCastleTest.kt
@@ -15,10 +15,11 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import mockwebserver3.MockWebServer
 import okhttp3.TestUtil.assumeNetwork
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension

--- a/okhttp/src/test/java/okhttp3/CacheControlJvmTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheControlJvmTest.kt
@@ -15,14 +15,16 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isSameAs
+import assertk.assertions.isTrue
+import java.util.concurrent.TimeUnit
 import okhttp3.CacheControl.Companion.parse
 import okhttp3.Headers.Companion.headersOf
-import org.junit.jupiter.api.Test
-import java.lang.Exception
-import java.lang.IllegalArgumentException
-import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 class CacheControlJvmTest {
   @Test
@@ -42,20 +44,20 @@ class CacheControlJvmTest {
       "no-cache, no-store, max-age=1, max-stale=2, min-fresh=3, only-if-cached, "
         + "no-transform, immutable"
     )
-    assertThat(cacheControl.noCache).isTrue
-    assertThat(cacheControl.noStore).isTrue
+    assertThat(cacheControl.noCache).isTrue()
+    assertThat(cacheControl.noStore).isTrue()
     assertThat(cacheControl.maxAgeSeconds).isEqualTo(1)
     assertThat(cacheControl.maxStaleSeconds).isEqualTo(2)
     assertThat(cacheControl.minFreshSeconds).isEqualTo(3)
-    assertThat(cacheControl.onlyIfCached).isTrue
-    assertThat(cacheControl.noTransform).isTrue
-    assertThat(cacheControl.immutable).isTrue
+    assertThat(cacheControl.onlyIfCached).isTrue()
+    assertThat(cacheControl.noTransform).isTrue()
+    assertThat(cacheControl.immutable).isTrue()
 
     // These members are accessible to response headers only.
     assertThat(cacheControl.sMaxAgeSeconds).isEqualTo(-1)
-    assertThat(cacheControl.isPrivate).isFalse
-    assertThat(cacheControl.isPublic).isFalse
-    assertThat(cacheControl.mustRevalidate).isFalse
+    assertThat(cacheControl.isPrivate).isFalse()
+    assertThat(cacheControl.isPublic).isFalse()
+    assertThat(cacheControl.mustRevalidate).isFalse()
   }
 
   @Test
@@ -65,16 +67,16 @@ class CacheControlJvmTest {
       Headers.Builder().set("Cache-Control", "").build()
     )
     assertThat(cacheControl.toString()).isEqualTo("")
-    assertThat(cacheControl.noCache).isFalse
-    assertThat(cacheControl.noStore).isFalse
+    assertThat(cacheControl.noCache).isFalse()
+    assertThat(cacheControl.noStore).isFalse()
     assertThat(cacheControl.maxAgeSeconds).isEqualTo(-1)
     assertThat(cacheControl.sMaxAgeSeconds).isEqualTo(-1)
-    assertThat(cacheControl.isPublic).isFalse
-    assertThat(cacheControl.mustRevalidate).isFalse
+    assertThat(cacheControl.isPublic).isFalse()
+    assertThat(cacheControl.mustRevalidate).isFalse()
     assertThat(cacheControl.maxStaleSeconds).isEqualTo(-1)
     assertThat(cacheControl.minFreshSeconds).isEqualTo(-1)
-    assertThat(cacheControl.onlyIfCached).isFalse
-    assertThat(cacheControl.mustRevalidate).isFalse
+    assertThat(cacheControl.onlyIfCached).isFalse()
+    assertThat(cacheControl.mustRevalidate).isFalse()
   }
 
   @Test
@@ -87,17 +89,17 @@ class CacheControlJvmTest {
         .set("Cache-Control", header)
         .build()
     )
-    assertThat(cacheControl.noCache).isTrue
-    assertThat(cacheControl.noStore).isTrue
+    assertThat(cacheControl.noCache).isTrue()
+    assertThat(cacheControl.noStore).isTrue()
     assertThat(cacheControl.maxAgeSeconds).isEqualTo(1)
     assertThat(cacheControl.sMaxAgeSeconds).isEqualTo(2)
-    assertThat(cacheControl.isPrivate).isTrue
-    assertThat(cacheControl.isPublic).isTrue
-    assertThat(cacheControl.mustRevalidate).isTrue
+    assertThat(cacheControl.isPrivate).isTrue()
+    assertThat(cacheControl.isPublic).isTrue()
+    assertThat(cacheControl.mustRevalidate).isTrue()
     assertThat(cacheControl.maxStaleSeconds).isEqualTo(3)
     assertThat(cacheControl.minFreshSeconds).isEqualTo(4)
-    assertThat(cacheControl.onlyIfCached).isTrue
-    assertThat(cacheControl.noTransform).isTrue
+    assertThat(cacheControl.onlyIfCached).isTrue()
+    assertThat(cacheControl.noTransform).isTrue()
     assertThat(cacheControl.toString()).isEqualTo(header)
   }
 
@@ -111,18 +113,18 @@ class CacheControlJvmTest {
         .set("Cache-Control", header)
         .build()
     )
-    assertThat(cacheControl.noCache).isFalse
-    assertThat(cacheControl.noStore).isFalse
+    assertThat(cacheControl.noCache).isFalse()
+    assertThat(cacheControl.noStore).isFalse()
     assertThat(cacheControl.maxAgeSeconds).isEqualTo(-1)
     assertThat(cacheControl.sMaxAgeSeconds).isEqualTo(-1)
-    assertThat(cacheControl.isPrivate).isTrue
-    assertThat(cacheControl.isPublic).isFalse
-    assertThat(cacheControl.mustRevalidate).isFalse
+    assertThat(cacheControl.isPrivate).isTrue()
+    assertThat(cacheControl.isPublic).isFalse()
+    assertThat(cacheControl.mustRevalidate).isFalse()
     assertThat(cacheControl.maxStaleSeconds).isEqualTo(-1)
     assertThat(cacheControl.minFreshSeconds).isEqualTo(-1)
-    assertThat(cacheControl.onlyIfCached).isFalse
-    assertThat(cacheControl.noTransform).isFalse
-    assertThat(cacheControl.immutable).isFalse
+    assertThat(cacheControl.onlyIfCached).isFalse()
+    assertThat(cacheControl.noTransform).isFalse()
+    assertThat(cacheControl.immutable).isFalse()
     assertThat(cacheControl.toString()).isEqualTo(header)
   }
 

--- a/okhttp/src/test/java/okhttp3/CacheCorruptionTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheCorruptionTest.kt
@@ -15,6 +15,9 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.startsWith
 import java.net.CookieManager
 import java.net.ResponseCache
 import java.text.DateFormat
@@ -34,7 +37,6 @@ import okhttp3.okio.LoggingFilesystem
 import okhttp3.testing.PlatformRule
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -94,7 +96,7 @@ class CacheCorruptionTest {
     assertThat(cache.networkCount()).isEqualTo(1)
     assertThat(cache.hitCount()).isEqualTo(1)
 
-    assertThat(response.handshake?.cipherSuite?.javaName).startsWith("SLT_")
+    assertThat(response.handshake!!.cipherSuite.javaName).startsWith("SLT_")
   }
 
   @Test

--- a/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
@@ -94,7 +94,7 @@ class CallHandshakeTest {
 
     val handshake = makeRequest(client)
 
-    assertThat(handshake.cipherSuite).isIn(expectedModernTls12CipherSuites)
+    assertThat(handshake.cipherSuite).isIn(*expectedModernTls12CipherSuites.toTypedArray())
 
     // Probably something like
     // TLS_AES_128_GCM_SHA256
@@ -104,7 +104,7 @@ class CallHandshakeTest {
     // TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
     // TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     assertThat(handshakeEnabledCipherSuites).containsExactly(
-      expectedConnectionCipherSuites(client))
+      *expectedConnectionCipherSuites(client).toTypedArray())
   }
 
   @Test
@@ -117,7 +117,7 @@ class CallHandshakeTest {
 
     val handshake = makeRequest(client)
 
-    assertThat(handshake.cipherSuite).isIn(expectedModernTls12CipherSuites)
+    assertThat(handshake.cipherSuite).isIn(*expectedModernTls12CipherSuites.toTypedArray())
 
     // Probably something like
     // TLS_AES_128_GCM_SHA256
@@ -146,7 +146,7 @@ class CallHandshakeTest {
 
     val handshake = makeRequest(client)
 
-    assertThat(handshake.cipherSuite).isIn(expectedModernTls13CipherSuites)
+    assertThat(handshake.cipherSuite).isIn(*expectedModernTls13CipherSuites.toTypedArray())
 
     // TODO: filter down to TLSv1.3 when only activated.
     // Probably something like

--- a/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallHandshakeTest.kt
@@ -15,6 +15,9 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isIn
 import javax.net.ssl.SSLSocket
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
@@ -31,7 +34,6 @@ import okhttp3.CipherSuite.Companion.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 import okhttp3.internal.effectiveCipherSuites
 import okhttp3.internal.platform.Platform
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -101,7 +103,7 @@ class CallHandshakeTest {
     // TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
     // TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
     // TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-    assertThat(handshakeEnabledCipherSuites).containsExactlyElementsOf(
+    assertThat(handshakeEnabledCipherSuites).containsExactly(
       expectedConnectionCipherSuites(client))
   }
 
@@ -130,8 +132,9 @@ class CallHandshakeTest {
     // TLS_RSA_WITH_AES_256_CBC_SHA
     // TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
     // TLS_RSA_WITH_AES_128_CBC_SHA
-    assertThat(handshakeEnabledCipherSuites).containsExactlyElementsOf(
-      expectedConnectionCipherSuites(client))
+    assertThat(handshakeEnabledCipherSuites).containsExactly(
+      *expectedConnectionCipherSuites(client).toTypedArray()
+    )
   }
 
   @Test
@@ -159,8 +162,9 @@ class CallHandshakeTest {
     // TLS_RSA_WITH_AES_256_CBC_SHA
     // TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
     // TLS_RSA_WITH_AES_128_CBC_SHA
-    assertThat(handshakeEnabledCipherSuites).containsExactlyElementsOf(
-      expectedConnectionCipherSuites(client))
+    assertThat(handshakeEnabledCipherSuites).containsExactly(
+      *expectedConnectionCipherSuites(client).toTypedArray()
+    )
   }
 
   @Test
@@ -178,8 +182,9 @@ class CallHandshakeTest {
     val expectedConnectionCipherSuites = expectedConnectionCipherSuites(client)
     // Will choose a poor cipher suite but not plaintext.
 //    assertThat(handshake.cipherSuite).isEqualTo("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
-    assertThat(handshakeEnabledCipherSuites).containsExactlyElementsOf(
-      expectedConnectionCipherSuites)
+    assertThat(handshakeEnabledCipherSuites).containsExactly(
+      *expectedConnectionCipherSuites.toTypedArray()
+    )
   }
 
   @Test
@@ -197,12 +202,14 @@ class CallHandshakeTest {
     val socketOrderedByDefaults =
       handshakeEnabledCipherSuites.sortedBy { ConnectionSpec.MODERN_TLS.cipherSuitesAsString!!.indexOf(it) }
 
-    assertThat(handshakeEnabledCipherSuites).containsExactlyElementsOf(socketOrderedByDefaults)
+    assertThat(handshakeEnabledCipherSuites).containsExactly(
+      *socketOrderedByDefaults.toTypedArray()
+    )
   }
 
   @Test
   fun advertisedOrderInRestricted() {
-    assertThat(ConnectionSpec.RESTRICTED_TLS.cipherSuites).containsExactly(
+    assertThat(ConnectionSpec.RESTRICTED_TLS.cipherSuites!!).containsExactly(
       TLS_AES_128_GCM_SHA256,
       TLS_AES_256_GCM_SHA384,
       TLS_CHACHA20_POLY1305_SHA256,
@@ -229,26 +236,26 @@ class CallHandshakeTest {
       ConnectionSpec.RESTRICTED_TLS.effectiveCipherSuites(platformDefaultCipherSuites)
 
     if (cipherSuites.contains(TLS_CHACHA20_POLY1305_SHA256.javaName)) {
-      assertThat(cipherSuites).containsExactlyElementsOf(listOf(
-        TLS_AES_128_GCM_SHA256,
-        TLS_AES_256_GCM_SHA384,
-        TLS_CHACHA20_POLY1305_SHA256,
-        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-        TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-      ).map { it.javaName })
+      assertThat(cipherSuites).containsExactly(
+        TLS_AES_128_GCM_SHA256.javaName,
+        TLS_AES_256_GCM_SHA384.javaName,
+        TLS_CHACHA20_POLY1305_SHA256.javaName,
+        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256.javaName,
+        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.javaName,
+        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.javaName,
+        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384.javaName,
+        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256.javaName,
+        TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256.javaName,
+      )
     } else {
-      assertThat(cipherSuites).containsExactlyElementsOf(listOf(
-        TLS_AES_128_GCM_SHA256,
-        TLS_AES_256_GCM_SHA384,
-        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-      ).map { it.javaName })
+      assertThat(cipherSuites).containsExactly(
+        TLS_AES_128_GCM_SHA256.javaName,
+        TLS_AES_256_GCM_SHA384.javaName,
+        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.javaName,
+        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256.javaName,
+        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384.javaName,
+        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.javaName,
+      )
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallKotlinTest.kt
@@ -15,6 +15,10 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotSameAs
 import java.io.IOException
 import java.net.Proxy
 import java.security.cert.X509Certificate
@@ -34,7 +38,6 @@ import okhttp3.internal.http.RecordingProxySelector
 import okhttp3.testing.Flaky
 import okhttp3.testing.PlatformRule
 import okio.BufferedSink
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/okhttp/src/test/java/okhttp3/CallTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallTest.kt
@@ -15,6 +15,22 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.doesNotContain
+import assertk.assertions.hasMessage
+import assertk.assertions.isCloseTo
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import assertk.assertions.isNotSameAs
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.startsWith
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InterruptedIOException
@@ -91,8 +107,6 @@ import okio.GzipSink
 import okio.Path.Companion.toPath
 import okio.buffer
 import okio.fakefilesystem.FakeFileSystem
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.data.Offset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.fail
@@ -512,7 +526,7 @@ open class CallTest {
       .build()
     executeSynchronously("/")
       .assertCode(401)
-    assertThat(authenticator.onlyRoute()).isNotNull
+    assertThat(authenticator.onlyRoute()).isNotNull()
   }
 
   @Test
@@ -997,7 +1011,7 @@ open class CallTest {
           chain.proceed(chain.request())
           fail<Unit>()
         } catch (expected: IllegalStateException) {
-          assertThat(expected).hasMessageContaining("please call response.close()")
+          assertThat(expected.message!!).contains("please call response.close()")
         }
         response
       })
@@ -1069,7 +1083,7 @@ open class CallTest {
       override fun contentType(): MediaType = "text/plain".toMediaType()
 
       override fun writeTo(sink: BufferedSink) {
-        assertThat(sink.timeout().hasDeadline()).isFalse
+        assertThat(sink.timeout().hasDeadline()).isFalse()
         sink.writeUtf8("def")
       }
     }
@@ -1102,7 +1116,7 @@ open class CallTest {
     val response2 = client.newCall(request2).execute()
     val body2 = response2.body.source()
     assertThat(body2.readUtf8()).isEqualTo("def")
-    assertThat(body2.timeout().hasDeadline()).isFalse
+    assertThat(body2.timeout().hasDeadline()).isFalse()
 
     // Use sequence numbers to confirm the connection was pooled.
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
@@ -1161,7 +1175,7 @@ open class CallTest {
       .dns(DoubleInetAddressDns())
       .eventListenerFactory(clientTestRule.wrap(listener))
       .build()
-    assertThat(client.retryOnConnectionFailure).isTrue
+    assertThat(client.retryOnConnectionFailure).isTrue()
     executeSynchronously("/").assertBody("seed connection pool")
     executeSynchronously("/").assertBody("retry success")
 
@@ -1496,7 +1510,7 @@ open class CallTest {
       client.newCall(request).execute()
       fail<Unit>()
     } catch (expected: SSLPeerUnverifiedException) {
-      assertThat(expected.message).startsWith("Certificate pinning failure!")
+      assertThat(expected.message!!).startsWith("Certificate pinning failure!")
     }
   }
 
@@ -1542,7 +1556,7 @@ open class CallTest {
       client.newCall(request2).execute()
       fail()
     } catch (e: IOException) {
-      assertThat(e).hasMessageStartingWith("unexpected end of stream on http://")
+      assertThat(e.message!!).startsWith("unexpected end of stream on http://")
       // expected
     }
 
@@ -2493,7 +2507,7 @@ open class CallTest {
     }
     val elapsedNanos = System.nanoTime() - startNanos
     assertThat(TimeUnit.NANOSECONDS.toMillis(elapsedNanos).toFloat())
-      .isCloseTo(cancelDelayMillis.toFloat(), Offset.offset(100f))
+      .isCloseTo(cancelDelayMillis.toFloat(), 100f)
   }
 
   @Test
@@ -2707,7 +2721,7 @@ open class CallTest {
     })
     latch.await()
     assertThat(bodyRef.get()).isEqualTo("A")
-    assertThat(failureRef.get()).isFalse
+    assertThat(failureRef.get()).isFalse()
   }
 
   @Test
@@ -2855,7 +2869,7 @@ open class CallTest {
     server.enqueue(MockResponse())
     executeSynchronously("/")
     val recordedRequest = server.takeRequest()
-    assertThat(recordedRequest.headers["User-Agent"]).matches(userAgent)
+    assertThat(recordedRequest.headers["User-Agent"]!!).isEqualTo(userAgent)
   }
 
   @Test
@@ -3181,7 +3195,7 @@ open class CallTest {
     )
     call.execute().use { response ->
       assertThat(response.code).isEqualTo(200)
-      assertThat(response.body.string()).isNotBlank
+      assertThat(response.body.string()).isNotEmpty()
     }
     if (!platform.isJdk8()) {
       val connectCount = listener.eventSequence.stream()
@@ -3684,7 +3698,7 @@ open class CallTest {
     upload(true, 1048576, 256)
     val recordedRequest = server.takeRequest()
     assertThat(recordedRequest.bodySize).isEqualTo(1048576)
-    assertThat(recordedRequest.chunkSizes).isNotEmpty
+    assertThat(recordedRequest.chunkSizes).isNotEmpty()
   }
 
   @Test
@@ -3692,7 +3706,7 @@ open class CallTest {
     upload(true, 1048576, 65536)
     val recordedRequest = server.takeRequest()
     assertThat(recordedRequest.bodySize).isEqualTo(1048576)
-    assertThat(recordedRequest.chunkSizes).isNotEmpty
+    assertThat(recordedRequest.chunkSizes).isNotEmpty()
   }
 
   @Test
@@ -4086,10 +4100,8 @@ open class CallTest {
     assertThat(response.header("h2")).isEqualTo("v2")
     assertThat(source.readUtf8(5)).isEqualTo("Hello")
     assertThat(source.readUtf8(7)).isEqualTo("Bonjour")
-    assertThat(source.exhausted()).isTrue
-    assertThat<Pair<String?, String?>?>(
-      response.trailers()
-    ).isEqualTo(headersOf("trailers", "boom"))
+    assertThat(source.exhausted()).isTrue()
+    assertThat(response.trailers()).isEqualTo(headersOf("trailers", "boom"))
   }
 
   @Test
@@ -4110,7 +4122,7 @@ open class CallTest {
       assertThat(response.header("h2")).isEqualTo("v2")
       assertThat(source.readUtf8(5)).isEqualTo("Hello")
       assertThat(source.readUtf8(7)).isEqualTo("Bonjour")
-      assertThat(source.exhausted()).isTrue
+      assertThat(source.exhausted()).isTrue()
       assertThat(response.trailers()).isEqualTo(headersOf("trailers", "boom"))
     }
   }
@@ -4147,7 +4159,7 @@ open class CallTest {
       },
     )
     executeSynchronously(request).assertFailure("boom")
-    assertThat(server.takeRequest().failure).isNotNull
+    assertThat(server.takeRequest().failure).isNotNull()
   }
 
   @Test
@@ -4205,7 +4217,7 @@ open class CallTest {
       })
       .build()
     executeSynchronously("/").assertFailure("Canceled")
-    assertThat(closed.get()).isTrue
+    assertThat(closed.get()).isTrue()
   }
 
   @Test
@@ -4234,7 +4246,7 @@ open class CallTest {
       response.priorResponse?.body?.string()
       fail<Unit>()
     } catch (expected: IllegalStateException) {
-      assertThat(expected.message).contains("Unreadable ResponseBody!")
+      assertThat(expected.message!!).contains("Unreadable ResponseBody!")
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/CallTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallTest.kt
@@ -4081,7 +4081,7 @@ open class CallTest {
       .build()
     executeSynchronously(request)
       .assertFailure(FileNotFoundException::class.java)
-    assertThat(called.get()).isEqualTo(1L)
+    assertThat(called.get()).isEqualTo(1)
   }
 
   @Test

--- a/okhttp/src/test/java/okhttp3/CertificatePinnerKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/CertificatePinnerKotlinTest.kt
@@ -15,11 +15,14 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
 import okhttp3.CertificatePinner.Companion.sha1Hash
 import okhttp3.CertificatePinner.Pin
 import okhttp3.tls.HeldCertificate
 import okio.ByteString.Companion.decodeBase64
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/okhttp/src/test/java/okhttp3/ConnectionListenerTest.kt
+++ b/okhttp/src/test/java/okhttp3/ConnectionListenerTest.kt
@@ -15,6 +15,11 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isIn
 import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.UnknownHostException
@@ -30,7 +35,6 @@ import okhttp3.internal.connection.RealConnectionPool.Companion.get
 import okhttp3.testing.Flaky
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.internal.TlsUtil.localhost
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test

--- a/okhttp/src/test/java/okhttp3/ConnectionReuseTest.kt
+++ b/okhttp/src/test/java/okhttp3/ConnectionReuseTest.kt
@@ -15,6 +15,8 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLException
 import mockwebserver3.MockResponse
@@ -28,7 +30,6 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.internal.closeQuietly
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.HandshakeCertificates
-import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.tls.TlsFatalAlert
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach

--- a/okhttp/src/test/java/okhttp3/ConscryptTest.kt
+++ b/okhttp/src/test/java/okhttp3/ConscryptTest.kt
@@ -15,11 +15,14 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
 import okhttp3.TestUtil.assumeNetwork
 import okhttp3.internal.platform.ConscryptPlatform
 import okhttp3.internal.platform.Platform
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.conscrypt.Conscrypt
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -75,7 +78,7 @@ class ConscryptTest {
   @Test
   fun testBuildIfSupported() {
     val actual = ConscryptPlatform.buildIfSupported()
-    assertThat(actual).isNotNull
+    assertThat(actual).isNotNull()
   }
 
   @Test

--- a/okhttp/src/test/java/okhttp3/CookieTest.kt
+++ b/okhttp/src/test/java/okhttp3/CookieTest.kt
@@ -15,6 +15,13 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Arrays
@@ -25,7 +32,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.internal.UTC
 import okhttp3.internal.http.MAX_DATE
 import okhttp3.internal.parseCookie
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -130,14 +136,14 @@ class CookieTest {
     val cookie = parse(url, "SID=31d4d96e407aad42; Path=/; Domain=example.com")
     assertThat(cookie!!.domain).isEqualTo("example.com")
     assertThat(cookie.path).isEqualTo("/")
-    assertThat(cookie.hostOnly).isFalse
+    assertThat(cookie.hostOnly).isFalse()
     assertThat(cookie.toString()).isEqualTo("SID=31d4d96e407aad42; domain=example.com; path=/")
   }
 
   @Test fun secureAndHttpOnly() {
     val cookie = parse(url, "SID=31d4d96e407aad42; Path=/; Secure; HttpOnly")
-    assertThat(cookie!!.secure).isTrue
-    assertThat(cookie.httpOnly).isTrue
+    assertThat(cookie!!.secure).isTrue()
+    assertThat(cookie.httpOnly).isTrue()
     assertThat(cookie.toString()).isEqualTo("SID=31d4d96e407aad42; path=/; secure; httponly")
   }
 
@@ -215,49 +221,49 @@ class CookieTest {
 
   @Test fun domainMatches() {
     val cookie = parse(url, "a=b; domain=example.com")
-    assertThat(cookie!!.matches("http://example.com".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://www.example.com".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://square.com".toHttpUrl())).isFalse
+    assertThat(cookie!!.matches("http://example.com".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://www.example.com".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://square.com".toHttpUrl())).isFalse()
   }
 
   /** If no domain is present, match only the origin domain.  */
   @Test fun domainMatchesNoDomain() {
     val cookie = parse(url, "a=b")
-    assertThat(cookie!!.matches("http://example.com".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://www.example.com".toHttpUrl())).isFalse
-    assertThat(cookie.matches("http://square.com".toHttpUrl())).isFalse
+    assertThat(cookie!!.matches("http://example.com".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://www.example.com".toHttpUrl())).isFalse()
+    assertThat(cookie.matches("http://square.com".toHttpUrl())).isFalse()
   }
 
   /** Ignore an optional leading `.` in the domain.  */
   @Test fun domainMatchesIgnoresLeadingDot() {
     val cookie = parse(url, "a=b; domain=.example.com")
-    assertThat(cookie!!.matches("http://example.com".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://www.example.com".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://square.com".toHttpUrl())).isFalse
+    assertThat(cookie!!.matches("http://example.com".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://www.example.com".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://square.com".toHttpUrl())).isFalse()
   }
 
   /** Ignore the entire attribute if the domain ends with `.`.  */
   @Test fun domainIgnoredWithTrailingDot() {
     val cookie = parse(url, "a=b; domain=example.com.")
-    assertThat(cookie!!.matches("http://example.com".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://www.example.com".toHttpUrl())).isFalse
-    assertThat(cookie.matches("http://square.com".toHttpUrl())).isFalse
+    assertThat(cookie!!.matches("http://example.com".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://www.example.com".toHttpUrl())).isFalse()
+    assertThat(cookie.matches("http://square.com".toHttpUrl())).isFalse()
   }
 
   @Test fun idnDomainMatches() {
     val cookie = parse("http://☃.net/".toHttpUrl(), "a=b; domain=☃.net")
-    assertThat(cookie!!.matches("http://☃.net/".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://xn--n3h.net/".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://www.☃.net/".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://www.xn--n3h.net/".toHttpUrl())).isTrue
+    assertThat(cookie!!.matches("http://☃.net/".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://xn--n3h.net/".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://www.☃.net/".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://www.xn--n3h.net/".toHttpUrl())).isTrue()
   }
 
   @Test fun punycodeDomainMatches() {
     val cookie = parse("http://xn--n3h.net/".toHttpUrl(), "a=b; domain=xn--n3h.net")
-    assertThat(cookie!!.matches("http://☃.net/".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://xn--n3h.net/".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://www.☃.net/".toHttpUrl())).isTrue
-    assertThat(cookie.matches("http://www.xn--n3h.net/".toHttpUrl())).isTrue
+    assertThat(cookie!!.matches("http://☃.net/".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://xn--n3h.net/".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://www.☃.net/".toHttpUrl())).isTrue()
+    assertThat(cookie.matches("http://www.xn--n3h.net/".toHttpUrl())).isTrue()
   }
 
   @Test fun domainMatchesIpAddress() {
@@ -269,13 +275,13 @@ class CookieTest {
   @Test fun domainMatchesIpv6Address() {
     val cookie = parse("http://[::1]/".toHttpUrl(), "a=b; domain=::1")
     assertThat(cookie!!.domain).isEqualTo("::1")
-    assertThat(cookie.matches("http://[::1]/".toHttpUrl())).isTrue
+    assertThat(cookie.matches("http://[::1]/".toHttpUrl())).isTrue()
   }
 
   @Test fun domainMatchesIpv6AddressWithCompression() {
     val cookie = parse("http://[0001:0000::]/".toHttpUrl(), "a=b; domain=0001:0000::")
     assertThat(cookie!!.domain).isEqualTo("1::")
-    assertThat(cookie.matches("http://[1::]/".toHttpUrl())).isTrue
+    assertThat(cookie.matches("http://[1::]/".toHttpUrl())).isTrue()
   }
 
   @Test fun domainMatchesIpv6AddressWithIpv4Suffix() {
@@ -283,7 +289,7 @@ class CookieTest {
       "http://[::1:ffff:ffff]/".toHttpUrl(), "a=b; domain=::1:255.255.255.255"
     )
     assertThat(cookie!!.domain).isEqualTo("::1:ffff:ffff")
-    assertThat(cookie.matches("http://[::1:ffff:ffff]/".toHttpUrl())).isTrue
+    assertThat(cookie.matches("http://[::1:ffff:ffff]/".toHttpUrl())).isTrue()
   }
 
   @Test fun ipv6AddressDoesntMatch() {
@@ -303,22 +309,22 @@ class CookieTest {
    */
   @Test fun domainIsPublicSuffix() {
     val ascii = "https://foo1.foo.bar.elb.amazonaws.com".toHttpUrl()
-    assertThat(parse(ascii, "a=b; domain=foo.bar.elb.amazonaws.com")).isNotNull
+    assertThat(parse(ascii, "a=b; domain=foo.bar.elb.amazonaws.com")).isNotNull()
     assertThat(parse(ascii, "a=b; domain=bar.elb.amazonaws.com")).isNull()
     assertThat(parse(ascii, "a=b; domain=com")).isNull()
     val unicode = "https://長.長.長崎.jp".toHttpUrl()
-    assertThat(parse(unicode, "a=b; domain=長.長崎.jp")).isNotNull
+    assertThat(parse(unicode, "a=b; domain=長.長崎.jp")).isNotNull()
     assertThat(parse(unicode, "a=b; domain=長崎.jp")).isNull()
     val punycode = "https://xn--ue5a.xn--ue5a.xn--8ltr62k.jp".toHttpUrl()
-    assertThat(parse(punycode, "a=b; domain=xn--ue5a.xn--8ltr62k.jp")).isNotNull
+    assertThat(parse(punycode, "a=b; domain=xn--ue5a.xn--8ltr62k.jp")).isNotNull()
     assertThat(parse(punycode, "a=b; domain=xn--8ltr62k.jp")).isNull()
   }
 
   @Test fun hostOnly() {
-    assertThat(parse(url, "a=b")!!.hostOnly).isTrue
+    assertThat(parse(url, "a=b")!!.hostOnly).isTrue()
     assertThat(
       parse(url, "a=b; domain=example.com")!!.hostOnly
-    ).isFalse
+    ).isFalse()
   }
 
   @Test fun defaultPath() {
@@ -343,13 +349,13 @@ class CookieTest {
   }
 
   @Test fun httpOnly() {
-    assertThat(parse(url, "a=b")!!.httpOnly).isFalse
-    assertThat(parse(url, "a=b; HttpOnly")!!.httpOnly).isTrue
+    assertThat(parse(url, "a=b")!!.httpOnly).isFalse()
+    assertThat(parse(url, "a=b; HttpOnly")!!.httpOnly).isTrue()
   }
 
   @Test fun secure() {
-    assertThat(parse(url, "a=b")!!.secure).isFalse
-    assertThat(parse(url, "a=b; Secure")!!.secure).isTrue
+    assertThat(parse(url, "a=b")!!.secure).isFalse()
+    assertThat(parse(url, "a=b; Secure")!!.secure).isTrue()
   }
 
   @Test fun maxAgeTakesPrecedenceOverExpires() {
@@ -385,10 +391,10 @@ class CookieTest {
   }
 
   @Test fun maxAgeOrExpiresMakesCookiePersistent() {
-    assertThat(parseCookie(0L, url, "a=b")!!.persistent).isFalse
-    assertThat(parseCookie(0L, url, "a=b; Max-Age=1")!!.persistent).isTrue
+    assertThat(parseCookie(0L, url, "a=b")!!.persistent).isFalse()
+    assertThat(parseCookie(0L, url, "a=b; Max-Age=1")!!.persistent).isTrue()
     assertThat(parseCookie(0L, url, "a=b; Expires=Thu, 01 Jan 1970 00:00:01 GMT")!!.persistent)
-      .isTrue
+      .isTrue()
   }
 
   @Test fun parseAll() {
@@ -413,10 +419,10 @@ class CookieTest {
     assertThat(cookie.expiresAt).isEqualTo(MAX_DATE)
     assertThat(cookie.domain).isEqualTo("example.com")
     assertThat(cookie.path).isEqualTo("/")
-    assertThat(cookie.secure).isFalse
-    assertThat(cookie.httpOnly).isFalse
-    assertThat(cookie.persistent).isFalse
-    assertThat(cookie.hostOnly).isFalse
+    assertThat(cookie.secure).isFalse()
+    assertThat(cookie.httpOnly).isFalse()
+    assertThat(cookie.persistent).isFalse()
+    assertThat(cookie.hostOnly).isFalse()
     assertThat(cookie.sameSite).isNull()
   }
 
@@ -432,11 +438,11 @@ class CookieTest {
     assertThat(cookie.expiresAt).isEqualTo(MAX_DATE)
     assertThat(cookie.domain).isEqualTo("example.com")
     assertThat(cookie.path).isEqualTo("/")
-    assertThat(cookie.secure).isFalse
-    assertThat(cookie.httpOnly).isFalse
+    assertThat(cookie.secure).isFalse()
+    assertThat(cookie.httpOnly).isFalse()
     // can't be unset
-    assertThat(cookie.persistent).isTrue
-    assertThat(cookie.hostOnly).isFalse
+    assertThat(cookie.persistent).isTrue()
+    assertThat(cookie.hostOnly).isFalse()
   }
 
   @Test fun builderNameValidation() {
@@ -500,7 +506,7 @@ class CookieTest {
       .hostOnlyDomain("squareup.com")
       .build()
     assertThat(cookie.domain).isEqualTo("squareup.com")
-    assertThat(cookie.hostOnly).isTrue
+    assertThat(cookie.hostOnly).isTrue()
   }
 
   @Test fun builderPath() {
@@ -528,7 +534,7 @@ class CookieTest {
       .hostOnlyDomain("example.com")
       .secure()
       .build()
-    assertThat(cookie.secure).isTrue
+    assertThat(cookie.secure).isTrue()
   }
 
   @Test fun builderHttpOnly() {
@@ -538,7 +544,7 @@ class CookieTest {
       .hostOnlyDomain("example.com")
       .httpOnly()
       .build()
-    assertThat(cookie.httpOnly).isTrue
+    assertThat(cookie.httpOnly).isTrue()
   }
 
   @Test fun builderIpv6() {

--- a/okhttp/src/test/java/okhttp3/CorrettoTest.kt
+++ b/okhttp/src/test/java/okhttp3/CorrettoTest.kt
@@ -15,9 +15,11 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import okhttp3.TestUtil.assumeNetwork
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test

--- a/okhttp/src/test/java/okhttp3/FastFallbackTest.kt
+++ b/okhttp/src/test/java/okhttp3/FastFallbackTest.kt
@@ -15,6 +15,10 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
 import java.io.IOException
 import java.net.Inet4Address
 import java.net.Inet6Address
@@ -30,7 +34,6 @@ import mockwebserver3.MockWebServer
 import mockwebserver3.SocketPolicy.ResetStreamAtStart
 import okhttp3.internal.http2.ErrorCode
 import okhttp3.testing.Flaky
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/okhttp/src/test/java/okhttp3/HandshakeTest.kt
+++ b/okhttp/src/test/java/okhttp3/HandshakeTest.kt
@@ -15,11 +15,16 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.hasMessage
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import java.io.IOException
 import java.security.cert.Certificate
 import okhttp3.Handshake.Companion.handshake
 import okhttp3.tls.HeldCertificate
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 

--- a/okhttp/src/test/java/okhttp3/HeadersChallengesTest.kt
+++ b/okhttp/src/test/java/okhttp3/HeadersChallengesTest.kt
@@ -15,8 +15,11 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import okhttp3.internal.http.parseChallenges
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 

--- a/okhttp/src/test/java/okhttp3/HeadersJvmTest.kt
+++ b/okhttp/src/test/java/okhttp3/HeadersJvmTest.kt
@@ -15,12 +15,14 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
 import java.time.Instant
-import java.util.*
+import java.util.Date
 import kotlin.test.fail
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.internal.EMPTY_HEADERS
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class HeadersJvmTest {

--- a/okhttp/src/test/java/okhttp3/HeadersKotlinTest.kt
+++ b/okhttp/src/test/java/okhttp3/HeadersKotlinTest.kt
@@ -15,10 +15,13 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import java.time.Instant
 import java.util.Date
 import okhttp3.Headers.Companion.headersOf
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class HeadersKotlinTest {

--- a/okhttp/src/test/java/okhttp3/HeadersRequestTest.kt
+++ b/okhttp/src/test/java/okhttp3/HeadersRequestTest.kt
@@ -15,11 +15,12 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.TestUtil.headerEntries
 import okhttp3.internal.http2.Http2ExchangeCodec.Companion.http2HeadersList
 import okhttp3.internal.http2.Http2ExchangeCodec.Companion.readHttp2HeadersList
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class HeadersRequestTest {

--- a/okhttp/src/test/java/okhttp3/HttpUrlJvmTest.kt
+++ b/okhttp/src/test/java/okhttp3/HttpUrlJvmTest.kt
@@ -15,12 +15,14 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import java.net.URI
 import java.net.URL
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 @Suppress("HttpUrlsUsage") // Don't warn if we should be using https://.
@@ -147,7 +149,7 @@ open class HttpUrlJvmTest {
     // option to the native-image command.
     platform.assumeNotGraalVMImage()
     val javaNetUrl = URL("mailto:user@example.com")
-    assertThat<HttpUrl>(javaNetUrl.toHttpUrlOrNull()).isNull()
+    assertThat(javaNetUrl.toHttpUrlOrNull()).isNull()
   }
 
   @Test
@@ -161,13 +163,13 @@ open class HttpUrlJvmTest {
   @Test
   fun fromUriUnsupportedScheme() {
     val uri = URI("mailto:user@example.com")
-    assertThat<HttpUrl>(uri.toHttpUrlOrNull()).isNull()
+    assertThat(uri.toHttpUrlOrNull()).isNull()
   }
 
   @Test
   fun fromUriPartial() {
     val uri = URI("/path")
-    assertThat<HttpUrl>(uri.toHttpUrlOrNull()).isNull()
+    assertThat(uri.toHttpUrlOrNull()).isNull()
   }
 
   @Test

--- a/okhttp/src/test/java/okhttp3/InsecureForHostTest.kt
+++ b/okhttp/src/test/java/okhttp3/InsecureForHostTest.kt
@@ -15,13 +15,17 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import javax.net.ssl.SSLException
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension

--- a/okhttp/src/test/java/okhttp3/JSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/JSSETest.kt
@@ -15,6 +15,11 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import mockwebserver3.MockResponse
@@ -24,7 +29,6 @@ import okhttp3.internal.connection
 import okhttp3.testing.PlatformRule
 import okhttp3.testing.PlatformVersion
 import okio.ByteString.Companion.toByteString
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
@@ -141,7 +145,7 @@ class JSSETest {
 
     assertEquals(2, sessionIds.size)
     assertNotEquals(sessionIds[0], sessionIds[1])
-    assertThat(sessionIds[0]).isNotBlank()
+    assertThat(sessionIds[0]).isNotEmpty()
   }
 
   private fun enableTls() {

--- a/okhttp/src/test/java/okhttp3/LoomTest.kt
+++ b/okhttp/src/test/java/okhttp3/LoomTest.kt
@@ -15,12 +15,14 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension

--- a/okhttp/src/test/java/okhttp3/MultipartReaderTest.kt
+++ b/okhttp/src/test/java/okhttp3/MultipartReaderTest.kt
@@ -15,17 +15,21 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import java.io.EOFException
+import java.net.ProtocolException
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.Buffer
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import java.io.EOFException
-import java.net.ProtocolException
 
 @Tag("Slowish")
 class MultipartReaderTest {

--- a/okhttp/src/test/java/okhttp3/OkHttpClientTest.kt
+++ b/okhttp/src/test/java/okhttp3/OkHttpClientTest.kt
@@ -15,6 +15,14 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isSameAs
 import java.io.IOException
 import java.net.CookieManager
 import java.net.Proxy
@@ -31,7 +39,6 @@ import mockwebserver3.MockWebServer
 import okhttp3.internal.platform.Platform.Companion.get
 import okhttp3.internal.proxy.NullProxySelector
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotSame
@@ -132,10 +139,10 @@ class OkHttpClientTest {
 
     // Values should be non-null.
     val a = client.newBuilder().build()
-    assertThat(a.dispatcher).isNotNull
-    assertThat(a.connectionPool).isNotNull
-    assertThat(a.sslSocketFactory).isNotNull
-    assertThat(a.x509TrustManager).isNotNull
+    assertThat(a.dispatcher).isNotNull()
+    assertThat(a.connectionPool).isNotNull()
+    assertThat(a.sslSocketFactory).isNotNull()
+    assertThat(a.x509TrustManager).isNotNull()
 
     // Multiple clients share the instances.
     val b = client.newBuilder().build()

--- a/okhttp/src/test/java/okhttp3/OkHttpTest.kt
+++ b/okhttp/src/test/java/okhttp3/OkHttpTest.kt
@@ -15,12 +15,13 @@
  */
 package okhttp3
 
-import org.assertj.core.api.Assertions.assertThat
+import assertk.assertThat
+import assertk.assertions.matches
 import org.junit.jupiter.api.Test
 
 class OkHttpTest {
   @Test
   fun testVersion() {
-    assertThat(OkHttp.VERSION).matches("[0-9]+\\.[0-9]+\\.[0-9]+(-.+)?")
+    assertThat(OkHttp.VERSION).matches(Regex("[0-9]+\\.[0-9]+\\.[0-9]+(-.+)?"))
   }
 }

--- a/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
+++ b/okhttp/src/test/java/okhttp3/OpenJSSETest.kt
@@ -15,7 +15,10 @@
  */
 package okhttp3
 
-import java.net.InetAddress
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import okhttp3.TestUtil.assumeNetwork
@@ -25,7 +28,6 @@ import okhttp3.internal.platform.OpenJSSEPlatform
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
@@ -63,7 +65,8 @@ class OpenJSSETest {
       assertEquals(TlsVersion.TLS_1_3, response.handshake?.tlsVersion)
       assertEquals(Protocol.HTTP_2, response.protocol)
 
-      assertThat(response.exchangeAccessor?.connectionAccessor?.socket()).isInstanceOf(SSLSocketImpl::class.java)
+      assertThat(response.exchangeAccessor!!.connectionAccessor.socket())
+        .isInstanceOf<SSLSocketImpl>()
     }
   }
 
@@ -91,7 +94,7 @@ class OpenJSSETest {
   @Test
   fun testBuildIfSupported() {
     val actual = OpenJSSEPlatform.buildIfSupported()
-    assertThat(actual).isNotNull
+    assertThat(actual).isNotNull()
   }
 
   private fun enableTls() {

--- a/okhttp/src/test/java/okhttp3/RecordingExecutor.kt
+++ b/okhttp/src/test/java/okhttp3/RecordingExecutor.kt
@@ -15,12 +15,13 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
 import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import okhttp3.internal.connection.RealCall
 import okhttp3.internal.finishedAccessor
-import org.assertj.core.api.Assertions.assertThat
 
 internal class RecordingExecutor(
   private val dispatcherTest: DispatcherTest

--- a/okhttp/src/test/java/okhttp3/RequestBodyTest.kt
+++ b/okhttp/src/test/java/okhttp3/RequestBodyTest.kt
@@ -15,6 +15,9 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import java.io.FileDescriptor
 import java.io.FileInputStream
 import java.io.IOException
@@ -25,7 +28,6 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okio.Buffer
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/okhttp/src/test/java/okhttp3/RequestTest.kt
+++ b/okhttp/src/test/java/okhttp3/RequestTest.kt
@@ -15,6 +15,13 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.isSameAs
+import assertk.assertions.isTrue
 import java.io.File
 import java.io.FileWriter
 import java.net.URI
@@ -26,7 +33,6 @@ import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.jupiter.api.Test
 
@@ -107,9 +113,7 @@ class RequestTest {
     assertThat(body.contentType()).isEqualTo(contentType)
     assertThat(body.contentLength()).isEqualTo(3)
     assertThat(bodyToHex(body)).isEqualTo("616263")
-    assertThat(bodyToHex(body))
-      .overridingErrorMessage("Retransmit body")
-      .isEqualTo("616263")
+    assertThat(bodyToHex(body), "Retransmit body").isEqualTo("616263")
   }
 
   @Test
@@ -137,9 +141,7 @@ class RequestTest {
     assertThat(body.contentType()).isEqualTo(contentType)
     assertThat(body.contentLength()).isEqualTo(3)
     assertThat(bodyToHex(body)).isEqualTo("616263")
-    assertThat(bodyToHex(body))
-      .overridingErrorMessage("Retransmit body")
-      .isEqualTo("616263")
+    assertThat(bodyToHex(body), "Retransmit body").isEqualTo("616263")
   }
 
   @Test
@@ -149,9 +151,7 @@ class RequestTest {
     assertThat(body.contentType()).isEqualTo(contentType)
     assertThat(body.contentLength()).isEqualTo(3)
     assertThat(bodyToHex(body)).isEqualTo("616263")
-    assertThat(bodyToHex(body))
-      .overridingErrorMessage("Retransmit body")
-      .isEqualTo("616263")
+    assertThat(bodyToHex(body), "Retransmit body").isEqualTo("616263")
   }
 
   @Test
@@ -161,9 +161,7 @@ class RequestTest {
     assertThat(body.contentType()).isEqualTo(contentType)
     assertThat(body.contentLength()).isEqualTo(5)
     assertThat(bodyToHex(body)).isEqualTo("48656c6c6f")
-    assertThat(bodyToHex(body))
-      .overridingErrorMessage("Retransmit body")
-      .isEqualTo("48656c6c6f")
+    assertThat(bodyToHex(body), "Retransmit body").isEqualTo("48656c6c6f")
   }
 
   @Test
@@ -177,9 +175,7 @@ class RequestTest {
     assertThat(body.contentType()).isEqualTo(contentType)
     assertThat(body.contentLength()).isEqualTo(3)
     assertThat(bodyToHex(body)).isEqualTo("616263")
-    assertThat(bodyToHex(body))
-      .overridingErrorMessage("Retransmit body")
-      .isEqualTo("616263")
+    assertThat(bodyToHex(body), "Retransmit body").isEqualTo("616263")
   }
 
   /** Common verbs used for apis such as GitHub, AWS, and Google Cloud.  */
@@ -245,7 +241,7 @@ class RequestTest {
       .url("https://square.com")
       .build()
     assertThat(request.headers("Cache-Control")).containsExactly("no-cache")
-    assertThat(request.cacheControl.noCache).isTrue
+    assertThat(request.cacheControl.noCache).isTrue()
   }
 
   @Test
@@ -489,7 +485,7 @@ class RequestTest {
     assertThat(requestB.tag(String::class.java)).isSameAs("b")
     assertThat(requestC.tag(String::class.java)).isSameAs("c")
   }
-  
+
   @Test
   fun requestToStringRedactsSensitiveHeaders() {
     val headers = Headers.Builder()

--- a/okhttp/src/test/java/okhttp3/ResponseBodyJvmTest.kt
+++ b/okhttp/src/test/java/okhttp3/ResponseBodyJvmTest.kt
@@ -15,25 +15,24 @@
  */
 package okhttp3
 
+import assertk.assertThat
 import assertk.assertions.isEqualTo
-import okio.buffer
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.ResponseBody.Companion.toResponseBody
-import okio.Buffer
-import okio.BufferedSource
-import okio.ByteString
-import okio.ForwardingSource
-import org.junit.jupiter.api.Test
+import assertk.assertions.isTrue
 import java.io.IOException
 import java.io.InputStreamReader
 import java.io.Reader
-import java.lang.AssertionError
-import java.lang.StringBuilder
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicBoolean
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.internal.and
+import okio.Buffer
+import okio.BufferedSource
+import okio.ByteString
 import okio.ByteString.Companion.decodeHex
-import org.assertj.core.api.Assertions.assertThat
+import okio.ForwardingSource
+import okio.buffer
+import org.junit.jupiter.api.Test
 
 class ResponseBodyJvmTest {
   @Test
@@ -120,7 +119,7 @@ class ResponseBodyJvmTest {
       }
     }
     assertThat(body.string()).isEqualTo("hello")
-    assertThat(closed.get()).isTrue
+    assertThat(closed.get()).isTrue()
   }
 
   @Test
@@ -201,7 +200,7 @@ class ResponseBodyJvmTest {
       }
     }
     body.charStream().close()
-    assertThat(closed.get()).isTrue
+    assertThat(closed.get()).isTrue()
   }
 
   @Test
@@ -230,17 +229,17 @@ class ResponseBodyJvmTest {
     val reader = body.charStream()
     assertThat(reader.read()).isEqualTo('h'.code)
     reader.close()
-    assertThat(closed.get()).isTrue
+    assertThat(closed.get()).isTrue()
   }
 
   @Test
   fun sourceSeesBom() {
     val body = "efbbbf68656c6c6f".decodeHex().toResponseBody()
     val source = body.source()
-    assertk.assertThat(source.readByte() and 0xff).isEqualTo(0xef)
-    assertk.assertThat(source.readByte() and 0xff).isEqualTo(0xbb)
-    assertk.assertThat(source.readByte() and 0xff).isEqualTo(0xbf)
-    assertk.assertThat(source.readUtf8()).isEqualTo("hello")
+    assertThat(source.readByte() and 0xff).isEqualTo(0xef)
+    assertThat(source.readByte() and 0xff).isEqualTo(0xbb)
+    assertThat(source.readByte() and 0xff).isEqualTo(0xbf)
+    assertThat(source.readUtf8()).isEqualTo("hello")
   }
 
   @Test
@@ -283,7 +282,7 @@ class ResponseBodyJvmTest {
       }
     }
     assertThat(body.bytes().size).isEqualTo(5)
-    assertThat(closed.get()).isTrue
+    assertThat(closed.get()).isTrue()
   }
 
   @Test
@@ -374,7 +373,7 @@ class ResponseBodyJvmTest {
       }
     }
     assertThat(body.byteString().size).isEqualTo(5)
-    assertThat(closed.get()).isTrue
+    assertThat(closed.get()).isTrue()
   }
 
   @Test
@@ -468,14 +467,14 @@ class ResponseBodyJvmTest {
       }
     }
     body.byteStream().close()
-    assertThat(closed.get()).isTrue
+    assertThat(closed.get()).isTrue()
   }
 
   @Test
   fun unicodeTextWithUnsupportedEncoding() {
     val text = "eile oli oliiviõli"
     val body = text.toResponseBody("text/plain; charset=unknown".toMediaType())
-    assertk.assertThat(body.string()).isEqualTo(text)
+    assertThat(body.string()).isEqualTo(text)
   }
 
   companion object {

--- a/okhttp/src/test/java/okhttp3/RouteFailureTest.kt
+++ b/okhttp/src/test/java/okhttp3/RouteFailureTest.kt
@@ -15,6 +15,10 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
 import java.io.IOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
@@ -22,18 +26,15 @@ import java.net.Proxy
 import java.net.SocketTimeoutException
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
-import mockwebserver3.SocketPolicy
 import mockwebserver3.SocketPolicy.ResetStreamAtStart
 import mockwebserver3.junit5.internal.MockWebServerInstance
 import okhttp3.internal.http.RecordingProxySelector
 import okhttp3.internal.http2.ErrorCode
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ArgumentsSource
 import org.junit.jupiter.params.provider.ValueSource
 
 class RouteFailureTest {

--- a/okhttp/src/test/java/okhttp3/ServerTruncatesRequestTest.kt
+++ b/okhttp/src/test/java/okhttp3/ServerTruncatesRequestTest.kt
@@ -15,6 +15,10 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
 import javax.net.ssl.SSLSocket
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
@@ -25,7 +29,6 @@ import okhttp3.internal.http2.ErrorCode
 import okhttp3.testing.PlatformRule
 import okio.BufferedSink
 import okio.IOException
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
@@ -231,7 +234,7 @@ class ServerTruncatesRequestTest {
 
     call1.execute().use { response ->
       assertThat(response.body.string()).isEqualTo("Req1")
-      assertThat(response.handshake).isNotNull
+      assertThat(response.handshake).isNotNull()
       assertThat(response.protocol == Protocol.HTTP_1_1)
     }
 

--- a/okhttp/src/test/java/okhttp3/SessionReuseTest.kt
+++ b/okhttp/src/test/java/okhttp3/SessionReuseTest.kt
@@ -15,6 +15,10 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEmpty
+import assertk.assertions.isNotEmpty
 import javax.net.ssl.SSLSocket
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
@@ -22,7 +26,6 @@ import okhttp3.testing.Flaky
 import okhttp3.testing.PlatformRule
 import okhttp3.testing.PlatformVersion
 import okio.ByteString.Companion.toByteString
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -128,14 +131,14 @@ class SessionReuseTest {
 
     if (platform.isConscrypt()) {
       if (tlsVersion == TlsVersion.TLS_1_3) {
-        assertThat(sessionIds[0]).isBlank()
-        assertThat(sessionIds[1]).isBlank()
+        assertThat(sessionIds[0]).isEmpty()
+        assertThat(sessionIds[1]).isEmpty()
 
         // https://github.com/google/conscrypt/issues/985
         // assertThat(directSessionIds).containsExactlyInAnyOrder(sessionIds[0], sessionIds[1])
       } else {
-        assertThat(sessionIds[0]).isNotBlank()
-        assertThat(sessionIds[1]).isNotBlank()
+        assertThat(sessionIds[0]).isNotEmpty()
+        assertThat(sessionIds[1]).isNotEmpty()
 
         assertThat(directSessionIds).containsExactlyInAnyOrder(sessionIds[1])
       }
@@ -148,7 +151,7 @@ class SessionReuseTest {
         // assertEquals(sessionIds[0], sessionIds[1])
         // assertThat(directSessionIds).contains(sessionIds[0], sessionIds[1])
       }
-      assertThat(sessionIds[0]).isNotBlank()
+      assertThat(sessionIds[0]).isNotEmpty()
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/SocketChannelTest.kt
+++ b/okhttp/src/test/java/okhttp3/SocketChannelTest.kt
@@ -15,6 +15,10 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
 import java.io.IOException
 import java.net.InetAddress
 import java.util.concurrent.CompletableFuture
@@ -37,7 +41,6 @@ import okhttp3.TlsVersion.TLS_1_3
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
@@ -180,7 +183,7 @@ class SocketChannelTest {
 
     assertThat(response).isNotNull()
 
-    assertThat(response.body.string()).isNotBlank()
+    assertThat(response.body.string()).isNotEmpty()
 
     if (socketMode is TlsInstance) {
       assertThat(response.handshake!!.tlsVersion).isEqualTo(socketMode.tlsVersion)

--- a/okhttp/src/test/java/okhttp3/URLConnectionTest.kt
+++ b/okhttp/src/test/java/okhttp3/URLConnectionTest.kt
@@ -2870,7 +2870,7 @@ class URLConnectionTest {
     assertThat(
       server.takeRequest().sequenceNumber,
       "When connection: close is used, each request should get its own connection"
-    ).isEqualTo(0L)
+    ).isEqualTo(0)
   }
 
   @Test
@@ -2885,7 +2885,7 @@ class URLConnectionTest {
     assertThat(
       server.takeRequest().sequenceNumber,
       "When connection: close is used, each request should get its own connection",
-    ).isEqualTo(0L)
+    ).isEqualTo(0)
   }
 
   @Test
@@ -2908,7 +2908,7 @@ class URLConnectionTest {
     assertThat(
       server.takeRequest().sequenceNumber,
       "When connection: close is used, each request should get its own connection"
-    ).isEqualTo(0L)
+    ).isEqualTo(0)
   }
 
   /**
@@ -3802,7 +3802,7 @@ class URLConnectionTest {
       MockResponse(body = "b")
     )
     val response1 = getResponse(newRequest("/"))
-    assertThat(response1.code).isEqualTo(HttpURLConnection.HTTP_NOT_MODIFIED.toLong())
+    assertThat(response1.code).isEqualTo(HttpURLConnection.HTTP_NOT_MODIFIED)
     assertContent("", response1)
     val response2 = getResponse(newRequest("/"))
     assertThat(response2.code).isEqualTo(HttpURLConnection.HTTP_OK)

--- a/okhttp/src/test/java/okhttp3/URLConnectionTest.kt
+++ b/okhttp/src/test/java/okhttp3/URLConnectionTest.kt
@@ -15,6 +15,19 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isIn
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -82,7 +95,6 @@ import okio.BufferedSink
 import okio.GzipSink
 import okio.buffer
 import okio.utf8Size
-import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.tls.TlsFatalAlert
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.fail
@@ -399,7 +411,7 @@ class URLConnectionTest {
     assertThat(
       requestAfter.sequenceNumber == 0
         || server.requestCount == 3 && server.takeRequest().sequenceNumber == 0
-    ).isTrue
+    ).isTrue()
   }
 
   internal enum class WriteKind {
@@ -477,7 +489,7 @@ class URLConnectionTest {
     val request = server.takeRequest()
     assertThat(request.bodySize).isEqualTo(n.toLong())
     if (uploadKind === TransferKind.CHUNKED) {
-      assertThat(request.chunkSizes).isNotEmpty
+      assertThat(request.chunkSizes).isNotEmpty()
     } else {
       assertThat(request.chunkSizes).isEmpty()
     }
@@ -625,8 +637,7 @@ class URLConnectionTest {
       fail<Any>()
     } catch (expected: IOException) {
       expected.assertSuppressed { throwables: List<Throwable>? ->
-        assertThat(throwables).hasSize(1)
-        Unit
+        assertThat(throwables!!.size).isEqualTo(1)
       }
     }
   }
@@ -685,9 +696,7 @@ class URLConnectionTest {
     } catch (expected: SSLHandshakeException) {
       // Allow conscrypt to fail in different ways
       if (!platform.isConscrypt()) {
-        assertThat(expected.cause).isInstanceOf(
-          CertificateException::class.java
-        )
+        assertThat(expected.cause!!).isInstanceOf<CertificateException>()
       }
     } catch (expected: TlsFatalAlert) {
     }
@@ -912,9 +921,8 @@ class URLConnectionTest {
     val call = proxyConfig.connect(server, client, url)
     assertContent("this response comes via a secure proxy", call.execute())
     val connect = server.takeRequest()
-    assertThat(connect.requestLine).overridingErrorMessage(
-      "Connect line failure on proxy"
-    ).isEqualTo("CONNECT android.com:443 HTTP/1.1")
+    assertThat(connect.requestLine, "Connect line failure on proxy")
+      .isEqualTo("CONNECT android.com:443 HTTP/1.1")
     assertThat(connect.headers["Host"]).isEqualTo("android.com:443")
     val get = server.takeRequest()
     assertThat(get.requestLine).isEqualTo("GET /foo HTTP/1.1")
@@ -1207,9 +1215,8 @@ class URLConnectionTest {
     server.enqueue(builder.build())
     server.enqueue(builder.build())
     val inputStream = getResponse(newRequest("/")).body.byteStream()
-    assertThat(inputStream.markSupported())
-      .overridingErrorMessage("This implementation claims to support mark().")
-      .isFalse
+    assertThat(inputStream.markSupported(), "This implementation claims to support mark().")
+      .isFalse()
     inputStream.mark(5)
     assertThat(readAscii(inputStream, 5)).isEqualTo("ABCDE")
     try {
@@ -2134,8 +2141,7 @@ class URLConnectionTest {
     val retry = server.takeRequest()
     assertThat(retry.requestLine).isEqualTo("GET /foo HTTP/1.1")
     if (reuse) {
-      assertThat(retry.sequenceNumber)
-        .overridingErrorMessage("Expected connection reuse")
+      assertThat(retry.sequenceNumber, "Expected connection reuse")
         .isEqualTo(1)
     }
   }
@@ -2167,8 +2173,7 @@ class URLConnectionTest {
     assertThat(first.requestLine).isEqualTo("GET / HTTP/1.1")
     val retry = server.takeRequest()
     assertThat(retry.requestLine).isEqualTo("GET /foo HTTP/1.1")
-    assertThat(retry.sequenceNumber)
-      .overridingErrorMessage("Expected connection reuse")
+    assertThat(retry.sequenceNumber, "Expected connection reuse")
       .isEqualTo(1)
   }
 
@@ -2311,11 +2316,9 @@ class URLConnectionTest {
     val server2Host = server2.hostName + ":" + server2.port
     assertThat(server.takeRequest().headers["Host"]).isEqualTo(server1Host)
     assertThat(server2.takeRequest().headers["Host"]).isEqualTo(server2Host)
-    assertThat(server.takeRequest().sequenceNumber)
-      .overridingErrorMessage("Expected connection reuse")
+    assertThat(server.takeRequest().sequenceNumber, "Expected connection reuse")
       .isEqualTo(1)
-    assertThat(server2.takeRequest().sequenceNumber)
-      .overridingErrorMessage("Expected connection reuse")
+    assertThat(server2.takeRequest().sequenceNumber, "Expected connection reuse")
       .isEqualTo(1)
   }
 
@@ -2864,11 +2867,10 @@ class URLConnectionTest {
     val b = getResponse(newRequest("/"))
     assertThat(b.code).isEqualTo(200)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
-    assertThat(server.takeRequest().sequenceNumber)
-      .overridingErrorMessage(
-        "When connection: close is used, each request should get its own connection"
-      )
-      .isEqualTo(0L)
+    assertThat(
+      server.takeRequest().sequenceNumber,
+      "When connection: close is used, each request should get its own connection"
+    ).isEqualTo(0L)
   }
 
   @Test
@@ -2880,11 +2882,10 @@ class URLConnectionTest {
     val b = getResponse(newRequest("/"))
     assertThat(b.code).isEqualTo(200)
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
-    assertThat(server.takeRequest().sequenceNumber)
-      .overridingErrorMessage(
-        "When connection: close is used, each request should get its own connection"
-      )
-      .isEqualTo(0L)
+    assertThat(
+      server.takeRequest().sequenceNumber,
+      "When connection: close is used, each request should get its own connection",
+    ).isEqualTo(0L)
   }
 
   @Test
@@ -2904,11 +2905,10 @@ class URLConnectionTest {
       "This is the new location!"
     )
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
-    assertThat(server.takeRequest().sequenceNumber)
-      .overridingErrorMessage(
-        "When connection: close is used, each request should get its own connection"
-      )
-      .isEqualTo(0L)
+    assertThat(
+      server.takeRequest().sequenceNumber,
+      "When connection: close is used, each request should get its own connection"
+    ).isEqualTo(0L)
   }
 
   /**

--- a/okhttp/src/test/java/okhttp3/WebPlatformUrlTest.kt
+++ b/okhttp/src/test/java/okhttp3/WebPlatformUrlTest.kt
@@ -15,12 +15,15 @@
  */
 package okhttp3
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import okhttp3.HttpUrl.Companion.defaultPort
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okio.buffer
 import okio.source
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 
@@ -69,12 +72,11 @@ class WebPlatformUrlTest {
     }
 
     if (testData.expectParseFailure()) {
-      assertThat(url).overridingErrorMessage("Expected URL to fail parsing").isNull()
+      assertThat(url, "Expected URL to fail parsing").isNull()
       return
     }
 
-    assertThat(url)
-      .overridingErrorMessage("Expected URL to parse successfully, but was null")
+    assertThat(url, "Expected URL to parse successfully, but was null")
       .isNotNull()
     val effectivePort = when {
       url!!.port != defaultPort(url.scheme) -> Integer.toString(url.port)
@@ -92,12 +94,12 @@ class WebPlatformUrlTest {
       url.host.contains(":") -> "[" + url.host + "]"
       else -> url.host
     }
-    assertThat(url.scheme).overridingErrorMessage("scheme").isEqualTo(testData.scheme)
-    assertThat(effectiveHost).overridingErrorMessage("host").isEqualTo(testData.host)
-    assertThat(effectivePort).overridingErrorMessage("port").isEqualTo(testData.port)
-    assertThat(url.encodedPath).overridingErrorMessage("path").isEqualTo(testData.path)
-    assertThat(effectiveQuery).overridingErrorMessage("query").isEqualTo(testData.query)
-    assertThat(effectiveFragment).overridingErrorMessage("fragment").isEqualTo(testData.fragment)
+    assertThat(url.scheme, "scheme").isEqualTo(testData.scheme)
+    assertThat(effectiveHost, "host").isEqualTo(testData.host)
+    assertThat(effectivePort, "port").isEqualTo(testData.port)
+    assertThat(url.encodedPath, "path").isEqualTo(testData.path)
+    assertThat(effectiveQuery, "query").isEqualTo(testData.query)
+    assertThat(effectiveFragment, "fragment").isEqualTo(testData.fragment)
   }
 
   companion object {

--- a/okhttp/src/test/java/okhttp3/internal/UtilTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/UtilTest.kt
@@ -15,18 +15,21 @@
  */
 package okhttp3.internal
 
-import okio.buffer
-import okio.source
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
-import org.assertj.core.api.Assertions.assertThatIllegalStateException
-import org.junit.jupiter.api.Test
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.nanoseconds
+import okio.buffer
+import okio.source
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class UtilTest {
     @Test
@@ -49,17 +52,19 @@ class UtilTest {
         assertThat(checkDuration("timeout", 0, TimeUnit.MILLISECONDS)).isEqualTo(0)
         assertThat(checkDuration("timeout", 1, TimeUnit.MILLISECONDS)).isEqualTo(1)
 
-        assertThatIllegalStateException().isThrownBy { checkDuration("timeout", -1, TimeUnit.MILLISECONDS) }
-            .withMessage("timeout < 0")
-        assertThatIllegalArgumentException().isThrownBy { checkDuration("timeout", 1, TimeUnit.NANOSECONDS) }
-            .withMessage("timeout too small")
-        assertThatIllegalArgumentException().isThrownBy {
-            checkDuration(
-                "timeout",
-                1L + Int.MAX_VALUE.toLong(),
-                TimeUnit.MILLISECONDS
-            )
-        }.withMessage("timeout too large")
+        assertThat(assertThrows<IllegalStateException> {
+          checkDuration("timeout", -1, TimeUnit.MILLISECONDS)
+        }).hasMessage("timeout < 0")
+        assertThat(assertThrows<IllegalArgumentException> {
+          checkDuration("timeout", 1, TimeUnit.NANOSECONDS)
+        }).hasMessage("timeout too small")
+        assertThat(assertThrows<IllegalArgumentException> {
+          checkDuration(
+            "timeout",
+            1L + Int.MAX_VALUE.toLong(),
+            TimeUnit.MILLISECONDS
+          )
+        }).hasMessage("timeout too large")
     }
 
     @Test
@@ -67,15 +72,17 @@ class UtilTest {
         assertThat(checkDuration("timeout", 0.milliseconds)).isEqualTo(0)
         assertThat(checkDuration("timeout", 1.milliseconds)).isEqualTo(1)
 
-        assertThatIllegalStateException().isThrownBy { checkDuration("timeout", (-1).milliseconds) }
-            .withMessage("timeout < 0")
-        assertThatIllegalArgumentException().isThrownBy { checkDuration("timeout", 1.nanoseconds) }
-            .withMessage("timeout too small")
-        assertThatIllegalArgumentException().isThrownBy {
-            checkDuration(
-                "timeout",
-                (1L + Int.MAX_VALUE).milliseconds
-            )
-        }.withMessage("timeout too large")
+        assertThat(assertThrows<IllegalStateException> {
+          checkDuration("timeout", (-1).milliseconds)
+        }).hasMessage("timeout < 0")
+        assertThat(assertThrows<IllegalArgumentException> {
+          checkDuration("timeout", 1.nanoseconds)
+        }).hasMessage("timeout too small")
+        assertThat(assertThrows<IllegalArgumentException> {
+          checkDuration(
+            "timeout",
+            (1L + Int.MAX_VALUE).milliseconds
+          )
+        }).hasMessage("timeout too large")
     }
 }

--- a/okhttp/src/test/java/okhttp3/internal/cache/DiskLruCacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/cache/DiskLruCacheTest.kt
@@ -15,6 +15,16 @@
  */
 package okhttp3.internal.cache
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isSameAs
+import assertk.assertions.isTrue
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.util.ArrayDeque
 import okhttp3.SimpleProvider
 import okhttp3.TestUtil
 import okhttp3.internal.cache.DiskLruCache.Editor
@@ -27,7 +37,6 @@ import okio.Path.Companion.toPath
 import okio.Source
 import okio.buffer
 import okio.fakefilesystem.FakeFileSystem
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Tag
@@ -36,11 +45,6 @@ import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
-import java.io.File
-import java.io.FileNotFoundException
-import java.io.IOException
-import java.util.ArrayDeque
-import java.util.NoSuchElementException
 
 class FileSystemParamProvider: SimpleProvider() {
   override fun arguments() = listOf(
@@ -1983,9 +1987,7 @@ class DiskLruCacheTest {
     assertThat(snapshotWhileEditing.hasNext()).isFalse() // entry still is being created/edited
     creator.commit()
     val snapshotAfterCommit = cache.snapshots()
-    assertThat(snapshotAfterCommit.hasNext()).withFailMessage(
-      "Entry has been removed during creation."
-    ).isTrue()
+    assertThat(snapshotAfterCommit.hasNext(), "Entry has been removed during creation.").isTrue()
     snapshotAfterCommit.next().close()
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskLoggerTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskLoggerTest.kt
@@ -15,7 +15,8 @@
  */
 package okhttp3.internal.concurrent
 
-import org.assertj.core.api.Assertions.assertThat
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.jupiter.api.Test
 
 class TaskLoggerTest {

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerRealBackendTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerRealBackendTest.kt
@@ -15,12 +15,15 @@
  */
 package okhttp3.internal.concurrent
 
+import assertk.assertThat
+import assertk.assertions.isCloseTo
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.data.Offset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -66,11 +69,11 @@ class TaskRunnerRealBackendTest {
 
     assertThat(log.take()).isEqualTo("runOnce delays.size=2")
     val t2 = System.nanoTime() / 1e6 - t1
-    assertThat(t2).isCloseTo(750.0, Offset.offset(250.0))
+    assertThat(t2).isCloseTo(750.0, 250.0)
 
     assertThat(log.take()).isEqualTo("runOnce delays.size=1")
     val t3 = System.nanoTime() / 1e6 - t1
-    assertThat(t3).isCloseTo(1750.0, Offset.offset(250.0))
+    assertThat(t3).isCloseTo(1750.0, 250.0)
   }
 
   @Test fun taskFailsWithUncheckedException() {

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
@@ -15,9 +15,14 @@
  */
 package okhttp3.internal.concurrent
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSameAs
 import java.util.concurrent.RejectedExecutionException
 import okhttp3.TestLogHandler
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -15,13 +15,18 @@
  */
 package okhttp3.internal.connection
 
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isTrue
 import okhttp3.ConnectionPool
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.TestUtil.awaitGarbageCollection
 import okhttp3.TestValueFactory
 import okhttp3.internal.concurrent.TaskRunner
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -47,27 +52,27 @@ class ConnectionPoolTest {
     // Running at time 50, the pool returns that nothing can be evicted until time 150.
     assertThat(pool.cleanup(50L)).isEqualTo(100L)
     assertThat(pool.connectionCount()).isEqualTo(1)
-    assertThat(c1.socket().isClosed).isFalse
+    assertThat(c1.socket().isClosed).isFalse()
 
     // Running at time 60, the pool returns that nothing can be evicted until time 150.
     assertThat(pool.cleanup(60L)).isEqualTo(90L)
     assertThat(pool.connectionCount()).isEqualTo(1)
-    assertThat(c1.socket().isClosed).isFalse
+    assertThat(c1.socket().isClosed).isFalse()
 
     // Running at time 149, the pool returns that nothing can be evicted until time 150.
     assertThat(pool.cleanup(149L)).isEqualTo(1L)
     assertThat(pool.connectionCount()).isEqualTo(1)
-    assertThat(c1.socket().isClosed).isFalse
+    assertThat(c1.socket().isClosed).isFalse()
 
     // Running at time 150, the pool evicts.
     assertThat(pool.cleanup(150L)).isEqualTo(0)
     assertThat(pool.connectionCount()).isEqualTo(0)
-    assertThat(c1.socket().isClosed).isTrue
+    assertThat(c1.socket().isClosed).isTrue()
 
     // Running again, the pool reports that no further runs are necessary.
     assertThat(pool.cleanup(150L)).isEqualTo(-1)
     assertThat(pool.connectionCount()).isEqualTo(0)
-    assertThat(c1.socket().isClosed).isTrue
+    assertThat(c1.socket().isClosed).isTrue()
   }
 
   @Test fun inUseConnectionsNotEvicted() {
@@ -84,17 +89,17 @@ class ConnectionPoolTest {
     // Running at time 50, the pool returns that nothing can be evicted until time 150.
     assertThat(pool.cleanup(50L)).isEqualTo(100L)
     assertThat(pool.connectionCount()).isEqualTo(1)
-    assertThat(c1.socket().isClosed).isFalse
+    assertThat(c1.socket().isClosed).isFalse()
 
     // Running at time 60, the pool returns that nothing can be evicted until time 160.
     assertThat(pool.cleanup(60L)).isEqualTo(100L)
     assertThat(pool.connectionCount()).isEqualTo(1)
-    assertThat(c1.socket().isClosed).isFalse
+    assertThat(c1.socket().isClosed).isFalse()
 
     // Running at time 160, the pool returns that nothing can be evicted until time 260.
     assertThat(pool.cleanup(160L)).isEqualTo(100L)
     assertThat(pool.connectionCount()).isEqualTo(1)
-    assertThat(c1.socket().isClosed).isFalse
+    assertThat(c1.socket().isClosed).isFalse()
   }
 
   @Test fun cleanupPrioritizesEarliestEviction() {
@@ -113,8 +118,8 @@ class ConnectionPoolTest {
     // Running at time 150, the pool evicts c2.
     assertThat(pool.cleanup(150L)).isEqualTo(0L)
     assertThat(pool.connectionCount()).isEqualTo(1)
-    assertThat(c1.socket().isClosed).isFalse
-    assertThat(c2.socket().isClosed).isTrue
+    assertThat(c1.socket().isClosed).isFalse()
+    assertThat(c2.socket().isClosed).isTrue()
 
     // Running at time 150, the pool returns that nothing can be evicted until time 175.
     assertThat(pool.cleanup(150L)).isEqualTo(25L)
@@ -123,8 +128,8 @@ class ConnectionPoolTest {
     // Running at time 175, the pool evicts c1.
     assertThat(pool.cleanup(175L)).isEqualTo(0L)
     assertThat(pool.connectionCount()).isEqualTo(0)
-    assertThat(c1.socket().isClosed).isTrue
-    assertThat(c2.socket().isClosed).isTrue
+    assertThat(c1.socket().isClosed).isTrue()
+    assertThat(c2.socket().isClosed).isTrue()
   }
 
   @Test fun oldestConnectionsEvictedIfIdleLimitExceeded() {
@@ -137,8 +142,8 @@ class ConnectionPoolTest {
     // With 2 connections, there's no need to evict until the connections time out.
     assertThat(pool.cleanup(100L)).isEqualTo(50L)
     assertThat(pool.connectionCount()).isEqualTo(2)
-    assertThat(c1.socket().isClosed).isFalse
-    assertThat(c2.socket().isClosed).isFalse
+    assertThat(c1.socket().isClosed).isFalse()
+    assertThat(c2.socket().isClosed).isFalse()
 
     // Add a third connection
     val c3 = factory.newConnection(pool, routeC1, 75L)
@@ -146,9 +151,9 @@ class ConnectionPoolTest {
     // The third connection bounces the first.
     assertThat(pool.cleanup(100L)).isEqualTo(0L)
     assertThat(pool.connectionCount()).isEqualTo(2)
-    assertThat(c1.socket().isClosed).isTrue
-    assertThat(c2.socket().isClosed).isFalse
-    assertThat(c3.socket().isClosed).isFalse
+    assertThat(c1.socket().isClosed).isTrue()
+    assertThat(c2.socket().isClosed).isFalse()
+    assertThat(c3.socket().isClosed).isFalse()
   }
 
   @Test fun leakedAllocation() {
@@ -161,7 +166,7 @@ class ConnectionPoolTest {
     assertThat(c1.calls).isEmpty()
 
     // Can't allocate once a leak has been detected.
-    assertThat(c1.noNewExchanges).isTrue
+    assertThat(c1.noNewExchanges).isTrue()
   }
 
   @Test fun interruptStopsThread() {
@@ -171,7 +176,7 @@ class ConnectionPoolTest {
       maxIdleConnections = 2
     )
     factory.newConnection(pool, routeA1)
-    assertThat(realTaskRunner.activeQueues()).isNotEmpty
+    assertThat(realTaskRunner.activeQueues()).isNotEmpty()
     Thread.sleep(100)
     val threads = arrayOfNulls<Thread>(Thread.activeCount() * 2)
     Thread.enumerate(threads)

--- a/okhttp/src/test/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
@@ -15,13 +15,16 @@
  */
 package okhttp3.internal.connection
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
 import java.io.IOException
 import java.net.UnknownServiceException
 import okhttp3.FakeRoutePlanner
 import okhttp3.FakeRoutePlanner.ConnectState.TLS_CONNECTED
 import okhttp3.internal.concurrent.TaskFaker
 import okhttp3.testing.Flaky
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test

--- a/okhttp/src/test/java/okhttp3/internal/connection/RetryConnectionTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/RetryConnectionTest.kt
@@ -15,6 +15,12 @@
  */
 package okhttp3.internal.connection
 
+import assertk.assertThat
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import java.io.IOException
 import java.security.cert.CertificateException
 import javax.net.ssl.SSLHandshakeException
@@ -24,7 +30,6 @@ import okhttp3.OkHttpClientTestRule
 import okhttp3.TestValueFactory
 import okhttp3.TlsVersion
 import okhttp3.tls.internal.TlsUtil.localhost
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -102,8 +107,7 @@ class RetryConnectionTest {
   }
 
   private fun assertEnabledProtocols(socket: SSLSocket, vararg required: TlsVersion) {
-    assertThat(socket.enabledProtocols)
-      .containsExactlyInAnyOrder(*javaNames(*required))
+    assertThat(socket.enabledProtocols.toList()).containsExactlyInAnyOrder(*javaNames(*required))
   }
 
   private fun javaNames(vararg tlsVersions: TlsVersion) =

--- a/okhttp/src/test/java/okhttp3/internal/connection/RouteSelectorTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/RouteSelectorTest.kt
@@ -15,6 +15,12 @@
  */
 package okhttp3.internal.connection
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isSameAs
+import assertk.assertions.isTrue
 import java.io.IOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
@@ -34,7 +40,6 @@ import okhttp3.TestValueFactory
 import okhttp3.internal.connection.RouteSelector.Companion.socketHost
 import okhttp3.internal.http.RecordingProxySelector
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
@@ -77,18 +82,18 @@ class RouteSelectorTest {
   @Test fun singleRoute() {
     val address = factory.newAddress()
     val routeSelector = newRouteSelector(address)
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[uriHost] = dns.allocate(1)
     val selection = routeSelector.next()
     assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(uriHost, 0), uriPort)
     dns.assertRequests(uriHost)
-    assertThat(selection.hasNext()).isFalse
+    assertThat(selection.hasNext()).isFalse()
     try {
       selection.next()
       fail<Any>()
     } catch (expected: NoSuchElementException) {
     }
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(routeSelector.hasNext()).isFalse()
     try {
       routeSelector.next()
       fail<Any>()
@@ -99,7 +104,7 @@ class RouteSelectorTest {
   @Test fun singleRouteReturnsFailedRoute() {
     val address = factory.newAddress()
     var routeSelector = newRouteSelector(address)
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[uriHost] = dns.allocate(1)
     var selection = routeSelector.next()
     val route = selection.next()
@@ -107,13 +112,13 @@ class RouteSelectorTest {
     routeSelector = newRouteSelector(address)
     selection = routeSelector.next()
     assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(uriHost, 0), uriPort)
-    assertThat(selection.hasNext()).isFalse
+    assertThat(selection.hasNext()).isFalse()
     try {
       selection.next()
       fail<Any>()
     } catch (expected: NoSuchElementException) {
     }
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(routeSelector.hasNext()).isFalse()
     try {
       routeSelector.next()
       fail<Any>()
@@ -126,13 +131,13 @@ class RouteSelectorTest {
       proxy = proxyA,
     )
     val routeSelector = newRouteSelector(address)
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[proxyAHost] = dns.allocate(2)
     val selection = routeSelector.next()
     assertRoute(selection.next(), address, proxyA, dns.lookup(proxyAHost, 0), proxyAPort)
     assertRoute(selection.next(), address, proxyA, dns.lookup(proxyAHost, 1), proxyAPort)
-    assertThat(selection.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
     dns.assertRequests(proxyAHost)
     proxySelector.assertRequests() // No proxy selector requests!
   }
@@ -142,13 +147,13 @@ class RouteSelectorTest {
       proxy = Proxy.NO_PROXY,
     )
     val routeSelector = newRouteSelector(address)
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[uriHost] = dns.allocate(2)
     val selection = routeSelector.next()
     assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(uriHost, 0), uriPort)
     assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(uriHost, 1), uriPort)
-    assertThat(selection.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
     dns.assertRequests(uriHost)
     proxySelector.assertRequests() // No proxy selector requests!
   }
@@ -166,12 +171,12 @@ class RouteSelectorTest {
       uriPort = uriPort,
     )
     val routeSelector = newRouteSelector(address)
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[bogusHostname] = dns.allocate(1)
     val selection = routeSelector.next()
     assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(bogusHostname, 0), uriPort)
-    assertThat(selection.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
     dns.assertRequests(bogusHostname)
     proxySelector.assertRequests() // No proxy selector requests!
   }
@@ -192,25 +197,25 @@ class RouteSelectorTest {
       proxySelector = nullProxySelector
     )
     val routeSelector = newRouteSelector(address)
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[uriHost] = dns.allocate(1)
     val selection = routeSelector.next()
     assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(uriHost, 0), uriPort)
     dns.assertRequests(uriHost)
-    assertThat(selection.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
   }
 
   @Test fun proxySelectorReturnsNoProxies() {
     val address = factory.newAddress()
     val routeSelector = newRouteSelector(address)
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[uriHost] = dns.allocate(2)
     val selection = routeSelector.next()
     assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(uriHost, 0), uriPort)
     assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(uriHost, 1), uriPort)
-    assertThat(selection.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
     dns.assertRequests(uriHost)
     proxySelector.assertRequests(address.url.toUri())
   }
@@ -223,24 +228,24 @@ class RouteSelectorTest {
     proxySelector.assertRequests(address.url.toUri())
 
     // First try the IP addresses of the first proxy, in sequence.
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[proxyAHost] = dns.allocate(2)
     val selection1 = routeSelector.next()
     assertRoute(selection1.next(), address, proxyA, dns.lookup(proxyAHost, 0), proxyAPort)
     assertRoute(selection1.next(), address, proxyA, dns.lookup(proxyAHost, 1), proxyAPort)
     dns.assertRequests(proxyAHost)
-    assertThat(selection1.hasNext()).isFalse
+    assertThat(selection1.hasNext()).isFalse()
 
     // Next try the IP address of the second proxy.
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[proxyBHost] = dns.allocate(1)
     val selection2 = routeSelector.next()
     assertRoute(selection2.next(), address, proxyB, dns.lookup(proxyBHost, 0), proxyBPort)
     dns.assertRequests(proxyBHost)
-    assertThat(selection2.hasNext()).isFalse
+    assertThat(selection2.hasNext()).isFalse()
 
     // No more proxies to try.
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(routeSelector.hasNext()).isFalse()
   }
 
   @Test fun proxySelectorDirectConnectionsAreSkipped() {
@@ -250,13 +255,13 @@ class RouteSelectorTest {
     proxySelector.assertRequests(address.url.toUri())
 
     // Only the origin server will be attempted.
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[uriHost] = dns.allocate(1)
     val selection = routeSelector.next()
     assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(uriHost, 0), uriPort)
     dns.assertRequests(uriHost)
-    assertThat(selection.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
   }
 
   @Test fun proxyDnsFailureContinuesToNextProxy() {
@@ -266,13 +271,13 @@ class RouteSelectorTest {
     proxySelector.proxies.add(proxyA)
     val routeSelector = newRouteSelector(address)
     proxySelector.assertRequests(address.url.toUri())
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[proxyAHost] = dns.allocate(1)
     val selection1 = routeSelector.next()
     assertRoute(selection1.next(), address, proxyA, dns.lookup(proxyAHost, 0), proxyAPort)
     dns.assertRequests(proxyAHost)
-    assertThat(selection1.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(selection1.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isTrue()
     dns.clear(proxyBHost)
     try {
       routeSelector.next()
@@ -280,13 +285,13 @@ class RouteSelectorTest {
     } catch (expected: UnknownHostException) {
     }
     dns.assertRequests(proxyBHost)
-    assertThat(routeSelector.hasNext()).isTrue
+    assertThat(routeSelector.hasNext()).isTrue()
     dns[proxyAHost] = dns.allocate(1)
     val selection2 = routeSelector.next()
     assertRoute(selection2.next(), address, proxyA, dns.lookup(proxyAHost, 0), proxyAPort)
     dns.assertRequests(proxyAHost)
-    assertThat(selection2.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection2.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
   }
 
   @Test fun multipleProxiesMultipleInetAddressesMultipleConfigurations() {
@@ -301,7 +306,7 @@ class RouteSelectorTest {
     assertRoute(selection1.next(), address, proxyA, dns.lookup(proxyAHost, 0), proxyAPort)
     dns.assertRequests(proxyAHost)
     assertRoute(selection1.next(), address, proxyA, dns.lookup(proxyAHost, 1), proxyAPort)
-    assertThat(selection1.hasNext()).isFalse
+    assertThat(selection1.hasNext()).isFalse()
 
     // Proxy B
     dns[proxyBHost] = dns.allocate(2)
@@ -309,10 +314,10 @@ class RouteSelectorTest {
     assertRoute(selection2.next(), address, proxyB, dns.lookup(proxyBHost, 0), proxyBPort)
     dns.assertRequests(proxyBHost)
     assertRoute(selection2.next(), address, proxyB, dns.lookup(proxyBHost, 1), proxyBPort)
-    assertThat(selection2.hasNext()).isFalse
+    assertThat(selection2.hasNext()).isFalse()
 
     // No more proxies to attempt.
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(routeSelector.hasNext()).isFalse()
   }
 
   @Test fun failedRouteWithSingleProxy() {
@@ -335,13 +340,13 @@ class RouteSelectorTest {
     // The first selection prioritizes the non-failed routes.
     val selection2 = routeSelector.next()
     assertThat(selection2.next()).isEqualTo(regularRoutes[1])
-    assertThat(selection2.hasNext()).isFalse
+    assertThat(selection2.hasNext()).isFalse()
 
     // The second selection will contain all failed routes.
     val selection3 = routeSelector.next()
     assertThat(selection3.next()).isEqualTo(regularRoutes[0])
-    assertThat(selection3.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection3.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
   }
 
   @Test fun failedRouteWithMultipleProxies() {
@@ -364,14 +369,14 @@ class RouteSelectorTest {
     val selection2 = routeSelector.next()
     dns.assertRequests(proxyAHost, proxyBHost)
     assertRoute(selection2.next(), address, proxyB, dns.lookup(proxyBHost, 0), proxyBPort)
-    assertThat(selection2.hasNext()).isFalse
+    assertThat(selection2.hasNext()).isFalse()
 
     // Confirm the last selection contains the postponed route from ProxyA.
     val selection3 = routeSelector.next()
     dns.assertRequests()
     assertRoute(selection3.next(), address, proxyA, dns.lookup(proxyAHost, 0), proxyAPort)
-    assertThat(selection3.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection3.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
   }
 
   @Test fun queryForAllSelectedRoutes() {
@@ -385,8 +390,8 @@ class RouteSelectorTest {
     assertRoute(routes[1], address, Proxy.NO_PROXY, dns.lookup(uriHost, 1), uriPort)
     assertThat(selection.next()).isSameAs(routes[0])
     assertThat(selection.next()).isSameAs(routes[1])
-    assertThat(selection.hasNext()).isFalse
-    assertThat(routeSelector.hasNext()).isFalse
+    assertThat(selection.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
   }
 
   @Test fun addressesNotSortedWhenFastFallbackIsOff() {

--- a/okhttp/src/test/java/okhttp3/internal/http/CancelTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http/CancelTest.kt
@@ -15,6 +15,11 @@
  */
 package okhttp3.internal.http
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
+import assertk.assertions.startsWith
 import java.io.IOException
 import java.net.ServerSocket
 import java.net.Socket
@@ -53,7 +58,6 @@ import okhttp3.internal.http.CancelTest.ConnectionType.HTTPS
 import okhttp3.testing.PlatformRule
 import okio.Buffer
 import okio.BufferedSink
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Timeout

--- a/okhttp/src/test/java/okhttp3/internal/http/HttpDateTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http/HttpDateTest.kt
@@ -15,9 +15,11 @@
  */
 package okhttp3.internal.http
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import java.util.Date
 import java.util.TimeZone
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/okhttp/src/test/java/okhttp3/internal/http2/FrameLogTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/FrameLogTest.kt
@@ -15,6 +15,9 @@
  */
 package okhttp3.internal.http2
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
 import okhttp3.internal.http2.Http2.FLAG_ACK
 import okhttp3.internal.http2.Http2.FLAG_END_HEADERS
 import okhttp3.internal.http2.Http2.FLAG_END_STREAM
@@ -29,7 +32,6 @@ import okhttp3.internal.http2.Http2.TYPE_SETTINGS
 import okhttp3.internal.http2.Http2.formatFlags
 import okhttp3.internal.http2.Http2.frameLog
 import okhttp3.internal.http2.Http2.frameLogWindowUpdate
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class FrameLogTest {

--- a/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.kt
@@ -15,6 +15,15 @@
  */
 package okhttp3.internal.http2
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.hasSize
+import assertk.assertions.isCloseTo
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import assertk.assertions.isTrue
 import java.io.EOFException
 import java.io.IOException
 import java.io.InterruptedIOException
@@ -35,8 +44,6 @@ import okio.Buffer
 import okio.BufferedSource
 import okio.Source
 import okio.buffer
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.data.Offset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.fail
@@ -72,7 +79,7 @@ class Http2ConnectionTest {
     assertThat(ping.streamId).isEqualTo(0)
     assertThat(ping.payload1).isEqualTo(2)
     assertThat(ping.payload2).isEqualTo(3)
-    assertThat(ping.ack).isTrue
+    assertThat(ping.ack).isTrue()
   }
 
   @Test fun peerHttp2ServerLowersInitialWindowSize() {
@@ -92,7 +99,7 @@ class Http2ConnectionTest {
     val ackFrame = peer.takeFrame()
     assertThat(ackFrame.type).isEqualTo(Http2.TYPE_SETTINGS)
     assertThat(ackFrame.streamId).isEqualTo(0)
-    assertThat(ackFrame.ack).isTrue
+    assertThat(ackFrame.ack).isTrue()
 
     // This stream was created *after* the connection settings were adjusted.
     val stream = connection.newStream(headerEntries("a", "android"), false)
@@ -122,7 +129,7 @@ class Http2ConnectionTest {
     val connection = connectWithSettings(client, settings)
 
     // verify the peer's settings were read and applied.
-    assertThat(connection.peerSettings.getEnablePush(true)).isFalse
+    assertThat(connection.peerSettings.getEnablePush(true)).isFalse()
   }
 
   @Test fun peerIncreasesMaxFrameSize() {
@@ -244,8 +251,8 @@ class Http2ConnectionTest {
       fail<Any?>()
     } catch (expected: ConnectionShutdownException) {
     }
-    assertThat(stream1.isOpen).isTrue
-    assertThat(stream2.isOpen).isFalse
+    assertThat(stream1.isOpen).isTrue()
+    assertThat(stream2.isOpen).isFalse()
     assertThat(connection.openStreamCount()).isEqualTo(1)
 
     // Verify the peer received what was expected.
@@ -525,7 +532,7 @@ class Http2ConnectionTest {
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()
     assertThat(synStream.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(synStream.outFinished).isFalse
+    assertThat(synStream.outFinished).isFalse()
     assertThat(synStream.streamId).isEqualTo(3)
     assertThat(synStream.associatedStreamId).isEqualTo(-1)
     assertThat(synStream.headerBlock).isEqualTo(headerEntries("b", "banana"))
@@ -554,7 +561,7 @@ class Http2ConnectionTest {
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()
     assertThat(synStream.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(synStream.outFinished).isFalse
+    assertThat(synStream.outFinished).isFalse()
     assertThat(synStream.streamId).isEqualTo(3)
     assertThat(synStream.associatedStreamId).isEqualTo(-1)
     assertThat(synStream.headerBlock).isEqualTo(headerEntries("a", "artichaut"))
@@ -582,7 +589,7 @@ class Http2ConnectionTest {
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()
     assertThat(synStream.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(synStream.outFinished).isFalse
+    assertThat(synStream.outFinished).isFalse()
     assertThat(synStream.streamId).isEqualTo(3)
     assertThat(synStream.associatedStreamId).isEqualTo(-1)
     assertThat(synStream.headerBlock).isEqualTo(headerEntries("a", "artichaut"))
@@ -718,10 +725,10 @@ class Http2ConnectionTest {
     assertThat(data1.type).isEqualTo(Http2.TYPE_DATA)
     assertThat(data1.streamId).isEqualTo(3)
     assertArrayEquals("abcdefghi".toByteArray(), data1.data)
-    assertThat(data1.inFinished).isFalse
+    assertThat(data1.inFinished).isFalse()
     val headers2 = peer.takeFrame()
     assertThat(headers2.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(headers2.inFinished).isTrue
+    assertThat(headers2.inFinished).isTrue()
   }
 
   @Test fun clientCannotReadTrailersWithoutExhaustingStream() {
@@ -812,7 +819,7 @@ class Http2ConnectionTest {
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()
     assertThat(synStream.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(synStream.outFinished).isFalse
+    assertThat(synStream.outFinished).isFalse()
     assertThat(synStream.streamId).isEqualTo(3)
     assertThat(synStream.associatedStreamId).isEqualTo(-1)
     assertThat(synStream.headerBlock).isEqualTo(headerEntries("a", "artichaut"))
@@ -843,7 +850,7 @@ class Http2ConnectionTest {
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()
     assertThat(synStream.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(synStream.outFinished).isFalse
+    assertThat(synStream.outFinished).isFalse()
     assertThat(synStream.streamId).isEqualTo(3)
     assertThat(synStream.associatedStreamId).isEqualTo(-1)
     assertThat(synStream.headerBlock).isEqualTo(headerEntries("b", "banana"))
@@ -893,7 +900,7 @@ class Http2ConnectionTest {
     assertThat(ping.streamId).isEqualTo(0)
     assertThat(ping.payload1).isEqualTo(2)
     assertThat(ping.payload2).isEqualTo(0)
-    assertThat(ping.ack).isTrue
+    assertThat(ping.ack).isTrue()
   }
 
   @Test fun clientPingsServer() {
@@ -918,7 +925,7 @@ class Http2ConnectionTest {
     assertThat(pingFrame.streamId).isEqualTo(0)
     assertThat(pingFrame.payload1).isEqualTo(Http2Connection.AWAIT_PING)
     assertThat(pingFrame.payload2).isEqualTo(0x4f4b6f6b) // OKok.
-    assertThat(pingFrame.ack).isFalse
+    assertThat(pingFrame.ack).isFalse()
   }
 
   @Test fun unexpectedPongIsNotReturned() {
@@ -1103,8 +1110,8 @@ class Http2ConnectionTest {
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()
     assertThat(synStream.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(synStream.inFinished).isFalse
-    assertThat(synStream.outFinished).isFalse
+    assertThat(synStream.inFinished).isFalse()
+    assertThat(synStream.outFinished).isFalse()
     val ping = peer.takeFrame()
     assertThat(ping.type).isEqualTo(Http2.TYPE_PING)
   }
@@ -1144,8 +1151,8 @@ class Http2ConnectionTest {
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()
     assertThat(synStream.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(synStream.inFinished).isTrue
-    assertThat(synStream.outFinished).isFalse
+    assertThat(synStream.inFinished).isTrue()
+    assertThat(synStream.outFinished).isFalse()
     val rstStream = peer.takeFrame()
     assertThat(rstStream.type).isEqualTo(Http2.TYPE_RST_STREAM)
     assertThat(rstStream.errorCode).isEqualTo(ErrorCode.CANCEL)
@@ -1184,15 +1191,15 @@ class Http2ConnectionTest {
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()
     assertThat(synStream.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(synStream.inFinished).isFalse
-    assertThat(synStream.outFinished).isFalse
+    assertThat(synStream.inFinished).isFalse()
+    assertThat(synStream.outFinished).isFalse()
     val data = peer.takeFrame()
     assertThat(data.type).isEqualTo(Http2.TYPE_DATA)
     assertArrayEquals("square".toByteArray(), data.data)
     val fin = peer.takeFrame()
     assertThat(fin.type).isEqualTo(Http2.TYPE_DATA)
-    assertThat(fin.inFinished).isTrue
-    assertThat(fin.outFinished).isFalse
+    assertThat(fin.inFinished).isTrue()
+    assertThat(fin.outFinished).isFalse()
     val rstStream = peer.takeFrame()
     assertThat(rstStream.type).isEqualTo(Http2.TYPE_RST_STREAM)
     assertThat(rstStream.errorCode).isEqualTo(ErrorCode.CANCEL)
@@ -1220,8 +1227,8 @@ class Http2ConnectionTest {
     // Verify the peer received what was expected.
     val synStream = peer.takeFrame()
     assertThat(synStream.type).isEqualTo(Http2.TYPE_HEADERS)
-    assertThat(synStream.inFinished).isTrue
-    assertThat(synStream.outFinished).isFalse
+    assertThat(synStream.inFinished).isTrue()
+    assertThat(synStream.outFinished).isFalse()
   }
 
   @Test fun remoteDoubleSynReply() {
@@ -1370,8 +1377,8 @@ class Http2ConnectionTest {
       fail<Any?>()
     } catch (expected: ConnectionShutdownException) {
     }
-    assertThat(stream1.isOpen).isTrue
-    assertThat(stream2.isOpen).isFalse
+    assertThat(stream1.isOpen).isTrue()
+    assertThat(stream2.isOpen).isFalse()
     assertThat(connection.openStreamCount()).isEqualTo(1)
 
     // Verify the peer received what was expected.
@@ -1489,7 +1496,7 @@ class Http2ConnectionTest {
     awaitWatchdogIdle()
     /* 200ms delta */
     assertThat(TimeUnit.NANOSECONDS.toMillis(elapsedNanos).toDouble())
-      .isCloseTo(500.0, Offset.offset(200.0))
+      .isCloseTo(500.0, 200.0)
     assertThat(connection.openStreamCount()).isEqualTo(0)
 
     // Verify the peer received what was expected.
@@ -1531,19 +1538,19 @@ class Http2ConnectionTest {
     val elapsedNanos = System.nanoTime() - startNanos
     awaitWatchdogIdle()
     /* 200ms delta */assertThat(TimeUnit.NANOSECONDS.toMillis(elapsedNanos).toDouble())
-      .isCloseTo(500.0, Offset.offset(200.0))
+      .isCloseTo(500.0, 200.0)
     assertThat(connection.openStreamCount()).isEqualTo(0)
 
     // When the timeout is sent the connection doesn't immediately go unhealthy.
-    assertThat(connection.isHealthy(System.nanoTime())).isTrue
+    assertThat(connection.isHealthy(System.nanoTime())).isTrue()
 
     // But if the ping doesn't arrive, the connection goes unhealthy.
     Thread.sleep(TimeUnit.NANOSECONDS.toMillis(Http2Connection.DEGRADED_PONG_TIMEOUT_NS.toLong()))
-    assertThat(connection.isHealthy(System.nanoTime())).isFalse
+    assertThat(connection.isHealthy(System.nanoTime())).isFalse()
 
     // When a pong does arrive, the connection becomes healthy again.
     connection.writePingAndAwaitPong()
-    assertThat(connection.isHealthy(System.nanoTime())).isTrue
+    assertThat(connection.isHealthy(System.nanoTime())).isTrue()
 
     // Verify the peer received what was expected.
     assertThat(peer.takeFrame().type).isEqualTo(Http2.TYPE_HEADERS)
@@ -1584,7 +1591,7 @@ class Http2ConnectionTest {
     val elapsedNanos = System.nanoTime() - startNanos
     awaitWatchdogIdle()
     /* 200ms delta */assertThat(TimeUnit.NANOSECONDS.toMillis(elapsedNanos).toDouble())
-      .isCloseTo(500.0, Offset.offset(200.0))
+      .isCloseTo(500.0, 200.0)
     assertThat(connection.openStreamCount()).isEqualTo(0)
 
     // Verify the peer received what was expected.
@@ -1629,7 +1636,7 @@ class Http2ConnectionTest {
     val elapsedNanos = System.nanoTime() - startNanos
     awaitWatchdogIdle()
     /* 200ms delta */assertThat(TimeUnit.NANOSECONDS.toMillis(elapsedNanos).toDouble())
-      .isCloseTo(500.0, Offset.offset(200.0))
+      .isCloseTo(500.0, 200.0)
     assertThat(connection.openStreamCount()).isEqualTo(0)
 
     // Verify the peer received what was expected.
@@ -1664,7 +1671,7 @@ class Http2ConnectionTest {
     val data = peer.takeFrame()
     assertThat(data.type).isEqualTo(Http2.TYPE_DATA)
     assertArrayEquals("abcdefghij".toByteArray(), data.data)
-    assertThat(data.inFinished).isTrue
+    assertThat(data.inFinished).isTrue()
   }
 
   @Test fun headers() {
@@ -1988,7 +1995,7 @@ class Http2ConnectionTest {
     val ackFrame = peer.takeFrame()
     assertThat(ackFrame.type).isEqualTo(Http2.TYPE_SETTINGS)
     assertThat(ackFrame.streamId).isEqualTo(0)
-    assertThat(ackFrame.ack).isTrue
+    assertThat(ackFrame.ack).isTrue()
     return connection
   }
 
@@ -2013,7 +2020,7 @@ class Http2ConnectionTest {
       streamId: Int, responseHeaders: List<Header>, last: Boolean
     ): Boolean {
       assertThat(streamId).isEqualTo(2)
-      assertThat(last).isTrue
+      assertThat(last).isTrue()
       events.add(responseHeaders)
       notifyAll()
       return false

--- a/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/Http2ConnectionTest.kt
@@ -103,7 +103,7 @@ class Http2ConnectionTest {
 
     // This stream was created *after* the connection settings were adjusted.
     val stream = connection.newStream(headerEntries("a", "android"), false)
-    assertThat(connection.peerSettings.initialWindowSize).isEqualTo(3368L)
+    assertThat(connection.peerSettings.initialWindowSize).isEqualTo(3368)
     // New Stream is has the most recent initial window size.
     assertThat(stream.writeBytesTotal).isEqualTo(0L)
     assertThat(stream.writeBytesMaximum).isEqualTo(3368L)
@@ -1032,7 +1032,7 @@ class Http2ConnectionTest {
     synchronized(connection) {
       assertThat(connection.peerSettings.headerTableSize).isEqualTo(-1)
       assertThat(connection.peerSettings.initialWindowSize)
-        .isEqualTo(Settings.DEFAULT_INITIAL_WINDOW_SIZE.toLong())
+        .isEqualTo(Settings.DEFAULT_INITIAL_WINDOW_SIZE)
       assertThat(connection.peerSettings.getMaxFrameSize(-1)).isEqualTo(-1)
       assertThat(connection.peerSettings.getMaxConcurrentStreams()).isEqualTo(60000)
     }

--- a/okhttp/src/test/java/okhttp3/internal/http2/Http2Test.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/Http2Test.kt
@@ -15,6 +15,10 @@
  */
 package okhttp3.internal.http2
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import java.io.IOException
 import java.util.Arrays
 import java.util.concurrent.atomic.AtomicInteger
@@ -36,7 +40,6 @@ import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
 import okio.GzipSink
 import okio.buffer
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 
@@ -70,7 +73,7 @@ class Http2Test {
         inFinished: Boolean, streamId: Int,
         associatedStreamId: Int, headerBlock: List<Header>
       ) {
-        assertThat(inFinished).isTrue
+        assertThat(inFinished).isTrue()
         assertThat(streamId).isEqualTo(expectedStreamId)
         assertThat(associatedStreamId).isEqualTo(-1)
         assertThat(headerBlock).isEqualTo(sentHeaders)
@@ -95,7 +98,7 @@ class Http2Test {
       ) {
         assertThat(streamDependency).isEqualTo(0)
         assertThat(weight).isEqualTo(256)
-        assertThat(exclusive).isFalse
+        assertThat(exclusive).isFalse()
       }
 
       override fun headers(
@@ -104,7 +107,7 @@ class Http2Test {
         associatedStreamId: Int,
         headerBlock: List<Header>
       ) {
-        assertThat(inFinished).isFalse
+        assertThat(inFinished).isFalse()
         assertThat(streamId).isEqualTo(expectedStreamId)
         assertThat(associatedStreamId).isEqualTo(-1)
         assertThat(headerBlock).isEqualTo(sentHeaders)
@@ -140,7 +143,7 @@ class Http2Test {
         inFinished: Boolean, streamId: Int,
         associatedStreamId: Int, headerBlock: List<Header>
       ) {
-        assertThat(inFinished).isFalse
+        assertThat(inFinished).isFalse()
         assertThat(streamId).isEqualTo(expectedStreamId)
         assertThat(associatedStreamId).isEqualTo(-1)
         assertThat(headerBlock).isEqualTo(sentHeaders)
@@ -248,9 +251,9 @@ class Http2Test {
     reader.nextFrame(requireSettings = false, object : BaseTestHandler() {
       override fun settings(clearPrevious: Boolean, settings: Settings) {
         // No clearPrevious in HTTP/2.
-        assertThat(clearPrevious).isFalse
+        assertThat(clearPrevious).isFalse()
         assertThat(settings.headerTableSize).isEqualTo(reducedTableSizeBytes)
-        assertThat(settings.getEnablePush(true)).isFalse
+        assertThat(settings.getEnablePush(true)).isFalse()
       }
     })
   }
@@ -378,7 +381,7 @@ class Http2Test {
     assertThat(sendPingFrame(true, expectedPayload1, expectedPayload2)).isEqualTo(frame)
     reader.nextFrame(requireSettings = false, object : BaseTestHandler() {
       override fun ping(ack: Boolean, payload1: Int, payload2: Int) {
-        assertThat(ack).isTrue
+        assertThat(ack).isTrue()
         assertThat(payload1).isEqualTo(expectedPayload1)
         assertThat(payload2).isEqualTo(expectedPayload2)
       }
@@ -398,7 +401,7 @@ class Http2Test {
     assertThat(sendDataFrame(Buffer().write(expectedData))).isEqualTo(frame)
     reader.nextFrame(requireSettings = false, object : BaseTestHandler() {
       override fun data(inFinished: Boolean, streamId: Int, source: BufferedSource, length: Int) {
-        assertThat(inFinished).isFalse
+        assertThat(inFinished).isFalse()
         assertThat(streamId).isEqualTo(expectedStreamId)
         assertThat(length).isEqualTo(Http2.INITIAL_MAX_FRAME_SIZE)
         val data = source.readByteString(length.toLong())
@@ -460,7 +463,7 @@ class Http2Test {
     frame.write(padding)
     reader.nextFrame(requireSettings = false, assertData())
     // Padding was skipped.
-    assertThat(frame.exhausted()).isTrue
+    assertThat(frame.exhausted()).isTrue()
   }
 
   @Test fun readPaddedDataFrameZeroPadding() {
@@ -490,7 +493,7 @@ class Http2Test {
     frame.write(padding)
     reader.nextFrame(requireSettings = false, assertHeaderBlock())
     // Padding was skipped.
-    assertThat(frame.exhausted()).isTrue
+    assertThat(frame.exhausted()).isTrue()
   }
 
   @Test fun readPaddedHeadersFrameZeroPadding() {
@@ -529,7 +532,7 @@ class Http2Test {
     frame.writeInt(expectedStreamId and 0x7fffffff)
     frame.writeAll(headerBlock)
     reader.nextFrame(requireSettings = false, assertHeaderBlock())
-    assertThat(frame.exhausted()).isTrue
+    assertThat(frame.exhausted()).isTrue()
   }
 
   @Test fun tooLargeDataFrame() {
@@ -720,7 +723,7 @@ class Http2Test {
         associatedStreamId: Int,
         headerBlock: List<Header>
       ) {
-        assertThat(inFinished).isFalse
+        assertThat(inFinished).isFalse()
         assertThat(streamId).isEqualTo(expectedStreamId)
         assertThat(associatedStreamId).isEqualTo(-1)
         assertThat(headerBlock).isEqualTo(headerEntries("foo", "barrr", "baz", "qux"))
@@ -731,7 +734,7 @@ class Http2Test {
   private fun assertData(): Http2Reader.Handler {
     return object : BaseTestHandler() {
       override fun data(inFinished: Boolean, streamId: Int, source: BufferedSource, length: Int) {
-        assertThat(inFinished).isFalse
+        assertThat(inFinished).isFalse()
         assertThat(streamId).isEqualTo(expectedStreamId)
         assertThat(length).isEqualTo(1123)
         val data = source.readByteString(length.toLong())

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -86,6 +86,7 @@ import okio.BufferedSink
 import okio.GzipSink
 import okio.buffer
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
@@ -260,7 +261,7 @@ class HttpOverHttp2Test {
     assertThat(response.body.string()).isEqualTo("ABCDE")
     val request = server.takeRequest()
     assertThat(request.requestLine).isEqualTo("POST /foo HTTP/1.1")
-    org.junit.jupiter.api.Assertions.assertArrayEquals(postBytes, request.body.readByteArray())
+    assertArrayEquals(postBytes, request.body.readByteArray())
       assertThat(request.headers["Content-Length"]).isNull()
   }
 
@@ -287,10 +288,8 @@ class HttpOverHttp2Test {
     assertThat(response.body.string()).isEqualTo("ABCDE")
     val request = server.takeRequest()
     assertThat(request.requestLine).isEqualTo("POST /foo HTTP/1.1")
-    org.junit.jupiter.api.Assertions.assertArrayEquals(postBytes, request.body.readByteArray())
-    assertThat(request.headers["Content-Length"]!!.toInt()).isEqualTo(
-      postBytes.size.toLong()
-    )
+    assertArrayEquals(postBytes, request.body.readByteArray())
+    assertThat(request.headers["Content-Length"]!!.toInt()).isEqualTo(postBytes.size)
   }
 
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
@@ -320,9 +319,8 @@ class HttpOverHttp2Test {
     assertThat(response.body.string()).isEqualTo("ABCDE")
     val request = server.takeRequest()
     assertThat(request.requestLine).isEqualTo("POST /foo HTTP/1.1")
-    org.junit.jupiter.api.Assertions.assertArrayEquals(postBytes, request.body.readByteArray())
-    assertThat(request.headers["Content-Length"]!!.toInt())
-      .isEqualTo(postBytes.size.toLong())
+    assertArrayEquals(postBytes, request.body.readByteArray())
+    assertThat(request.headers["Content-Length"]!!.toInt()).isEqualTo(postBytes.size)
   }
 
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
@@ -1140,7 +1138,8 @@ class HttpOverHttp2Test {
 
   /** Make a call and canceling it as soon as it's accepted by the server.  */
   private fun callAndCancel(
-    expectedSequenceNumber: Int, responseDequeuedLatch: CountDownLatch?,
+    expectedSequenceNumber: Int,
+    responseDequeuedLatch: CountDownLatch?,
     requestCanceledLatch: CountDownLatch?
   ) {
     val call = client.newCall(Request(server.url("/")))
@@ -1155,7 +1154,7 @@ class HttpOverHttp2Test {
       }
     })
     assertThat(server.takeRequest().sequenceNumber)
-      .isEqualTo(expectedSequenceNumber.toLong())
+      .isEqualTo(expectedSequenceNumber)
     responseDequeuedLatch!!.await()
     call.cancel()
     requestCanceledLatch!!.countDown()
@@ -1382,9 +1381,9 @@ class HttpOverHttp2Test {
     // doesn't wait to read the client's DATA frame and may send a DATA frame before the client
     // does. So we can't assume the client's empty DATA will be logged first.
     assertThat(countFrames(logs, "FINE: >> 0x00000003     0 DATA          END_STREAM"))
-      .isEqualTo(1L)
+      .isEqualTo(1)
     assertThat(countFrames(logs, "FINE: >> 0x00000003     3 DATA          END_STREAM"))
-      .isEqualTo(1L)
+      .isEqualTo(1)
   }
 
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
@@ -1410,13 +1409,13 @@ class HttpOverHttp2Test {
     // Confirm a single ping was sent and received, and its reply was sent and received.
     val logs = testLogHandler.takeAll()
     assertThat(countFrames(logs, "FINE: >> 0x00000000     8 PING          "))
-      .isEqualTo(1L)
+      .isEqualTo(1)
     assertThat(countFrames(logs, "FINE: << 0x00000000     8 PING          "))
-      .isEqualTo(1L)
+      .isEqualTo(1)
     assertThat(countFrames(logs, "FINE: >> 0x00000000     8 PING          ACK"))
-      .isEqualTo(1L)
+      .isEqualTo(1)
     assertThat(countFrames(logs, "FINE: << 0x00000000     8 PING          ACK"))
-      .isEqualTo(1L)
+      .isEqualTo(1)
   }
 
   @Flaky @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)
@@ -1456,9 +1455,9 @@ class HttpOverHttp2Test {
     // Confirm a single ping was sent but not acknowledged.
     val logs = testLogHandler.takeAll()
     assertThat(countFrames(logs, "FINE: >> 0x00000000     8 PING          "))
-      .isEqualTo(1L)
+      .isEqualTo(1)
     assertThat(countFrames(logs, "FINE: << 0x00000000     8 PING          ACK"))
-      .isEqualTo(0L)
+      .isEqualTo(0)
   }
 
   @ParameterizedTest @ArgumentsSource(ProtocolParamProvider::class)

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -15,6 +15,14 @@
  */
 package okhttp3.internal.http2
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.hasMessage
+import assertk.assertions.isCloseTo
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import java.io.File
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -77,8 +85,6 @@ import okio.Buffer
 import okio.BufferedSink
 import okio.GzipSink
 import okio.buffer
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.data.Offset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -356,9 +362,10 @@ class HttpOverHttp2Test {
     // Cancel the call and discard what we've buffered for the response body. This should free up
     // the connection flow-control window so new requests can proceed.
     call1.cancel()
-    assertThat(response1.body.source().discard(1, TimeUnit.SECONDS))
-      .overridingErrorMessage("Call should not have completed successfully.")
-      .isFalse
+    assertThat(
+      response1.body.source().discard(1, TimeUnit.SECONDS),
+      "Call should not have completed successfully."
+    ).isFalse()
     val call2 = client.newCall(Request(server.url("/")))
     val response2 = call2.execute()
     assertThat(response2.body.string()).isEqualTo("abc")
@@ -1351,8 +1358,7 @@ class HttpOverHttp2Test {
     assertThat(response.body.string()).isEqualTo("ABC")
     assertThat(response.protocol).isEqualTo(protocol)
     val logs = testLogHandler.takeAll()
-    assertThat(firstFrame(logs, "HEADERS"))
-      .overridingErrorMessage("header logged")
+    assertThat(firstFrame(logs, "HEADERS")!!, "header logged")
       .contains("HEADERS       END_STREAM|END_HEADERS")
   }
 
@@ -1370,8 +1376,7 @@ class HttpOverHttp2Test {
     assertThat(response.body.string()).isEqualTo("ABC")
     assertThat(response.protocol).isEqualTo(protocol)
     val logs = testLogHandler.takeAll()
-    assertThat(firstFrame(logs, "HEADERS"))
-      .overridingErrorMessage("header logged")
+    assertThat(firstFrame(logs, "HEADERS")!!, "header logged")
       .contains("HEADERS       END_HEADERS")
     // While MockWebServer waits to read the client's HEADERS frame before sending the response, it
     // doesn't wait to read the client's DATA frame and may send a DATA frame before the client
@@ -1446,7 +1451,7 @@ class HttpOverHttp2Test {
     }
     val elapsedUntilFailure = System.nanoTime() - executeAtNanos
     assertThat(TimeUnit.NANOSECONDS.toMillis(elapsedUntilFailure).toDouble())
-      .isCloseTo(1000.0, Offset.offset(250.0))
+      .isCloseTo(1000.0, 250.0)
 
     // Confirm a single ping was sent but not acknowledged.
     val logs = testLogHandler.takeAll()
@@ -1930,10 +1935,10 @@ class HttpOverHttp2Test {
       call.execute()
       fail<Any?>()
     } catch (expected: IOException) {
-      assertThat(call.isCanceled()).isTrue
+      assertThat(call.isCanceled()).isTrue()
     }
     val recordedRequest = server.takeRequest()
-    assertThat(recordedRequest.failure).hasMessage("stream was reset: CANCEL")
+    assertThat(recordedRequest.failure!!).hasMessage("stream was reset: CANCEL")
   }
 
   @ParameterizedTest

--- a/okhttp/src/test/java/okhttp3/internal/idn/StringprepTablesReaderTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/idn/StringprepTablesReaderTest.kt
@@ -15,12 +15,13 @@
  */
 package okhttp3.internal.idn
 
+import assertk.assertThat
+import assertk.assertions.hasSize
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import okio.Buffer
 import okio.FileSystem
 import okio.Path.Companion.toPath
-import org.assertj.core.api.Assertions.assertThat
 
 class StringprepTablesReaderTest {
   @Test fun readRfc3491FromResources() {

--- a/okhttp/src/test/java/okhttp3/internal/idn/StringprepTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/idn/StringprepTest.kt
@@ -15,11 +15,13 @@
  */
 package okhttp3.internal.idn
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import okio.Buffer
 import okio.ByteString.Companion.decodeHex
 import okio.FileSystem
 import okio.Path.Companion.toPath
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class StringprepTest {

--- a/okhttp/src/test/java/okhttp3/internal/publicsuffix/PublicSuffixDatabaseTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/publicsuffix/PublicSuffixDatabaseTest.kt
@@ -15,8 +15,11 @@
  */
 package okhttp3.internal.publicsuffix
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import kotlin.test.assertEquals
-import kotlin.test.assertSame
 import okhttp3.internal.toCanonicalHost
 import okio.Buffer
 import okio.FileSystem
@@ -24,7 +27,6 @@ import okio.GzipSource
 import okio.Path.Companion.toPath
 import okio.buffer
 import okio.use
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.jupiter.api.Test
 
@@ -146,7 +148,7 @@ class PublicSuffixDatabaseTest {
       val result = publicSuffixDatabase.getEffectiveTldPlusOne("squareup.com")
       assertThat(result).isEqualTo("squareup.com")
     } finally {
-      assertThat(Thread.interrupted()).isTrue
+      assertThat(Thread.interrupted()).isTrue()
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/tls/HostnameVerifierTest.kt
@@ -16,10 +16,15 @@
  */
 package okhttp3.internal.tls
 
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isTrue
 import java.io.ByteArrayInputStream
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
-import java.util.stream.Stream
 import javax.net.ssl.SSLSession
 import javax.security.auth.x500.X500Principal
 import okhttp3.FakeSSLSession
@@ -28,7 +33,6 @@ import okhttp3.internal.canParseAsIpAddress
 import okhttp3.internal.platform.Platform.Companion.isAndroid
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.HeldCertificate
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -44,7 +48,7 @@ class HostnameVerifierTest {
 
   @Test fun verify() {
     val session = FakeSSLSession()
-    assertThat(verifier.verify("localhost", session)).isFalse
+    assertThat(verifier.verify("localhost", session)).isFalse()
   }
 
   @Test fun verifyCn() {
@@ -78,9 +82,9 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("a.foo.com", session)).isFalse
-    assertThat(verifier.verify("bar.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("a.foo.com", session)).isFalse()
+    assertThat(verifier.verify("bar.com", session)).isFalse()
   }
 
   @Test fun verifyNonAsciiCn() {
@@ -114,8 +118,8 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("\u82b1\u5b50.co.jp", session)).isFalse
-    assertThat(verifier.verify("a.\u82b1\u5b50.co.jp", session)).isFalse
+    assertThat(verifier.verify("\u82b1\u5b50.co.jp", session)).isFalse()
+    assertThat(verifier.verify("a.\u82b1\u5b50.co.jp", session)).isFalse()
   }
 
   @Test fun verifySubjectAlt() {
@@ -150,10 +154,10 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("a.foo.com", session)).isFalse
-    assertThat(verifier.verify("bar.com", session)).isTrue
-    assertThat(verifier.verify("a.bar.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("a.foo.com", session)).isFalse()
+    assertThat(verifier.verify("bar.com", session)).isTrue()
+    assertThat(verifier.verify("a.bar.com", session)).isFalse()
   }
 
   /**
@@ -208,16 +212,16 @@ class HostnameVerifierTest {
       assertThat(certificateSANs(peerCertificate)).containsExactly("bar.com", "������.co.jp")
     }
 
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("a.foo.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("a.foo.com", session)).isFalse()
     // these checks test alternative subjects. The test data contains an
     // alternative subject starting with a japanese kanji character. This is
     // not supported by Android because the underlying implementation from
     // harmony follows the definition from rfc 1034 page 10 for alternative
     // subject names. This causes the code to drop all alternative subjects.
-    assertThat(verifier.verify("bar.com", session)).isTrue
-    assertThat(verifier.verify("a.bar.com", session)).isFalse
-    assertThat(verifier.verify("a.\u82b1\u5b50.co.jp", session)).isFalse
+    assertThat(verifier.verify("bar.com", session)).isTrue()
+    assertThat(verifier.verify("a.bar.com", session)).isFalse()
+    assertThat(verifier.verify("a.\u82b1\u5b50.co.jp", session)).isFalse()
   }
 
   @Test fun verifySubjectAltOnly() {
@@ -251,10 +255,10 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("foo.com", session)).isTrue
-    assertThat(verifier.verify("a.foo.com", session)).isFalse
-    assertThat(verifier.verify("foo.com", session)).isTrue
-    assertThat(verifier.verify("a.foo.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isTrue()
+    assertThat(verifier.verify("a.foo.com", session)).isFalse()
+    assertThat(verifier.verify("foo.com", session)).isTrue()
+    assertThat(verifier.verify("a.foo.com", session)).isFalse()
   }
 
   @Test fun verifyMultipleCn() {
@@ -289,12 +293,12 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("a.foo.com", session)).isFalse
-    assertThat(verifier.verify("bar.com", session)).isFalse
-    assertThat(verifier.verify("a.bar.com", session)).isFalse
-    assertThat(verifier.verify("\u82b1\u5b50.co.jp", session)).isFalse
-    assertThat(verifier.verify("a.\u82b1\u5b50.co.jp", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("a.foo.com", session)).isFalse()
+    assertThat(verifier.verify("bar.com", session)).isFalse()
+    assertThat(verifier.verify("a.bar.com", session)).isFalse()
+    assertThat(verifier.verify("\u82b1\u5b50.co.jp", session)).isFalse()
+    assertThat(verifier.verify("a.\u82b1\u5b50.co.jp", session)).isFalse()
   }
 
   @Test fun verifyWilcardCn() {
@@ -328,10 +332,10 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("www.foo.com", session)).isFalse
-    assertThat(verifier.verify("\u82b1\u5b50.foo.com", session)).isFalse
-    assertThat(verifier.verify("a.b.foo.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("www.foo.com", session)).isFalse()
+    assertThat(verifier.verify("\u82b1\u5b50.foo.com", session)).isFalse()
+    assertThat(verifier.verify("a.b.foo.com", session)).isFalse()
   }
 
   @Test fun verifyWilcardCnOnTld() {
@@ -366,8 +370,8 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("foo.co.jp", session)).isFalse
-    assertThat(verifier.verify("\u82b1\u5b50.co.jp", session)).isFalse
+    assertThat(verifier.verify("foo.co.jp", session)).isFalse()
+    assertThat(verifier.verify("\u82b1\u5b50.co.jp", session)).isFalse()
   }
 
   /**
@@ -423,19 +427,19 @@ class HostnameVerifierTest {
     }
 
     // try the foo.com variations
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("www.foo.com", session)).isFalse
-    assertThat(verifier.verify("\u82b1\u5b50.foo.com", session)).isFalse
-    assertThat(verifier.verify("a.b.foo.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("www.foo.com", session)).isFalse()
+    assertThat(verifier.verify("\u82b1\u5b50.foo.com", session)).isFalse()
+    assertThat(verifier.verify("a.b.foo.com", session)).isFalse()
     // these checks test alternative subjects. The test data contains an
     // alternative subject starting with a japanese kanji character. This is
     // not supported by Android because the underlying implementation from
     // harmony follows the definition from rfc 1034 page 10 for alternative
     // subject names. This causes the code to drop all alternative subjects.
-    assertThat(verifier.verify("bar.com", session)).isFalse
-    assertThat(verifier.verify("www.bar.com", session)).isTrue
-    assertThat(verifier.verify("\u82b1\u5b50.bar.com", session)).isFalse
-    assertThat(verifier.verify("a.b.bar.com", session)).isFalse
+    assertThat(verifier.verify("bar.com", session)).isFalse()
+    assertThat(verifier.verify("www.bar.com", session)).isTrue()
+    assertThat(verifier.verify("\u82b1\u5b50.bar.com", session)).isFalse()
+    assertThat(verifier.verify("a.b.bar.com", session)).isFalse()
   }
 
   @Test fun subjectAltUsesLocalDomainAndIp() {
@@ -469,11 +473,11 @@ class HostnameVerifierTest {
       X500Principal("CN=localhost")
     )
     val session = FakeSSLSession(certificate)
-    assertThat(verifier.verify("localhost", session)).isTrue
-    assertThat(verifier.verify("localhost.localdomain", session)).isTrue
-    assertThat(verifier.verify("local.host", session)).isFalse
-    assertThat(verifier.verify("127.0.0.1", session)).isTrue
-    assertThat(verifier.verify("127.0.0.2", session)).isFalse
+    assertThat(verifier.verify("localhost", session)).isTrue()
+    assertThat(verifier.verify("localhost.localdomain", session)).isTrue()
+    assertThat(verifier.verify("local.host", session)).isFalse()
+    assertThat(verifier.verify("127.0.0.1", session)).isTrue()
+    assertThat(verifier.verify("127.0.0.2", session)).isFalse()
   }
 
   @Test fun wildcardsCannotMatchIpAddresses() {
@@ -493,7 +497,7 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("127.0.0.1", session)).isFalse
+    assertThat(verifier.verify("127.0.0.1", session)).isFalse()
   }
 
   /**
@@ -518,7 +522,7 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("google.com", session)).isFalse
+    assertThat(verifier.verify("google.com", session)).isFalse()
   }
 
   @Test fun subjectAltName() {
@@ -547,11 +551,11 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("bar.com", session)).isTrue
-    assertThat(verifier.verify("baz.com", session)).isTrue
-    assertThat(verifier.verify("a.foo.com", session)).isFalse
-    assertThat(verifier.verify("quux.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("bar.com", session)).isTrue()
+    assertThat(verifier.verify("baz.com", session)).isTrue()
+    assertThat(verifier.verify("a.foo.com", session)).isFalse()
+    assertThat(verifier.verify("quux.com", session)).isFalse()
   }
 
   @Test fun subjectAltNameWithWildcard() {
@@ -580,13 +584,13 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("bar.com", session)).isTrue
-    assertThat(verifier.verify("a.baz.com", session)).isTrue
-    assertThat(verifier.verify("baz.com", session)).isFalse
-    assertThat(verifier.verify("a.foo.com", session)).isFalse
-    assertThat(verifier.verify("a.bar.com", session)).isFalse
-    assertThat(verifier.verify("quux.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("bar.com", session)).isTrue()
+    assertThat(verifier.verify("a.baz.com", session)).isTrue()
+    assertThat(verifier.verify("baz.com", session)).isFalse()
+    assertThat(verifier.verify("a.foo.com", session)).isFalse()
+    assertThat(verifier.verify("a.bar.com", session)).isFalse()
+    assertThat(verifier.verify("quux.com", session)).isFalse()
   }
 
   @Test fun subjectAltNameWithIPAddresses() {
@@ -616,18 +620,18 @@ class HostnameVerifierTest {
       -----END CERTIFICATE-----
       """.trimIndent()
     )
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("::1", session)).isTrue
-    assertThat(verifier.verify("::2", session)).isFalse
-    assertThat(verifier.verify("::5", session)).isTrue
-    assertThat(verifier.verify("2a03:2880:f003:c07:face:b00c::2", session)).isTrue
-    assertThat(verifier.verify("2a03:2880:f003:c07:face:b00c:0:2", session)).isTrue
-    assertThat(verifier.verify("2a03:2880:f003:c07:FACE:B00C:0:2", session)).isTrue
-    assertThat(verifier.verify("2a03:2880:f003:c07:face:b00c:0:3", session)).isFalse
-    assertThat(verifier.verify("127.0.0.1", session)).isFalse
-    assertThat(verifier.verify("192.168.1.1", session)).isTrue
-    assertThat(verifier.verify("::ffff:192.168.1.1", session)).isTrue
-    assertThat(verifier.verify("0:0:0:0:0:FFFF:C0A8:0101", session)).isTrue
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("::1", session)).isTrue()
+    assertThat(verifier.verify("::2", session)).isFalse()
+    assertThat(verifier.verify("::5", session)).isTrue()
+    assertThat(verifier.verify("2a03:2880:f003:c07:face:b00c::2", session)).isTrue()
+    assertThat(verifier.verify("2a03:2880:f003:c07:face:b00c:0:2", session)).isTrue()
+    assertThat(verifier.verify("2a03:2880:f003:c07:FACE:B00C:0:2", session)).isTrue()
+    assertThat(verifier.verify("2a03:2880:f003:c07:face:b00c:0:3", session)).isFalse()
+    assertThat(verifier.verify("127.0.0.1", session)).isFalse()
+    assertThat(verifier.verify("192.168.1.1", session)).isTrue()
+    assertThat(verifier.verify("::ffff:192.168.1.1", session)).isTrue()
+    assertThat(verifier.verify("0:0:0:0:0:FFFF:C0A8:0101", session)).isTrue()
   }
 
   @Test fun generatedCertificate() {
@@ -636,8 +640,8 @@ class HostnameVerifierTest {
       .addSubjectAlternativeName("foo.com")
       .build()
     val session = session(heldCertificate.certificatePem())
-    assertThat(verifier.verify("foo.com", session)).isTrue
-    assertThat(verifier.verify("bar.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isTrue()
+    assertThat(verifier.verify("bar.com", session)).isFalse()
   }
 
   @Test fun specialKInHostname() {
@@ -649,17 +653,17 @@ class HostnameVerifierTest {
       .addSubjectAlternativeName("tel.com")
       .build()
     val session = session(heldCertificate.certificatePem())
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("bar.com", session)).isFalse
-    assertThat(verifier.verify("k.com", session)).isTrue
-    assertThat(verifier.verify("K.com", session)).isTrue
-    assertThat(verifier.verify("\u2121.com", session)).isFalse
-    assertThat(verifier.verify("℡.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("bar.com", session)).isFalse()
+    assertThat(verifier.verify("k.com", session)).isTrue()
+    assertThat(verifier.verify("K.com", session)).isTrue()
+    assertThat(verifier.verify("\u2121.com", session)).isFalse()
+    assertThat(verifier.verify("℡.com", session)).isFalse()
 
     // These should ideally be false, but we know that hostname is usually already checked by us
-    assertThat(verifier.verify("\u212A.com", session)).isFalse
+    assertThat(verifier.verify("\u212A.com", session)).isFalse()
     // Kelvin character below
-    assertThat(verifier.verify("K.com", session)).isFalse
+    assertThat(verifier.verify("K.com", session)).isFalse()
   }
 
   @Test fun specialKInCert() {
@@ -671,12 +675,12 @@ class HostnameVerifierTest {
       .addSubjectAlternativeName("\u212A.com")
       .build()
     val session = session(heldCertificate.certificatePem())
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("bar.com", session)).isFalse
-    assertThat(verifier.verify("k.com", session)).isFalse
-    assertThat(verifier.verify("K.com", session)).isFalse
-    assertThat(verifier.verify("tel.com", session)).isFalse
-    assertThat(verifier.verify("k.com", session)).isFalse
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("bar.com", session)).isFalse()
+    assertThat(verifier.verify("k.com", session)).isFalse()
+    assertThat(verifier.verify("K.com", session)).isFalse()
+    assertThat(verifier.verify("tel.com", session)).isFalse()
+    assertThat(verifier.verify("k.com", session)).isFalse()
   }
 
   @Test fun specialKInExternalCert() {
@@ -720,20 +724,18 @@ class HostnameVerifierTest {
     } else {
       assertThat(certificateSANs(peerCertificate)).containsExactly("���.com", "���.com")
     }
-    assertThat(verifier.verify("tel.com", session)).isFalse
-    assertThat(verifier.verify("k.com", session)).isFalse
-    assertThat(verifier.verify("foo.com", session)).isFalse
-    assertThat(verifier.verify("bar.com", session)).isFalse
-    assertThat(verifier.verify("k.com", session)).isFalse
-    assertThat(verifier.verify("K.com", session)).isFalse
+    assertThat(verifier.verify("tel.com", session)).isFalse()
+    assertThat(verifier.verify("k.com", session)).isFalse()
+    assertThat(verifier.verify("foo.com", session)).isFalse()
+    assertThat(verifier.verify("bar.com", session)).isFalse()
+    assertThat(verifier.verify("k.com", session)).isFalse()
+    assertThat(verifier.verify("K.com", session)).isFalse()
   }
 
-  private fun certificateSANs(peerCertificate: X509Certificate): Stream<String> {
-    val subjectAlternativeNames = peerCertificate.subjectAlternativeNames
-    return if (subjectAlternativeNames == null) {
-      Stream.empty()
-    } else {
-      subjectAlternativeNames.stream().map { c: List<*> -> c[1] as String }
+  private fun certificateSANs(peerCertificate: X509Certificate): List<String> {
+    return when (val subjectAlternativeNames = peerCertificate.subjectAlternativeNames) {
+      null -> listOf()
+      else -> subjectAlternativeNames.map { c: List<*> -> c[1] as String }
     }
   }
 
@@ -765,44 +767,44 @@ class HostnameVerifierTest {
     )
 
     // Replacement characters are deliberate, from certificate loading.
-    assertThat(verifier.verify("���.com", session)).isFalse
-    assertThat(verifier.verify("℡.com", session)).isFalse
+    assertThat(verifier.verify("���.com", session)).isFalse()
+    assertThat(verifier.verify("℡.com", session)).isFalse()
   }
 
   @Test fun thatCatchesErrorsWithBadSession() {
     val localVerifier = OkHttpClient().hostnameVerifier
 
     // Since this is public API, okhttp3.internal.tls.OkHostnameVerifier.verify is also
-    assertThat(verifier).isInstanceOf(OkHostnameVerifier::class.java)
+    assertThat(verifier).isInstanceOf<OkHostnameVerifier>()
     val handshakeCertificates = platform.localhostHandshakeCertificates()
     val session = handshakeCertificates.sslContext().createSSLEngine().session
-    assertThat(localVerifier.verify("\uD83D\uDCA9.com", session)).isFalse
+    assertThat(localVerifier.verify("\uD83D\uDCA9.com", session)).isFalse()
   }
 
   @Test fun verifyAsIpAddress() {
     // IPv4
-    assertThat("127.0.0.1".canParseAsIpAddress()).isTrue
-    assertThat("1.2.3.4".canParseAsIpAddress()).isTrue
+    assertThat("127.0.0.1".canParseAsIpAddress()).isTrue()
+    assertThat("1.2.3.4".canParseAsIpAddress()).isTrue()
 
     // IPv6
-    assertThat("::1".canParseAsIpAddress()).isTrue
-    assertThat("2001:db8::1".canParseAsIpAddress()).isTrue
-    assertThat("::192.168.0.1".canParseAsIpAddress()).isTrue
-    assertThat("::ffff:192.168.0.1".canParseAsIpAddress()).isTrue
-    assertThat("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210".canParseAsIpAddress()).isTrue
-    assertThat("1080:0:0:0:8:800:200C:417A".canParseAsIpAddress()).isTrue
-    assertThat("1080::8:800:200C:417A".canParseAsIpAddress()).isTrue
-    assertThat("FF01::101".canParseAsIpAddress()).isTrue
-    assertThat("0:0:0:0:0:0:13.1.68.3".canParseAsIpAddress()).isTrue
-    assertThat("0:0:0:0:0:FFFF:129.144.52.38".canParseAsIpAddress()).isTrue
-    assertThat("::13.1.68.3".canParseAsIpAddress()).isTrue
-    assertThat("::FFFF:129.144.52.38".canParseAsIpAddress()).isTrue
+    assertThat("::1".canParseAsIpAddress()).isTrue()
+    assertThat("2001:db8::1".canParseAsIpAddress()).isTrue()
+    assertThat("::192.168.0.1".canParseAsIpAddress()).isTrue()
+    assertThat("::ffff:192.168.0.1".canParseAsIpAddress()).isTrue()
+    assertThat("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210".canParseAsIpAddress()).isTrue()
+    assertThat("1080:0:0:0:8:800:200C:417A".canParseAsIpAddress()).isTrue()
+    assertThat("1080::8:800:200C:417A".canParseAsIpAddress()).isTrue()
+    assertThat("FF01::101".canParseAsIpAddress()).isTrue()
+    assertThat("0:0:0:0:0:0:13.1.68.3".canParseAsIpAddress()).isTrue()
+    assertThat("0:0:0:0:0:FFFF:129.144.52.38".canParseAsIpAddress()).isTrue()
+    assertThat("::13.1.68.3".canParseAsIpAddress()).isTrue()
+    assertThat("::FFFF:129.144.52.38".canParseAsIpAddress()).isTrue()
 
     // Hostnames
-    assertThat("go".canParseAsIpAddress()).isFalse
-    assertThat("localhost".canParseAsIpAddress()).isFalse
-    assertThat("squareup.com".canParseAsIpAddress()).isFalse
-    assertThat("www.nintendo.co.jp".canParseAsIpAddress()).isFalse
+    assertThat("go".canParseAsIpAddress()).isFalse()
+    assertThat("localhost".canParseAsIpAddress()).isFalse()
+    assertThat("squareup.com".canParseAsIpAddress()).isFalse()
+    assertThat("www.nintendo.co.jp".canParseAsIpAddress()).isFalse()
   }
 
   private fun certificate(certificate: String): X509Certificate {

--- a/okhttp/src/test/java/okhttp3/internal/ws/MessageDeflaterInflaterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/MessageDeflaterInflaterTest.kt
@@ -15,13 +15,15 @@
  */
 package okhttp3.internal.ws
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isLessThan
 import java.io.EOFException
 import okhttp3.TestUtil.fragmentBuffer
 import okio.Buffer
 import okio.ByteString
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketExtensionsTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketExtensionsTest.kt
@@ -15,8 +15,9 @@
  */
 package okhttp3.internal.ws
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import okhttp3.Headers.Companion.headersOf
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class WebSocketExtensionsTest {

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketReaderTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketReaderTest.kt
@@ -15,6 +15,11 @@
  */
 package okhttp3.internal.ws
 
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.matches
+import assertk.fail
 import java.io.EOFException
 import java.io.IOException
 import java.net.ProtocolException
@@ -26,9 +31,7 @@ import okio.ByteString.Companion.EMPTY
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 
 class WebSocketReaderTest {
@@ -74,7 +77,7 @@ class WebSocketReaderTest {
     data.write("0a00".decodeHex()) // Empty pong.
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message)
         .isEqualTo("Control frames must be final.")
@@ -85,7 +88,7 @@ class WebSocketReaderTest {
     data.write("ca00".decodeHex()) // Empty pong, flag 1 set.
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message).isEqualTo("Unexpected rsv1 flag")
     }
@@ -95,7 +98,7 @@ class WebSocketReaderTest {
     data.write("ca00".decodeHex()) // Empty pong, flag 1 set.
     try {
       clientReaderWithCompression.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message).isEqualTo("Unexpected rsv1 flag")
     }
@@ -105,7 +108,7 @@ class WebSocketReaderTest {
     data.write("c000".decodeHex()) // Empty continuation, flag 1 set.
     try {
       clientReaderWithCompression.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message).isEqualTo("Unexpected rsv1 flag")
     }
@@ -115,7 +118,7 @@ class WebSocketReaderTest {
     data.write("aa00".decodeHex()) // Empty pong, flag 2 set.
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message).isEqualTo("Unexpected rsv2 flag")
     }
@@ -123,7 +126,7 @@ class WebSocketReaderTest {
     data.write("9a00".decodeHex()) // Empty pong, flag 3 set.
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message).isEqualTo("Unexpected rsv3 flag")
     }
@@ -133,7 +136,7 @@ class WebSocketReaderTest {
     data.write("8100".decodeHex())
     try {
       serverReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message)
         .isEqualTo("Client-sent frames must be masked.")
@@ -144,7 +147,7 @@ class WebSocketReaderTest {
     data.write("8180".decodeHex())
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message)
         .isEqualTo("Server-sent frames must not be masked.")
@@ -155,7 +158,7 @@ class WebSocketReaderTest {
     data.write("8a7e007e".decodeHex())
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message)
         .isEqualTo("Control frame must be less than 125B.")
@@ -214,7 +217,7 @@ class WebSocketReaderTest {
     data.write("817f8000000000000000".decodeHex())
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message).isEqualTo(
         "Frame length 0x8000000000000000 > 0x7FFFFFFFFFFFFFFF"
@@ -298,7 +301,7 @@ class WebSocketReaderTest {
     data.write("810548656c".decodeHex()) // Length = 5, "Hel"
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (ignored: EOFException) {
     }
   }
@@ -307,7 +310,7 @@ class WebSocketReaderTest {
     data.write("c10548656c6c6f".decodeHex()) // Uncompressed 'Hello', flag 1 set
     try {
       clientReaderWithCompression.processNextFrame()
-      fail()
+      fail("")
     } catch (ignored: IOException) {
     }
   }
@@ -316,7 +319,7 @@ class WebSocketReaderTest {
     data.write("8a0548656c".decodeHex()) // Length = 5, "Hel"
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (ignored: EOFException) {
     }
   }
@@ -325,7 +328,7 @@ class WebSocketReaderTest {
     data.write("818537fa213d7f9f4d".decodeHex()) // Length = 5, "Hel"
     try {
       serverReader.processNextFrame()
-      fail()
+      fail("")
     } catch (ignored: EOFException) {
     }
   }
@@ -334,7 +337,7 @@ class WebSocketReaderTest {
     data.write("8a8537fa213d7f9f4d".decodeHex()) // Length = 5, "Hel"
     try {
       serverReader.processNextFrame()
-      fail()
+      fail("")
     } catch (ignored: EOFException) {
     }
   }
@@ -360,7 +363,7 @@ class WebSocketReaderTest {
     data.write("8264".decodeHex()).write(bytes, 100, 100)
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message)
         .isEqualTo("Expected continuation opcode. Got: 2")
@@ -389,7 +392,7 @@ class WebSocketReaderTest {
     data.write("880100".decodeHex()) // Close with invalid 1-byte payload
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message)
         .isEqualTo("Malformed close payload length of 1.")
@@ -413,7 +416,7 @@ class WebSocketReaderTest {
     data.write("88020001".decodeHex()) // Close with code 1
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message)
         .isEqualTo("Code must be in range [1000,5000): 1")
@@ -421,7 +424,7 @@ class WebSocketReaderTest {
     data.write("88021388".decodeHex()) // Close with code 5000
     try {
       clientReader.processNextFrame()
-      fail()
+      fail("")
     } catch (e: ProtocolException) {
       assertThat(e.message)
         .isEqualTo("Code must be in range [1000,5000): 5000")
@@ -439,10 +442,10 @@ class WebSocketReaderTest {
     while (!data.exhausted()) {
       try {
         clientReader.processNextFrame()
-        fail()
+        fail("")
       } catch (e: ProtocolException) {
-        assertThat(e.message)
-          .matches("Code \\d+ is reserved and may not be used.")
+        assertThat(e.message!!)
+          .matches(Regex("Code \\d+ is reserved and may not be used."))
       }
       count++
     }
@@ -457,9 +460,9 @@ class WebSocketReaderTest {
     clientReaderWithCompression.close()
     try {
       clientReaderWithCompression.processNextFrame()
-      fail()
+      fail("")
     } catch (e: Exception) {
-      assertThat(e.message).contains("closed")
+      assertThat(e.message!!).contains("closed")
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketWriterTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketWriterTest.kt
@@ -15,6 +15,8 @@
  */
 package okhttp3.internal.ws
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import java.util.Random
 import okhttp3.TestUtil.repeat
 import okhttp3.internal.format
@@ -28,7 +30,6 @@ import okio.ByteString.Companion.EMPTY
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.encodeUtf8
 import okio.ByteString.Companion.toByteString
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.AfterEachCallback
@@ -46,8 +47,7 @@ class WebSocketWriterTest {
   @RegisterExtension
   val noDataLeftBehind = AfterEachCallback { context: ExtensionContext ->
     if (context.executionException.isPresent) return@AfterEachCallback
-    assertThat(data.readByteString().hex())
-      .overridingErrorMessage("Data not empty")
+    assertThat(data.readByteString().hex(), "Data not empty")
       .isEqualTo("")
   }
 

--- a/samples/compare/build.gradle.kts
+++ b/samples/compare/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   testImplementation(libs.jettyClient)
   testImplementation(libs.junit)
   testImplementation(libs.assertj.core)
+  testImplementation(libs.assertk)
 }
 
 tasks.compileJava {

--- a/samples/compare/src/test/kotlin/okhttp3/compare/ApacheHttpClientTest.kt
+++ b/samples/compare/src/test/kotlin/okhttp3/compare/ApacheHttpClientTest.kt
@@ -15,12 +15,14 @@
  */
 package okhttp3.compare
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.startsWith
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.core5.http.io.entity.EntityUtils
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -55,6 +57,6 @@ class ApacheHttpClientTest {
       assertThat(recorded.headers["Accept"]).isEqualTo("text/plain")
       assertThat(recorded.headers["Accept-Encoding"]).isEqualTo("gzip, x-gzip, deflate")
       assertThat(recorded.headers["Connection"]).isEqualTo("keep-alive")
-      assertThat(recorded.headers["User-Agent"]).startsWith("Apache-HttpClient/")
+      assertThat(recorded.headers["User-Agent"]!!).startsWith("Apache-HttpClient/")
   }
 }

--- a/samples/compare/src/test/kotlin/okhttp3/compare/JavaHttpClientTest.kt
+++ b/samples/compare/src/test/kotlin/okhttp3/compare/JavaHttpClientTest.kt
@@ -15,15 +15,19 @@
  */
 package okhttp3.compare
 
-import mockwebserver3.MockResponse
-import mockwebserver3.MockWebServer
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.matches
 import java.net.http.HttpClient
 import java.net.http.HttpClient.Redirect.NORMAL
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse.BodyHandlers
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
 import okhttp3.testing.PlatformRule
 import okhttp3.testing.PlatformVersion
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -66,6 +70,6 @@ class JavaHttpClientTest {
       }
       assertThat(recorded.headers["HTTP2-Settings"]).isNotNull()
       assertThat(recorded.headers["Upgrade"]).isEqualTo("h2c") // HTTP/2 over plaintext!
-      assertThat(recorded.headers["User-Agent"]).matches("Java-http-client/.*")
+      assertThat(recorded.headers["User-Agent"]!!).matches(Regex("Java-http-client/.*"))
   }
 }

--- a/samples/compare/src/test/kotlin/okhttp3/compare/JettyHttpClientTest.kt
+++ b/samples/compare/src/test/kotlin/okhttp3/compare/JettyHttpClientTest.kt
@@ -15,9 +15,12 @@
  */
 package okhttp3.compare
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.matches
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
-import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jetty.client.HttpClient
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -54,6 +57,6 @@ class JettyHttpClientTest {
       assertThat(recorded.headers["Accept"]).isEqualTo("text/plain")
       assertThat(recorded.headers["Accept-Encoding"]).isEqualTo("gzip")
       assertThat(recorded.headers["Connection"]).isNull()
-      assertThat(recorded.headers["User-Agent"]).matches("Jetty/.*")
+      assertThat(recorded.headers["User-Agent"]!!).matches(Regex("Jetty/.*"))
   }
 }

--- a/samples/compare/src/test/kotlin/okhttp3/compare/OkHttpClientTest.kt
+++ b/samples/compare/src/test/kotlin/okhttp3/compare/OkHttpClientTest.kt
@@ -15,12 +15,14 @@
  */
 package okhttp3.compare
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.matches
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.testing.PlatformRule
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -49,6 +51,6 @@ class OkHttpClientTest {
       assertThat(recorded.headers["Accept"]).isEqualTo("text/plain")
       assertThat(recorded.headers["Accept-Encoding"]).isEqualTo("gzip")
       assertThat(recorded.headers["Connection"]).isEqualTo("Keep-Alive")
-      assertThat(recorded.headers["User-Agent"]).matches("okhttp/.*")
+      assertThat(recorded.headers["User-Agent"]!!).matches(Regex("okhttp/.*"))
   }
 }


### PR DESCRIPTION
When we split tests into multiplatform we switched them from AssertJ to assertk. I'm migrating everything over to assertk so that I can merge tests back together without changing assertion APIs.