### PR TITLE
Fix ConnectionPoolTest bug

### DIFF
--- a/okhttp/src/test/java/okhttp3/FakeRoutePlanner.kt
+++ b/okhttp/src/test/java/okhttp3/FakeRoutePlanner.kt
@@ -24,13 +24,9 @@ import okhttp3.internal.connection.RoutePlanner
 import okhttp3.internal.connection.RoutePlanner.ConnectResult
 
 class FakeRoutePlanner(
-  private val taskFaker: TaskFaker,
+  val factory: TestValueFactory = TestValueFactory(),
+  val taskFaker: TaskFaker = factory.taskFaker,
 ) : RoutePlanner, Closeable {
-  /**
-   * Note that we don't use the same [TaskFaker] for this factory. That way off-topic tasks like
-   * connection pool maintenance tasks don't add noise to route planning tests.
-   */
-  val factory = TestValueFactory()
   val pool = factory.newConnectionPool(routePlanner = this)
   val events = LinkedBlockingDeque<String>()
   var canceled = false

--- a/okhttp/src/test/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/FastFallbackExchangeFinderTest.kt
@@ -41,7 +41,12 @@ import org.junit.jupiter.api.Test
 internal class FastFallbackExchangeFinderTest {
   private val taskFaker = TaskFaker()
   private val taskRunner = taskFaker.taskRunner
-  private val routePlanner = FakeRoutePlanner(taskFaker)
+
+  /**
+   * Note that we don't use the same [TaskFaker] for this factory. That way off-topic tasks like
+   * connection pool maintenance tasks don't add noise to route planning tests.
+   */
+  private val routePlanner = FakeRoutePlanner(taskFaker = taskFaker)
   private val finder = FastFallbackExchangeFinder(routePlanner, taskRunner)
 
   @AfterEach


### PR DESCRIPTION
1. Advance taskFaker time forward to the present when the test starts.
    * Fixes a problem introduced in https://github.com/square/okhttp/pull/8360
3. Stop having multiple factories and taskfakers floating around.