### PR TITLE
allow configuring web socket close timeout

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -808,6 +808,7 @@ class MockWebServer : Closeable {
         extensions = WebSocketExtensions.parse(webSocketResponse.headers),
         // Compress all messages if compression is enabled.
         minimumDeflateSize = 0L,
+        closeTimeoutMillis = RealWebSocket.CANCEL_AFTER_CLOSE_MILLIS,
       )
     val name = "MockWebServer WebSocket ${request.path!!}"
     webSocket.initReaderAndWriter(name, streams)

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -918,6 +918,7 @@ public class okhttp3/OkHttpClient : okhttp3/Call$Factory, okhttp3/WebSocket$Fact
 	public final fun callTimeoutMillis ()I
 	public final fun certificateChainCleaner ()Lokhttp3/internal/tls/CertificateChainCleaner;
 	public final fun certificatePinner ()Lokhttp3/CertificatePinner;
+	public final fun closeTimeoutMillis ()I
 	public final fun connectTimeoutMillis ()I
 	public final fun connectionPool ()Lokhttp3/ConnectionPool;
 	public final fun connectionSpecs ()Ljava/util/List;
@@ -961,6 +962,9 @@ public final class okhttp3/OkHttpClient$Builder {
 	public final fun callTimeout (Ljava/time/Duration;)Lokhttp3/OkHttpClient$Builder;
 	public final fun callTimeout-LRDsOJo (J)Lokhttp3/OkHttpClient$Builder;
 	public final fun certificatePinner (Lokhttp3/CertificatePinner;)Lokhttp3/OkHttpClient$Builder;
+	public final fun closeTimeout (JLjava/util/concurrent/TimeUnit;)Lokhttp3/OkHttpClient$Builder;
+	public final fun closeTimeout (Ljava/time/Duration;)Lokhttp3/OkHttpClient$Builder;
+	public final fun closeTimeout-LRDsOJo (J)Lokhttp3/OkHttpClient$Builder;
 	public final fun connectTimeout (JLjava/util/concurrent/TimeUnit;)Lokhttp3/OkHttpClient$Builder;
 	public final fun connectTimeout (Ljava/time/Duration;)Lokhttp3/OkHttpClient$Builder;
 	public final fun connectTimeout-LRDsOJo (J)Lokhttp3/OkHttpClient$Builder;

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -252,6 +252,10 @@ open class OkHttpClient internal constructor(
   @get:JvmName("pingIntervalMillis")
   val pingIntervalMillis: Int = builder.pingInterval
 
+  /** Web socket close timeout (in milliseconds). */
+  @get:JvmName("closeTimeoutMillis")
+  val closeTimeoutMillis: Int = builder.closeTimeout
+
   /**
    * Minimum outbound web socket message size (in bytes) that will be compressed.
    * The default is 1024 bytes.
@@ -327,6 +331,7 @@ open class OkHttpClient internal constructor(
         // extensions is always null for clients:
         extensions = null,
         minimumDeflateSize = minWebSocketMessageToCompress,
+        closeTimeoutMillis = closeTimeoutMillis.toLong(),
       )
     webSocket.connect(this)
     return webSocket
@@ -572,6 +577,7 @@ open class OkHttpClient internal constructor(
     internal var readTimeout = 10_000
     internal var writeTimeout = 10_000
     internal var pingInterval = 0
+    internal var closeTimeout = RealWebSocket.CANCEL_AFTER_CLOSE_MILLIS.toInt()
     internal var minWebSocketMessageToCompress = RealWebSocket.DEFAULT_MINIMUM_DEFLATE_SIZE
     internal var routeDatabase: RouteDatabase? = null
     internal var taskRunner: TaskRunner? = null
@@ -606,6 +612,7 @@ open class OkHttpClient internal constructor(
       this.readTimeout = okHttpClient.readTimeoutMillis
       this.writeTimeout = okHttpClient.writeTimeoutMillis
       this.pingInterval = okHttpClient.pingIntervalMillis
+      this.closeTimeout = okHttpClient.closeTimeoutMillis
       this.minWebSocketMessageToCompress = okHttpClient.minWebSocketMessageToCompress
       this.routeDatabase = okHttpClient.routeDatabase
       this.taskRunner = okHttpClient.taskRunner
@@ -1274,6 +1281,49 @@ open class OkHttpClient internal constructor(
     fun pingInterval(duration: KotlinDuration) =
       apply {
         pingInterval = checkDuration("duration", duration)
+      }
+
+    /**
+     * Sets the close timeout for web socket connections. A value of 0 means no timeout, otherwise
+     * values must be between 1 and [Integer.MAX_VALUE] when converted to milliseconds.
+     *
+     * The close timeout is the maximum amount of time after the client calls [close] to wait
+     * for a graceful shutdown. If the server doesn't respond the web socket will be canceled.
+     * The default value is 60 seconds.
+     */
+    fun closeTimeout(
+      timeout: Long,
+      unit: TimeUnit,
+    ) = apply {
+      closeTimeout = checkDuration("timeout", timeout, unit)
+    }
+
+    /**
+     * Sets the close timeout for web socket connections. A value of 0 means no timeout, otherwise
+     * values must be between 1 and [Integer.MAX_VALUE] when converted to milliseconds.
+     *
+     * The close timeout is the maximum amount of time after the client calls [close] to wait
+     * for a graceful shutdown. If the server doesn't respond the web socket will be canceled.
+     * The default value is 60 seconds.
+     */
+    @SuppressLint("NewApi")
+    @IgnoreJRERequirement
+    fun closeTimeout(duration: Duration) =
+      apply {
+        closeTimeout(duration.toMillis(), MILLISECONDS)
+      }
+
+    /**
+     * Sets the close timeout for web socket connections. A value of 0 means no timeout, otherwise
+     * values must be between 1 and [Integer.MAX_VALUE] when converted to milliseconds.
+     *
+     * The close timeout is the maximum amount of time after the client calls [close] to wait
+     * for a graceful shutdown. If the server doesn't respond the web socket will be canceled.
+     * The default value is 60 seconds.
+     */
+    fun closeTimeout(duration: KotlinDuration) =
+      apply {
+        closeTimeout = checkDuration("duration", duration)
       }
 
     /**

--- a/okhttp/src/main/kotlin/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/ws/RealWebSocket.kt
@@ -64,6 +64,7 @@ class RealWebSocket(
   private var extensions: WebSocketExtensions?,
   /** If compression is negotiated, outbound messages of this size and larger will be compressed. */
   private var minimumDeflateSize: Long,
+  private val closeTimeoutMillis: Long,
 ) : WebSocket, WebSocketReader.FrameCallback {
   private val key: String
 
@@ -469,7 +470,7 @@ class RealWebSocket(
     code: Int,
     reason: String?,
   ): Boolean {
-    return close(code, reason, CANCEL_AFTER_CLOSE_MILLIS)
+    return close(code, reason, closeTimeoutMillis)
   }
 
   @Synchronized fun close(
@@ -712,7 +713,7 @@ class RealWebSocket(
      * The maximum amount of time after the client calls [close] to wait for a graceful shutdown. If
      * the server doesn't respond the web socket will be canceled.
      */
-    private const val CANCEL_AFTER_CLOSE_MILLIS = 60L * 1000
+    const val CANCEL_AFTER_CLOSE_MILLIS = 60L * 1000
 
     /**
      * The smallest message that will be compressed. We use 1024 because smaller messages already

--- a/okhttp/src/test/java/okhttp3/OkHttpClientTest.kt
+++ b/okhttp/src/test/java/okhttp3/OkHttpClientTest.kt
@@ -74,6 +74,7 @@ class OkHttpClientTest {
     assertThat(client.readTimeoutMillis).isEqualTo(10000)
     assertThat(client.writeTimeoutMillis).isEqualTo(10000)
     assertThat(client.pingIntervalMillis).isEqualTo(0)
+    assertThat(client.closeTimeoutMillis).isEqualTo(60_000)
   }
 
   @Test fun webSocketDefaults() {

--- a/okhttp/src/test/java/okhttp3/internal/ws/RealWebSocketTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/RealWebSocketTest.kt
@@ -460,6 +460,7 @@ class RealWebSocketTest {
             responseHeaders,
           ),
           RealWebSocket.DEFAULT_MINIMUM_DEFLATE_SIZE,
+          RealWebSocket.CANCEL_AFTER_CLOSE_MILLIS,
         )
       webSocket!!.initReaderAndWriter(name, this)
     }

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.kt
@@ -1214,6 +1214,7 @@ class WebSocketHttpTest {
         client.pingIntervalMillis.toLong(),
         null,
         0L,
+        client.closeTimeoutMillis.toLong(),
       )
     webSocket.connect(client)
     return webSocket


### PR DESCRIPTION
The default timeout of 60 seconds is too high for one of my use cases. I tried my best to match the existing API. Please feel free to give me feedback on how I can make this as good as possible to increase the likelihood of it being merged.

PS Thanks for the efforts maintaining critical infrastructure like this library.



<details>

<summary><em>Edit: Figured it out. My JVM was set to Java 8 SDK.</em> I sadly could not run `./gradlew checks`. I included the errors I got.</summary>

```
❯ ./gradlew checks                                                  
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.5/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 
Type-safe project accessors is an incubating feature.
Project accessors enabled, but root project name not explicitly set for 'buildSrc'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking caching.

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'okhttp-parent'.
> Could not resolve all files for configuration ':classpath'.
   > Could not resolve de.mannodermaus.gradle.plugins:android-junit5:1.10.0.0.
     Required by:
         project :
      > No matching variant of de.mannodermaus.gradle.plugins:android-junit5:1.10.0.0 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.5' but:
          - Variant 'apiElements' capability de.mannodermaus.gradle.plugins:android-junit5:1.10.0.0 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
          - Variant 'runtimeElements' capability de.mannodermaus.gradle.plugins:android-junit5:1.10.0.0 declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
   > Could not resolve com.android.tools.build:gradle:8.2.0.
     Required by:
         project :
      > No matching variant of com.android.tools.build:gradle:8.2.0 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.5' but:
          - Variant 'apiElements' capability com.android.tools.build:gradle:8.2.0 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
          - Variant 'javadocElements' capability com.android.tools.build:gradle:8.2.0 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
          - Variant 'runtimeElements' capability com.android.tools.build:gradle:8.2.0 declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
          - Variant 'sourcesElements' capability com.android.tools.build:gradle:8.2.0 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
   > Could not resolve com.diffplug.spotless:spotless-plugin-gradle:6.23.3.
     Required by:
         project :
      > No matching variant of com.diffplug.spotless:spotless-plugin-gradle:6.23.3 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.5' but:
          - Variant 'apiElements' capability com.diffplug.spotless:spotless-plugin-gradle:6.23.3 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
          - Variant 'javadocElements' capability com.diffplug.spotless:spotless-plugin-gradle:6.23.3 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
          - Variant 'runtimeElements' capability com.diffplug.spotless:spotless-plugin-gradle:6.23.3 declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
          - Variant 'sourcesElements' capability com.diffplug.spotless:spotless-plugin-gradle:6.23.3 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
   > Could not resolve com.vanniktech:gradle-maven-publish-plugin:0.27.0.
     Required by:
         project :
      > No matching variant of com.vanniktech:gradle-maven-publish-plugin:0.27.0 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.5' but:
          - Variant 'apiElements' capability com.vanniktech:gradle-maven-publish-plugin:0.27.0 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
          - Variant 'runtimeElements' capability com.vanniktech:gradle-maven-publish-plugin:0.27.0 declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')
          - Variant 'sourcesElements' capability com.vanniktech:gradle-maven-publish-plugin:0.27.0 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.5')

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 5s
4 actionable tasks: 1 executed, 3 up-to-date
```

</details>
