### PR TITLE
Network pinning on Android

### DIFF
--- a/android-test/src/androidDeviceTest/java/okhttp/android/test/AndroidNetworkPinningTest.kt
+++ b/android-test/src/androidDeviceTest/java/okhttp/android/test/AndroidNetworkPinningTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp.android.test
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.filters.SdkSuppress
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.junit5.StartStop
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.android.AndroidNetworkPinning
+import okhttp3.internal.platform.PlatformRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("Slow")
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.Q)
+class AndroidNetworkPinningTest {
+
+  val applicationContext = ApplicationProvider.getApplicationContext<Context>()
+  val connectivityManager = applicationContext.getSystemService(ConnectivityManager::class.java)
+
+  private var client: OkHttpClient =
+    OkHttpClient
+      .Builder()
+      .addInterceptor(AndroidNetworkPinning())
+      .addInterceptor {
+        it
+          .proceed(it.request())
+          .newBuilder()
+          .header("used-dns", it.dns.javaClass.simpleName)
+          .build()
+      }.build()
+
+  @StartStop
+  private val server = MockWebServer()
+
+  @BeforeEach
+  fun setup() {
+    // Needed because of Platform.resetForTests
+    PlatformRegistry.applicationContext = applicationContext
+  }
+
+  @Test
+  fun testDefaultRequest() {
+    server.enqueue(MockResponse(200, body = "Hello"))
+
+    val request = Request.Builder().url(server.url("/")).build()
+
+    val response = client.newCall(request).execute()
+
+    response.use {
+      assertEquals(200, response.code)
+      assertNotEquals("AndroidDns", response.header("used-dns"))
+    }
+  }
+
+  @Test
+  fun testPinnedRequest() {
+    server.enqueue(MockResponse(200, body = "Hello"))
+
+    val network = connectivityManager.activeNetwork
+
+    assumeTrue(network != null)
+
+    val request =
+      Request
+        .Builder()
+        .url(server.url("/"))
+        .tag<Network>(network)
+        .build()
+
+    val response = client.newCall(request).execute()
+
+    response.use {
+      assertEquals(200, response.code)
+      assertEquals("AndroidDns", response.header("used-dns"))
+    }
+  }
+}

--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -1312,3 +1312,8 @@ public abstract class okhttp3/WebSocketListener {
 	public fun onOpen (Lokhttp3/WebSocket;Lokhttp3/Response;)V
 }
 
+public final class okhttp3/android/AndroidNetworkPinning : okhttp3/Interceptor {
+	public fun <init> ()V
+	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
+}
+

--- a/okhttp/src/androidMain/kotlin/okhttp3/android/AndroidNetworkPinning.kt
+++ b/okhttp/src/androidMain/kotlin/okhttp3/android/AndroidNetworkPinning.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.android
+
+import android.net.Network
+import android.os.Build
+import androidx.annotation.RequiresApi
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.android.internal.AndroidDns
+import okhttp3.internal.SuppressSignatureCheck
+
+/**
+ * Interceptor that supports Network Pinning on Android via Request tags.
+ *
+ * Apply as an Application [Interceptor] and based on [okhttp3.Request#tag] with type [Network],
+ * the appropriate [okhttp3.Dns] and [javax.net.SocketFactory] will be configured.
+ */
+@RequiresApi(Build.VERSION_CODES.Q)
+@SuppressSignatureCheck
+class AndroidNetworkPinning : Interceptor {
+
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val request = chain.request()
+
+    val pinnedNetwork = request.tag<Network>()
+
+    val effectiveChain = if (pinnedNetwork != null)
+      chain.withSocketFactory(pinnedNetwork.socketFactory)
+        .withDns(AndroidDns(pinnedNetwork))
+    else chain
+
+    return effectiveChain.proceed(request)
+  }
+}

--- a/okhttp/src/androidMain/kotlin/okhttp3/android/internal/AndroidDns.kt
+++ b/okhttp/src/androidMain/kotlin/okhttp3/android/internal/AndroidDns.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.android.internal
+
+import android.net.DnsResolver
+import android.net.Network
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.net.InetAddress
+import java.net.UnknownHostException
+import java.util.concurrent.CompletableFuture
+import okhttp3.Dns
+import okhttp3.internal.SuppressSignatureCheck
+
+@RequiresApi(Build.VERSION_CODES.Q)
+@SuppressSignatureCheck
+internal class AndroidDns(
+  val network: Network,
+) : Dns {
+  // API 29+
+  private val dnsResolver = DnsResolver.getInstance()
+
+  override fun lookup(hostname: String): List<InetAddress> {
+    // API 24+
+    val result = CompletableFuture<List<InetAddress>>()
+
+    dnsResolver.query(
+      network,
+      hostname,
+      DnsResolver.FLAG_EMPTY,
+      { it.run() },
+      null,
+      object : DnsResolver.Callback<List<InetAddress>> {
+        override fun onAnswer(
+          answer: List<InetAddress>,
+          rcode: Int,
+        ) {
+          result.complete(answer)
+        }
+
+        override fun onError(error: DnsResolver.DnsException) {
+          result.completeExceptionally(
+            UnknownHostException(error.message).apply {
+              initCause(error)
+            },
+          )
+        }
+      },
+    )
+
+    return result.get()
+  }
+}


### PR DESCRIPTION
Cleanly pinning network on Android - https://github.com/square/okhttp/issues/8286

```
    OkHttpClient
      .Builder()
      .addInterceptor(AndroidNetworkPinning())
      .build()

// Substitute in some preferred network here
val activeNetwork = connectivityManager.activeNetwork

val request = Request.Builder()
  .url(server.url("/"))
  .tag<Network>(activeNetwork)
  .build()
```
