### PR TITLE
Support minimum connection pool size

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
@@ -39,6 +39,7 @@ import okhttp3.internal.connection.RealCall
 import okhttp3.internal.connection.RealConnection
 import okhttp3.internal.connection.RealConnectionPool
 import okhttp3.internal.connection.RealRoutePlanner
+import okhttp3.internal.connection.RouteDatabase
 import okhttp3.internal.http.RealInterceptorChain
 import okhttp3.internal.http.RecordingProxySelector
 import okhttp3.tls.HandshakeCertificates
@@ -104,6 +105,14 @@ class TestValueFactory : Closeable {
       keepAliveDuration = 100L,
       timeUnit = TimeUnit.NANOSECONDS,
       connectionListener = ConnectionListener.NONE,
+      readTimeoutMillis = 10_000,
+      writeTimeoutMillis = 10_000,
+      socketConnectTimeoutMillis = 10_000,
+      socketReadTimeoutMillis = 10_000,
+      pingIntervalMillis = 10_000,
+      retryOnConnectionFailure = true,
+      fastFallback = true,
+      routeDatabase = RouteDatabase(),
     )
   }
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
@@ -35,7 +35,6 @@ import okhttp3.internal.RecordingOkAuthenticator
 import okhttp3.internal.concurrent.TaskFaker
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.connection.CallConnectionUser
-import okhttp3.internal.connection.ExchangeFinder
 import okhttp3.internal.connection.FastFallbackExchangeFinder
 import okhttp3.internal.connection.RealCall
 import okhttp3.internal.connection.RealConnection
@@ -123,9 +122,9 @@ class TestValueFactory : Closeable {
             fastFallback = true,
             address = address,
             routeDatabase = RouteDatabase(),
-            connectionUser = user
+            connectionUser = user,
           ),
-          taskRunner
+          taskRunner,
         )
       },
     )

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -391,6 +391,7 @@ public final class okhttp3/ConnectionPool$AddressPolicy {
 	public final field backoffDelayMillis J
 	public final field backoffJitterMillis I
 	public final field minimumConcurrentCalls I
+	public fun <init> ()V
 	public fun <init> (IJI)V
 	public synthetic fun <init> (IJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -923,6 +923,7 @@ public class okhttp3/OkHttpClient : okhttp3/Call$Factory, okhttp3/WebSocket$Fact
 	public final fun -deprecated_sslSocketFactory ()Ljavax/net/ssl/SSLSocketFactory;
 	public final fun -deprecated_writeTimeoutMillis ()I
 	public fun <init> ()V
+	public final fun address (Lokhttp3/HttpUrl;)Lokhttp3/Address;
 	public final fun authenticator ()Lokhttp3/Authenticator;
 	public final fun cache ()Lokhttp3/Cache;
 	public final fun callTimeoutMillis ()I
@@ -932,7 +933,6 @@ public class okhttp3/OkHttpClient : okhttp3/Call$Factory, okhttp3/WebSocket$Fact
 	public final fun connectionPool ()Lokhttp3/ConnectionPool;
 	public final fun connectionSpecs ()Ljava/util/List;
 	public final fun cookieJar ()Lokhttp3/CookieJar;
-	public final fun createAddress (Lokhttp3/HttpUrl;)Lokhttp3/Address;
 	public final fun dispatcher ()Lokhttp3/Dispatcher;
 	public final fun dns ()Lokhttp3/Dns;
 	public final fun eventListenerFactory ()Lokhttp3/EventListener$Factory;

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -384,6 +384,15 @@ public final class okhttp3/ConnectionPool {
 	public final fun connectionCount ()I
 	public final fun evictAll ()V
 	public final fun idleConnectionCount ()I
+	public final fun setPolicy (Lokhttp3/Address;Lokhttp3/ConnectionPool$AddressPolicy;)V
+}
+
+public final class okhttp3/ConnectionPool$AddressPolicy {
+	public final field backoffDelayMillis J
+	public final field backoffJitterMillis I
+	public final field minimumConcurrentCalls I
+	public fun <init> (IJI)V
+	public synthetic fun <init> (IJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class okhttp3/ConnectionSpec {
@@ -922,6 +931,7 @@ public class okhttp3/OkHttpClient : okhttp3/Call$Factory, okhttp3/WebSocket$Fact
 	public final fun connectionPool ()Lokhttp3/ConnectionPool;
 	public final fun connectionSpecs ()Ljava/util/List;
 	public final fun cookieJar ()Lokhttp3/CookieJar;
+	public final fun createAddress (Lokhttp3/HttpUrl;)Lokhttp3/Address;
 	public final fun dispatcher ()Lokhttp3/Dispatcher;
 	public final fun dns ()Lokhttp3/Dns;
 	public final fun eventListenerFactory ()Lokhttp3/EventListener$Factory;

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -110,6 +110,7 @@ class ConnectionPool internal constructor(
     delegate.evictAll()
   }
 
+  @ExperimentalOkHttpApi
   fun setPolicy(
     address: Address,
     policy: AddressPolicy,

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -92,4 +92,25 @@ class ConnectionPool internal constructor(
   fun evictAll() {
     delegate.evictAll()
   }
+
+  fun setPolicy(
+    address: Address,
+    policy: AddressPolicy,
+  ) {
+    delegate.setPolicy(address, policy)
+  }
+
+  /**
+   * A policy for how the pool should treat a specific address.
+   *
+   * @param minimumConcurrentCalls How many concurrent calls should be possible to make at any time.
+   *    The pool will passively try to pre-emptively open connections to satisfy this minimum.
+   * @param backoffDelayMillis How long to wait to retry pre-emptive connection attempts that fail.
+   * @param backoffJitterMillis How much jitter to introduce in connection retry backoff delays
+   */
+  data class AddressPolicy(
+    val minimumConcurrentCalls: Int,
+    val backoffDelayMillis: Long = 60 * 1000,
+    val backoffJitterMillis: Int = 100,
+  )
 }

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -19,6 +19,7 @@ package okhttp3
 import java.util.concurrent.TimeUnit
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.connection.RealConnectionPool
+import okhttp3.internal.connection.RouteDatabase
 
 /**
  * Manages reuse of HTTP and HTTP/2 connections for reduced network latency. HTTP requests that
@@ -39,6 +40,14 @@ class ConnectionPool internal constructor(
     timeUnit: TimeUnit = TimeUnit.MINUTES,
     taskRunner: TaskRunner = TaskRunner.INSTANCE,
     connectionListener: ConnectionListener = ConnectionListener.NONE,
+    readTimeoutMillis: Int = 10_000,
+    writeTimeoutMillis: Int = 10_000,
+    socketConnectTimeoutMillis: Int = 10_000,
+    socketReadTimeoutMillis: Int = 10_000,
+    pingIntervalMillis: Int = 10_000,
+    retryOnConnectionFailure: Boolean = true,
+    fastFallback: Boolean = true,
+    routeDatabase: RouteDatabase = RouteDatabase(),
   ) : this(
     RealConnectionPool(
       taskRunner = taskRunner,
@@ -46,6 +55,14 @@ class ConnectionPool internal constructor(
       keepAliveDuration = keepAliveDuration,
       timeUnit = timeUnit,
       connectionListener = connectionListener,
+      readTimeoutMillis = readTimeoutMillis,
+      writeTimeoutMillis = writeTimeoutMillis,
+      socketConnectTimeoutMillis = socketConnectTimeoutMillis,
+      socketReadTimeoutMillis = socketReadTimeoutMillis,
+      pingIntervalMillis = pingIntervalMillis,
+      retryOnConnectionFailure = retryOnConnectionFailure,
+      fastFallback = fastFallback,
+      routeDatabase = routeDatabase,
     ),
   )
 

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -145,6 +145,7 @@ class ConnectionPool internal constructor(
     /**
      * How many concurrent calls should be possible to make at any time.
      * The pool will routinely try to pre-emptively open connections to satisfy this minimum.
+     * Connections will still be closed if they idle beyond the keep-alive but will be replaced.
      */
     @JvmField val minimumConcurrentCalls: Int = 0,
     /** How long to wait to retry pre-emptive connection attempts that fail. */

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -145,9 +145,6 @@ class ConnectionPool internal constructor(
     /**
      * How many concurrent calls should be possible to make at any time.
      * The pool will routinely try to pre-emptively open connections to satisfy this minimum.
-     *
-     * This feature must not be used on Android because it may result in network traffic while
-     * the app is backgrounded. On Android, leave this set to 0.
      */
     @JvmField val minimumConcurrentCalls: Int = 0,
     /** How long to wait to retry pre-emptive connection attempts that fail. */

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.connection.FastFallbackExchangeFinder
 import okhttp3.internal.connection.ForceConnectRoutePlanner
-import okhttp3.internal.connection.PoolConnectionUser
 import okhttp3.internal.connection.RealConnectionPool
 import okhttp3.internal.connection.RealRoutePlanner
 import okhttp3.internal.connection.RouteDatabase
@@ -59,7 +58,7 @@ class ConnectionPool internal constructor(
       keepAliveDuration = keepAliveDuration,
       timeUnit = timeUnit,
       connectionListener = connectionListener,
-      exchangeFinderFactory =  { pool, address, user ->
+      exchangeFinderFactory = { pool, address, user ->
         FastFallbackExchangeFinder(
           ForceConnectRoutePlanner(
             RealRoutePlanner(
@@ -79,8 +78,7 @@ class ConnectionPool internal constructor(
           ),
           taskRunner,
         )
-      }
-
+      },
     ),
   )
 
@@ -147,12 +145,13 @@ class ConnectionPool internal constructor(
     /**
      * How many concurrent calls should be possible to make at any time.
      * The pool will routinely try to pre-emptively open connections to satisfy this minimum.
+     *
+     * This feature must not be used on Android because it may result in network traffic while
+     * the app is backgrounded. On Android, leave this set to 0.
      */
-    @JvmField val minimumConcurrentCalls: Int,
-
+    @JvmField val minimumConcurrentCalls: Int = 0,
     /** How long to wait to retry pre-emptive connection attempts that fail. */
     @JvmField val backoffDelayMillis: Long = 60 * 1000,
-
     /** How much jitter to introduce in connection retry backoff delays */
     @JvmField val backoffJitterMillis: Int = 100,
   )

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -128,6 +128,10 @@ class ConnectionPool internal constructor(
     delegate.evictAll()
   }
 
+  /**
+   * Sets a policy that applies to [address].
+   * Overwrites any existing policy for that address.
+   */
   @ExperimentalOkHttpApi
   fun setPolicy(
     address: Address,
@@ -138,15 +142,18 @@ class ConnectionPool internal constructor(
 
   /**
    * A policy for how the pool should treat a specific address.
-   *
-   * @param minimumConcurrentCalls How many concurrent calls should be possible to make at any time.
-   *    The pool will passively try to pre-emptively open connections to satisfy this minimum.
-   * @param backoffDelayMillis How long to wait to retry pre-emptive connection attempts that fail.
-   * @param backoffJitterMillis How much jitter to introduce in connection retry backoff delays
    */
-  data class AddressPolicy(
-    val minimumConcurrentCalls: Int,
-    val backoffDelayMillis: Long = 60 * 1000,
-    val backoffJitterMillis: Int = 100,
+  class AddressPolicy(
+    /**
+     * How many concurrent calls should be possible to make at any time.
+     * The pool will routinely try to pre-emptively open connections to satisfy this minimum.
+     */
+    @JvmField val minimumConcurrentCalls: Int,
+
+    /** How long to wait to retry pre-emptive connection attempts that fail. */
+    @JvmField val backoffDelayMillis: Long = 60 * 1000,
+
+    /** How much jitter to introduce in connection retry backoff delays */
+    @JvmField val backoffJitterMillis: Int = 100,
   )
 }

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -136,9 +136,6 @@ open class OkHttpClient internal constructor(
   @get:JvmName("dispatcher")
   val dispatcher: Dispatcher = builder.dispatcher
 
-  @get:JvmName("connectionPool")
-  val connectionPool: ConnectionPool = builder.connectionPool
-
   /**
    * Returns an immutable list of interceptors that observe the full span of each call: from before
    * the connection is established (if any) until after the response source is selected (either the
@@ -264,6 +261,19 @@ open class OkHttpClient internal constructor(
 
   internal val routeDatabase: RouteDatabase = builder.routeDatabase ?: RouteDatabase()
   internal val taskRunner: TaskRunner = builder.taskRunner ?: TaskRunner.INSTANCE
+
+  @get:JvmName("connectionPool")
+  val connectionPool: ConnectionPool =
+    builder.connectionPool ?: ConnectionPool(
+      readTimeoutMillis = readTimeoutMillis,
+      writeTimeoutMillis = writeTimeoutMillis,
+      socketConnectTimeoutMillis = connectTimeoutMillis,
+      socketReadTimeoutMillis = readTimeoutMillis,
+      pingIntervalMillis = pingIntervalMillis,
+      retryOnConnectionFailure = retryOnConnectionFailure,
+      fastFallback = fastFallback,
+      routeDatabase = routeDatabase,
+    )
 
   constructor() : this(Builder())
 
@@ -547,7 +557,7 @@ open class OkHttpClient internal constructor(
 
   class Builder() {
     internal var dispatcher: Dispatcher = Dispatcher()
-    internal var connectionPool: ConnectionPool = ConnectionPool()
+    internal var connectionPool: ConnectionPool? = null
     internal val interceptors: MutableList<Interceptor> = mutableListOf()
     internal val networkInterceptors: MutableList<Interceptor> = mutableListOf()
     internal var eventListenerFactory: EventListener.Factory = EventListener.NONE.asFactory()

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -302,6 +302,32 @@ open class OkHttpClient internal constructor(
     verifyClientState()
   }
 
+  fun createAddress(url: HttpUrl): Address {
+    var useSslSocketFactory: SSLSocketFactory? = null
+    var useHostnameVerifier: HostnameVerifier? = null
+    var useCertificatePinner: CertificatePinner? = null
+    if (url.isHttps) {
+      useSslSocketFactory = sslSocketFactory
+      useHostnameVerifier = hostnameVerifier
+      useCertificatePinner = certificatePinner
+    }
+
+    return Address(
+      uriHost = url.host,
+      uriPort = url.port,
+      dns = dns,
+      socketFactory = socketFactory,
+      sslSocketFactory = useSslSocketFactory,
+      hostnameVerifier = useHostnameVerifier,
+      certificatePinner = useCertificatePinner,
+      proxyAuthenticator = proxyAuthenticator,
+      proxy = proxy,
+      protocols = protocols,
+      connectionSpecs = connectionSpecs,
+      proxySelector = proxySelector,
+    )
+  }
+
   private fun verifyClientState() {
     check(null !in (interceptors as List<Interceptor?>)) {
       "Null interceptor: $interceptors"

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -273,7 +273,10 @@ open class OkHttpClient internal constructor(
       retryOnConnectionFailure = retryOnConnectionFailure,
       fastFallback = fastFallback,
       routeDatabase = routeDatabase,
-    )
+    ).also {
+      // Cache the pool in the builder so that it will be shared with other clients
+      builder.connectionPool = it
+    }
 
   constructor() : this(Builder())
 

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -306,9 +306,10 @@ open class OkHttpClient internal constructor(
   }
 
   /**
-   * Creates an [Address] of out of the provided [HttpUrl].
+   * Creates an [Address] of out of the provided [HttpUrl]
+   * that uses this client’s DNS, TLS, and proxy configuration.
    */
-  fun createAddress(url: HttpUrl): Address {
+  fun address(url: HttpUrl): Address {
     var useSslSocketFactory: SSLSocketFactory? = null
     var useHostnameVerifier: HostnameVerifier? = null
     var useCertificatePinner: CertificatePinner? = null

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -302,6 +302,9 @@ open class OkHttpClient internal constructor(
     verifyClientState()
   }
 
+  /**
+   * Creates an [Address] of out of the provided [HttpUrl].
+   */
   fun createAddress(url: HttpUrl): Address {
     var useSslSocketFactory: SSLSocketFactory? = null
     var useHostnameVerifier: HostnameVerifier? = null

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/ForceConnectRoutePlanner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/ForceConnectRoutePlanner.kt
@@ -1,0 +1,22 @@
+package okhttp3.internal.connection
+
+import okhttp3.Address
+import okhttp3.HttpUrl
+
+/**
+ * A RoutePlanner that will always generate a ConnectPlan, ignoring any connection pooling
+ */
+class ForceConnectRoutePlanner(private val delegate: RealRoutePlanner) : RoutePlanner {
+  override val address: Address
+    get() = delegate.address
+  override val deferredPlans: ArrayDeque<RoutePlanner.Plan>
+    get() = delegate.deferredPlans
+
+  override fun isCanceled(): Boolean = delegate.isCanceled()
+
+  override fun plan(): RoutePlanner.Plan = delegate.planConnect()
+
+  override fun hasNext(failedConnection: RealConnection?): Boolean = delegate.hasNext(failedConnection)
+
+  override fun sameHostAndPort(url: HttpUrl): Boolean = delegate.sameHostAndPort(url)
+}

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/ForceConnectRoutePlanner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/ForceConnectRoutePlanner.kt
@@ -1,18 +1,17 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one or more
- *  contributor license agreements.  See the NOTICE file distributed with
- *  this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
- *  (the "License"); you may not use this file except in compliance with
- *  the License.  You may obtain a copy of the License at
+ * Copyright (C) 2024 Square, Inc.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package okhttp3.internal.connection
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/ForceConnectRoutePlanner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/ForceConnectRoutePlanner.kt
@@ -1,22 +1,24 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package okhttp3.internal.connection
 
-import okhttp3.Address
-import okhttp3.HttpUrl
-
 /**
- * A RoutePlanner that will always generate a ConnectPlan, ignoring any connection pooling
+ * A RoutePlanner that will always establish a new connection, ignoring any connection pooling
  */
-class ForceConnectRoutePlanner(private val delegate: RealRoutePlanner) : RoutePlanner {
-  override val address: Address
-    get() = delegate.address
-  override val deferredPlans: ArrayDeque<RoutePlanner.Plan>
-    get() = delegate.deferredPlans
-
-  override fun isCanceled(): Boolean = delegate.isCanceled()
-
-  override fun plan(): RoutePlanner.Plan = delegate.planConnect()
-
-  override fun hasNext(failedConnection: RealConnection?): Boolean = delegate.hasNext(failedConnection)
-
-  override fun sameHostAndPort(url: HttpUrl): Boolean = delegate.sameHostAndPort(url)
+class ForceConnectRoutePlanner(private val delegate: RealRoutePlanner) : RoutePlanner by delegate {
+  override fun plan(): RoutePlanner.Plan = delegate.planConnect() // not delegate.plan()
 }

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/PoolConnectionUser.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/PoolConnectionUser.kt
@@ -1,0 +1,105 @@
+package okhttp3.internal.connection
+
+import java.io.IOException
+import java.net.InetAddress
+import java.net.Proxy
+import java.net.Socket
+import okhttp3.Connection
+import okhttp3.Handshake
+import okhttp3.HttpUrl
+import okhttp3.Protocol
+import okhttp3.Route
+
+/**
+ * A user that is a connection pool creating connections in the background
+ * without an intent to immediately use them.
+ *
+ * Most of this class's functionality is currently stubbed out, but will be revisited in the future.
+ */
+class PoolConnectionUser : ConnectionUser {
+  override fun addPlanToCancel(connectPlan: ConnectPlan) {
+  }
+
+  override fun removePlanToCancel(connectPlan: ConnectPlan) {
+  }
+
+  override fun updateRouteDatabaseAfterSuccess(route: Route) {
+  }
+
+  override fun connectStart(route: Route) {
+  }
+
+  override fun secureConnectStart() {
+  }
+
+  override fun secureConnectEnd(handshake: Handshake?) {
+  }
+
+  override fun callConnectEnd(
+    route: Route,
+    protocol: Protocol?,
+  ) {
+  }
+
+  override fun connectionConnectEnd(
+    connection: Connection,
+    route: Route,
+  ) {
+  }
+
+  override fun connectFailed(
+    route: Route,
+    protocol: Protocol?,
+    e: IOException,
+  ) {
+  }
+
+  override fun connectionAcquired(connection: Connection) {
+  }
+
+  override fun acquireConnectionNoEvents(connection: RealConnection) {
+  }
+
+  override fun releaseConnectionNoEvents(): Socket? {
+    return null
+  }
+
+  override fun connectionReleased(connection: Connection) {
+  }
+
+  override fun connectionConnectionAcquired(connection: RealConnection) {
+  }
+
+  override fun connectionConnectionReleased(connection: RealConnection) {
+  }
+
+  override fun connectionConnectionClosed(connection: RealConnection) {
+  }
+
+  override fun noNewExchanges(connection: RealConnection) {
+  }
+
+  override fun doExtensiveHealthChecks(): Boolean = false
+
+  override fun isCanceled(): Boolean = false
+
+  override fun candidateConnection(): RealConnection? = null
+
+  override fun proxySelectStart(url: HttpUrl) {
+  }
+
+  override fun proxySelectEnd(
+    url: HttpUrl,
+    proxies: List<Proxy>,
+  ) {
+  }
+
+  override fun dnsStart(socketHost: String) {
+  }
+
+  override fun dnsEnd(
+    socketHost: String,
+    result: List<InetAddress>,
+  ) {
+  }
+}

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/PoolConnectionUser.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/PoolConnectionUser.kt
@@ -1,18 +1,17 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one or more
- *  contributor license agreements.  See the NOTICE file distributed with
- *  this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
- *  (the "License"); you may not use this file except in compliance with
- *  the License.  You may obtain a copy of the License at
+ * Copyright (C) 2024 Square, Inc.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package okhttp3.internal.connection
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/PoolConnectionUser.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/PoolConnectionUser.kt
@@ -1,3 +1,19 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package okhttp3.internal.connection
 
 import java.io.IOException
@@ -13,10 +29,8 @@ import okhttp3.Route
 /**
  * A user that is a connection pool creating connections in the background
  * without an intent to immediately use them.
- *
- * Most of this class's functionality is currently stubbed out, but will be revisited in the future.
  */
-class PoolConnectionUser : ConnectionUser {
+object PoolConnectionUser : ConnectionUser {
   override fun addPlanToCancel(connectPlan: ConnectPlan) {
   }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -256,7 +256,7 @@ class RealCall(
           pingIntervalMillis = client.pingIntervalMillis,
           retryOnConnectionFailure = client.retryOnConnectionFailure,
           fastFallback = client.fastFallback,
-          address = createAddress(request.url),
+          address = client.createAddress(request.url),
           connectionUser = CallConnectionUser(this, connectionPool.connectionListener, chain),
           routeDatabase = client.routeDatabase,
         )
@@ -457,32 +457,6 @@ class RealCall(
     }
 
     interceptorScopedExchange = null
-  }
-
-  private fun createAddress(url: HttpUrl): Address {
-    var sslSocketFactory: SSLSocketFactory? = null
-    var hostnameVerifier: HostnameVerifier? = null
-    var certificatePinner: CertificatePinner? = null
-    if (url.isHttps) {
-      sslSocketFactory = client.sslSocketFactory
-      hostnameVerifier = client.hostnameVerifier
-      certificatePinner = client.certificatePinner
-    }
-
-    return Address(
-      uriHost = url.host,
-      uriPort = url.port,
-      dns = client.dns,
-      socketFactory = client.socketFactory,
-      sslSocketFactory = sslSocketFactory,
-      hostnameVerifier = hostnameVerifier,
-      certificatePinner = certificatePinner,
-      proxyAuthenticator = client.proxyAuthenticator,
-      proxy = client.proxy,
-      protocols = client.protocols,
-      connectionSpecs = client.connectionSpecs,
-      proxySelector = client.proxySelector,
-    )
   }
 
   fun retryAfterFailure(): Boolean {

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -25,14 +25,9 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-import javax.net.ssl.HostnameVerifier
-import javax.net.ssl.SSLSocketFactory
-import okhttp3.Address
 import okhttp3.Call
 import okhttp3.Callback
-import okhttp3.CertificatePinner
 import okhttp3.EventListener
-import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -251,7 +251,7 @@ class RealCall(
           pingIntervalMillis = client.pingIntervalMillis,
           retryOnConnectionFailure = client.retryOnConnectionFailure,
           fastFallback = client.fastFallback,
-          address = client.createAddress(request.url),
+          address = client.address(request.url),
           connectionUser = CallConnectionUser(this, connectionPool.connectionListener, chain),
           routeDatabase = client.routeDatabase,
         )

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -348,12 +348,12 @@ class RealConnection(
     val oldLimit = allocationLimit
     allocationLimit = settings.getMaxConcurrentStreams()
 
-    if (oldLimit > allocationLimit) {
+    if (allocationLimit < oldLimit) {
       // We might need new connections to keep policies satisfied
-      connectionPool.checkAllPolicies()
-    } else if (oldLimit < allocationLimit) {
+      connectionPool.scheduleConnectionOpener()
+    } else if (allocationLimit > oldLimit) {
       // We might no longer need some connections
-      connectionPool.scheduleCleanup()
+      connectionPool.scheduleConnectionCloser()
     }
   }
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -47,7 +47,7 @@ class RealConnectionPool(
 ) {
   private val keepAliveDurationNs: Long = timeUnit.toNanos(keepAliveDuration)
   private val policies: MutableMap<Address, ConnectionPool.AddressPolicy> = mutableMapOf()
-  private val user = PoolConnectionUser()
+  private val user = PoolConnectionUser
 
   private val cleanupQueue: TaskQueue = taskRunner.newQueue()
   private val cleanupTask =

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -40,7 +40,7 @@ class RealConnectionPool(
   keepAliveDuration: Long,
   timeUnit: TimeUnit,
   internal val connectionListener: ConnectionListener,
-  private val exchangeFinderFactory: (RealConnectionPool, Address, ConnectionUser) -> ExchangeFinder
+  private val exchangeFinderFactory: (RealConnectionPool, Address, ConnectionUser) -> ExchangeFinder,
 ) {
   private val keepAliveDurationNs: Long = timeUnit.toNanos(keepAliveDuration)
   private val policies: MutableMap<Address, ConnectionPool.AddressPolicy> = mutableMapOf()
@@ -327,9 +327,10 @@ class RealConnectionPool(
    */
   fun ensureMinimumConnections(address: Address): Long {
     val policy = policies[address] ?: return -1 // No need to keep checking if there is no policy
-    val relevantConnections = connections.filter {
-      synchronized(it) { it.isEligible(address, null) }
-    }
+    val relevantConnections =
+      connections.filter {
+        synchronized(it) { it.isEligible(address, null) }
+      }
 
     when {
       // We already have an existing http/2 connection that can handle all of our streams

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealRoutePlanner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealRoutePlanner.kt
@@ -129,7 +129,7 @@ class RealRoutePlanner(
 
   /** Plans to make a new connection by deciding which route to try next. */
   @Throws(IOException::class)
-  private fun planConnect(): ConnectPlan {
+  internal fun planConnect(): ConnectPlan {
     // Use a route from a preceding coalesced connection.
     val localNextRouteToTry = nextRouteToTry
     if (localNextRouteToTry != null) {

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -21,20 +21,15 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isTrue
-import okhttp3.Address
 import okhttp3.ConnectionPool
 import okhttp3.FakeRoutePlanner
-import okhttp3.HttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.OkHttpClientTestRule
 import okhttp3.Request
 import okhttp3.TestUtil.awaitGarbageCollection
 import okhttp3.TestValueFactory
 import okhttp3.internal.concurrent.TaskRunner
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
 
 class ConnectionPoolTest {
   private val factory = TestValueFactory()

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -218,7 +218,7 @@ class ConnectionPoolTest {
 
     // Force the task to run again, make sure it doesn't duplicate the connection unnecessarily
     routePlanner.addPlan()
-    pool.checkAllPolicies()
+    pool.scheduleConnectionOpener()
     factory.taskFaker.runTasks()
     assertThat(pool.connectionCount()).isEqualTo(1)
 


### PR DESCRIPTION
This PR adds support for configuring the connection pool to proactively create connections to specified hosts. This is useful for "prewarming" the connection pool before it starts being used.

The main public API change is adding `ConnectionPool.setPolicy(Address, AddressPolicy)`. A policy specifies how many _concurrent streams_ should be supported by the pool (which might be satisfied by a single http/2 connection or by N http/1.1 connections).

The main internal change is adding a new task queue to `RealConnectionPool` which checks to see if it needs to create new connections to satisfy existing policies. This task is enqueued any time a policy changes, a connection is closed, or an http/2 connection's settings decrease the number of concurrent streams supported.