### PR TITLE
Hide the value of sensitive query parameters in log

### DIFF
--- a/okhttp-logging-interceptor/api/logging-interceptor.api
+++ b/okhttp-logging-interceptor/api/logging-interceptor.api
@@ -7,6 +7,7 @@ public final class okhttp3/logging/HttpLoggingInterceptor : okhttp3/Interceptor 
 	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
 	public final fun level (Lokhttp3/logging/HttpLoggingInterceptor$Level;)V
 	public final fun redactHeader (Ljava/lang/String;)V
+	public final fun redactQueryParams ([Ljava/lang/String;)V
 	public final fun setLevel (Lokhttp3/logging/HttpLoggingInterceptor$Level;)Lokhttp3/logging/HttpLoggingInterceptor;
 }
 

--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -323,6 +323,9 @@ class HttpLoggingInterceptor
     }
 
     private fun sanitizeUrl(url: HttpUrl): String {
+      if (queryParamsNameToRedact.isEmpty()) {
+        return url.toString()
+      }
       val params = ArrayList<Pair<String, String>>()
       for (parameterName in url.queryParameterNames) {
         params.add(

--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -178,7 +178,7 @@ class HttpLoggingInterceptor
 
       val connection = chain.connection()
       var requestStartMessage =
-        ("--> ${request.method} ${sanitizeUrl(request.url)}${if (connection != null) " " + connection.protocol() else ""}")
+        ("--> ${request.method} ${redactUrl(request.url)}${if (connection != null) " " + connection.protocol() else ""}")
       if (!logHeaders && requestBody != null) {
         requestStartMessage += " (${requestBody.contentLength()}-byte body)"
       }
@@ -261,7 +261,7 @@ class HttpLoggingInterceptor
         buildString {
           append("<-- ${response.code}")
           if (response.message.isNotEmpty()) append(" ${response.message}")
-          append(" ${sanitizeUrl(response.request.url)} (${tookMs}ms")
+          append(" ${redactUrl(response.request.url)} (${tookMs}ms")
           if (!logHeaders) append(", $bodySize body")
           append(")")
         },
@@ -322,7 +322,7 @@ class HttpLoggingInterceptor
       return response
     }
 
-    internal fun sanitizeUrl(url: HttpUrl): String {
+    internal fun redactUrl(url: HttpUrl): String {
       if (queryParamsNameToRedact.isEmpty() || url.querySize == 0) {
         return url.toString()
       }

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
@@ -951,12 +951,15 @@ class HttpLoggingInterceptorTest {
   @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
   @Test
   fun preserveQueryParamsAfterRedacted() {
-    url = server.url("""/api/login?
+    url =
+      server.url(
+        """/api/login?
       |user=test_user&
       |authentication=basic&
       |password=confidential_password&
       |authentication=rather simple login method
-    """.trimMargin())
+        """.trimMargin(),
+      )
     val networkInterceptor =
       HttpLoggingInterceptor(networkLogs).setLevel(
         Level.BASIC,

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
@@ -906,9 +906,6 @@ class HttpLoggingInterceptorTest {
   @Test
   fun sensitiveQueryParamsAreRedacted() {
     url = server.url("/api/login?user=test_user&authentication=basic&password=confidential_password")
-    val sanitizedUrl = "${server.url("/")}api/login?user=██&authentication=basic&password=██"
-    val sanitizedUrlPattern = sanitizedUrl.replace("?", """\?""")
-
     val networkInterceptor =
       HttpLoggingInterceptor(networkLogs).setLevel(
         Level.BASIC,
@@ -938,6 +935,57 @@ class HttpLoggingInterceptorTest {
         )
         .execute()
     response.body.close()
+    val sanitizedUrl = networkInterceptor.sanitizeUrl(url)
+    val sanitizedUrlPattern = sanitizedUrl.replace("?", """\?""")
+    applicationLogs
+      .assertLogEqual("--> GET $sanitizedUrl")
+      .assertLogMatch(Regex("""<-- 200 OK $sanitizedUrlPattern \(\d+ms, \d+-byte body\)"""))
+      .assertNoMoreLogs()
+    networkLogs
+      .assertLogEqual("--> GET $sanitizedUrl http/1.1")
+      .assertLogMatch(Regex("""<-- 200 OK $sanitizedUrlPattern \(\d+ms, \d+-byte body\)"""))
+      .assertNoMoreLogs()
+  }
+
+  @Test
+  fun preserveQueryParamsAfterSanitized() {
+    url = server.url("""/api/login?
+      |user=test_user&
+      |authentication=basic&
+      |password=confidential_password&
+      |authentication=rather simple login method
+    """.trimMargin())
+    val networkInterceptor =
+      HttpLoggingInterceptor(networkLogs).setLevel(
+        Level.BASIC,
+      )
+    networkInterceptor.redactQueryParams("user", "passWord")
+
+    val applicationInterceptor =
+      HttpLoggingInterceptor(applicationLogs).setLevel(
+        Level.BASIC,
+      )
+    applicationInterceptor.redactQueryParams("user", "PassworD")
+
+    client =
+      OkHttpClient.Builder()
+        .addNetworkInterceptor(networkInterceptor)
+        .addInterceptor(applicationInterceptor)
+        .build()
+    server.enqueue(
+      MockResponse.Builder()
+        .build(),
+    )
+    val response =
+      client
+        .newCall(
+          request()
+            .build(),
+        )
+        .execute()
+    response.body.close()
+    val sanitizedUrl = networkInterceptor.sanitizeUrl(url)
+    val sanitizedUrlPattern = sanitizedUrl.replace("?", """\?""")
     applicationLogs
       .assertLogEqual("--> GET $sanitizedUrl")
       .assertLogMatch(Regex("""<-- 200 OK $sanitizedUrlPattern \(\d+ms, \d+-byte body\)"""))

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
@@ -903,6 +903,7 @@ class HttpLoggingInterceptorTest {
       .assertNoMoreLogs()
   }
 
+  @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
   @Test
   fun sensitiveQueryParamsAreRedacted() {
     url = server.url("/api/login?user=test_user&authentication=basic&password=confidential_password")
@@ -947,6 +948,7 @@ class HttpLoggingInterceptorTest {
       .assertNoMoreLogs()
   }
 
+  @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
   @Test
   fun preserveQueryParamsAfterRedacted() {
     url = server.url("""/api/login?

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
@@ -935,20 +935,20 @@ class HttpLoggingInterceptorTest {
         )
         .execute()
     response.body.close()
-    val sanitizedUrl = networkInterceptor.sanitizeUrl(url)
-    val sanitizedUrlPattern = sanitizedUrl.replace("?", """\?""")
+    val redactedUrl = networkInterceptor.redactUrl(url)
+    val redactedUrlPattern = redactedUrl.replace("?", """\?""")
     applicationLogs
-      .assertLogEqual("--> GET $sanitizedUrl")
-      .assertLogMatch(Regex("""<-- 200 OK $sanitizedUrlPattern \(\d+ms, \d+-byte body\)"""))
+      .assertLogEqual("--> GET $redactedUrl")
+      .assertLogMatch(Regex("""<-- 200 OK $redactedUrlPattern \(\d+ms, \d+-byte body\)"""))
       .assertNoMoreLogs()
     networkLogs
-      .assertLogEqual("--> GET $sanitizedUrl http/1.1")
-      .assertLogMatch(Regex("""<-- 200 OK $sanitizedUrlPattern \(\d+ms, \d+-byte body\)"""))
+      .assertLogEqual("--> GET $redactedUrl http/1.1")
+      .assertLogMatch(Regex("""<-- 200 OK $redactedUrlPattern \(\d+ms, \d+-byte body\)"""))
       .assertNoMoreLogs()
   }
 
   @Test
-  fun preserveQueryParamsAfterSanitized() {
+  fun preserveQueryParamsAfterRedacted() {
     url = server.url("""/api/login?
       |user=test_user&
       |authentication=basic&
@@ -984,15 +984,15 @@ class HttpLoggingInterceptorTest {
         )
         .execute()
     response.body.close()
-    val sanitizedUrl = networkInterceptor.sanitizeUrl(url)
-    val sanitizedUrlPattern = sanitizedUrl.replace("?", """\?""")
+    val redactedUrl = networkInterceptor.redactUrl(url)
+    val redactedUrlPattern = redactedUrl.replace("?", """\?""")
     applicationLogs
-      .assertLogEqual("--> GET $sanitizedUrl")
-      .assertLogMatch(Regex("""<-- 200 OK $sanitizedUrlPattern \(\d+ms, \d+-byte body\)"""))
+      .assertLogEqual("--> GET $redactedUrl")
+      .assertLogMatch(Regex("""<-- 200 OK $redactedUrlPattern \(\d+ms, \d+-byte body\)"""))
       .assertNoMoreLogs()
     networkLogs
-      .assertLogEqual("--> GET $sanitizedUrl http/1.1")
-      .assertLogMatch(Regex("""<-- 200 OK $sanitizedUrlPattern \(\d+ms, \d+-byte body\)"""))
+      .assertLogEqual("--> GET $redactedUrl http/1.1")
+      .assertLogMatch(Regex("""<-- 200 OK $redactedUrlPattern \(\d+ms, \d+-byte body\)"""))
       .assertNoMoreLogs()
   }
 


### PR DESCRIPTION
For logging interceptor: add an option to hide the value of sensitive query parameters in the request and response URL. 
Inspired by the implementation of header redaction in `okhttp3.logging.HttpLoggingInterceptor`

**To use**
Call the method `redactQueryParams(the list of query parameters to hide value, separated by commas)` from a `okhttp3.logging.HttpLoggingInterceptor` instance. For example, to hide the value of "user" and "password" query parameters, use `interceptor.redactQueryParams("user", "password")`.
- Original URL: `http://localhost:8000/api/login?user=user1&authentication=basic&password=confidential_password"`
- With the method applied: `http://localhost:8000/api/login?user=██&authentication=basic&password=██"`