### PR TITLE
Simplify the DnsOverHttps logic

### DIFF
--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
@@ -70,13 +70,14 @@ class DnsOverHttps internal constructor(
 
   @Throws(UnknownHostException::class)
   private fun lookupHttps(hostname: String): List<InetAddress> {
-    val networkRequests = buildList {
-      add(client.newCall(buildRequest(hostname, DnsRecordCodec.TYPE_A)))
+    val networkRequests =
+      buildList {
+        add(client.newCall(buildRequest(hostname, DnsRecordCodec.TYPE_A)))
 
-      if (includeIPv6) {
-        add(client.newCall(buildRequest(hostname, DnsRecordCodec.TYPE_AAAA)))
+        if (includeIPv6) {
+          add(client.newCall(buildRequest(hostname, DnsRecordCodec.TYPE_AAAA)))
+        }
       }
-    }
 
     val failures = ArrayList<Exception>(2)
     val results = ArrayList<InetAddress>(5)
@@ -276,8 +277,7 @@ class DnsOverHttps internal constructor(
         this.bootstrapDnsHosts = bootstrapDnsHosts
       }
 
-    fun bootstrapDnsHosts(vararg bootstrapDnsHosts: InetAddress): Builder =
-      bootstrapDnsHosts(bootstrapDnsHosts.toList())
+    fun bootstrapDnsHosts(vararg bootstrapDnsHosts: InetAddress): Builder = bootstrapDnsHosts(bootstrapDnsHosts.toList())
 
     fun systemDns(systemDns: Dns) =
       apply {


### PR DESCRIPTION
Rely on OkHttpClient caching, instead of a cache only request.

Possibly a slight performance regression, making extra conditional requests, but it's unclear that that is not intended.