### PR TITLE
Revert "Move RealCall and RealConnection to loom safe locks"

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
@@ -31,7 +31,6 @@ import javax.net.SocketFactory
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLSocketFactory
-import kotlin.concurrent.withLock
 import okhttp3.internal.RecordingOkAuthenticator
 import okhttp3.internal.concurrent.TaskFaker
 import okhttp3.internal.concurrent.TaskRunner
@@ -94,7 +93,7 @@ class TestValueFactory : Closeable {
         socket = Socket(),
         idleAtNs = idleAtNanos,
       )
-    result.lock.withLock { pool.put(result) }
+    synchronized(result) { pool.put(result) }
     return result
   }
 

--- a/okhttp/src/main/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Dispatcher.kt
@@ -22,9 +22,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
-import okhttp3.internal.assertNotHeld
+import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.connection.RealCall
 import okhttp3.internal.connection.RealCall.AsyncCall
 import okhttp3.internal.okHttpName
@@ -38,8 +36,6 @@ import okhttp3.internal.threadFactory
  * concurrently.
  */
 class Dispatcher() {
-  internal val lock: ReentrantLock = ReentrantLock()
-
   /**
    * The maximum number of requests to execute concurrently. Above this requests queue in memory,
    * waiting for the running calls to complete.
@@ -47,11 +43,10 @@ class Dispatcher() {
    * If more than [maxRequests] requests are in flight when this is invoked, those requests will
    * remain in flight.
    */
-  var maxRequests = 64
-    get() = lock.withLock { field }
+  @get:Synchronized var maxRequests = 64
     set(maxRequests) {
       require(maxRequests >= 1) { "max < 1: $maxRequests" }
-      lock.withLock {
+      synchronized(this) {
         field = maxRequests
       }
       promoteAndExecute()
@@ -67,11 +62,10 @@ class Dispatcher() {
    *
    * WebSocket connections to hosts **do not** count against this limit.
    */
-  var maxRequestsPerHost = 5
-    get() = lock.withLock { field }
+  @get:Synchronized var maxRequestsPerHost = 5
     set(maxRequestsPerHost) {
       require(maxRequestsPerHost >= 1) { "max < 1: $maxRequestsPerHost" }
-      lock.withLock {
+      synchronized(this) {
         field = maxRequestsPerHost
       }
       promoteAndExecute()
@@ -88,31 +82,29 @@ class Dispatcher() {
    * This means that if you are doing synchronous calls the network layer will not truly be idle
    * until every returned [Response] has been closed.
    */
+  @set:Synchronized
+  @get:Synchronized
   var idleCallback: Runnable? = null
-    get() = lock.withLock { field }
-    set(value) {
-      lock.withLock { field = value }
-    }
 
   private var executorServiceOrNull: ExecutorService? = null
 
+  @get:Synchronized
   @get:JvmName("executorService")
   val executorService: ExecutorService
-    get() =
-      lock.withLock {
-        if (executorServiceOrNull == null) {
-          executorServiceOrNull =
-            ThreadPoolExecutor(
-              0,
-              Int.MAX_VALUE,
-              60,
-              TimeUnit.SECONDS,
-              SynchronousQueue(),
-              threadFactory("$okHttpName Dispatcher", false),
-            )
-        }
-        return executorServiceOrNull!!
+    get() {
+      if (executorServiceOrNull == null) {
+        executorServiceOrNull =
+          ThreadPoolExecutor(
+            0,
+            Int.MAX_VALUE,
+            60,
+            TimeUnit.SECONDS,
+            SynchronousQueue(),
+            threadFactory("$okHttpName Dispatcher", false),
+          )
       }
+      return executorServiceOrNull!!
+    }
 
   /** Ready async calls in the order they'll be run. */
   private val readyAsyncCalls = ArrayDeque<AsyncCall>()
@@ -128,7 +120,7 @@ class Dispatcher() {
   }
 
   internal fun enqueue(call: AsyncCall) {
-    lock.withLock {
+    synchronized(this) {
       readyAsyncCalls.add(call)
 
       // Mutate the AsyncCall so that it shares the AtomicInteger of an existing running call to
@@ -155,17 +147,15 @@ class Dispatcher() {
    * Cancel all calls currently enqueued or executing. Includes calls executed both
    * [synchronously][Call.execute] and [asynchronously][Call.enqueue].
    */
-  fun cancelAll() {
-    lock.withLock {
-      for (call in readyAsyncCalls) {
-        call.call.cancel()
-      }
-      for (call in runningAsyncCalls) {
-        call.call.cancel()
-      }
-      for (call in runningSyncCalls) {
-        call.cancel()
-      }
+  @Synchronized fun cancelAll() {
+    for (call in readyAsyncCalls) {
+      call.call.cancel()
+    }
+    for (call in runningAsyncCalls) {
+      call.call.cancel()
+    }
+    for (call in runningSyncCalls) {
+      call.cancel()
     }
   }
 
@@ -177,11 +167,11 @@ class Dispatcher() {
    * @return true if the dispatcher is currently running calls.
    */
   private fun promoteAndExecute(): Boolean {
-    lock.assertNotHeld()
+    this.assertThreadDoesntHoldLock()
 
     val executableCalls = mutableListOf<AsyncCall>()
     val isRunning: Boolean
-    lock.withLock {
+    synchronized(this) {
       val i = readyAsyncCalls.iterator()
       while (i.hasNext()) {
         val asyncCall = i.next()

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/ConnectPlan.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/ConnectPlan.kt
@@ -26,7 +26,6 @@ import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSocket
-import kotlin.concurrent.withLock
 import okhttp3.CertificatePinner
 import okhttp3.ConnectionSpec
 import okhttp3.Handshake
@@ -504,7 +503,7 @@ class ConnectPlan(
     val pooled3 = routePlanner.planReusePooledConnection(this, routes)
     if (pooled3 != null) return pooled3.connection
 
-    connection.lock.withLock {
+    synchronized(connection) {
       connectionPool.put(connection)
       user.acquireConnectionNoEvents(connection)
     }

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealRoutePlanner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealRoutePlanner.kt
@@ -19,7 +19,6 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.Socket
 import java.net.UnknownServiceException
-import kotlin.concurrent.withLock
 import okhttp3.Address
 import okhttp3.ConnectionSpec
 import okhttp3.HttpUrl
@@ -95,7 +94,7 @@ class RealRoutePlanner(
     val healthy = candidate.isHealthy(connectionUser.doExtensiveHealthChecks())
     var noNewExchangesEvent = false
     val toClose: Socket? =
-      candidate.lock.withLock {
+      synchronized(candidate) {
         when {
           !healthy -> {
             noNewExchangesEvent = !candidate.noNewExchanges
@@ -320,7 +319,7 @@ class RealRoutePlanner(
    * connections.
    */
   private fun retryRoute(connection: RealConnection): Route? {
-    return connection.lock.withLock {
+    return synchronized(connection) {
       when {
         connection.routeFailureCount != 0 -> null
 

--- a/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Writer.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2Writer.kt
@@ -17,10 +17,8 @@ package okhttp3.internal.http2
 
 import java.io.Closeable
 import java.io.IOException
-import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level.FINE
 import java.util.logging.Logger
-import kotlin.concurrent.withLock
 import okhttp3.internal.format
 import okhttp3.internal.http2.Http2.CONNECTION_PREFACE
 import okhttp3.internal.http2.Http2.FLAG_ACK
@@ -49,43 +47,39 @@ class Http2Writer(
   private val sink: BufferedSink,
   private val client: Boolean,
 ) : Closeable {
-  internal val lock: ReentrantLock = ReentrantLock()
-
   private val hpackBuffer: Buffer = Buffer()
   private var maxFrameSize: Int = INITIAL_MAX_FRAME_SIZE
   private var closed: Boolean = false
   val hpackWriter: Hpack.Writer = Hpack.Writer(out = hpackBuffer)
 
+  @Synchronized
   @Throws(IOException::class)
   fun connectionPreface() {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      if (!client) return // Nothing to write; servers don't send connection headers!
-      if (logger.isLoggable(FINE)) {
-        logger.fine(format(">> CONNECTION ${CONNECTION_PREFACE.hex()}"))
-      }
-      sink.write(CONNECTION_PREFACE)
-      sink.flush()
+    if (closed) throw IOException("closed")
+    if (!client) return // Nothing to write; servers don't send connection headers!
+    if (logger.isLoggable(FINE)) {
+      logger.fine(format(">> CONNECTION ${CONNECTION_PREFACE.hex()}"))
     }
+    sink.write(CONNECTION_PREFACE)
+    sink.flush()
   }
 
   /** Applies `peerSettings` and then sends a settings ACK. */
+  @Synchronized
   @Throws(IOException::class)
   fun applyAndAckSettings(peerSettings: Settings) {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      this.maxFrameSize = peerSettings.getMaxFrameSize(maxFrameSize)
-      if (peerSettings.headerTableSize != -1) {
-        hpackWriter.resizeHeaderTable(peerSettings.headerTableSize)
-      }
-      frameHeader(
-        streamId = 0,
-        length = 0,
-        type = TYPE_SETTINGS,
-        flags = FLAG_ACK,
-      )
-      sink.flush()
+    if (closed) throw IOException("closed")
+    this.maxFrameSize = peerSettings.getMaxFrameSize(maxFrameSize)
+    if (peerSettings.headerTableSize != -1) {
+      hpackWriter.resizeHeaderTable(peerSettings.headerTableSize)
     }
+    frameHeader(
+      streamId = 0,
+      length = 0,
+      type = TYPE_SETTINGS,
+      flags = FLAG_ACK,
+    )
+    sink.flush()
   }
 
   /**
@@ -100,57 +94,54 @@ class Http2Writer(
    * @param promisedStreamId server-initiated stream ID.  Must be an even number.
    * @param requestHeaders minimally includes `:method`, `:scheme`, `:authority`, and `:path`.
    */
+  @Synchronized
   @Throws(IOException::class)
   fun pushPromise(
     streamId: Int,
     promisedStreamId: Int,
     requestHeaders: List<Header>,
   ) {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      hpackWriter.writeHeaders(requestHeaders)
+    if (closed) throw IOException("closed")
+    hpackWriter.writeHeaders(requestHeaders)
 
-      val byteCount = hpackBuffer.size
-      val length = minOf(maxFrameSize - 4L, byteCount).toInt()
-      frameHeader(
-        streamId = streamId,
-        length = length + 4,
-        type = TYPE_PUSH_PROMISE,
-        flags = if (byteCount == length.toLong()) FLAG_END_HEADERS else 0,
-      )
-      sink.writeInt(promisedStreamId and 0x7fffffff)
-      sink.write(hpackBuffer, length.toLong())
+    val byteCount = hpackBuffer.size
+    val length = minOf(maxFrameSize - 4L, byteCount).toInt()
+    frameHeader(
+      streamId = streamId,
+      length = length + 4,
+      type = TYPE_PUSH_PROMISE,
+      flags = if (byteCount == length.toLong()) FLAG_END_HEADERS else 0,
+    )
+    sink.writeInt(promisedStreamId and 0x7fffffff)
+    sink.write(hpackBuffer, length.toLong())
 
-      if (byteCount > length) writeContinuationFrames(streamId, byteCount - length)
-    }
+    if (byteCount > length) writeContinuationFrames(streamId, byteCount - length)
   }
 
+  @Synchronized
   @Throws(IOException::class)
   fun flush() {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      sink.flush()
-    }
+    if (closed) throw IOException("closed")
+    sink.flush()
   }
 
+  @Synchronized
   @Throws(IOException::class)
   fun rstStream(
     streamId: Int,
     errorCode: ErrorCode,
   ) {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      require(errorCode.httpCode != -1)
+    if (closed) throw IOException("closed")
+    require(errorCode.httpCode != -1)
 
-      frameHeader(
-        streamId = streamId,
-        length = 4,
-        type = TYPE_RST_STREAM,
-        flags = FLAG_NONE,
-      )
-      sink.writeInt(errorCode.httpCode)
-      sink.flush()
-    }
+    frameHeader(
+      streamId = streamId,
+      length = 4,
+      type = TYPE_RST_STREAM,
+      flags = FLAG_NONE,
+    )
+    sink.writeInt(errorCode.httpCode)
+    sink.flush()
   }
 
   /** The maximum size of bytes that may be sent in a single call to [data]. */
@@ -163,6 +154,7 @@ class Http2Writer(
    * @param source the buffer to draw bytes from. May be null if byteCount is 0.
    * @param byteCount must be between 0 and the minimum of `source.length` and [maxDataLength].
    */
+  @Synchronized
   @Throws(IOException::class)
   fun data(
     outFinished: Boolean,
@@ -170,12 +162,10 @@ class Http2Writer(
     source: Buffer?,
     byteCount: Int,
   ) {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      var flags = FLAG_NONE
-      if (outFinished) flags = flags or FLAG_END_STREAM
-      dataFrame(streamId, flags, source, byteCount)
-    }
+    if (closed) throw IOException("closed")
+    var flags = FLAG_NONE
+    if (outFinished) flags = flags or FLAG_END_STREAM
+    dataFrame(streamId, flags, source, byteCount)
   }
 
   @Throws(IOException::class)
@@ -197,53 +187,51 @@ class Http2Writer(
   }
 
   /** Write okhttp's settings to the peer. */
+  @Synchronized
   @Throws(IOException::class)
   fun settings(settings: Settings) {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      frameHeader(
-        streamId = 0,
-        length = settings.size() * 6,
-        type = TYPE_SETTINGS,
-        flags = FLAG_NONE,
-      )
-      for (i in 0 until Settings.COUNT) {
-        if (!settings.isSet(i)) continue
-        val id =
-          when (i) {
-            4 -> 3 // SETTINGS_MAX_CONCURRENT_STREAMS renumbered.
-            7 -> 4 // SETTINGS_INITIAL_WINDOW_SIZE renumbered.
-            else -> i
-          }
-        sink.writeShort(id)
-        sink.writeInt(settings[i])
-      }
-      sink.flush()
+    if (closed) throw IOException("closed")
+    frameHeader(
+      streamId = 0,
+      length = settings.size() * 6,
+      type = TYPE_SETTINGS,
+      flags = FLAG_NONE,
+    )
+    for (i in 0 until Settings.COUNT) {
+      if (!settings.isSet(i)) continue
+      val id =
+        when (i) {
+          4 -> 3 // SETTINGS_MAX_CONCURRENT_STREAMS renumbered.
+          7 -> 4 // SETTINGS_INITIAL_WINDOW_SIZE renumbered.
+          else -> i
+        }
+      sink.writeShort(id)
+      sink.writeInt(settings[i])
     }
+    sink.flush()
   }
 
   /**
    * Send a connection-level ping to the peer. `ack` indicates this is a reply. The data in
    * `payload1` and `payload2` opaque binary, and there are no rules on the content.
    */
+  @Synchronized
   @Throws(IOException::class)
   fun ping(
     ack: Boolean,
     payload1: Int,
     payload2: Int,
   ) {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      frameHeader(
-        streamId = 0,
-        length = 8,
-        type = TYPE_PING,
-        flags = if (ack) FLAG_ACK else FLAG_NONE,
-      )
-      sink.writeInt(payload1)
-      sink.writeInt(payload2)
-      sink.flush()
-    }
+    if (closed) throw IOException("closed")
+    frameHeader(
+      streamId = 0,
+      length = 8,
+      type = TYPE_PING,
+      flags = if (ack) FLAG_ACK else FLAG_NONE,
+    )
+    sink.writeInt(payload1)
+    sink.writeInt(payload2)
+    sink.flush()
   }
 
   /**
@@ -254,63 +242,61 @@ class Http2Writer(
    * @param errorCode reason for closing the connection.
    * @param debugData only valid for HTTP/2; opaque debug data to send.
    */
+  @Synchronized
   @Throws(IOException::class)
   fun goAway(
     lastGoodStreamId: Int,
     errorCode: ErrorCode,
     debugData: ByteArray,
   ) {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      require(errorCode.httpCode != -1) { "errorCode.httpCode == -1" }
-      frameHeader(
-        streamId = 0,
-        length = 8 + debugData.size,
-        type = TYPE_GOAWAY,
-        flags = FLAG_NONE,
-      )
-      sink.writeInt(lastGoodStreamId)
-      sink.writeInt(errorCode.httpCode)
-      if (debugData.isNotEmpty()) {
-        sink.write(debugData)
-      }
-      sink.flush()
+    if (closed) throw IOException("closed")
+    require(errorCode.httpCode != -1) { "errorCode.httpCode == -1" }
+    frameHeader(
+      streamId = 0,
+      length = 8 + debugData.size,
+      type = TYPE_GOAWAY,
+      flags = FLAG_NONE,
+    )
+    sink.writeInt(lastGoodStreamId)
+    sink.writeInt(errorCode.httpCode)
+    if (debugData.isNotEmpty()) {
+      sink.write(debugData)
     }
+    sink.flush()
   }
 
   /**
    * Inform peer that an additional `windowSizeIncrement` bytes can be sent on `streamId`, or the
    * connection if `streamId` is zero.
    */
+  @Synchronized
   @Throws(IOException::class)
   fun windowUpdate(
     streamId: Int,
     windowSizeIncrement: Long,
   ) {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      require(windowSizeIncrement != 0L && windowSizeIncrement <= 0x7fffffffL) {
-        "windowSizeIncrement == 0 || windowSizeIncrement > 0x7fffffffL: $windowSizeIncrement"
-      }
-      if (logger.isLoggable(FINE)) {
-        logger.fine(
-          frameLogWindowUpdate(
-            inbound = false,
-            streamId = streamId,
-            length = 4,
-            windowSizeIncrement = windowSizeIncrement,
-          ),
-        )
-      }
-      frameHeader(
-        streamId = streamId,
-        length = 4,
-        type = TYPE_WINDOW_UPDATE,
-        flags = FLAG_NONE,
-      )
-      sink.writeInt(windowSizeIncrement.toInt())
-      sink.flush()
+    if (closed) throw IOException("closed")
+    require(windowSizeIncrement != 0L && windowSizeIncrement <= 0x7fffffffL) {
+      "windowSizeIncrement == 0 || windowSizeIncrement > 0x7fffffffL: $windowSizeIncrement"
     }
+    if (logger.isLoggable(FINE)) {
+      logger.fine(
+        frameLogWindowUpdate(
+          inbound = false,
+          streamId = streamId,
+          length = 4,
+          windowSizeIncrement = windowSizeIncrement,
+        ),
+      )
+    }
+    frameHeader(
+      streamId = streamId,
+      length = 4,
+      type = TYPE_WINDOW_UPDATE,
+      flags = FLAG_NONE,
+    )
+    sink.writeInt(windowSizeIncrement.toInt())
+    sink.flush()
   }
 
   @Throws(IOException::class)
@@ -331,12 +317,11 @@ class Http2Writer(
     sink.writeInt(streamId and 0x7fffffff)
   }
 
+  @Synchronized
   @Throws(IOException::class)
   override fun close() {
-    lock.withLock {
-      closed = true
-      sink.close()
-    }
+    closed = true
+    sink.close()
   }
 
   @Throws(IOException::class)
@@ -358,30 +343,29 @@ class Http2Writer(
     }
   }
 
+  @Synchronized
   @Throws(IOException::class)
   fun headers(
     outFinished: Boolean,
     streamId: Int,
     headerBlock: List<Header>,
   ) {
-    lock.withLock {
-      if (closed) throw IOException("closed")
-      hpackWriter.writeHeaders(headerBlock)
+    if (closed) throw IOException("closed")
+    hpackWriter.writeHeaders(headerBlock)
 
-      val byteCount = hpackBuffer.size
-      val length = minOf(maxFrameSize.toLong(), byteCount)
-      var flags = if (byteCount == length) FLAG_END_HEADERS else 0
-      if (outFinished) flags = flags or FLAG_END_STREAM
-      frameHeader(
-        streamId = streamId,
-        length = length.toInt(),
-        type = TYPE_HEADERS,
-        flags = flags,
-      )
-      sink.write(hpackBuffer, length)
+    val byteCount = hpackBuffer.size
+    val length = minOf(maxFrameSize.toLong(), byteCount)
+    var flags = if (byteCount == length) FLAG_END_HEADERS else 0
+    if (outFinished) flags = flags or FLAG_END_STREAM
+    frameHeader(
+      streamId = streamId,
+      length = length.toInt(),
+      type = TYPE_HEADERS,
+      flags = flags,
+    )
+    sink.write(hpackBuffer, length)
 
-      if (byteCount > length) writeContinuationFrames(streamId, byteCount - length)
-    }
+    if (byteCount > length) writeContinuationFrames(streamId, byteCount - length)
   }
 
   companion object {

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -21,7 +21,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isTrue
-import kotlin.concurrent.withLock
 import okhttp3.Address
 import okhttp3.ConnectionPool
 import okhttp3.FakeRoutePlanner
@@ -97,7 +96,7 @@ class ConnectionPoolTest {
         .build()
     val call = client.newCall(Request(addressA.url)) as RealCall
     call.enterNetworkInterceptorExchange(call.request(), true, factory.newChain(call))
-    c1.lock.withLock { call.acquireConnectionNoEvents(c1) }
+    synchronized(c1) { call.acquireConnectionNoEvents(c1) }
 
     // Running at time 50, the pool returns that nothing can be evicted until time 150.
     assertThat(pool.closeConnections(50L)).isEqualTo(100L)
@@ -343,6 +342,6 @@ class ConnectionPoolTest {
         .build()
     val call = client.newCall(Request(connection.route().address.url)) as RealCall
     call.enterNetworkInterceptorExchange(call.request(), true, factory.newChain(call))
-    connection.lock.withLock { call.acquireConnectionNoEvents(connection) }
+    synchronized(connection) { call.acquireConnectionNoEvents(connection) }
   }
 }


### PR DESCRIPTION
Reverts square/okhttp#8290

Unfortunately I think this PR is missing some `synchronized` blocks that needed to be converted to `withLock {}` blocks. Mixing and matching the two definitely doesn’t work, and our tests aren’t sophisticated enough to cover that.

I think this is a good idea; we just need to be particularly precise with the implementation. Every occurrence of a lock needs to be fixed together; otherwise we split the lock.