### PR TITLE
Mechanically tag all new APIs as @ExperimentalOkHttpApi

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 @file:Suppress("UnstableApiUsage")
 
+import com.diffplug.gradle.spotless.KotlinExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
@@ -7,7 +8,10 @@ import java.net.URI
 import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.js.translate.context.Namer.kotlin
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferExtension
 
 buildscript {
@@ -213,6 +217,15 @@ subprojects {
   tasks.withType<JavaCompile> {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
+  }
+}
+
+// Opt-in to @ExperimentalOkHttpApi everywhere.
+subprojects {
+  plugins.withId("org.jetbrains.kotlin.jvm") {
+    kotlinExtension.sourceSets.configureEach {
+      languageSettings.optIn("okhttp3.ExperimentalOkHttpApi")
+    }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -227,6 +227,11 @@ subprojects {
       languageSettings.optIn("okhttp3.ExperimentalOkHttpApi")
     }
   }
+  plugins.withId("org.jetbrains.kotlin.android") {
+    kotlinExtension.sourceSets.configureEach {
+      languageSettings.optIn("okhttp3.ExperimentalOkHttpApi")
+    }
+  }
 }
 
 /** Configure publishing and signing for published Java and JavaPlatform subprojects. */

--- a/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
@@ -24,11 +24,13 @@ import java.util.logging.Level
 import java.util.logging.Logger
 import javax.net.ServerSocketFactory
 import javax.net.ssl.SSLSocketFactory
+import okhttp3.ExperimentalOkHttpApi
 import okhttp3.HttpUrl
 import okhttp3.Protocol
 import org.junit.rules.ExternalResource
 
 class MockWebServer : ExternalResource(), Closeable {
+  @ExperimentalOkHttpApi
   val delegate = mockwebserver3.MockWebServer()
 
   val requestCount: Int by delegate::requestCount

--- a/mockwebserver-junit4/src/main/kotlin/mockwebserver3/junit4/MockWebServerRule.kt
+++ b/mockwebserver-junit4/src/main/kotlin/mockwebserver3/junit4/MockWebServerRule.kt
@@ -19,6 +19,7 @@ import java.io.IOException
 import java.util.logging.Level
 import java.util.logging.Logger
 import mockwebserver3.MockWebServer
+import okhttp3.ExperimentalOkHttpApi
 import org.junit.rules.ExternalResource
 
 /**
@@ -37,6 +38,7 @@ import org.junit.rules.ExternalResource
  * @JvmField @Rule val serverRule = MockWebServerRule()
  * ```
  */
+@ExperimentalOkHttpApi
 class MockWebServerRule : ExternalResource() {
   val server: MockWebServer = MockWebServer()
 
@@ -56,6 +58,7 @@ class MockWebServerRule : ExternalResource() {
     }
   }
 
+  @ExperimentalOkHttpApi
   companion object {
     private val logger = Logger.getLogger(MockWebServerRule::class.java.name)
   }

--- a/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/MockWebServerExtension.kt
+++ b/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/MockWebServerExtension.kt
@@ -21,6 +21,7 @@ import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.jvm.optionals.getOrNull
 import mockwebserver3.MockWebServer
+import okhttp3.ExperimentalOkHttpApi
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * - The test lifecycle default (passed into test method, plus @BeforeEach, @AfterEach)
  * - named instances with @MockWebServerInstance.
  */
+@ExperimentalOkHttpApi
 class MockWebServerExtension :
   BeforeEachCallback, AfterEachCallback, ParameterResolver {
   private val ExtensionContext.resource: ServersForTest

--- a/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/MockWebServerInstance.kt
+++ b/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/MockWebServerInstance.kt
@@ -15,6 +15,9 @@
  */
 package mockwebserver3.junit5.internal
 
+import okhttp3.ExperimentalOkHttpApi
+
+@ExperimentalOkHttpApi
 annotation class MockWebServerInstance(
   val name: String,
 )

--- a/mockwebserver/src/main/kotlin/mockwebserver3/Dispatcher.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/Dispatcher.kt
@@ -16,8 +16,10 @@
 package mockwebserver3
 
 import mockwebserver3.SocketPolicy.KeepOpen
+import okhttp3.ExperimentalOkHttpApi
 
 /** Handler for mock server requests. */
+@ExperimentalOkHttpApi
 abstract class Dispatcher {
   /**
    * Returns a response to satisfy `request`. This method may block (for instance, to wait on

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockResponse.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockResponse.kt
@@ -20,6 +20,7 @@ package mockwebserver3
 import java.util.concurrent.TimeUnit
 import mockwebserver3.SocketPolicy.KeepOpen
 import mockwebserver3.internal.toMockResponseBody
+import okhttp3.ExperimentalOkHttpApi
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.WebSocketListener
@@ -28,6 +29,7 @@ import okhttp3.internal.http2.Settings
 import okio.Buffer
 
 /** A scripted response to be replayed by the mock web server. */
+@ExperimentalOkHttpApi
 class MockResponse {
   /** Returns the HTTP response line, such as "HTTP/1.1 200 OK". */
   val status: String
@@ -112,6 +114,7 @@ class MockResponse {
 
   override fun toString(): String = status
 
+  @ExperimentalOkHttpApi
   class Builder : Cloneable {
     var inTunnel: Boolean
       internal set
@@ -453,6 +456,7 @@ class MockResponse {
     fun build(): MockResponse = MockResponse(this)
   }
 
+  @ExperimentalOkHttpApi
   companion object {
     private const val CHUNKED_BODY_HEADER = "Transfer-encoding: chunked"
   }

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockResponseBody.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockResponseBody.kt
@@ -17,6 +17,7 @@
 package mockwebserver3
 
 import java.io.IOException
+import okhttp3.ExperimentalOkHttpApi
 import okio.BufferedSink
 
 /**
@@ -25,6 +26,7 @@ import okio.BufferedSink
  * Unlike [okhttp3.ResponseBody], this interface is designed to be implemented by writers and not
  * called by readers.
  */
+@ExperimentalOkHttpApi
 interface MockResponseBody {
   /** The length of this response in bytes, or -1 if unknown. */
   val contentLength: Long

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -63,6 +63,7 @@ import mockwebserver3.internal.ThrottledSink
 import mockwebserver3.internal.TriggerSink
 import mockwebserver3.internal.duplex.RealStream
 import mockwebserver3.internal.sleepNanos
+import okhttp3.ExperimentalOkHttpApi
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.HttpUrl
@@ -97,6 +98,7 @@ import okio.source
  * A scriptable web server. Callers supply canned responses and the server replays them upon request
  * in sequence.
  */
+@ExperimentalOkHttpApi
 class MockWebServer : Closeable {
   private val taskRunnerBackend =
     TaskRunner.RealBackend(
@@ -1164,6 +1166,7 @@ class MockWebServer : Closeable {
     }
   }
 
+  @ExperimentalOkHttpApi
   companion object {
     private const val CLIENT_AUTH_NONE = 0
     private const val CLIENT_AUTH_REQUESTED = 1

--- a/mockwebserver/src/main/kotlin/mockwebserver3/PushPromise.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/PushPromise.kt
@@ -15,9 +15,11 @@
  */
 package mockwebserver3
 
+import okhttp3.ExperimentalOkHttpApi
 import okhttp3.Headers
 
 /** An HTTP request initiated by the server. */
+@ExperimentalOkHttpApi
 class PushPromise(
   val method: String,
   val path: String,

--- a/mockwebserver/src/main/kotlin/mockwebserver3/QueueDispatcher.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/QueueDispatcher.kt
@@ -20,10 +20,12 @@ import java.net.HttpURLConnection.HTTP_UNAVAILABLE
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.logging.Logger
+import okhttp3.ExperimentalOkHttpApi
 
 /**
  * Default dispatcher that processes a script of responses. Populate the script by calling [enqueueResponse].
  */
+@ExperimentalOkHttpApi
 open class QueueDispatcher : Dispatcher() {
   protected val responseQueue: BlockingQueue<MockResponse> = LinkedBlockingQueue()
   private var failFastResponse: MockResponse? = null
@@ -81,6 +83,7 @@ open class QueueDispatcher : Dispatcher() {
     this.failFastResponse = failFastResponse
   }
 
+  @ExperimentalOkHttpApi
   companion object {
     /**
      * Enqueued on shutdown to release threads waiting on [dispatch]. Note that this response

--- a/mockwebserver/src/main/kotlin/mockwebserver3/RecordedRequest.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/RecordedRequest.kt
@@ -20,6 +20,7 @@ import java.io.IOException
 import java.net.Inet6Address
 import java.net.Socket
 import javax.net.ssl.SSLSocket
+import okhttp3.ExperimentalOkHttpApi
 import okhttp3.Handshake
 import okhttp3.Handshake.Companion.handshake
 import okhttp3.Headers
@@ -29,6 +30,7 @@ import okhttp3.internal.platform.Platform
 import okio.Buffer
 
 /** An HTTP request that came into the mock web server. */
+@ExperimentalOkHttpApi
 class RecordedRequest(
   val requestLine: String,
   /** All headers. */

--- a/mockwebserver/src/main/kotlin/mockwebserver3/SocketPolicy.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/SocketPolicy.kt
@@ -16,6 +16,8 @@
 
 package mockwebserver3
 
+import okhttp3.ExperimentalOkHttpApi
+
 /**
  * What should be done with the incoming socket.
  *
@@ -29,6 +31,7 @@ package mockwebserver3
  * client behavior non-deterministic. Add delays in the client to improve the chances that the
  * server has closed the socket before follow up requests are made.
  */
+@ExperimentalOkHttpApi
 sealed interface SocketPolicy {
   /**
    * Shutdown [MockWebServer] after writing response.
@@ -115,6 +118,7 @@ sealed interface SocketPolicy {
   /**
    * Fail HTTP/2 requests without processing them by sending [http2ErrorCode].
    */
+  @ExperimentalOkHttpApi
   class ResetStreamAtStart(
     val http2ErrorCode: Int = 0,
   ) : SocketPolicy

--- a/mockwebserver/src/main/kotlin/mockwebserver3/Stream.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/Stream.kt
@@ -15,12 +15,14 @@
  */
 package mockwebserver3
 
+import okhttp3.ExperimentalOkHttpApi
 import okio.BufferedSink
 import okio.BufferedSource
 
 /**
  * A bidirectional sequence of data frames exchanged between client and server.
  */
+@ExperimentalOkHttpApi
 interface Stream {
   val requestBody: BufferedSource
   val responseBody: BufferedSink

--- a/mockwebserver/src/main/kotlin/mockwebserver3/StreamHandler.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/StreamHandler.kt
@@ -15,12 +15,15 @@
  */
 package mockwebserver3
 
+import okhttp3.ExperimentalOkHttpApi
+
 /**
  * Handles a call's stream directly. Use this instead of [MockResponseBody] to begin sending
  * response data before all request data has been received.
  *
  * See [okhttp3.RequestBody.isDuplex].
  */
+@ExperimentalOkHttpApi
 interface StreamHandler {
   fun handle(stream: Stream)
 }

--- a/okhttp-android/src/main/kotlin/okhttp3/android/AndroidAsyncDns.kt
+++ b/okhttp-android/src/main/kotlin/okhttp3/android/AndroidAsyncDns.kt
@@ -25,6 +25,7 @@ import java.net.InetAddress
 import java.net.UnknownHostException
 import java.util.concurrent.Executors
 import okhttp3.AsyncDns
+import okhttp3.ExperimentalOkHttpApi
 
 /**
  * DNS implementation based on android.net.DnsResolver, which submits a request for

--- a/okhttp-android/src/main/kotlin/okhttp3/android/AndroidAsyncDns.kt
+++ b/okhttp-android/src/main/kotlin/okhttp3/android/AndroidAsyncDns.kt
@@ -35,6 +35,7 @@ import okhttp3.AsyncDns
  * @param network network to use, if not selects the default network.
  */
 @RequiresApi(Build.VERSION_CODES.Q)
+@ExperimentalOkHttpApi
 class AndroidAsyncDns(
   private val dnsClass: AsyncDns.DnsClass,
   private val network: Network? = null,
@@ -74,6 +75,7 @@ class AndroidAsyncDns(
     )
   }
 
+  @ExperimentalOkHttpApi
   companion object {
     @RequiresApi(Build.VERSION_CODES.Q)
     val IPv4 = AndroidAsyncDns(dnsClass = AsyncDns.DnsClass.IPV4)

--- a/okhttp-coroutines/src/main/kotlin/okhttp3/JvmCallExtensions.kt
+++ b/okhttp-coroutines/src/main/kotlin/okhttp3/JvmCallExtensions.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import okio.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@ExperimentalOkHttpApi
 suspend fun Call.executeAsync(): Response =
   suspendCancellableCoroutine { continuation ->
     continuation.invokeOnCancellation {

--- a/okhttp-java-net-cookiejar/src/main/kotlin/okhttp3/java/net/cookiejar/JavaNetCookieJar.kt
+++ b/okhttp-java-net-cookiejar/src/main/kotlin/okhttp3/java/net/cookiejar/JavaNetCookieJar.kt
@@ -23,6 +23,7 @@ import java.net.HttpCookie
 import java.util.Collections
 import okhttp3.Cookie
 import okhttp3.CookieJar
+import okhttp3.ExperimentalOkHttpApi
 import okhttp3.HttpUrl
 import okhttp3.internal.cookieToString
 import okhttp3.internal.delimiterOffset
@@ -31,6 +32,7 @@ import okhttp3.internal.platform.Platform.Companion.WARN
 import okhttp3.internal.trimSubstring
 
 /** A cookie jar that delegates to a [java.net.CookieHandler]. */
+@ExperimentalOkHttpApi
 class JavaNetCookieJar(private val cookieHandler: CookieHandler) : CookieJar {
   override fun saveFromResponse(
     url: HttpUrl,

--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSources.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSources.kt
@@ -16,6 +16,7 @@
 package okhttp3.sse
 
 import okhttp3.Call
+import okhttp3.ExperimentalOkHttpApi
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import okhttp3.sse.internal.RealEventSource
@@ -29,6 +30,7 @@ object EventSources {
   fun createFactory(client: OkHttpClient) = createFactory(client as Call.Factory)
 
   @JvmStatic
+  @ExperimentalOkHttpApi
   fun createFactory(callFactory: Call.Factory): EventSource.Factory {
     return EventSource.Factory { request, listener ->
       val actualRequest =

--- a/okhttp/src/main/kotlin/okhttp3/AsyncDns.kt
+++ b/okhttp/src/main/kotlin/okhttp3/AsyncDns.kt
@@ -32,6 +32,7 @@ import okio.IOException
  *
  * Implementations of this interface must be safe for concurrent use.
  */
+@ExperimentalOkHttpApi
 interface AsyncDns {
   /**
    * Query DNS records for `hostname`, in the order they are received.
@@ -44,6 +45,7 @@ interface AsyncDns {
   /**
    * Callback to receive results from the DNS Queries.
    */
+  @ExperimentalOkHttpApi
   interface Callback {
     /**
      * Return addresses for a dns query for a single class of IPv4 (A) or IPv6 (AAAA).
@@ -67,11 +69,13 @@ interface AsyncDns {
    * Class of DNS addresses, such that clients that treat these differently, such
    * as attempting IPv6 first, can make such decisions.
    */
+  @ExperimentalOkHttpApi
   enum class DnsClass(val type: Int) {
     IPV4(TYPE_A),
     IPV6(TYPE_AAAA),
   }
 
+  @ExperimentalOkHttpApi
   companion object {
     const val TYPE_A = 1
     const val TYPE_AAAA = 28

--- a/okhttp/src/main/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Cache.kt
@@ -147,6 +147,7 @@ class Cache internal constructor(
   fileSystem: FileSystem,
   taskRunner: TaskRunner,
 ) : Closeable, Flushable {
+  @ExperimentalOkHttpApi
   constructor(
     directory: Path,
     maxSize: Long,
@@ -384,6 +385,7 @@ class Cache internal constructor(
     get() = cache.directory.toFile()
 
   @get:JvmName("directoryPath")
+  @ExperimentalOkHttpApi
   val directoryPath: Path
     get() = cache.directory
 

--- a/okhttp/src/main/kotlin/okhttp3/CacheControl.kt
+++ b/okhttp/src/main/kotlin/okhttp3/CacheControl.kt
@@ -189,16 +189,19 @@ class CacheControl internal constructor(
      * @param maxAge a non-negative integer. This is stored and transmitted with [TimeUnit.SECONDS]
      *     precision; finer precision will be lost.
      */
+    @ExperimentalOkHttpApi
     fun maxAge(
       maxAge: Int,
       timeUnit: DurationUnit,
     ) = commonMaxAge(maxAge, timeUnit)
 
+    @ExperimentalOkHttpApi
     fun maxStale(
       maxStale: Int,
       timeUnit: DurationUnit,
     ) = commonMaxStale(maxStale, timeUnit)
 
+    @ExperimentalOkHttpApi
     fun minFresh(
       minFresh: Int,
       timeUnit: DurationUnit,

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionListener.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionListener.kt
@@ -24,6 +24,7 @@ import okio.IOException
  * attempt to mutate the event parameters, or be reentrant back into the client.
  * Any IO - writing to files or network should be done asynchronously.
  */
+@ExperimentalOkHttpApi
 abstract class ConnectionListener {
   /**
    * Invoked as soon as a call causes a connection to be started.
@@ -77,6 +78,7 @@ abstract class ConnectionListener {
    */
   open fun noNewExchanges(connection: Connection) {}
 
+  @ExperimentalOkHttpApi
   companion object {
     val NONE: ConnectionListener = object : ConnectionListener() {}
   }

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -50,6 +50,7 @@ class ConnectionPool internal constructor(
   )
 
   // Public API
+  @ExperimentalOkHttpApi
   constructor(
     maxIdleConnections: Int = 5,
     keepAliveDuration: Long = 5,

--- a/okhttp/src/main/kotlin/okhttp3/Cookie.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Cookie.kt
@@ -92,7 +92,6 @@ class Cookie private constructor(
    * This is true unless 'domain' is present.
    */
   @get:JvmName("hostOnly") val hostOnly: Boolean,
-
   /**
    * Returns a string describing whether this cookie is sent for cross-site calls.
    *

--- a/okhttp/src/main/kotlin/okhttp3/Cookie.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Cookie.kt
@@ -92,6 +92,7 @@ class Cookie private constructor(
    * This is true unless 'domain' is present.
    */
   @get:JvmName("hostOnly") val hostOnly: Boolean,
+
   /**
    * Returns a string describing whether this cookie is sent for cross-site calls.
    *
@@ -117,7 +118,9 @@ class Cookie private constructor(
    *  - "None": the cookie is always sent. The "Secure" attribute must also be set when setting this
    *    value.
    */
-  @get:JvmName("sameSite") val sameSite: String?,
+  @get:JvmName("sameSite")
+  @property:ExperimentalOkHttpApi
+  val sameSite: String?,
 ) {
   /**
    * Returns true if this cookie should be included on a request to [url]. In addition to this
@@ -286,6 +289,7 @@ class Cookie private constructor(
     }
   }
 
+  @ExperimentalOkHttpApi
   fun newBuilder(): Builder = Builder(this)
 
   /**
@@ -377,6 +381,7 @@ class Cookie private constructor(
         this.httpOnly = true
       }
 
+    @ExperimentalOkHttpApi
     fun sameSite(sameSite: String) =
       apply {
         require(sameSite.trim() == sameSite) { "sameSite is not trimmed" }

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -166,6 +166,7 @@ open class OkHttpClient internal constructor(
     builder.retryOnConnectionFailure
 
   @get:JvmName("fastFallback")
+  @ExperimentalOkHttpApi
   val fastFallback: Boolean = builder.fastFallback
 
   @get:JvmName("authenticator")
@@ -717,6 +718,7 @@ open class OkHttpClient internal constructor(
      *
      * [rfc_6555]: https://datatracker.ietf.org/doc/html/rfc6555
      */
+    @ExperimentalOkHttpApi
     fun fastFallback(fastFallback: Boolean) =
       apply {
         this.fastFallback = fastFallback

--- a/okhttp/src/main/kotlin/okhttp3/Protocol.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Protocol.kt
@@ -91,6 +91,7 @@ enum class Protocol(private val protocol: String) {
    * HTTP/3 is not natively supported by OkHttp, but provided to allow a theoretical interceptor
    * that provides support.
    */
+  @ExperimentalOkHttpApi
   HTTP_3("h3"),
   ;
 

--- a/okhttp/src/main/kotlin/okhttp3/Request.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Request.kt
@@ -68,6 +68,7 @@ class Request internal constructor(builder: Builder) {
    *
    * @param method defaults to "GET" if [body] is null, and "POST" otherwise.
    */
+  @ExperimentalOkHttpApi
   constructor(
     url: HttpUrl,
     headers: Headers = headersOf(),
@@ -97,6 +98,7 @@ class Request internal constructor(builder: Builder) {
   inline fun <reified T : Any> tag(): T? = tag(T::class)
 
   /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
+  @ExperimentalOkHttpApi
   fun <T : Any> tag(type: KClass<T>): T? = type.java.cast(tags[type])
 
   /**
@@ -293,6 +295,7 @@ class Request internal constructor(builder: Builder) {
      * Use this API to attach timing, debugging, or other application data to a request so that
      * you may read it in interceptors, event listeners, or callbacks.
      */
+    @ExperimentalOkHttpApi
     fun <T : Any> tag(
       type: KClass<T>,
       tag: T?,

--- a/okhttp/src/main/kotlin/okhttp3/RequestBody.kt
+++ b/okhttp/src/main/kotlin/okhttp3/RequestBody.kt
@@ -120,6 +120,7 @@ abstract class RequestBody {
     /** Returns a new request body that transmits this. */
     @JvmStatic
     @JvmName("create")
+    @ExperimentalOkHttpApi
     fun FileDescriptor.toRequestBody(contentType: MediaType? = null): RequestBody {
       return object : RequestBody() {
         override fun contentType() = contentType
@@ -162,6 +163,7 @@ abstract class RequestBody {
     /** Returns a new request body that transmits the content of this. */
     @JvmStatic
     @JvmName("create")
+    @ExperimentalOkHttpApi
     fun Path.asRequestBody(
       fileSystem: FileSystem,
       contentType: MediaType? = null,
@@ -252,6 +254,7 @@ abstract class RequestBody {
      * ```
      */
     @JvmStatic
+    @ExperimentalOkHttpApi
     fun RequestBody.gzip(): RequestBody {
       return object : RequestBody() {
         override fun contentType(): MediaType? {

--- a/okhttp/src/main/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Response.kt
@@ -395,6 +395,7 @@ class Response internal constructor(
 
     open fun priorResponse(priorResponse: Response?) = commonPriorResponse(priorResponse)
 
+    @ExperimentalOkHttpApi
     open fun trailers(trailersFn: (() -> Headers)): Builder = commonTrailers(trailersFn)
 
     open fun sentRequestAtMillis(sentRequestAtMillis: Long) =


### PR DESCRIPTION
In a follow-up PR I intend to remove the annotation on any API that we're willing to commit to for OkHttp 5.0.0.

In a follow-up PR I'd also like to hide all remaining APIs from Java langauge callers.