### PR TITLE
Cache URL Override

### DIFF
--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
@@ -186,16 +186,24 @@ class DnsOverHttps internal constructor(
     throw unknownHostException
   }
 
-  private fun getCacheOnlyResponse(request: Request): Response? {
-    if (!post && client.cache != null) {
+  private fun getCacheOnlyResponse(
+    request: Request,
+  ): Response? {
+    if (client.cache != null) {
       try {
         // Use the cache without hitting the network first
         // 504 code indicates that the Cache is stale
-        val preferCache =
+        val onlyIfCached =
           CacheControl.Builder()
             .onlyIfCached()
             .build()
-        val cacheRequest = request.newBuilder().cacheControl(preferCache).build()
+
+        var cacheUrl = request.url
+
+        val cacheRequest = request.newBuilder()
+          .cacheControl(onlyIfCached)
+          .cacheUrlOverride(cacheUrl)
+          .build()
 
         val cacheResponse = client.newCall(cacheRequest).execute()
 
@@ -247,7 +255,12 @@ class DnsOverHttps internal constructor(
       val query = DnsRecordCodec.encodeQuery(hostname, type)
 
       if (post) {
-        url(url).post(query.toRequestBody(DNS_MESSAGE))
+        url(url)
+          .cacheUrlOverride(
+            url.newBuilder()
+              .addQueryParameter("hostname", hostname).build()
+          )
+          .post(query.toRequestBody(DNS_MESSAGE))
       } else {
         val encoded = query.base64Url().replace("=", "")
         val requestUrl = url.newBuilder().addQueryParameter("dns", encoded).build()
@@ -313,7 +326,8 @@ class DnsOverHttps internal constructor(
         this.bootstrapDnsHosts = bootstrapDnsHosts
       }
 
-    fun bootstrapDnsHosts(vararg bootstrapDnsHosts: InetAddress): Builder = bootstrapDnsHosts(bootstrapDnsHosts.toList())
+    fun bootstrapDnsHosts(vararg bootstrapDnsHosts: InetAddress): Builder =
+      bootstrapDnsHosts(bootstrapDnsHosts.toList())
 
     fun systemDns(systemDns: Dns) =
       apply {

--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
@@ -186,9 +186,7 @@ class DnsOverHttps internal constructor(
     throw unknownHostException
   }
 
-  private fun getCacheOnlyResponse(
-    request: Request,
-  ): Response? {
+  private fun getCacheOnlyResponse(request: Request): Response? {
     if (client.cache != null) {
       try {
         // Use the cache without hitting the network first
@@ -200,10 +198,11 @@ class DnsOverHttps internal constructor(
 
         var cacheUrl = request.url
 
-        val cacheRequest = request.newBuilder()
-          .cacheControl(onlyIfCached)
-          .cacheUrlOverride(cacheUrl)
-          .build()
+        val cacheRequest =
+          request.newBuilder()
+            .cacheControl(onlyIfCached)
+            .cacheUrlOverride(cacheUrl)
+            .build()
 
         val cacheResponse = client.newCall(cacheRequest).execute()
 
@@ -258,7 +257,7 @@ class DnsOverHttps internal constructor(
         url(url)
           .cacheUrlOverride(
             url.newBuilder()
-              .addQueryParameter("hostname", hostname).build()
+              .addQueryParameter("hostname", hostname).build(),
           )
           .post(query.toRequestBody(DNS_MESSAGE))
       } else {
@@ -326,8 +325,7 @@ class DnsOverHttps internal constructor(
         this.bootstrapDnsHosts = bootstrapDnsHosts
       }
 
-    fun bootstrapDnsHosts(vararg bootstrapDnsHosts: InetAddress): Builder =
-      bootstrapDnsHosts(bootstrapDnsHosts.toList())
+    fun bootstrapDnsHosts(vararg bootstrapDnsHosts: InetAddress): Builder = bootstrapDnsHosts(bootstrapDnsHosts.toList())
 
     fun systemDns(systemDns: Dns) =
       apply {

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
@@ -32,12 +32,9 @@ import java.util.concurrent.TimeUnit
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import okhttp3.Cache
-import okhttp3.Call
 import okhttp3.Dns
-import okhttp3.EventListener
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
-import okhttp3.Response
 import okhttp3.testing.PlatformRule
 import okio.Buffer
 import okio.ByteString.Companion.decodeHex
@@ -59,27 +56,6 @@ class DnsOverHttpsTest {
   private val bootstrapClient =
     OkHttpClient.Builder()
       .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
-      .eventListener(object : EventListener() {
-        override fun callStart(call: Call) {
-          println("callStart " + call.request().url + " " + call.request().cacheUrlOverride)
-        }
-
-        override fun satisfactionFailure(call: Call, response: Response) {
-          println("satisfactionFailure " + call.request().url)
-        }
-
-        override fun cacheHit(call: Call, response: Response) {
-          println("cacheHit " + call.request().url)
-        }
-
-        override fun cacheMiss(call: Call) {
-          println("cacheMiss " + call.request().url)
-        }
-
-        override fun cacheConditionalHit(call: Call, cachedResponse: Response) {
-          println("cacheConditionalHit " + call.request().url)
-        }
-      })
       .build()
 
   @BeforeEach
@@ -343,7 +319,7 @@ class DnsOverHttpsTest {
   private fun buildLocalhost(
     bootstrapClient: OkHttpClient,
     includeIPv6: Boolean,
-    post: Boolean = false
+    post: Boolean = false,
   ): DnsOverHttps {
     val url = server.url("/lookup?ct")
     return DnsOverHttps.Builder().client(bootstrapClient)

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
@@ -173,26 +173,20 @@ class DnsOverHttpsTest {
     val cache = Cache("cache".toPath(), (100 * 1024).toLong(), cacheFs)
     val cachedClient = bootstrapClient.newBuilder().cache(cache).build()
     val cachedDns = buildLocalhost(cachedClient, false)
-    server.enqueue(
-      dnsResponse(
-        "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c000500010" +
-          "0000a6d000603617069c012c0300005000100000cde000c04737461720463313072c012c04200010001000" +
-          "0003b00049df00112",
+
+    repeat(2) {
+      server.enqueue(
+        dnsResponse(
+          "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c000500010" +
+            "0000a6d000603617069c012c0300005000100000cde000c04737461720463313072c012c04200010001000" +
+            "0003b00049df00112",
+        )
+          .newBuilder()
+          .setHeader("cache-control", "private, max-age=298")
+          .build(),
       )
-        .newBuilder()
-        .setHeader("cache-control", "private, max-age=298")
-        .build(),
-    )
-    server.enqueue(
-      dnsResponse(
-        "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c000500010" +
-          "0000a6d000603617069c012c0300005000100000cde000c04737461720463313072c012c04200010001000" +
-          "0003b00049df00112",
-      )
-        .newBuilder()
-        .setHeader("cache-control", "private, max-age=298")
-        .build(),
-    )
+    }
+
     var result = cachedDns.lookup("google.com")
     assertThat(result).containsExactly(address("157.240.1.18"))
     var recordedRequest = server.takeRequest()
@@ -217,36 +211,18 @@ class DnsOverHttpsTest {
     val cache = Cache("cache".toPath(), (100 * 1024).toLong(), cacheFs)
     val cachedClient = bootstrapClient.newBuilder().cache(cache).build()
     val cachedDns = buildLocalhost(cachedClient, false, post = true)
-    server.enqueue(
-      dnsResponse(
-        "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c000500010" +
-          "0000a6d000603617069c012c0300005000100000cde000c04737461720463313072c012c04200010001000" +
-          "0003b00049df00112",
+    repeat(2) {
+      server.enqueue(
+        dnsResponse(
+          "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c000500010" +
+            "0000a6d000603617069c012c0300005000100000cde000c04737461720463313072c012c04200010001000" +
+            "0003b00049df00112",
+        )
+          .newBuilder()
+          .setHeader("cache-control", "private, max-age=298")
+          .build(),
       )
-        .newBuilder()
-        .setHeader("cache-control", "private, max-age=298")
-        .build(),
-    )
-    server.enqueue(
-      dnsResponse(
-        "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c000500010" +
-          "0000a6d000603617069c012c0300005000100000cde000c04737461720463313072c012c04200010001000" +
-          "0003b00049df00112",
-      )
-        .newBuilder()
-        .setHeader("cache-control", "private, max-age=298")
-        .build(),
-    )
-    server.enqueue(
-      dnsResponse(
-        "0000818000010003000000000567726170680866616365626f6f6b03636f6d0000010001c00c000500010" +
-          "0000a6d000603617069c012c0300005000100000cde000c04737461720463313072c012c04200010001000" +
-          "0003b00049df00112",
-      )
-        .newBuilder()
-        .setHeader("cache-control", "private, max-age=298")
-        .build(),
-    )
+    }
 
     var result = cachedDns.lookup("google.com")
     assertThat(result).containsExactly(address("157.240.1.18"))

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -1030,6 +1030,7 @@ public final class okhttp3/Request {
 	public synthetic fun <init> (Lokhttp3/HttpUrl;Lokhttp3/Headers;Ljava/lang/String;Lokhttp3/RequestBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun body ()Lokhttp3/RequestBody;
 	public final fun cacheControl ()Lokhttp3/CacheControl;
+	public final fun cacheUrlOverride ()Lokhttp3/HttpUrl;
 	public final fun header (Ljava/lang/String;)Ljava/lang/String;
 	public final fun headers ()Lokhttp3/Headers;
 	public final fun headers (Ljava/lang/String;)Ljava/util/List;
@@ -1048,6 +1049,7 @@ public class okhttp3/Request$Builder {
 	public fun addHeader (Ljava/lang/String;Ljava/lang/String;)Lokhttp3/Request$Builder;
 	public fun build ()Lokhttp3/Request;
 	public fun cacheControl (Lokhttp3/CacheControl;)Lokhttp3/Request$Builder;
+	public final fun cacheUrlOverride (Lokhttp3/HttpUrl;)Lokhttp3/Request$Builder;
 	public final fun delete ()Lokhttp3/Request$Builder;
 	public fun delete (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
 	public static synthetic fun delete$default (Lokhttp3/Request$Builder;Lokhttp3/RequestBody;ILjava/lang/Object;)Lokhttp3/Request$Builder;

--- a/okhttp/src/main/kotlin/okhttp3/Request.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Request.kt
@@ -325,7 +325,8 @@ class Request internal constructor(builder: Builder) {
      * Override the [Request.url] for caching, if it is either polluted with
      * transient query params, or has a canonical URL possibly for a CDN.
      *
-     * If set, this will also allow caching for POST requests.
+     * Note that POST requests will not be sent to the server if this URL is set
+     * and matches a cached response.
      */
     fun cacheUrlOverride(cacheUrlOverride: HttpUrl?) =
       apply {

--- a/okhttp/src/main/kotlin/okhttp3/Request.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Request.kt
@@ -54,6 +54,9 @@ class Request internal constructor(builder: Builder) {
   @get:JvmName("body")
   val body: RequestBody? = builder.body
 
+  @get:JvmName("cacheUrlOverride")
+  val cacheUrlOverride: HttpUrl? = builder.cacheUrlOverride
+
   internal val tags: Map<KClass<*>, Any> = builder.tags.toMap()
 
   internal var lazyCacheControl: CacheControl? = null
@@ -183,6 +186,7 @@ class Request internal constructor(builder: Builder) {
     internal var method: String
     internal var headers: Headers.Builder
     internal var body: RequestBody? = null
+    internal var cacheUrlOverride: HttpUrl? = null
 
     /** A mutable map of tags, or an immutable empty map if we don't have any. */
     internal var tags = mapOf<KClass<*>, Any>()
@@ -202,6 +206,7 @@ class Request internal constructor(builder: Builder) {
           else -> request.tags.toMutableMap()
         }
       this.headers = request.headers.newBuilder()
+      this.cacheUrlOverride = request.cacheUrlOverride
     }
 
     open fun url(url: HttpUrl): Builder =
@@ -315,6 +320,16 @@ class Request internal constructor(builder: Builder) {
       type: Class<in T>,
       tag: T?,
     ) = commonTag(type.kotlin, tag)
+
+    /**
+     * Override the [Request.url] for caching, if it is either polluted with
+     * transient query params, or has a canonical URL possibly for a CDN.
+     *
+     * If set, this will also allow caching for POST requests.
+     */
+    fun cacheUrlOverride(cacheUrlOverride: HttpUrl?) = apply {
+        this.cacheUrlOverride = cacheUrlOverride
+      }
 
     open fun build(): Request = Request(this)
   }

--- a/okhttp/src/main/kotlin/okhttp3/Request.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Request.kt
@@ -327,7 +327,8 @@ class Request internal constructor(builder: Builder) {
      *
      * If set, this will also allow caching for POST requests.
      */
-    fun cacheUrlOverride(cacheUrlOverride: HttpUrl?) = apply {
+    fun cacheUrlOverride(cacheUrlOverride: HttpUrl?) =
+      apply {
         this.cacheUrlOverride = cacheUrlOverride
       }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheInterceptor.kt
@@ -290,11 +290,15 @@ class CacheInterceptor(internal val cache: Cache?) : Interceptor {
 }
 
 private fun Request.requestForCache(): Request {
-  return cacheUrlOverride?.let {
+  val cacheUrlOverride = cacheUrlOverride
+
+  return if (cacheUrlOverride != null && (method == "GET" || method == "POST")) {
     newBuilder()
       .get()
-      .url(it)
+      .url(cacheUrlOverride)
       .cacheUrlOverride(null)
       .build()
-  } ?: this
+  } else {
+    this
+  }
 }

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheStrategy.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheStrategy.kt
@@ -152,7 +152,7 @@ class CacheStrategy internal constructor(
       // If this response shouldn't have been stored, it should never be used as a response source.
       // This check should be redundant as long as the persistence store is well-behaved and the
       // rules are constant.
-      if (!isCacheable(cacheResponse, request)) {
+      if (!isCacheable(cacheResponse)) {
         return CacheStrategy(request, null)
       }
 
@@ -292,7 +292,6 @@ class CacheStrategy internal constructor(
     /** Returns true if [response] can be stored to later serve another request. */
     fun isCacheable(
       response: Response,
-      request: Request,
     ): Boolean {
       // Always go to network for uncacheable response codes (RFC 7231 section 6.1), This
       // implementation doesn't support caching partial content.
@@ -334,7 +333,7 @@ class CacheStrategy internal constructor(
       }
 
       // A 'no-store' directive on request or response prevents the response from being cached.
-      return !response.cacheControl.noStore && !request.cacheControl.noStore
+      return !response.cacheControl.noStore && !response.request.cacheControl.noStore
     }
   }
 }

--- a/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheStrategy.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheStrategy.kt
@@ -152,7 +152,7 @@ class CacheStrategy internal constructor(
       // If this response shouldn't have been stored, it should never be used as a response source.
       // This check should be redundant as long as the persistence store is well-behaved and the
       // rules are constant.
-      if (!isCacheable(cacheResponse)) {
+      if (!isCacheable(cacheResponse, request)) {
         return CacheStrategy(request, null)
       }
 
@@ -292,6 +292,7 @@ class CacheStrategy internal constructor(
     /** Returns true if [response] can be stored to later serve another request. */
     fun isCacheable(
       response: Response,
+      request: Request,
     ): Boolean {
       // Always go to network for uncacheable response codes (RFC 7231 section 6.1), This
       // implementation doesn't support caching partial content.
@@ -333,7 +334,7 @@ class CacheStrategy internal constructor(
       }
 
       // A 'no-store' directive on request or response prevents the response from being cached.
-      return !response.cacheControl.noStore && !response.request.cacheControl.noStore
+      return !response.cacheControl.noStore && !request.cacheControl.noStore
     }
   }
 }

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -3268,7 +3268,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   }
 
   @Test
-  fun getHasCorrectResponseIsCorrect() {
+  fun getHasCorrectResponse() {
     val request = Request(server.url("/abc"))
 
     val response = testBasicCachingRules(request)

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -43,7 +43,6 @@ import mockwebserver3.RecordedRequest
 import mockwebserver3.SocketPolicy.DisconnectAtEnd
 import mockwebserver3.junit5.internal.MockWebServerInstance
 import okhttp3.Cache.Companion.key
-import okhttp3.Cache.Companion.keyUrl
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -2708,7 +2707,7 @@ class CacheTest {
         .build(),
     )
     val url = server.url("/")
-    val urlKey = keyUrl(url)
+    val urlKey = key(url)
     val entryMetadata =
       """
       $url
@@ -2757,7 +2756,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   @Test
   fun testGoldenCacheHttpsResponseOkHttp27() {
     val url = server.url("/")
-    val urlKey = keyUrl(url)
+    val urlKey = key(url)
     val prefix = get().getPrefix()
     val entryMetadata =
       """
@@ -2805,7 +2804,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   @Test
   fun testGoldenCacheHttpsResponseOkHttp30() {
     val url = server.url("/")
-    val urlKey = keyUrl(url)
+    val urlKey = key(url)
     val prefix = get().getPrefix()
     val entryMetadata =
       """
@@ -2857,7 +2856,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   @Test
   fun testGoldenCacheHttpResponseOkHttp30() {
     val url = server.url("/")
-    val urlKey = keyUrl(url)
+    val urlKey = key(url)
     val prefix = get().getPrefix()
     val entryMetadata =
       """

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -982,30 +982,24 @@ class CacheTest {
 
   @Test
   fun requestMethodOptionsIsNotCached() {
-    testRequestMethod("OPTIONS", false, true)
+    testRequestMethod("OPTIONS", false)
   }
 
   @Test
   fun requestMethodGetIsCached() {
-    testRequestMethod("GET", true, true)
+    testRequestMethod("GET", true)
   }
 
   @Test
   fun requestMethodHeadIsNotCached() {
     // We could support this but choose not to for implementation simplicity
-    testRequestMethod("HEAD", false, true)
+    testRequestMethod("HEAD", false)
   }
 
   @Test
   fun requestMethodPostIsNotCached() {
     // We could support this but choose not to for implementation simplicity
-    testRequestMethod("POST", false, true)
-  }
-
-  @Test
-  fun requestMethodPostIsNotCachedUnlessOverride() {
-    // We could support this but choose not to for implementation simplicity
-    testRequestMethod("POST", true, withOverride = true)
+    testRequestMethod("POST", false)
   }
 
   @Test
@@ -1015,12 +1009,12 @@ class CacheTest {
 
   @Test
   fun requestMethodDeleteIsNotCached() {
-    testRequestMethod("DELETE", false, true)
+    testRequestMethod("DELETE", false)
   }
 
   @Test
   fun requestMethodTraceIsNotCached() {
-    testRequestMethod("TRACE", false, true)
+    testRequestMethod("TRACE", false)
   }
 
   private fun testRequestMethod(

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -3278,7 +3278,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   }
 
   @Test
-  fun postWithOverrideResponseIsCorrect() {
+  fun postWithOverrideResponse() {
     val url = server.url("/abc?token=123")
     val cacheUrlOverride = url.newBuilder().removeAllQueryParameters("token").build()
 

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -43,6 +43,7 @@ import mockwebserver3.RecordedRequest
 import mockwebserver3.SocketPolicy.DisconnectAtEnd
 import mockwebserver3.junit5.internal.MockWebServerInstance
 import okhttp3.Cache.Companion.key
+import okhttp3.Cache.Companion.keyUrl
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -2707,7 +2708,7 @@ class CacheTest {
         .build(),
     )
     val url = server.url("/")
-    val urlKey = key(url)
+    val urlKey = keyUrl(url)
     val entryMetadata =
       """
       $url
@@ -2756,7 +2757,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   @Test
   fun testGoldenCacheHttpsResponseOkHttp27() {
     val url = server.url("/")
-    val urlKey = key(url)
+    val urlKey = keyUrl(url)
     val prefix = get().getPrefix()
     val entryMetadata =
       """
@@ -2804,7 +2805,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   @Test
   fun testGoldenCacheHttpsResponseOkHttp30() {
     val url = server.url("/")
-    val urlKey = key(url)
+    val urlKey = keyUrl(url)
     val prefix = get().getPrefix()
     val entryMetadata =
       """
@@ -2856,7 +2857,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   @Test
   fun testGoldenCacheHttpResponseOkHttp30() {
     val url = server.url("/")
-    val urlKey = key(url)
+    val urlKey = keyUrl(url)
     val prefix = get().getPrefix()
     val entryMetadata =
       """

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -982,44 +982,51 @@ class CacheTest {
 
   @Test
   fun requestMethodOptionsIsNotCached() {
-    testRequestMethod("OPTIONS", false)
+    testRequestMethod("OPTIONS", false, true)
   }
 
   @Test
   fun requestMethodGetIsCached() {
-    testRequestMethod("GET", true)
+    testRequestMethod("GET", true, true)
   }
 
   @Test
   fun requestMethodHeadIsNotCached() {
     // We could support this but choose not to for implementation simplicity
-    testRequestMethod("HEAD", false)
+    testRequestMethod("HEAD", false, true)
   }
 
   @Test
   fun requestMethodPostIsNotCached() {
     // We could support this but choose not to for implementation simplicity
-    testRequestMethod("POST", false)
+    testRequestMethod("POST", false, true)
+  }
+
+  @Test
+  fun requestMethodPostIsNotCachedUnlessOverride() {
+    // We could support this but choose not to for implementation simplicity
+    testRequestMethod("POST", true, withOverride = true)
   }
 
   @Test
   fun requestMethodPutIsNotCached() {
-    testRequestMethod("PUT", false)
+    testRequestMethod("PUT", false, true)
   }
 
   @Test
   fun requestMethodDeleteIsNotCached() {
-    testRequestMethod("DELETE", false)
+    testRequestMethod("DELETE", false, true)
   }
 
   @Test
   fun requestMethodTraceIsNotCached() {
-    testRequestMethod("TRACE", false)
+    testRequestMethod("TRACE", false, true)
   }
 
   private fun testRequestMethod(
     requestMethod: String,
     expectCached: Boolean,
+    withOverride: Boolean = false,
   ) {
     // 1. Seed the cache (potentially).
     // 2. Expect a cache hit or miss.
@@ -1038,6 +1045,11 @@ class CacheTest {
     val request =
       Request.Builder()
         .url(url)
+        .apply {
+          if (withOverride) {
+            cacheUrlOverride(url)
+          }
+        }
         .method(requestMethod, requestBodyOrNull(requestMethod))
         .build()
     val response1 = client.newCall(request).execute()
@@ -3248,6 +3260,48 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
         "A", "a1", "Content-Length", "4", "B", "b4", "B", "b5", "C", "c6",
       ),
     )
+  }
+
+  @Test
+  fun getHasCorrectResponseIsCorrect() {
+    val request = Request(server.url("/abc"))
+
+    val response = testBasicCachingRules(request)
+
+    assertThat(response.request.url).isEqualTo(request.url)
+    assertThat(response.cacheResponse!!.request.url).isEqualTo(request.url)
+  }
+
+  @Test
+  fun postWithOverrideResponseIsCorrect() {
+    val url = server.url("/abc?token=123")
+    val cacheUrlOverride = url.newBuilder().removeAllQueryParameters("token").build()
+
+    val request =
+      Request.Builder()
+        .url(url)
+        .method("POST", "XYZ".toRequestBody())
+        .cacheUrlOverride(cacheUrlOverride)
+        .build()
+
+    val response = testBasicCachingRules(request)
+
+    assertThat(response.request.url).isEqualTo(request.url)
+    assertThat(response.cacheResponse!!.request.url).isEqualTo(cacheUrlOverride)
+  }
+
+  private fun testBasicCachingRules(request: Request): Response {
+    val mockResponse =
+      MockResponse.Builder()
+        .addHeader("Last-Modified: " + formatDate(-1, TimeUnit.HOURS))
+        .addHeader("Expires: " + formatDate(1, TimeUnit.HOURS))
+        .status("HTTP/1.1 200 Fantastic")
+    server.enqueue(mockResponse.build())
+
+    client.newCall(request).execute().use {
+      it.body.bytes()
+    }
+    return client.newCall(request).execute()
   }
 
   private operator fun get(url: HttpUrl): Response {

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -1003,7 +1003,7 @@ class CacheTest {
   }
 
   @Test
-  fun requestMethodPostIsNotCachedUnlessOverriden() {
+  fun requestMethodPostIsNotCachedUnlessOverridden() {
     // Supported via cacheUrlOverride
     testRequestMethod("POST", true, withOverride = true)
   }

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -1003,8 +1003,19 @@ class CacheTest {
   }
 
   @Test
+  fun requestMethodPostIsNotCachedUnlessOverriden() {
+    // Supported via cacheUrlOverride
+    testRequestMethod("POST", true, withOverride = true)
+  }
+
+  @Test
   fun requestMethodPutIsNotCached() {
-    testRequestMethod("PUT", false, true)
+    testRequestMethod("PUT", false)
+  }
+
+  @Test
+  fun requestMethodPutIsNotCachedEvenWithOverride() {
+    testRequestMethod("PUT", false, withOverride = true)
   }
 
   @Test


### PR DESCRIPTION
A minimal change to allow a cacheUrlOverride on request for the following examples

- Define the canonical resource this request represents, such as the origin server for a CDN request
- Remove transient query params such as S3 tokens
- A narrow window of POST support - by declaring a POST should otherwise be treated as a GET, and define an appropriate unique url to represent the body if relevant.

It is implemented almost entirely within CacheInterceptor, mutating the request/response that Cache sees to avoid a broader change such as supporting POSTs.

Addresses https://github.com/square/okhttp/issues/8211 also https://github.com/square/okhttp/issues/8113

