### PR TITLE
Allow GET requests to have a request body

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/http/HttpMethod.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http/HttpMethod.kt
@@ -34,7 +34,7 @@ object HttpMethod {
     )
 
   @JvmStatic // Despite being 'internal', this method is called by popular 3rd party SDKs.
-  fun permitsRequestBody(method: String): Boolean = !(method == "GET" || method == "HEAD")
+  fun permitsRequestBody(method: String): Boolean = method != "HEAD"
 
   fun redirectsWithBody(method: String): Boolean = method == "PROPFIND"
 

--- a/okhttp/src/test/java/okhttp3/PublicInternalApiTest.kt
+++ b/okhttp/src/test/java/okhttp3/PublicInternalApiTest.kt
@@ -27,7 +27,7 @@ class PublicInternalApiTest {
   @Test
   fun permitsRequestBody() {
     assertTrue(permitsRequestBody("POST"))
-    assertFalse(permitsRequestBody("GET"))
+    assertFalse(permitsRequestBody("HEAD"))
   }
 
   @Test

--- a/okhttp/src/test/java/okhttp3/URLConnectionTest.kt
+++ b/okhttp/src/test/java/okhttp3/URLConnectionTest.kt
@@ -1829,7 +1829,7 @@ class URLConnectionTest {
 
   @Test
   fun setValidRequestMethod() {
-    assertMethodForbidsRequestBody("GET")
+    assertMethodPermitsRequestBody("GET")
     assertMethodPermitsRequestBody("DELETE")
     assertMethodForbidsRequestBody("HEAD")
     assertMethodPermitsRequestBody("OPTIONS")


### PR DESCRIPTION
Although it is not recommended, if agreed between client and server, GET requests may have content.

* As per [RFC 9110 - HTTP Semantics - section 9.3.1. GET](https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.1):
_(...) A client [SHOULD NOT](https://datatracker.ietf.org/doc/html/rfc2119#section-4) generate content in a GET request unless it
is made directly to an origin server that has previously indicated,
in or out of band, that such a request has a purpose and will be
adequately supported. (...)_
( != [_must not_](https://datatracker.ietf.org/doc/html/rfc2119#section-2))