### PR TITLE
Concurrent tests and avoid testing HTTP/2 Frames with Log Handler.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -186,6 +186,10 @@ subprojects {
 
     systemProperty("okhttp.platform", platform)
     systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
+    systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+    systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
+    systemProperty("junit.jupiter.execution.parallel.config.strategy", "dynamic")
+    systemProperty("junit.jupiter.execution.parallel.config.dynamic.factor", "1.0")
   }
 
   // https://publicobject.com/2023/04/16/read-a-project-file-in-a-kotlin-multiplatform-test/

--- a/mockwebserver/src/test/java/mockwebserver3/internal/http2/Http2Server.kt
+++ b/mockwebserver/src/test/java/mockwebserver3/internal/http2/Http2Server.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+
 package mockwebserver3.internal.http2
 
 import java.io.File

--- a/mockwebserver/src/test/java/mockwebserver3/internal/http2/Http2Server.kt
+++ b/mockwebserver/src/test/java/mockwebserver3/internal/http2/Http2Server.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
 package mockwebserver3.internal.http2
 
 import java.io.File

--- a/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceRecorder.kt
+++ b/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceRecorder.kt
@@ -19,6 +19,7 @@ import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
+import assertk.fail
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 import okhttp3.Response
@@ -96,7 +97,8 @@ class EventSourceRecorder : EventSourceListener() {
   }
 
   fun assertOpen(): EventSource {
-    val event = nextEvent() as Open
+    val event = nextEvent()
+    check(event is Open) { "Expected Open but was $event" }
     return event.eventSource
   }
 
@@ -105,7 +107,8 @@ class EventSourceRecorder : EventSourceListener() {
   }
 
   fun assertFailure(message: String?) {
-    val event = nextEvent() as Failure
+    val event = nextEvent()
+    check(event is Failure) { "Expected Failure but was $event" }
     if (message != null) {
       assertThat(event.t!!.message).isEqualTo(message)
     } else {

--- a/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceRecorder.kt
+++ b/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceRecorder.kt
@@ -79,7 +79,7 @@ class EventSourceRecorder : EventSourceListener() {
   }
 
   private fun nextEvent(): Any {
-    return events.poll(10, TimeUnit.SECONDS)
+    return events.poll(25, TimeUnit.SECONDS)
       ?: throw AssertionError("Timed out waiting for event.")
   }
 

--- a/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceRecorder.kt
+++ b/okhttp-sse/src/test/java/okhttp3/sse/internal/EventSourceRecorder.kt
@@ -19,7 +19,6 @@ import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
-import assertk.fail
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 import okhttp3.Response

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -55,6 +55,7 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
   private var defaultUncaughtExceptionHandler: Thread.UncaughtExceptionHandler? = null
   private var taskQueuesWereIdle: Boolean = false
   val connectionListener = RecordingConnectionListener()
+  val taskLogger = RecordingTaskLogger()
 
   var logger: Logger? = null
 
@@ -88,8 +89,6 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
       override fun publish(record: LogRecord) {
         val recorded =
           when (record.loggerName) {
-            TaskRunner::class.java.name -> recordTaskRunner
-            Http2::class.java.name -> recordFrames
             "javax.net.ssl" -> recordSslDebug && !sslExcludeFilter.matches(record.message)
             else -> false
           }
@@ -121,8 +120,6 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
   private fun applyLogger(fn: Logger.() -> Unit) {
     Logger.getLogger(OkHttpClient::class.java.`package`.name).fn()
     Logger.getLogger(OkHttpClient::class.java.name).fn()
-    Logger.getLogger(Http2::class.java.name).fn()
-    Logger.getLogger(TaskRunner::class.java.name).fn()
     Logger.getLogger("javax.net.ssl").fn()
   }
 
@@ -158,7 +155,7 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
   private fun initialClientBuilder(): OkHttpClient.Builder =
     if (isLoom()) {
       val backend = TaskRunner.RealBackend(loomThreadFactory())
-      val taskRunner = TaskRunner(backend)
+      val taskRunner = TaskRunner(backend, logger = taskLogger)
 
       OkHttpClient.Builder()
         .connectionPool(
@@ -170,8 +167,12 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
         .dispatcher(Dispatcher(backend.executor))
         .taskRunnerInternal(taskRunner)
     } else {
+      val backend = TaskRunner.RealBackend(loomThreadFactory())
+      val taskRunner = TaskRunner(backend, logger = taskLogger)
+
       OkHttpClient.Builder()
         .connectionPool(ConnectionPool(connectionListener = connectionListener))
+        .taskRunnerInternal(taskRunner)
     }
 
   private fun loomThreadFactory(): ThreadFactory {
@@ -320,6 +321,14 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
 
   fun recordedConnectionEventTypes(): List<String> {
     return connectionListener.recordedEventTypes()
+  }
+
+  fun takeFrameLogs(): List<String> {
+    return connectionListener.takeFrameLogs()
+  }
+
+  fun takeFrameLog(): String {
+    return connectionListener.takeFrameLog()
   }
 
   companion object {

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -18,6 +18,7 @@
 package okhttp3
 
 import android.annotation.SuppressLint
+import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import java.util.logging.Handler
@@ -166,7 +167,7 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
         .dispatcher(Dispatcher(backend.executor))
         .taskRunnerInternal(taskRunner)
     } else {
-      val backend = TaskRunner.RealBackend(loomThreadFactory())
+      val backend = TaskRunner.RealBackend(SharedExecutor)
       val taskRunner = TaskRunner(backend, logger = taskLogger)
 
       OkHttpClient.Builder()
@@ -331,6 +332,8 @@ class OkHttpClientTestRule : BeforeEachCallback, AfterEachCallback {
   }
 
   companion object {
+    val SharedExecutor by lazy { Executors.newCachedThreadPool() }
+
     /**
      * A network that resolves only one IP address per host. Use this when testing route selection
      * fallbacks to prevent the host machine's various IP addresses from interfering.

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -29,7 +29,6 @@ import kotlin.concurrent.withLock
 import okhttp3.internal.buildConnectionPool
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.connection.RealConnectionPool
-import okhttp3.internal.http2.Http2
 import okhttp3.internal.taskRunnerInternal
 import okhttp3.testing.Flaky
 import okhttp3.testing.PlatformRule.Companion.LOOM_PROPERTY

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingConnectionListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingConnectionListener.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "CANNOT_OVERRIDE_INVISIBLE_MEMBER")
+
 package okhttp3
 
 import assertk.assertThat
@@ -54,12 +55,13 @@ open class RecordingConnectionListener(
   override fun logFrame(frameLog: () -> String) {
     frameLogs.add(frameLog())
   }
+
   fun takeFrameLog(): String {
     return frameLogs.take()
   }
 
   fun takeFrameLogs(): List<String> {
-    synchronized (frameLogs) {
+    synchronized(frameLogs) {
       return frameLogs.toList().also {
         frameLogs.clear()
       }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingTaskLogger.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingTaskLogger.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "CANNOT_OVERRIDE_INVISIBLE_MEMBER")
+package okhttp3
+
+import java.util.concurrent.LinkedBlockingQueue
+import okhttp3.internal.concurrent.Task
+import okhttp3.internal.concurrent.TaskLogger
+import okhttp3.internal.concurrent.TaskQueue
+
+class RecordingTaskLogger: TaskLogger {
+  private val logs = LinkedBlockingQueue<String>()
+
+  override fun taskLog(task: Task, queue: TaskQueue, messageBlock: () -> String) {
+    logs.add(messageBlock())
+  }
+
+  override fun <T> logElapsed(task: Task, queue: TaskQueue, block: () -> T): T {
+    return block()
+  }
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingTaskLogger.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingTaskLogger.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "CANNOT_OVERRIDE_INVISIBLE_MEMBER")
+
 package okhttp3
 
 import java.util.concurrent.LinkedBlockingQueue
@@ -21,14 +22,22 @@ import okhttp3.internal.concurrent.Task
 import okhttp3.internal.concurrent.TaskLogger
 import okhttp3.internal.concurrent.TaskQueue
 
-class RecordingTaskLogger: TaskLogger {
+class RecordingTaskLogger : TaskLogger {
   private val logs = LinkedBlockingQueue<String>()
 
-  override fun taskLog(task: Task, queue: TaskQueue, messageBlock: () -> String) {
+  override fun taskLog(
+    task: Task,
+    queue: TaskQueue,
+    messageBlock: () -> String,
+  ) {
     logs.add(messageBlock())
   }
 
-  override fun <T> logElapsed(task: Task, queue: TaskQueue, block: () -> T): T {
+  override fun <T> logElapsed(
+    task: Task,
+    queue: TaskQueue,
+    block: () -> T,
+  ): T {
     return block()
   }
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingTaskLogger.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingTaskLogger.kt
@@ -20,6 +20,7 @@ package okhttp3
 import java.util.concurrent.LinkedBlockingQueue
 import okhttp3.internal.concurrent.Task
 import okhttp3.internal.concurrent.TaskLogger
+import okhttp3.internal.concurrent.TaskLogger.Logging.logString
 import okhttp3.internal.concurrent.TaskQueue
 
 class RecordingTaskLogger : TaskLogger {
@@ -30,14 +31,16 @@ class RecordingTaskLogger : TaskLogger {
     queue: TaskQueue,
     messageBlock: () -> String,
   ) {
-    logs.add(messageBlock())
+    logs.add(logString(queue, messageBlock(), task))
   }
 
-  override fun <T> logElapsed(
-    task: Task,
-    queue: TaskQueue,
-    block: () -> T,
-  ): T {
-    return block()
+  fun takeAllLogs(): List<String> {
+    synchronized(logs) {
+      return logs.toList().also {
+        logs.clear()
+      }
+    }
   }
+
+  override val loggingEnabled: Boolean = true
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
@@ -166,7 +166,7 @@ class TaskFaker : Closeable {
 
         override fun <T> decorate(queue: BlockingQueue<T>) = TaskFakerBlockingQueue(queue)
       },
-      logger = taskLogger
+      logger = taskLogger,
     )
 
   /** Wait for the test thread to proceed. */

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
 package okhttp3.internal.concurrent
 
 import assertk.assertThat
@@ -164,7 +165,6 @@ class TaskFaker : Closeable {
 
         override fun <T> decorate(queue: BlockingQueue<T>) = TaskFakerBlockingQueue(queue)
       },
-      logger = logger,
     )
 
   /** Wait for the test thread to proceed. */

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+
 package okhttp3.internal.concurrent
 
 import assertk.assertThat

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/testing/PlatformRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/testing/PlatformRule.kt
@@ -350,6 +350,13 @@ open class PlatformRule
       }
     }
 
+    fun assumeNotWindows() {
+      assumeFalse(isWindows, "This test fails on Windows.")
+    }
+
+    val isWindows: Boolean
+      get() = System.getProperty("os.name", "?").startsWith("Windows")
+
     val isAndroid: Boolean
       get() = Platform.Companion.isAndroid
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
@@ -104,7 +104,7 @@ internal interface TaskLogger {
     fun logString(
       queue: TaskQueue,
       message: String,
-      task: Task
+      task: Task,
     ) = "${queue.name} ${"%-22s".format(message)}: ${task.name}"
 
     /**

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskLogger.kt
@@ -35,10 +35,18 @@ internal interface TaskLogger {
   ): T
 
   object Noop : TaskLogger {
-    override fun taskLog(task: Task, queue: TaskQueue, messageBlock: () -> String) {
+    override fun taskLog(
+      task: Task,
+      queue: TaskQueue,
+      messageBlock: () -> String,
+    ) {
     }
 
-    override fun <T> logElapsed(task: Task, queue: TaskQueue, block: () -> T): T {
+    override fun <T> logElapsed(
+      task: Task,
+      queue: TaskQueue,
+      block: () -> T,
+    ): T {
       return block()
     }
   }

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskQueue.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskQueue.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import okhttp3.internal.assertNotHeld
+import okhttp3.internal.concurrent.TaskLogger.Logging.formatDuration
 import okhttp3.internal.okHttpName
 
 /**

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
@@ -45,7 +45,7 @@ class TaskRunner internal constructor(
   val backend: Backend,
   internal val logger: TaskLogger,
 ) {
-  constructor(backend: Backend): this(backend, TaskLogger.Noop)
+  constructor(backend: Backend) : this(backend, TaskLogger.Noop)
 
   val lock: ReentrantLock = ReentrantLock()
   val condition: Condition = lock.newCondition()
@@ -289,17 +289,19 @@ class TaskRunner internal constructor(
 
   class RealBackend internal constructor(val executor: ExecutorService) : Backend {
     constructor(threadFactory: ThreadFactory) :
-      this(ThreadPoolExecutor(
-        // corePoolSize:
-        0,
-        // maximumPoolSize:
-        Int.MAX_VALUE,
-        // keepAliveTime:
-        60L,
-        TimeUnit.SECONDS,
-        SynchronousQueue(),
-        threadFactory,
-      ))
+      this(
+        ThreadPoolExecutor(
+          // corePoolSize:
+          0,
+          // maximumPoolSize:
+          Int.MAX_VALUE,
+          // keepAliveTime:
+          60L,
+          TimeUnit.SECONDS,
+          SynchronousQueue(),
+          threadFactory,
+        ),
+      )
 
     override fun nanoTime() = System.nanoTime()
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -159,7 +159,7 @@ class RealConnection(
     socket.soTimeout = 0 // HTTP/2 connection timeouts are set per-stream.
     val flowControlListener = connectionListener as? FlowControlListener ?: FlowControlListener.None
     val http2Connection =
-      Http2Connection.Builder(client = true, taskRunner)
+      Http2Connection.Builder(client = true, taskRunner, frameLogger = connectionPool.frameLogger)
         .socket(socket, route.address.url.host, source, sink)
         .listener(this)
         .pingIntervalMillis(pingIntervalMillis)

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -29,6 +29,7 @@ import okhttp3.internal.concurrent.Task
 import okhttp3.internal.concurrent.TaskQueue
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.connection.RealCall.CallReference
+import okhttp3.internal.http2.FrameLogger
 import okhttp3.internal.okHttpName
 import okhttp3.internal.platform.Platform
 
@@ -47,6 +48,9 @@ class RealConnectionPool(
     object : Task("$okHttpName ConnectionPool") {
       override fun runOnce(): Long = cleanup(System.nanoTime())
     }
+
+  internal val frameLogger: FrameLogger =
+    if (connectionListener is FrameLogger) connectionListener else FrameLogger.Logging
 
   /**
    * Holding the lock of the connection being added or removed when mutating this, and check its

--- a/okhttp/src/main/kotlin/okhttp3/internal/http2/FrameLogger.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http2/FrameLogger.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.http2
+
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Internal interface for HTTP/2 Frame Logging.
+ */
+internal interface FrameLogger {
+  fun logFrame(frameLog: () -> String)
+
+  object Noop : FrameLogger {
+    override fun logFrame(frameLog: () -> String) {
+    }
+  }
+
+  object Logging : FrameLogger {
+    private val logger = Logger.getLogger(Http2::class.java.name)
+
+    override fun logFrame(frameLog: () -> String) {
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, frameLog())
+      }
+    }
+  }
+}

--- a/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Reader.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Reader.kt
@@ -58,7 +58,7 @@ class Http2Reader internal constructor(
   /** Creates a frame reader with max header table size of 4096. */
   private val source: BufferedSource,
   private val client: Boolean,
-  private val frameLogger: FrameLogger = FrameLogger.Noop
+  private val frameLogger: FrameLogger = FrameLogger.Noop,
 ) : Closeable {
   private val continuation: ContinuationSource = ContinuationSource(this.source, frameLogger)
   private val hpackReader: Hpack.Reader =
@@ -382,10 +382,10 @@ class Http2Reader internal constructor(
     }
     frameLogger.logFrame {
       frameLogWindowUpdate(
-            inbound = true,
-            streamId = streamId,
-            length = length,
-            windowSizeIncrement = increment,
+        inbound = true,
+        streamId = streamId,
+        length = length,
+        windowSizeIncrement = increment,
       )
     }
     handler.windowUpdate(streamId, increment)
@@ -402,7 +402,7 @@ class Http2Reader internal constructor(
    */
   internal class ContinuationSource(
     private val source: BufferedSource,
-    private val frameLogger: FrameLogger
+    private val frameLogger: FrameLogger,
   ) : Source {
     var length: Int = 0
     var flags: Int = 0

--- a/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Writer.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Writer.kt
@@ -44,7 +44,7 @@ import okio.BufferedSink
 class Http2Writer internal constructor(
   private val sink: BufferedSink,
   private val client: Boolean,
-  private val frameLogger: FrameLogger = FrameLogger.Noop
+  private val frameLogger: FrameLogger = FrameLogger.Noop,
 ) : Closeable {
   private val hpackBuffer: Buffer = Buffer()
   private var maxFrameSize: Int = INITIAL_MAX_FRAME_SIZE

--- a/okhttp/src/test/java/okhttp3/CacheCorruptionTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheCorruptionTest.kt
@@ -19,7 +19,6 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.startsWith
 import java.net.CookieManager
-import java.net.ResponseCache
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -41,7 +40,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.parallel.Isolated
 
+@Isolated
 class CacheCorruptionTest {
   var fileSystem = FakeFileSystem()
 
@@ -77,7 +78,6 @@ class CacheCorruptionTest {
 
   @AfterEach
   fun tearDown() {
-    ResponseCache.setDefault(null)
     if (this::cache.isInitialized) {
       cache.delete()
     }

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -2699,6 +2699,8 @@ class CacheTest {
    */
   @Test
   fun testGoldenCacheResponse() {
+    platform.assumeNotWindows()
+
     cache.close()
     server.enqueue(
       MockResponse.Builder()
@@ -2755,6 +2757,8 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   /** Exercise the cache format in OkHttp 2.7 and all earlier releases.  */
   @Test
   fun testGoldenCacheHttpsResponseOkHttp27() {
+    platform.assumeNotWindows()
+
     val url = server.url("/")
     val urlKey = key(url)
     val prefix = get().getPrefix()
@@ -2803,6 +2807,8 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
   /** The TLS version is present in OkHttp 3.0 and beyond.  */
   @Test
   fun testGoldenCacheHttpsResponseOkHttp30() {
+    platform.assumeNotWindows()
+
     val url = server.url("/")
     val urlKey = key(url)
     val prefix = get().getPrefix()
@@ -2855,6 +2861,8 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
 
   @Test
   fun testGoldenCacheHttpResponseOkHttp30() {
+    platform.assumeNotWindows()
+
     val url = server.url("/")
     val urlKey = key(url)
     val prefix = get().getPrefix()

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -65,8 +65,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.parallel.Isolated
 
 @Tag("Slow")
+@Isolated
 class CacheTest {
   val fileSystem = FakeFileSystem()
 

--- a/okhttp/src/test/java/okhttp3/CallTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallTest.kt
@@ -31,7 +31,6 @@ import assertk.assertions.isNotSameAs
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.startsWith
-import assertk.fail
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InterruptedIOException
@@ -118,7 +117,6 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.extension.RegisterExtension
-import org.junit.jupiter.api.parallel.Isolated
 import org.junitpioneer.jupiter.RetryingTest
 
 @Timeout(30)

--- a/okhttp/src/test/java/okhttp3/CallWithLogsTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallWithLogsTest.kt
@@ -83,6 +83,7 @@ open class CallWithLogsTest {
     cache.close()
     fileSystem.checkNoOpenFiles()
   }
+
   @Test
   fun exceptionThrownByOnResponseIsRedactedAndLogged() {
     server.enqueue(MockResponse())

--- a/okhttp/src/test/java/okhttp3/CallWithLogsTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallWithLogsTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.fail
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.junit5.internal.MockWebServerInstance
+import okhttp3.TestUtil.awaitGarbageCollection
+import okhttp3.okio.LoggingFilesystem
+import okhttp3.testing.PlatformRule
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.parallel.Isolated
+
+@Timeout(30)
+@Isolated
+open class CallWithLogsTest {
+  private val fileSystem = FakeFileSystem()
+
+  @RegisterExtension
+  val platform = PlatformRule()
+
+  @RegisterExtension
+  val clientTestRule = OkHttpClientTestRule()
+
+  @RegisterExtension
+  val testLogHandler = TestLogHandler(OkHttpClient::class.java)
+
+  private lateinit var server: MockWebServer
+  private lateinit var server2: MockWebServer
+
+  private var listener = RecordingEventListener()
+  private var client =
+    clientTestRule.newClientBuilder()
+      .eventListenerFactory(clientTestRule.wrap(listener))
+      .build()
+  private val cache =
+    Cache(
+      directory = "/cache".toPath(),
+      maxSize = Int.MAX_VALUE.toLong(),
+      fileSystem = LoggingFilesystem(fileSystem),
+    )
+
+  @BeforeEach
+  fun setUp(
+    server: MockWebServer,
+    @MockWebServerInstance("server2") server2: MockWebServer,
+  ) {
+    this.server = server
+    this.server2 = server2
+
+    platform.assumeNotOpenJSSE()
+  }
+
+  @AfterEach
+  fun tearDown() {
+    cache.close()
+    fileSystem.checkNoOpenFiles()
+  }
+  @Test
+  fun exceptionThrownByOnResponseIsRedactedAndLogged() {
+    server.enqueue(MockResponse())
+    val request = Request(server.url("/secret"))
+    client.newCall(request).enqueue(
+      object : Callback {
+        override fun onFailure(
+          call: Call,
+          e: IOException,
+        ) {
+          fail("")
+        }
+
+        override fun onResponse(
+          call: Call,
+          response: Response,
+        ) {
+          throw IOException("a")
+        }
+      },
+    )
+    assertThat(testLogHandler.take())
+      .isEqualTo("INFO: Callback failure for call to " + server.url("/") + "...")
+  }
+
+  @Test
+  fun leakedResponseBodyLogsStackTrace() {
+    server.enqueue(
+      MockResponse(body = "This gets leaked."),
+    )
+    client =
+      clientTestRule.newClientBuilder()
+        .connectionPool(ConnectionPool(0, 10, TimeUnit.MILLISECONDS))
+        .build()
+    val request = Request(server.url("/"))
+    client.newCall(request).execute() // Ignore the response so it gets leaked then GC'd.
+    awaitGarbageCollection()
+    val message = testLogHandler.take()
+    assertThat(message).contains(
+      "A connection to ${server.url("/")} was leaked. Did you forget to close a response body?",
+    )
+  }
+
+  @Tag("Slowish")
+  @Test
+  fun asyncLeakedResponseBodyLogsStackTrace() {
+    server.enqueue(MockResponse(body = "This gets leaked."))
+    client =
+      clientTestRule.newClientBuilder()
+        .connectionPool(ConnectionPool(0, 10, TimeUnit.MILLISECONDS))
+        .build()
+    val request = Request(server.url("/"))
+    val latch = CountDownLatch(1)
+    client.newCall(request).enqueue(
+      object : Callback {
+        override fun onFailure(
+          call: Call,
+          e: IOException,
+        ) {
+          fail("")
+        }
+
+        override fun onResponse(
+          call: Call,
+          response: Response,
+        ) {
+          // Ignore the response so it gets leaked then GC'd.
+          latch.countDown()
+        }
+      },
+    )
+    latch.await()
+    // There's some flakiness when triggering a GC for objects in a separate thread. Adding a
+    // small delay appears to ensure the objects will get GC'd.
+    Thread.sleep(200)
+    awaitGarbageCollection()
+    val message = testLogHandler.take()
+    assertThat(message).contains(
+      "A connection to ${server.url("/")} was leaked. Did you forget to close a response body?",
+    )
+  }
+}

--- a/okhttp/src/test/java/okhttp3/OkHttpClientTest.kt
+++ b/okhttp/src/test/java/okhttp3/OkHttpClientTest.kt
@@ -27,7 +27,6 @@ import java.io.IOException
 import java.net.CookieManager
 import java.net.Proxy
 import java.net.ProxySelector
-import java.net.ResponseCache
 import java.net.SocketAddress
 import java.net.URI
 import java.time.Duration
@@ -47,7 +46,9 @@ import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.parallel.Isolated
 
+@Isolated
 class OkHttpClientTest {
   @RegisterExtension
   var platform = PlatformRule()
@@ -64,7 +65,6 @@ class OkHttpClientTest {
   @AfterEach fun tearDown() {
     ProxySelector.setDefault(DEFAULT_PROXY_SELECTOR)
     CookieManager.setDefault(DEFAULT_COOKIE_HANDLER)
-    ResponseCache.setDefault(DEFAULT_RESPONSE_CACHE)
   }
 
   @Test fun durationDefaults() {
@@ -441,6 +441,5 @@ class OkHttpClientTest {
   companion object {
     private val DEFAULT_PROXY_SELECTOR = ProxySelector.getDefault()
     private val DEFAULT_COOKIE_HANDLER = CookieManager.getDefault()
-    private val DEFAULT_RESPONSE_CACHE = ResponseCache.getDefault()
   }
 }

--- a/okhttp/src/test/java/okhttp3/ServerTruncatesRequestTest.kt
+++ b/okhttp/src/test/java/okhttp3/ServerTruncatesRequestTest.kt
@@ -69,6 +69,9 @@ class ServerTruncatesRequestTest {
 
   @Test
   fun serverTruncatesRequestOnLongPostHttp1() {
+    // java.net.SocketException: An established connection was aborted by the software in your host machine
+    platform.assumeNotWindows()
+
     serverTruncatesRequestOnLongPost(https = false)
   }
 
@@ -171,6 +174,9 @@ class ServerTruncatesRequestTest {
 
   @Test
   fun serverTruncatesRequestButTrailersCanStillBeReadHttp1() {
+    // java.net.SocketException: An established connection was aborted by the software in your host machine
+    platform.assumeNotWindows()
+
     serverTruncatesRequestButTrailersCanStillBeRead(http2 = false)
   }
 

--- a/okhttp/src/test/java/okhttp3/URLConnectionTest.kt
+++ b/okhttp/src/test/java/okhttp3/URLConnectionTest.kt
@@ -107,10 +107,12 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.Isolated
 import org.opentest4j.TestAbortedException
 
 /** Android's URLConnectionTest, ported to exercise OkHttp's Call API.  */
 @Tag("Slow")
+@Isolated
 class URLConnectionTest {
   @RegisterExtension
   val platform = PlatformRule()

--- a/okhttp/src/test/java/okhttp3/internal/cache2/FileOperatorTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/cache2/FileOperatorTest.kt
@@ -21,6 +21,7 @@ import java.io.File
 import java.io.RandomAccessFile
 import java.util.Random
 import kotlin.test.assertFailsWith
+import okhttp3.testing.PlatformRule
 import okio.Buffer
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
@@ -30,9 +31,13 @@ import okio.source
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 
 class FileOperatorTest {
+  @JvmField @RegisterExtension
+  val platform = PlatformRule()
+
   @TempDir
   var tempDir: File? = null
   private var file: File? = null
@@ -40,13 +45,15 @@ class FileOperatorTest {
 
   @BeforeEach
   fun setUp() {
+    platform.assumeNotWindows()
+
     file = File(tempDir, "test")
     randomAccessFile = RandomAccessFile(file, "rw")
   }
 
   @AfterEach
   fun tearDown() {
-    randomAccessFile!!.close()
+    randomAccessFile?.close()
   }
 
   @Test

--- a/okhttp/src/test/java/okhttp3/internal/cache2/RelayTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/cache2/RelayTest.kt
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors
 import kotlin.test.assertFailsWith
 import okhttp3.internal.cache2.Relay.Companion.edit
 import okhttp3.internal.cache2.Relay.Companion.read
+import okhttp3.testing.PlatformRule
 import okio.Buffer
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
@@ -38,10 +39,14 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 
 @Tag("Slowish")
 class RelayTest {
+  @JvmField @RegisterExtension
+  val platform = PlatformRule()
+
   @TempDir
   var tempDir: File? = null
   private val executor = Executors.newCachedThreadPool()
@@ -157,6 +162,8 @@ class RelayTest {
 
   @Test
   fun closeBeforeExhaustLeavesDirtyFile() {
+    platform.assumeNotWindows()
+
     val upstream = Buffer()
     upstream.writeUtf8("abcdefghij")
     val relay1 = edit(file, upstream, metadata, 5)

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskLoggerTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskLoggerTest.kt
@@ -17,6 +17,7 @@ package okhttp3.internal.concurrent
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import okhttp3.internal.concurrent.TaskLogger.Logging.formatDuration
 import org.junit.jupiter.api.Test
 
 class TaskLoggerTest {

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerRealBackendTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerRealBackendTest.kt
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
 
 /**
  * Integration test to confirm that [TaskRunner] works with a real backend. Business logic is all
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Test
  * busiest of CI servers.
  */
 @Tag("Slowish")
+@Isolated
 class TaskRunnerRealBackendTest {
   private val log = LinkedBlockingDeque<String>()
 

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
@@ -23,16 +23,11 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isSameAs
 import java.util.concurrent.RejectedExecutionException
 import kotlin.test.assertFailsWith
-import okhttp3.TestLogHandler
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
 
 class TaskRunnerTest {
   private val taskFaker = TaskFaker()
-
-  @RegisterExtension @JvmField
-  val testLogHandler = TestLogHandler(taskFaker.logger)
 
   private val taskRunner = taskFaker.taskRunner
   private val log = mutableListOf<String>()
@@ -61,10 +56,10 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -92,16 +87,16 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 run again after  50 µs: task",
-      "FINE: Q10000 finished run in   0 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 run again after 150 µs: task",
-      "FINE: Q10000 finished run in   0 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 run again after  50 µs: task",
+      "Q10000 finished run in   0 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 run again after 150 µs: task",
+      "Q10000 finished run in   0 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -133,14 +128,14 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 scheduled after  50 µs: task",
-      "FINE: Q10000 already scheduled     : task",
-      "FINE: Q10000 finished run in   0 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 scheduled after  50 µs: task",
+      "Q10000 already scheduled     : task",
+      "Q10000 finished run in   0 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -172,14 +167,14 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 scheduled after 200 µs: task",
-      "FINE: Q10000 run again after  50 µs: task",
-      "FINE: Q10000 finished run in   0 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 scheduled after 200 µs: task",
+      "Q10000 run again after  50 µs: task",
+      "Q10000 finished run in   0 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -198,9 +193,9 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 canceled              : task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 canceled              : task",
     )
   }
 
@@ -228,10 +223,10 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -250,10 +245,10 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -271,10 +266,10 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -303,13 +298,13 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 run again after  50 µs: task",
-      "FINE: Q10000 finished run in   0 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 run again after  50 µs: task",
+      "Q10000 finished run in   0 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -328,9 +323,9 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 canceled              : task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 canceled              : task",
     )
   }
 
@@ -358,10 +353,10 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -391,16 +386,16 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task one",
-      "FINE: Q10000 scheduled after 100 µs: task two",
-      "FINE: Q10000 scheduled after 100 µs: task three",
-      "FINE: Q10000 starting              : task one",
-      "FINE: Q10000 finished run in   0 µs: task one",
-      "FINE: Q10000 starting              : task two",
-      "FINE: Q10000 finished run in   0 µs: task two",
-      "FINE: Q10000 starting              : task three",
-      "FINE: Q10000 finished run in   0 µs: task three",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task one",
+      "Q10000 scheduled after 100 µs: task two",
+      "Q10000 scheduled after 100 µs: task three",
+      "Q10000 starting              : task one",
+      "Q10000 finished run in   0 µs: task one",
+      "Q10000 starting              : task two",
+      "Q10000 finished run in   0 µs: task two",
+      "Q10000 starting              : task three",
+      "Q10000 finished run in   0 µs: task three",
     )
   }
 
@@ -430,16 +425,16 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactlyInAnyOrder(
-      "FINE: Q10000 scheduled after 100 µs: task one",
-      "FINE: Q10001 scheduled after 100 µs: task two",
-      "FINE: Q10002 scheduled after 100 µs: task three",
-      "FINE: Q10000 starting              : task one",
-      "FINE: Q10000 finished run in   0 µs: task one",
-      "FINE: Q10001 starting              : task two",
-      "FINE: Q10001 finished run in   0 µs: task two",
-      "FINE: Q10002 starting              : task three",
-      "FINE: Q10002 finished run in   0 µs: task three",
+    assertThat(taskFaker.takeAllLogs()).containsExactlyInAnyOrder(
+      "Q10000 scheduled after 100 µs: task one",
+      "Q10001 scheduled after 100 µs: task two",
+      "Q10002 scheduled after 100 µs: task three",
+      "Q10000 starting              : task one",
+      "Q10000 finished run in   0 µs: task one",
+      "Q10001 starting              : task two",
+      "Q10001 finished run in   0 µs: task two",
+      "Q10002 starting              : task three",
+      "Q10002 finished run in   0 µs: task three",
     )
   }
 
@@ -455,9 +450,9 @@ class TaskRunnerTest {
 
     assertThat(redQueue.scheduledTasks.toString()).isEqualTo("[task one, task two]")
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task one",
-      "FINE: Q10000 scheduled after 200 µs: task two",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task one",
+      "Q10000 scheduled after 200 µs: task two",
     )
   }
 
@@ -504,16 +499,16 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task one",
-      "FINE: Q10000 scheduled after 200 µs: task two",
-      "FINE: Q10000 starting              : task one",
-      "FINE: Q10000 scheduled after 200 µs: task one",
-      "FINE: Q10000 finished run in   0 µs: task one",
-      "FINE: Q10000 starting              : task two",
-      "FINE: Q10000 finished run in   0 µs: task two",
-      "FINE: Q10000 starting              : task one",
-      "FINE: Q10000 finished run in   0 µs: task one",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task one",
+      "Q10000 scheduled after 200 µs: task two",
+      "Q10000 starting              : task one",
+      "Q10000 scheduled after 200 µs: task one",
+      "Q10000 finished run in   0 µs: task one",
+      "Q10000 starting              : task two",
+      "Q10000 finished run in   0 µs: task two",
+      "Q10000 starting              : task one",
+      "Q10000 finished run in   0 µs: task one",
     )
   }
 
@@ -542,13 +537,13 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task one",
-      "FINE: Q10001 scheduled after 200 µs: task two",
-      "FINE: Q10000 starting              : task one",
-      "FINE: Q10000 finished run in   0 µs: task one",
-      "FINE: Q10001 starting              : task two",
-      "FINE: Q10001 finished run in   0 µs: task two",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task one",
+      "Q10001 scheduled after 200 µs: task two",
+      "Q10000 starting              : task one",
+      "Q10000 finished run in   0 µs: task one",
+      "Q10001 starting              : task two",
+      "Q10001 finished run in   0 µs: task two",
     )
   }
 
@@ -562,10 +557,10 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after   0 µs: lucky task",
-      "FINE: Q10000 starting              : lucky task",
-      "FINE: Q10000 finished run in   0 µs: lucky task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after   0 µs: lucky task",
+      "Q10000 starting              : lucky task",
+      "Q10000 finished run in   0 µs: lucky task",
     )
   }
 
@@ -584,9 +579,9 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 canceled              : task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 canceled              : task",
     )
   }
 
@@ -614,10 +609,10 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 scheduled after 100 µs: task",
-      "FINE: Q10000 starting              : task",
-      "FINE: Q10000 finished run in   0 µs: task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 scheduled after 100 µs: task",
+      "Q10000 starting              : task",
+      "Q10000 finished run in   0 µs: task",
     )
   }
 
@@ -630,8 +625,8 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 schedule canceled (queue is shutdown): task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 schedule canceled (queue is shutdown): task",
     )
   }
 
@@ -651,8 +646,8 @@ class TaskRunnerTest {
 
     taskFaker.assertNoMoreTasks()
 
-    assertThat(testLogHandler.takeAll()).containsExactly(
-      "FINE: Q10000 schedule failed (queue is shutdown): task",
+    assertThat(taskFaker.takeAllLogs()).containsExactly(
+      "Q10000 schedule failed (queue is shutdown): task",
     )
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
@@ -18,7 +18,7 @@ package okhttp3.internal.connection
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.hasMessage
-import assertk.assertions.isEqualTo
+import assertk.assertions.isSameInstanceAs
 import java.io.IOException
 import java.net.UnknownServiceException
 import kotlin.test.assertFailsWith
@@ -28,6 +28,7 @@ import okhttp3.internal.concurrent.TaskFaker
 import okhttp3.testing.Flaky
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
 import org.junitpioneer.jupiter.RetryingTest
 
 /**
@@ -40,6 +41,7 @@ import org.junitpioneer.jupiter.RetryingTest
  *  * attempt to find a connection
  *  * step through time, asserting that the expected side effects are performed.
  */
+@Isolated
 internal class FastFallbackExchangeFinderTest {
   private val taskFaker = TaskFaker()
   private val taskRunner = taskFaker.taskRunner
@@ -59,7 +61,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan0.connection)
+      assertThat(result0).isSameInstanceAs(plan0.connection)
     }
 
     taskFaker.runTasks()
@@ -77,7 +79,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan0.connection)
+      assertThat(result0).isSameInstanceAs(plan0.connection)
     }
 
     taskFaker.runTasks()
@@ -103,7 +105,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan0.connection)
+      assertThat(result0).isSameInstanceAs(plan0.connection)
     }
 
     taskFaker.runTasks()
@@ -141,7 +143,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan1.connection)
+      assertThat(result0).isSameInstanceAs(plan1.connection)
     }
 
     taskFaker.runTasks()
@@ -171,7 +173,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan1.connection)
+      assertThat(result0).isSameInstanceAs(plan1.connection)
     }
 
     taskFaker.runTasks()
@@ -211,7 +213,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan2.connection)
+      assertThat(result0).isSameInstanceAs(plan2.connection)
     }
 
     taskFaker.runTasks()
@@ -253,9 +255,9 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan0.connection)
+      assertThat(result0).isSameInstanceAs(plan0.connection)
       val result1 = finder.find()
-      assertThat(result1).isEqualTo(plan1.connection)
+      assertThat(result1).isSameInstanceAs(plan1.connection)
     }
 
     taskFaker.runTasks()
@@ -278,9 +280,9 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan1.connection)
+      assertThat(result0).isSameInstanceAs(plan1.connection)
       val result1 = finder.find()
-      assertThat(result1).isEqualTo(plan2.connection)
+      assertThat(result1).isSameInstanceAs(plan2.connection)
     }
 
     taskFaker.runTasks()
@@ -351,7 +353,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan1.connection)
+      assertThat(result0).isSameInstanceAs(plan1.connection)
     }
 
     taskFaker.runTasks()
@@ -447,7 +449,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan1.connection)
+      assertThat(result0).isSameInstanceAs(plan1.connection)
     }
 
     taskFaker.runTasks()
@@ -476,7 +478,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan2.connection)
+      assertThat(result0).isSameInstanceAs(plan2.connection)
     }
 
     taskFaker.runTasks()
@@ -521,7 +523,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan0.connection)
+      assertThat(result0).isSameInstanceAs(plan0.connection)
     }
 
     taskFaker.runTasks()
@@ -563,7 +565,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan1.connection)
+      assertThat(result0).isSameInstanceAs(plan1.connection)
     }
 
     taskFaker.runTasks()
@@ -587,7 +589,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan1.connection)
+      assertThat(result0).isSameInstanceAs(plan1.connection)
     }
 
     taskFaker.runTasks()
@@ -637,7 +639,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan3.connection)
+      assertThat(result0).isSameInstanceAs(plan3.connection)
     }
 
     taskFaker.runTasks()
@@ -716,7 +718,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan4.connection)
+      assertThat(result0).isSameInstanceAs(plan4.connection)
     }
 
     taskFaker.runTasks()
@@ -802,7 +804,7 @@ internal class FastFallbackExchangeFinderTest {
 
     taskRunner.newQueue().execute("connect") {
       val result0 = finder.find()
-      assertThat(result0).isEqualTo(plan0.connection)
+      assertThat(result0).isSameInstanceAs(plan0.connection)
     }
 
     taskFaker.runTasks()

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -71,7 +71,6 @@ import okhttp3.RequestBody
 import okhttp3.Response
 import okhttp3.Route
 import okhttp3.SimpleProvider
-import okhttp3.TestLogHandler
 import okhttp3.TestUtil.assumeNotWindows
 import okhttp3.TestUtil.repeat
 import okhttp3.internal.DoubleInetAddressDns

--- a/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/tls/ClientAuthTest.kt
@@ -52,9 +52,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.parallel.Isolated
 import org.junitpioneer.jupiter.RetryingTest
 
 @Tag("Slowish")
+@Isolated
 class ClientAuthTest {
   @RegisterExtension
   val platform = PlatformRule()

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketRecorder.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketRecorder.kt
@@ -129,7 +129,7 @@ class WebSocketRecorder(
   }
 
   private fun nextEvent(): Any {
-    return events.poll(10, TimeUnit.SECONDS)
+    return events.poll(25, TimeUnit.SECONDS)
       ?: throw AssertionError("Timed out waiting for event.")
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketRecorder.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketRecorder.kt
@@ -168,12 +168,14 @@ class WebSocketRecorder(
   }
 
   fun assertOpen(): WebSocket {
-    val event = nextEvent() as Open
+    val event = nextEvent()
+    check(event is Open) { "Expected Open but was $event" }
     return event.webSocket
   }
 
   fun assertFailure(t: Throwable?) {
-    val event = nextEvent() as Failure
+    val event = nextEvent()
+    check(event is Failure) { "Expected Failure but was $event" }
     assertThat(event.response).isNull()
     assertThat(event.t).isSameAs(t)
   }
@@ -182,7 +184,8 @@ class WebSocketRecorder(
     cls: Class<out IOException?>?,
     vararg messages: String,
   ) {
-    val event = nextEvent() as Failure
+    val event = nextEvent()
+    check(event is Failure) { "Expected Failure but was $event" }
     assertThat(event.response).isNull()
     assertThat(event.t.javaClass).isEqualTo(cls)
     if (messages.isNotEmpty()) {
@@ -191,7 +194,8 @@ class WebSocketRecorder(
   }
 
   fun assertFailure() {
-    nextEvent() as Failure
+    val event = nextEvent()
+    check(event is Failure) { "Expected Failure but was $event" }
   }
 
   fun assertFailure(
@@ -200,7 +204,8 @@ class WebSocketRecorder(
     cls: Class<out IOException?>?,
     message: String?,
   ) {
-    val event = nextEvent() as Failure
+    val event = nextEvent()
+    check(event is Failure) { "Expected Failure but was $event" }
     assertThat(event.response!!.code).isEqualTo(code)
     if (body != null) {
       assertThat(event.responseBody).isEqualTo(body)


### PR DESCRIPTION
Use test concurrency as a way to flush out flaky tests and work through them.

Introduce a lot of internal API for Frame and Task logging. Use them to avoid relying on flaky TestLogHandler.

fixes https://github.com/square/okhttp/issues/8230

Mainly for discussion at this point, and confirming it's no longer flaky.