### PR TITLE
Add connection pool pre-warming tests

### DIFF
--- a/okhttp/src/test/java/okhttp3/FakeRoutePlanner.kt
+++ b/okhttp/src/test/java/okhttp3/FakeRoutePlanner.kt
@@ -30,17 +30,15 @@ class FakeRoutePlanner(
    * Note that we don't use the same [TaskFaker] for this factory. That way off-topic tasks like
    * connection pool maintenance tasks don't add noise to route planning tests.
    */
-  private val factory = TestValueFactory()
-
-  private val pool = factory.newConnectionPool()
-
+  val factory = TestValueFactory()
+  val pool = factory.newConnectionPool(routePlanner = this)
   val events = LinkedBlockingDeque<String>()
   var canceled = false
   var autoGeneratePlans = false
   var defaultConnectionIdleAtNanos = Long.MAX_VALUE
   private var nextPlanId = 0
   private var nextPlanIndex = 0
-  private val plans = mutableListOf<FakePlan>()
+  val plans = mutableListOf<FakePlan>()
 
   override val deferredPlans = ArrayDeque<RoutePlanner.Plan>()
 


### PR DESCRIPTION
1. The first test just needed to be uncommented now that https://github.com/square/okhttp/pull/8348 is merged
2. A second test was added to exercise http2-specific functionality