### PR TITLE
Support oneshot forms

### DIFF
--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -816,6 +816,7 @@ public final class okhttp3/MultipartBody : okhttp3/RequestBody {
 	public final fun boundary ()Ljava/lang/String;
 	public fun contentLength ()J
 	public fun contentType ()Lokhttp3/MediaType;
+	public fun isOneShot ()Z
 	public final fun part (I)Lokhttp3/MultipartBody$Part;
 	public final fun parts ()Ljava/util/List;
 	public final fun size ()I

--- a/okhttp/src/main/kotlin/okhttp3/MultipartBody.kt
+++ b/okhttp/src/main/kotlin/okhttp3/MultipartBody.kt
@@ -50,7 +50,7 @@ class MultipartBody internal constructor(
   fun part(index: Int): Part = parts[index]
 
   override fun isOneShot(): Boolean {
-    return parts.find { it.body.isOneShot() } != null
+    return parts.any { it.body.isOneShot() }
   }
 
   /** A combination of [type] and [boundaryByteString]. */

--- a/okhttp/src/main/kotlin/okhttp3/MultipartBody.kt
+++ b/okhttp/src/main/kotlin/okhttp3/MultipartBody.kt
@@ -49,6 +49,10 @@ class MultipartBody internal constructor(
 
   fun part(index: Int): Part = parts[index]
 
+  override fun isOneShot(): Boolean {
+    return parts.find { it.body.isOneShot() } != null
+  }
+
   /** A combination of [type] and [boundaryByteString]. */
   override fun contentType(): MediaType = contentType
 


### PR DESCRIPTION
If a multipart form has a oneshot Part, then it is also oneshot.

Fix for https://github.com/square/okhttp/issues/8138