### PR TITLE
Extract a test thread factory

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/TestUtilJvm.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/TestUtilJvm.kt
@@ -20,6 +20,7 @@ import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.UnknownHostException
 import java.util.Arrays
+import java.util.concurrent.ThreadFactory
 import okhttp3.internal.http2.Header
 import okio.Buffer
 import okio.FileSystem
@@ -121,6 +122,17 @@ object TestUtil {
   fun Throwable.assertSuppressed(block: (List<@JvmSuppressWildcards Throwable>) -> Unit) {
     if (isGraalVmImage) return
     block(suppressed.toList())
+  }
+
+  @JvmStatic
+  fun threadFactory(name: String): ThreadFactory {
+    return object : ThreadFactory {
+      private var nextId = 1
+
+      override fun newThread(runnable: Runnable): Thread {
+        return Thread(runnable, "$name-${nextId++}")
+      }
+    }
   }
 }
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
@@ -21,11 +21,11 @@ import java.io.Closeable
 import java.util.AbstractQueue
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.Executors
-import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 import kotlin.concurrent.withLock
 import okhttp3.OkHttpClient
+import okhttp3.TestUtil.threadFactory
 
 /**
  * Runs a [TaskRunner] in a controlled environment so that everything is sequential and
@@ -59,14 +59,7 @@ class TaskFaker : Closeable {
   val logger = Logger.getLogger("TaskFaker." + instance++)
 
   /** Though this executor service may hold many threads, they are not executed concurrently. */
-  private val tasksExecutor =
-    Executors.newCachedThreadPool(
-      object : ThreadFactory {
-        private var nextId = 1
-
-        override fun newThread(runnable: Runnable) = Thread(runnable, "TaskFaker-${nextId++}")
-      },
-    )
+  private val tasksExecutor = Executors.newCachedThreadPool(threadFactory("TaskFaker"))
 
   /**
    * True if this task faker has ever had multiple tasks scheduled to run concurrently. Guarded by

--- a/okhttp-tls/src/test/java/okhttp3/tls/HandshakeCertificatesTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/HandshakeCertificatesTest.kt
@@ -30,6 +30,7 @@ import javax.net.SocketFactory
 import javax.net.ssl.SSLSocket
 import okhttp3.Handshake
 import okhttp3.Handshake.Companion.handshake
+import okhttp3.TestUtil.threadFactory
 import okhttp3.internal.closeQuietly
 import okhttp3.testing.PlatformRule
 import okio.ByteString.Companion.toByteString
@@ -47,7 +48,7 @@ class HandshakeCertificatesTest {
   private var serverSocket: ServerSocket? = null
 
   @BeforeEach fun setUp() {
-    executorService = Executors.newCachedThreadPool()
+    executorService = Executors.newCachedThreadPool(threadFactory("HandshakeCertificatesTest"))
   }
 
   @AfterEach fun tearDown() {

--- a/okhttp/src/test/java/okhttp3/SocksProxy.kt
+++ b/okhttp/src/test/java/okhttp3/SocksProxy.kt
@@ -30,9 +30,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.Level
 import java.util.logging.Logger
+import okhttp3.TestUtil.threadFactory
 import okhttp3.internal.and
 import okhttp3.internal.closeQuietly
-import okhttp3.internal.threadFactory
 import okhttp3.internal.threadName
 import okio.Buffer
 import okio.BufferedSink
@@ -47,7 +47,7 @@ import okio.use
  * See [RFC 1928](https://www.ietf.org/rfc/rfc1928.txt).
  */
 class SocksProxy {
-  private val executor = Executors.newCachedThreadPool(threadFactory("SocksProxy", false))
+  private val executor = Executors.newCachedThreadPool(threadFactory("SocksProxy"))
   private var serverSocket: ServerSocket? = null
   private val connectionCount = AtomicInteger()
   private val openSockets = Collections.newSetFromMap(ConcurrentHashMap<Socket, Boolean>())

--- a/okhttp/src/test/java/okhttp3/internal/cache2/RelayTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/cache2/RelayTest.kt
@@ -25,6 +25,7 @@ import java.io.IOException
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import kotlin.test.assertFailsWith
+import okhttp3.TestUtil.threadFactory
 import okhttp3.internal.cache2.Relay.Companion.edit
 import okhttp3.internal.cache2.Relay.Companion.read
 import okio.Buffer
@@ -44,7 +45,7 @@ import org.junit.jupiter.api.io.TempDir
 class RelayTest {
   @TempDir
   var tempDir: File? = null
-  private val executor = Executors.newCachedThreadPool()
+  private val executor = Executors.newCachedThreadPool(threadFactory("RelayTest"))
   private val metadata: ByteString = "great metadata!".encodeUtf8()
   private lateinit var file: File
 

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -74,6 +74,7 @@ import okhttp3.SimpleProvider
 import okhttp3.TestLogHandler
 import okhttp3.TestUtil.assumeNotWindows
 import okhttp3.TestUtil.repeat
+import okhttp3.TestUtil.threadFactory
 import okhttp3.internal.DoubleInetAddressDns
 import okhttp3.internal.EMPTY_REQUEST
 import okhttp3.internal.RecordingOkAuthenticator
@@ -509,7 +510,7 @@ class HttpOverHttp2Test {
     setUp(protocol, mockWebServer)
     server.enqueue(MockResponse(body = "A"))
     server.enqueue(MockResponse(body = "A"))
-    val executor = Executors.newCachedThreadPool()
+    val executor = Executors.newCachedThreadPool(threadFactory("HttpOverHttp2Test"))
     val countDownLatch = CountDownLatch(2)
     executor.execute(AsyncRequest("/r1", countDownLatch))
     executor.execute(AsyncRequest("/r2", countDownLatch))

--- a/okhttp/src/test/java/okhttp3/internal/http2/MockHttp2Peer.kt
+++ b/okhttp/src/test/java/okhttp3/internal/http2/MockHttp2Peer.kt
@@ -24,8 +24,8 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.logging.Logger
+import okhttp3.TestUtil.threadFactory
 import okhttp3.internal.closeQuietly
-import okhttp3.internal.threadFactory
 import okio.Buffer
 import okio.BufferedSource
 import okio.ByteString
@@ -41,7 +41,7 @@ class MockHttp2Peer : Closeable {
   private val outFrames: MutableList<OutFrame> = ArrayList()
   private val inFrames: BlockingQueue<InFrame> = LinkedBlockingQueue()
   private var port = 0
-  private val executor = Executors.newSingleThreadExecutor(threadFactory("MockHttp2Peer", false))
+  private val executor = Executors.newSingleThreadExecutor(threadFactory("MockHttp2Peer"))
   private var serverSocket: ServerSocket? = null
   private var socket: Socket? = null
 


### PR DESCRIPTION
This is different from the production thread factory:
 - No daemon threads in tests. We don't need 'em.
 - Threads are numbered in tests. We do need that.