### PR TITLE
Change parameter order for Cache constructor

### DIFF
--- a/okhttp-android/src/test/kotlin/okhttp3/android/RobolectricOkHttpClientTest.kt
+++ b/okhttp-android/src/test/kotlin/okhttp3/android/RobolectricOkHttpClientTest.kt
@@ -51,7 +51,7 @@ class RobolectricOkHttpClientTest {
     context = ApplicationProvider.getApplicationContext<Application>()
     client =
       OkHttpClient.Builder()
-        .cache(Cache("/cache".toPath(), 10_000_000, FakeFileSystem()))
+        .cache(Cache(FakeFileSystem(), "/cache".toPath(), 10_000_000))
         .build()
   }
 

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
@@ -170,7 +170,7 @@ class DnsOverHttpsTest {
   // 5. unsuccessful response
   @Test
   fun usesCache() {
-    val cache = Cache("cache".toPath(), (100 * 1024).toLong(), cacheFs)
+    val cache = Cache(cacheFs, "cache".toPath(), (100 * 1024).toLong())
     val cachedClient = bootstrapClient.newBuilder().cache(cache).build()
     val cachedDns = buildLocalhost(cachedClient, false)
 
@@ -208,7 +208,7 @@ class DnsOverHttpsTest {
 
   @Test
   fun usesCacheEvenForPost() {
-    val cache = Cache("cache".toPath(), (100 * 1024).toLong(), cacheFs)
+    val cache = Cache(cacheFs, "cache".toPath(), (100 * 1024).toLong())
     val cachedClient = bootstrapClient.newBuilder().cache(cache).build()
     val cachedDns = buildLocalhost(cachedClient, false, post = true)
     repeat(2) {

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -68,7 +68,7 @@ public final class okhttp3/Cache : java/io/Closeable, java/io/Flushable {
 	public static final field Companion Lokhttp3/Cache$Companion;
 	public final fun -deprecated_directory ()Ljava/io/File;
 	public fun <init> (Ljava/io/File;J)V
-	public fun <init> (Lokio/Path;JLokio/FileSystem;)V
+	public fun <init> (Lokio/FileSystem;Lokio/Path;J)V
 	public fun close ()V
 	public final fun delete ()V
 	public final fun directory ()Ljava/io/File;

--- a/okhttp/src/main/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Cache.kt
@@ -151,16 +151,23 @@ class Cache internal constructor(
   fileSystem: FileSystem,
   taskRunner: TaskRunner,
 ) : Closeable, Flushable {
-  @ExperimentalOkHttpApi
+  /** Create a cache of at most [maxSize] bytes in [directory]. */
   constructor(
+    fileSystem: FileSystem,
     directory: Path,
     maxSize: Long,
-    fileSystem: FileSystem,
   ) : this(
     directory,
     maxSize,
     fileSystem,
     TaskRunner.INSTANCE,
+  )
+
+  /** Create a cache of at most [maxSize] bytes in [directory]. */
+  constructor(directory: File, maxSize: Long) : this(
+    FileSystem.SYSTEM,
+    directory.toOkioPath(),
+    maxSize,
   )
 
   internal val cache =
@@ -182,13 +189,6 @@ class Cache internal constructor(
 
   val isClosed: Boolean
     get() = cache.isClosed()
-
-  /** Create a cache of at most [maxSize] bytes in [directory]. */
-  constructor(directory: File, maxSize: Long) : this(
-    directory.toOkioPath(),
-    maxSize,
-    FileSystem.SYSTEM,
-  )
 
   internal fun get(request: Request): Response? {
     val key = key(request.url)
@@ -389,7 +389,6 @@ class Cache internal constructor(
     get() = cache.directory.toFile()
 
   @get:JvmName("directoryPath")
-  @ExperimentalOkHttpApi
   val directoryPath: Path
     get() = cache.directory
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/NativeImageTestsAccessors.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/NativeImageTestsAccessors.kt
@@ -29,7 +29,7 @@ internal fun buildCache(
   maxSize: Long,
   fileSystem: FileSystem,
 ): Cache {
-  return Cache(file, maxSize, fileSystem)
+  return Cache(fileSystem, file, maxSize)
 }
 
 internal var RealConnection.idleAtNsAccessor: Long

--- a/okhttp/src/test/java/okhttp3/CacheTest.kt
+++ b/okhttp/src/test/java/okhttp3/CacheTest.kt
@@ -92,7 +92,7 @@ class CacheTest {
     platform.assumeNotOpenJSSE()
     server.protocolNegotiationEnabled = false
     fileSystem.emulateUnix()
-    cache = Cache("/cache/".toPath(), Long.MAX_VALUE, fileSystem)
+    cache = Cache(fileSystem, "/cache/".toPath(), Long.MAX_VALUE)
     client =
       clientTestRule.newClientBuilder()
         .cache(cache)
@@ -2758,7 +2758,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
     writeFile(cache.directoryPath, "$urlKey.0", entryMetadata)
     writeFile(cache.directoryPath, "$urlKey.1", entryBody)
     writeFile(cache.directoryPath, "journal", journalBody)
-    cache = Cache(cache.directory.path.toPath(), Int.MAX_VALUE.toLong(), fileSystem)
+    cache = Cache(fileSystem, cache.directory.path.toPath(), Int.MAX_VALUE.toLong())
     client =
       client.newBuilder()
         .cache(cache)
@@ -2807,7 +2807,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
     writeFile(cache.directoryPath, "$urlKey.1", entryBody)
     writeFile(cache.directoryPath, "journal", journalBody)
     cache.close()
-    cache = Cache(cache.directory.path.toPath(), Int.MAX_VALUE.toLong(), fileSystem)
+    cache = Cache(fileSystem, cache.directory.path.toPath(), Int.MAX_VALUE.toLong())
     client =
       client.newBuilder()
         .cache(cache)
@@ -2860,7 +2860,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
     writeFile(cache.directoryPath, "$urlKey.1", entryBody)
     writeFile(cache.directoryPath, "journal", journalBody)
     cache.close()
-    cache = Cache(cache.directory.path.toPath(), Int.MAX_VALUE.toLong(), fileSystem)
+    cache = Cache(fileSystem, cache.directory.path.toPath(), Int.MAX_VALUE.toLong())
     client =
       client.newBuilder()
         .cache(cache)
@@ -2905,7 +2905,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
     writeFile(cache.directoryPath, "$urlKey.1", entryBody)
     writeFile(cache.directoryPath, "journal", journalBody)
     cache.close()
-    cache = Cache(cache.directory.path.toPath(), Int.MAX_VALUE.toLong(), fileSystem)
+    cache = Cache(fileSystem, cache.directory.path.toPath(), Int.MAX_VALUE.toLong())
     client =
       client.newBuilder()
         .cache(cache)
@@ -3496,7 +3496,7 @@ CLEAN $urlKey ${entryMetadata.length} ${entryBody.length}
         }
       }
     val path: Path = "/cache".toPath()
-    val c = Cache(path, 100000L, loggingFileSystem)
+    val c = Cache(loggingFileSystem, path, 100000L)
     assertThat(c.directoryPath).isEqualTo(path)
     c.size()
     assertThat(events).containsExactly(

--- a/okhttp/src/test/java/okhttp3/CallTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallTest.kt
@@ -146,9 +146,9 @@ open class CallTest {
   private val callback = RecordingCallback()
   private val cache =
     Cache(
+      fileSystem = LoggingFilesystem(fileSystem),
       directory = "/cache".toPath(),
       maxSize = Int.MAX_VALUE.toLong(),
-      fileSystem = LoggingFilesystem(fileSystem),
     )
 
   @BeforeEach

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -125,7 +125,7 @@ class HttpOverHttp2Test {
   private lateinit var protocol: Protocol
   private lateinit var client: OkHttpClient
   private val fileSystem: FakeFileSystem = FakeFileSystem()
-  private val cache: Cache = Cache("/tmp/cache".toPath(), Long.MAX_VALUE, fileSystem)
+  private val cache: Cache = Cache(fileSystem, "/tmp/cache".toPath(), Long.MAX_VALUE)
   private lateinit var scheme: String
 
   private fun configureClientTestRule(): OkHttpClientTestRule {

--- a/samples/tlssurvey/src/main/kotlin/okhttp3/survey/RunSurvey.kt
+++ b/samples/tlssurvey/src/main/kotlin/okhttp3/survey/RunSurvey.kt
@@ -31,7 +31,7 @@ suspend fun main() {
 
   val client =
     OkHttpClient.Builder()
-      .cache(Cache("build/okhttp_cache".toPath(), 100_000_000, FileSystem.SYSTEM))
+      .cache(Cache(FileSystem.SYSTEM, "build/okhttp_cache".toPath(), 100_000_000))
       .build()
 
   val sslLabsClients = SslLabsClient(client).clients()


### PR DESCRIPTION
Put FileSystem before Path, as is convention.

Also put this new constructor in the public API.