### PR TITLE
Move coroutines extensions to okhttp3.coroutines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 @file:Suppress("UnstableApiUsage")
 
-import com.diffplug.gradle.spotless.KotlinExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
@@ -9,9 +8,7 @@ import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jetbrains.kotlin.js.translate.context.Namer.kotlin
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferExtension
 
 buildscript {

--- a/okhttp-coroutines/api/okhttp-coroutines.api
+++ b/okhttp-coroutines/api/okhttp-coroutines.api
@@ -1,4 +1,4 @@
-public final class okhttp3/JvmCallExtensionsKt {
+public final class okhttp3/coroutines/ExecuteAsyncKt {
 	public static final fun executeAsync (Lokhttp3/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/okhttp-coroutines/src/main/kotlin/okhttp3/coroutines/ExecuteAsync.kt
+++ b/okhttp-coroutines/src/main/kotlin/okhttp3/coroutines/ExecuteAsync.kt
@@ -15,11 +15,14 @@
  *
  */
 
-package okhttp3
+package okhttp3.coroutines
 
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
 import okhttp3.internal.closeQuietly
 import okio.IOException
 

--- a/okhttp-coroutines/src/test/kotlin/okhttp3/coroutines/ExecuteAsyncTest.kt
+++ b/okhttp-coroutines/src/test/kotlin/okhttp3/coroutines/ExecuteAsyncTest.kt
@@ -14,10 +14,7 @@
  * limitations under the License.
  *
  */
-
-@file:OptIn(ExperimentalCoroutinesApi::class)
-
-package okhttp3
+package okhttp3.coroutines
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -28,7 +25,6 @@ import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.job
@@ -39,7 +35,14 @@ import kotlinx.coroutines.withTimeout
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.SocketPolicy.DisconnectAfterRequest
+import okhttp3.Callback
+import okhttp3.FailingCall
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClientTestRule
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
 import okio.Buffer
 import okio.ForwardingSource
 import okio.buffer
@@ -48,7 +51,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.fail
 
-class SuspendCallTest {
+class ExecuteAsyncTest {
   @RegisterExtension
   val clientTestRule = OkHttpClientTestRule()
 

--- a/okhttp/src/test/java/okhttp3/internal/publicsuffix/PublicSuffixListGenerator.kt
+++ b/okhttp/src/test/java/okhttp3/internal/publicsuffix/PublicSuffixListGenerator.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.executeAsync
+import okhttp3.coroutines.executeAsync
 import okhttp3.internal.publicsuffix.PublicSuffixDatabase.Companion.PUBLIC_SUFFIX_RESOURCE
 import okio.BufferedSink
 import okio.ByteString

--- a/samples/tlssurvey/src/main/kotlin/okhttp3/survey/Iana.kt
+++ b/samples/tlssurvey/src/main/kotlin/okhttp3/survey/Iana.kt
@@ -18,7 +18,7 @@ package okhttp3.survey
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.executeAsync
+import okhttp3.coroutines.executeAsync
 import okhttp3.survey.types.SuiteId
 import okio.ByteString.Companion.decodeHex
 import okio.IOException


### PR DESCRIPTION
This has the side-effect of fixing our packaging of this module. Previously the okhttp-coroutines.jar contained the code from the :okhttp artifact, not the :okhttp-coroutines artifact. I suspect something in one of our build steps is incorrectly using the package names (only) as a cache key, and it should instead be using the package contents.