### PR TITLE
Use the name webSocketCloseTimeout

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -813,7 +813,7 @@ class MockWebServer : Closeable {
         extensions = WebSocketExtensions.parse(webSocketResponse.headers),
         // Compress all messages if compression is enabled.
         minimumDeflateSize = 0L,
-        closeTimeoutMillis = RealWebSocket.CANCEL_AFTER_CLOSE_MILLIS,
+        webSocketCloseTimeout = RealWebSocket.CANCEL_AFTER_CLOSE_MILLIS,
       )
     val name = "MockWebServer WebSocket ${request.path!!}"
     webSocket.initReaderAndWriter(name, streams)

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -918,7 +918,6 @@ public class okhttp3/OkHttpClient : okhttp3/Call$Factory, okhttp3/WebSocket$Fact
 	public final fun callTimeoutMillis ()I
 	public final fun certificateChainCleaner ()Lokhttp3/internal/tls/CertificateChainCleaner;
 	public final fun certificatePinner ()Lokhttp3/CertificatePinner;
-	public final fun closeTimeoutMillis ()I
 	public final fun connectTimeoutMillis ()I
 	public final fun connectionPool ()Lokhttp3/ConnectionPool;
 	public final fun connectionSpecs ()Ljava/util/List;
@@ -945,6 +944,7 @@ public class okhttp3/OkHttpClient : okhttp3/Call$Factory, okhttp3/WebSocket$Fact
 	public final fun retryOnConnectionFailure ()Z
 	public final fun socketFactory ()Ljavax/net/SocketFactory;
 	public final fun sslSocketFactory ()Ljavax/net/ssl/SSLSocketFactory;
+	public final fun webSocketCloseTimeout ()I
 	public final fun writeTimeoutMillis ()I
 	public final fun x509TrustManager ()Ljavax/net/ssl/X509TrustManager;
 }
@@ -962,9 +962,6 @@ public final class okhttp3/OkHttpClient$Builder {
 	public final fun callTimeout (Ljava/time/Duration;)Lokhttp3/OkHttpClient$Builder;
 	public final fun callTimeout-LRDsOJo (J)Lokhttp3/OkHttpClient$Builder;
 	public final fun certificatePinner (Lokhttp3/CertificatePinner;)Lokhttp3/OkHttpClient$Builder;
-	public final fun closeTimeout (JLjava/util/concurrent/TimeUnit;)Lokhttp3/OkHttpClient$Builder;
-	public final fun closeTimeout (Ljava/time/Duration;)Lokhttp3/OkHttpClient$Builder;
-	public final fun closeTimeout-LRDsOJo (J)Lokhttp3/OkHttpClient$Builder;
 	public final fun connectTimeout (JLjava/util/concurrent/TimeUnit;)Lokhttp3/OkHttpClient$Builder;
 	public final fun connectTimeout (Ljava/time/Duration;)Lokhttp3/OkHttpClient$Builder;
 	public final fun connectTimeout-LRDsOJo (J)Lokhttp3/OkHttpClient$Builder;
@@ -996,6 +993,9 @@ public final class okhttp3/OkHttpClient$Builder {
 	public final fun socketFactory (Ljavax/net/SocketFactory;)Lokhttp3/OkHttpClient$Builder;
 	public final fun sslSocketFactory (Ljavax/net/ssl/SSLSocketFactory;)Lokhttp3/OkHttpClient$Builder;
 	public final fun sslSocketFactory (Ljavax/net/ssl/SSLSocketFactory;Ljavax/net/ssl/X509TrustManager;)Lokhttp3/OkHttpClient$Builder;
+	public final fun webSocketCloseTimeout (JLjava/util/concurrent/TimeUnit;)Lokhttp3/OkHttpClient$Builder;
+	public final fun webSocketCloseTimeout (Ljava/time/Duration;)Lokhttp3/OkHttpClient$Builder;
+	public final fun webSocketCloseTimeout-LRDsOJo (J)Lokhttp3/OkHttpClient$Builder;
 	public final fun writeTimeout (JLjava/util/concurrent/TimeUnit;)Lokhttp3/OkHttpClient$Builder;
 	public final fun writeTimeout (Ljava/time/Duration;)Lokhttp3/OkHttpClient$Builder;
 	public final fun writeTimeout-LRDsOJo (J)Lokhttp3/OkHttpClient$Builder;

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -256,8 +256,8 @@ open class OkHttpClient internal constructor(
   val pingIntervalMillis: Int = builder.pingInterval
 
   /** Web socket close timeout (in milliseconds). */
-  @get:JvmName("closeTimeoutMillis")
-  val closeTimeoutMillis: Int = builder.closeTimeout
+  @get:JvmName("webSocketCloseTimeout")
+  val webSocketCloseTimeout: Int = builder.webSocketCloseTimeout
 
   /**
    * Minimum outbound web socket message size (in bytes) that will be compressed.
@@ -334,7 +334,7 @@ open class OkHttpClient internal constructor(
         // extensions is always null for clients:
         extensions = null,
         minimumDeflateSize = minWebSocketMessageToCompress,
-        closeTimeoutMillis = closeTimeoutMillis.toLong(),
+        webSocketCloseTimeout = webSocketCloseTimeout.toLong(),
       )
     webSocket.connect(this)
     return webSocket
@@ -580,7 +580,7 @@ open class OkHttpClient internal constructor(
     internal var readTimeout = 10_000
     internal var writeTimeout = 10_000
     internal var pingInterval = 0
-    internal var closeTimeout = RealWebSocket.CANCEL_AFTER_CLOSE_MILLIS.toInt()
+    internal var webSocketCloseTimeout = RealWebSocket.CANCEL_AFTER_CLOSE_MILLIS.toInt()
     internal var minWebSocketMessageToCompress = RealWebSocket.DEFAULT_MINIMUM_DEFLATE_SIZE
     internal var routeDatabase: RouteDatabase? = null
     internal var taskRunner: TaskRunner? = null
@@ -615,7 +615,7 @@ open class OkHttpClient internal constructor(
       this.readTimeout = okHttpClient.readTimeoutMillis
       this.writeTimeout = okHttpClient.writeTimeoutMillis
       this.pingInterval = okHttpClient.pingIntervalMillis
-      this.closeTimeout = okHttpClient.closeTimeoutMillis
+      this.webSocketCloseTimeout = okHttpClient.webSocketCloseTimeout
       this.minWebSocketMessageToCompress = okHttpClient.minWebSocketMessageToCompress
       this.routeDatabase = okHttpClient.routeDatabase
       this.taskRunner = okHttpClient.taskRunner
@@ -1291,43 +1291,43 @@ open class OkHttpClient internal constructor(
      * Sets the close timeout for web socket connections. A value of 0 means no timeout, otherwise
      * values must be between 1 and [Integer.MAX_VALUE] when converted to milliseconds.
      *
-     * The close timeout is the maximum amount of time after the client calls [close] to wait
-     * for a graceful shutdown. If the server doesn't respond the web socket will be canceled.
+     * The close timeout is the maximum amount of time after the client calls [WebSocket.close] to
+     * wait for a graceful shutdown. If the server doesn't respond the web socket will be canceled.
      * The default value is 60 seconds.
      */
-    fun closeTimeout(
+    fun webSocketCloseTimeout(
       timeout: Long,
       unit: TimeUnit,
     ) = apply {
-      closeTimeout = checkDuration("timeout", timeout, unit)
+      webSocketCloseTimeout = checkDuration("webSocketCloseTimeout", timeout, unit)
     }
 
     /**
      * Sets the close timeout for web socket connections. A value of 0 means no timeout, otherwise
      * values must be between 1 and [Integer.MAX_VALUE] when converted to milliseconds.
      *
-     * The close timeout is the maximum amount of time after the client calls [close] to wait
-     * for a graceful shutdown. If the server doesn't respond the web socket will be canceled.
+     * The close timeout is the maximum amount of time after the client calls [WebSocket.close] to
+     * wait for a graceful shutdown. If the server doesn't respond the web socket will be canceled.
      * The default value is 60 seconds.
      */
     @SuppressLint("NewApi")
     @IgnoreJRERequirement
-    fun closeTimeout(duration: Duration) =
+    fun webSocketCloseTimeout(duration: Duration) =
       apply {
-        closeTimeout(duration.toMillis(), MILLISECONDS)
+        webSocketCloseTimeout(duration.toMillis(), MILLISECONDS)
       }
 
     /**
      * Sets the close timeout for web socket connections. A value of 0 means no timeout, otherwise
      * values must be between 1 and [Integer.MAX_VALUE] when converted to milliseconds.
      *
-     * The close timeout is the maximum amount of time after the client calls [close] to wait
-     * for a graceful shutdown. If the server doesn't respond the web socket will be canceled.
+     * The close timeout is the maximum amount of time after the client calls [WebSocket.close] to
+     * wait for a graceful shutdown. If the server doesn't respond the web socket will be canceled.
      * The default value is 60 seconds.
      */
-    fun closeTimeout(duration: KotlinDuration) =
+    fun webSocketCloseTimeout(duration: KotlinDuration) =
       apply {
-        closeTimeout = checkDuration("duration", duration)
+        webSocketCloseTimeout = checkDuration("duration", duration)
       }
 
     /**

--- a/okhttp/src/main/kotlin/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/ws/RealWebSocket.kt
@@ -64,7 +64,7 @@ class RealWebSocket(
   private var extensions: WebSocketExtensions?,
   /** If compression is negotiated, outbound messages of this size and larger will be compressed. */
   private var minimumDeflateSize: Long,
-  private val closeTimeoutMillis: Long,
+  private val webSocketCloseTimeout: Long,
 ) : WebSocket, WebSocketReader.FrameCallback {
   private val key: String
 
@@ -470,7 +470,7 @@ class RealWebSocket(
     code: Int,
     reason: String?,
   ): Boolean {
-    return close(code, reason, closeTimeoutMillis)
+    return close(code, reason, webSocketCloseTimeout)
   }
 
   @Synchronized fun close(

--- a/okhttp/src/test/java/okhttp3/OkHttpClientTest.kt
+++ b/okhttp/src/test/java/okhttp3/OkHttpClientTest.kt
@@ -74,7 +74,7 @@ class OkHttpClientTest {
     assertThat(client.readTimeoutMillis).isEqualTo(10000)
     assertThat(client.writeTimeoutMillis).isEqualTo(10000)
     assertThat(client.pingIntervalMillis).isEqualTo(0)
-    assertThat(client.closeTimeoutMillis).isEqualTo(60_000)
+    assertThat(client.webSocketCloseTimeout).isEqualTo(60_000)
   }
 
   @Test fun webSocketDefaults() {

--- a/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/ws/WebSocketHttpTest.kt
@@ -1216,7 +1216,7 @@ class WebSocketHttpTest {
         client.pingIntervalMillis.toLong(),
         null,
         0L,
-        client.closeTimeoutMillis.toLong(),
+        client.webSocketCloseTimeout.toLong(),
       )
     webSocket.connect(client)
     return webSocket


### PR DESCRIPTION
The name closeTimeout might be mistaken as a regular HTTP option.