### PR TITLE
Avoid checking file metadata in graal tests

### DIFF
--- a/native-image-tests/src/main/kotlin/okhttp3/PublicSuffixDatabaseTest.kt
+++ b/native-image-tests/src/main/kotlin/okhttp3/PublicSuffixDatabaseTest.kt
@@ -20,10 +20,16 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.internal.publicsuffix.PublicSuffixDatabase
+import okhttp3.testing.PlatformRule
 import okio.FileSystem
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class PublicSuffixDatabaseTest {
+  @RegisterExtension
+  @JvmField
+  val platform = PlatformRule()
+
   @Test
   fun testResourcesLoaded() {
     val url = "https://api.twitter.com".toHttpUrl()
@@ -33,6 +39,8 @@ class PublicSuffixDatabaseTest {
 
   @Test
   fun testPublicSuffixes() {
+    platform.assumeNotLoom()
+
     val metadata = FileSystem.RESOURCES.metadata(PublicSuffixDatabase.PUBLIC_SUFFIX_RESOURCE)
     assertThat(metadata.size!!).isGreaterThan(30000)
   }

--- a/native-image-tests/src/main/kotlin/okhttp3/PublicSuffixDatabaseTest.kt
+++ b/native-image-tests/src/main/kotlin/okhttp3/PublicSuffixDatabaseTest.kt
@@ -39,7 +39,7 @@ class PublicSuffixDatabaseTest {
 
   @Test
   fun testPublicSuffixes() {
-    platform.assumeNotLoom()
+    platform.assumeNotGraalVMImage()
 
     val metadata = FileSystem.RESOURCES.metadata(PublicSuffixDatabase.PUBLIC_SUFFIX_RESOURCE)
     assertThat(metadata.size!!).isGreaterThan(30000)


### PR DESCRIPTION
Failing in https://github.com/square/okhttp/actions/runs/7313504687/job/19925152167