### PR TITLE
Resolve JDKs if necessary

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,19 @@
 rootProject.name = "okhttp-parent"
 
+plugins {
+  id("org.gradle.toolchains.foojay-resolver") version("0.7.0")
+}
+
+toolchainManagement {
+  jvm {
+    javaRepositories {
+      repository("foojay") {
+        resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
+      }
+    }
+  }
+}
+
 include(":mockwebserver")
 project(":mockwebserver").name = "mockwebserver3"
 include(":mockwebserver-deprecated")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,17 +1,7 @@
 rootProject.name = "okhttp-parent"
 
 plugins {
-  id("org.gradle.toolchains.foojay-resolver") version("0.7.0")
-}
-
-toolchainManagement {
-  jvm {
-    javaRepositories {
-      repository("foojay") {
-        resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
-      }
-    }
-  }
+  id("org.gradle.toolchains.foojay-resolver-convention") version("0.7.0")
 }
 
 include(":mockwebserver")


### PR DESCRIPTION
Without this, developers need to prepare their environments or they might see failures like this:

    Execution failed for task ':okhttp-idna-mapping-table:test'.
    > Error while evaluating property 'javaLauncher' of task ':okhttp-idna-mapping-table:test'.
       > Failed to calculate the value of task ':okhttp-idna-mapping-table:test' property 'javaLauncher'.
          > No matching toolchains found for requested specification: {languageVersion=21, vendor=any, implementation=vendor-specific} for MAC_OS on aarch64.
             > No locally installed toolchains match and toolchain download repositories have not been configured.