### PR TITLE
Allow Addresses to have a max calls per connection

### DIFF
--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -393,8 +393,8 @@ public final class okhttp3/ConnectionPool$AddressPolicy {
 	public final field maximumConcurrentCallsPerConnection I
 	public final field minimumConcurrentCalls I
 	public fun <init> ()V
-	public fun <init> (IIJI)V
-	public synthetic fun <init> (IIJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IJII)V
+	public synthetic fun <init> (IJIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class okhttp3/ConnectionSpec {

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -384,17 +384,25 @@ public final class okhttp3/ConnectionPool {
 	public final fun connectionCount ()I
 	public final fun evictAll ()V
 	public final fun idleConnectionCount ()I
+	public final fun setDefaultPolicy (Lokhttp3/ConnectionPool$ConnectionPoolPolicy;)V
 	public final fun setPolicy (Lokhttp3/Address;Lokhttp3/ConnectionPool$AddressPolicy;)V
 }
 
 public final class okhttp3/ConnectionPool$AddressPolicy {
 	public final field backoffDelayMillis J
 	public final field backoffJitterMillis I
-	public final field maximumConcurrentCallsPerConnection I
+	public final field maximumConcurrentCallsPerConnection Ljava/lang/Integer;
 	public final field minimumConcurrentCalls I
 	public fun <init> ()V
-	public fun <init> (IJII)V
-	public synthetic fun <init> (IJIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IJILjava/lang/Integer;)V
+	public synthetic fun <init> (IJILjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class okhttp3/ConnectionPool$ConnectionPoolPolicy {
+	public final field maximumConcurrentCallsPerConnection I
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class okhttp3/ConnectionSpec {

--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -390,10 +390,11 @@ public final class okhttp3/ConnectionPool {
 public final class okhttp3/ConnectionPool$AddressPolicy {
 	public final field backoffDelayMillis J
 	public final field backoffJitterMillis I
+	public final field maximumConcurrentCallsPerConnection I
 	public final field minimumConcurrentCalls I
 	public fun <init> ()V
-	public fun <init> (IJI)V
-	public synthetic fun <init> (IJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IIJI)V
+	public synthetic fun <init> (IIJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class okhttp3/ConnectionSpec {

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -148,15 +148,14 @@ class ConnectionPool internal constructor(
      * Connections will still be closed if they idle beyond the keep-alive but will be replaced.
      */
     @JvmField val minimumConcurrentCalls: Int = 0,
-    /**
-     * The maximum number of concurrent calls per connection.
-     *
-     * Set this value to 1 to disable HTTP/2 connection coalescing
-     */
-    @JvmField val maximumConcurrentCallsPerConnection: Int = Int.MAX_VALUE,
     /** How long to wait to retry pre-emptive connection attempts that fail. */
     @JvmField val backoffDelayMillis: Long = 60 * 1000,
     /** How much jitter to introduce in connection retry backoff delays */
     @JvmField val backoffJitterMillis: Int = 100,
+    /**
+     * The maximum number of concurrent calls per connection.
+     * Set this value to 1 to disable HTTP/2 connection coalescing
+     */
+    @JvmField val maximumConcurrentCallsPerConnection: Int = Int.MAX_VALUE,
   )
 }

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -178,5 +178,11 @@ class ConnectionPool internal constructor(
      * Set this value to 1 to disable HTTP/2 connection coalescing
      */
     @JvmField val maximumConcurrentCallsPerConnection: Int = Int.MAX_VALUE,
-  )
+  ) {
+    init {
+      require(maximumConcurrentCallsPerConnection > 0) {
+        "maximumConcurrentCallsPerConnection is not allowed to be less than one (1)."
+      }
+    }
+  }
 }

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -139,6 +139,15 @@ class ConnectionPool internal constructor(
   }
 
   /**
+   * Sets a default AddressPolicy that applies to all addresses.
+   * Overwrites any existing default policy.
+   */
+  @ExperimentalOkHttpApi
+  fun setDefaultPolicy(policy: ConnectionPoolPolicy) {
+    delegate.setDefaultPolicy(policy)
+  }
+
+  /**
    * A policy for how the pool should treat a specific address.
    */
   class AddressPolicy(
@@ -152,6 +161,18 @@ class ConnectionPool internal constructor(
     @JvmField val backoffDelayMillis: Long = 60 * 1000,
     /** How much jitter to introduce in connection retry backoff delays */
     @JvmField val backoffJitterMillis: Int = 100,
+    /**
+     * The maximum number of concurrent calls per connection for a given address.
+     * Set this value to 1 to disable HTTP/2 connection coalescing
+     */
+    @JvmField val maximumConcurrentCallsPerConnection: Int? = null,
+  )
+
+  /**
+   * A default policy for all connections. Overridable by [AddressPolicy]
+   * for specific addresses.
+   */
+  class ConnectionPoolPolicy(
     /**
      * The maximum number of concurrent calls per connection.
      * Set this value to 1 to disable HTTP/2 connection coalescing

--- a/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/main/kotlin/okhttp3/ConnectionPool.kt
@@ -148,6 +148,12 @@ class ConnectionPool internal constructor(
      * Connections will still be closed if they idle beyond the keep-alive but will be replaced.
      */
     @JvmField val minimumConcurrentCalls: Int = 0,
+    /**
+     * The maximum number of concurrent calls per connection.
+     *
+     * Set this value to 1 to disable HTTP/2 connection coalescing
+     */
+    @JvmField val maximumConcurrentCallsPerConnection: Int = Int.MAX_VALUE,
     /** How long to wait to retry pre-emptive connection attempts that fail. */
     @JvmField val backoffDelayMillis: Long = 60 * 1000,
     /** How much jitter to introduce in connection retry backoff delays */

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -357,7 +357,7 @@ class RealConnection(
     connection: Http2Connection,
     settings: Settings,
   ) {
-   this.withLock {
+    this.withLock {
       this.lastMaxConcurrentStreamsFromSettings = settings.getMaxConcurrentStreams()
       recalculateAllocationLimit()
     }
@@ -369,7 +369,7 @@ class RealConnection(
    * made during settings changes
    */
   internal fun recalculateAllocationLimit() {
-   this.withLock {
+    this.withLock {
       val oldLimit = allocationLimit
       allocationLimit = getMaximumAllocationLimit()
 
@@ -425,7 +425,7 @@ class RealConnection(
     e: IOException?,
   ) {
     var noNewExchangesEvent = false
-   this.withLock {
+    this.withLock {
       if (e is StreamResetException) {
         when {
           e.errorCode == ErrorCode.REFUSED_STREAM -> {

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -384,13 +384,14 @@ class RealConnection(
     }
   }
 
-  private fun getMaximumAllocationLimit() : Int {
+  private fun getMaximumAllocationLimit(): Int {
     // if we have not negotiated a max per streams yet, don't check for the policy override
     val negotiatedMaxCurrentStreams = lastMaxConcurrentStreamsFromSettings ?: return 1
 
-    val maxPolicyValue = connectionPool.getPolicy(route.address)
-      ?.maximumConcurrentCallsPerConnection
-      ?: Int.MAX_VALUE
+    val maxPolicyValue =
+      connectionPool.getPolicy(route.address)
+        ?.maximumConcurrentCallsPerConnection
+        ?: Int.MAX_VALUE
 
     return min(maxPolicyValue, negotiatedMaxCurrentStreams)
   }

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -388,8 +388,7 @@ class RealConnection(
     val negotiatedMaxCurrentStreams = lastMaxConcurrentStreamsFromSettings ?: return 1
 
     val maxPolicyValue =
-      connectionPool.getPolicy(route.address)
-        ?.maximumConcurrentCallsPerConnection
+      connectionPool.getMaximumCallsPerConnection(route.address)
         ?: Int.MAX_VALUE
 
     return min(maxPolicyValue, negotiatedMaxCurrentStreams)

--- a/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.locks.ReentrantLock
 import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSocket
-import kotlin.concurrent.withLock
 import kotlin.math.min
 import okhttp3.Address
 import okhttp3.Connection
@@ -339,7 +338,7 @@ class RealConnection(
       return http2Connection.isHealthy(nowNs)
     }
 
-    val idleDurationNs = lock.withLock { nowNs - idleAtNs }
+    val idleDurationNs = this.withLock { nowNs - idleAtNs }
     if (idleDurationNs >= IDLE_CONNECTION_HEALTHY_NS && doExtensiveChecks) {
       return socket.isHealthy(source)
     }
@@ -358,7 +357,7 @@ class RealConnection(
     connection: Http2Connection,
     settings: Settings,
   ) {
-    lock.withLock {
+   this.withLock {
       this.lastMaxConcurrentStreamsFromSettings = settings.getMaxConcurrentStreams()
       recalculateAllocationLimit()
     }
@@ -370,7 +369,7 @@ class RealConnection(
    * made during settings changes
    */
   internal fun recalculateAllocationLimit() {
-    lock.withLock {
+   this.withLock {
       val oldLimit = allocationLimit
       allocationLimit = getMaximumAllocationLimit()
 
@@ -426,7 +425,7 @@ class RealConnection(
     e: IOException?,
   ) {
     var noNewExchangesEvent = false
-    lock.withLock {
+   this.withLock {
       if (e is StreamResetException) {
         when {
           e.errorCode == ErrorCode.REFUSED_STREAM -> {

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -470,6 +470,8 @@ class ConnectionPoolTest {
     settings[Settings.MAX_CONCURRENT_STREAMS] = amount
     connection.readerRunnable.applyAndAckSettings(true, settings)
     assertThat(connection.peerSettings[Settings.MAX_CONCURRENT_STREAMS]).isEqualTo(amount)
+    // temporary fix of flaky test until we can get Http/2 connections happy with serial task runners
+    Thread.sleep(100)
     taskFaker.runTasks()
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -227,6 +227,9 @@ class ConnectionPoolTest {
     assertThat(pool.connectionCount()).isEqualTo(2)
     forceConnectionsToExpire(pool, expireTime)
     assertThat(pool.connectionCount()).isEqualTo(1)
+
+//    setPolicy(pool, address, ConnectionPool.AddressPolicy(3))
+//    assertThat(pool.connectionCount()).isEqualTo(3)
   }
 
   @Test fun connectionPreWarmingHttp2() {

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -333,7 +333,6 @@ class ConnectionPoolTest {
     assertThat(pool.connectionCount()).isEqualTo(3)
   }
 
-
   private fun setPolicy(
     pool: RealConnectionPool,
     address: Address,

--- a/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -277,7 +277,7 @@ class ConnectionPoolTest {
 
     // Add a connection to the pool that won't expire for a while
     routePlanner.defaultConnectionIdleAtNanos = expireLater
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(1))
+    setPolicy(pool, address, ConnectionPool.AddressPolicy(minimumConcurrentCalls = 1))
     assertThat(pool.connectionCount()).isEqualTo(1)
 
     // All other connections created will expire sooner
@@ -287,31 +287,31 @@ class ConnectionPoolTest {
     // which can satisfy a larger policy
     val connection = routePlanner.plans.first().connection
     val http2Connection = connectHttp2(peer, connection, 5)
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(5))
+    setPolicy(pool, address, ConnectionPool.AddressPolicy(minimumConcurrentCalls = 5))
     assertThat(pool.connectionCount()).isEqualTo(1)
 
     // Decrease the policy max connections, and check that new connections are created
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(5, 1))
+    setPolicy(pool, address, ConnectionPool.AddressPolicy(minimumConcurrentCalls = 5, maximumConcurrentCallsPerConnection = 1))
     // fills up the first connect and then adds single connections
     // 5 = 1 + 1 + 1 + 1 + 1 (five unique connections)
     assertThat(pool.connectionCount()).isEqualTo(5)
 
     // increase the policy max connections, and check that new connections are created
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(5, 2))
+    setPolicy(pool, address, ConnectionPool.AddressPolicy(minimumConcurrentCalls = 5, maximumConcurrentCallsPerConnection = 2))
     forceConnectionsToExpire(pool, expireSooner)
     // fills up the first connect and then adds single connections
     // 5 = 2 + 1 + 1 + 1 (four unique connections)
     assertThat(pool.connectionCount()).isEqualTo(4)
 
     // increase the policy max connections, and check that new connections are created
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(5, 4))
+    setPolicy(pool, address, ConnectionPool.AddressPolicy(minimumConcurrentCalls = 5, maximumConcurrentCallsPerConnection = 4))
     forceConnectionsToExpire(pool, expireSooner)
     // fills up the first connect and then adds single connections
     // 5 = 4 + 1 (two unique connections)
     assertThat(pool.connectionCount()).isEqualTo(2)
 
     // Decrease the policy max connections, and check that new connections are created
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(5, 3))
+    setPolicy(pool, address, ConnectionPool.AddressPolicy(minimumConcurrentCalls = 5, maximumConcurrentCallsPerConnection = 3))
     // fills up the first connect and then removes an unused after
     // 5 = 3 + 1 + 1 (three unique connections)
     assertThat(pool.connectionCount()).isEqualTo(3)


### PR DESCRIPTION
### Overview
This adds the ability for the Address Policy to also contain a maximum number of connections per Stream.

Additionally creates a ConnectionPoolPolicy which can have default options set up for all connections in the pool.

### Context
In some environments it seems that OkHttp's HTTP/2 gets worse the more streams that are packed onto a single connection. 
By adding in the ability for users to alter their client's AddressPolicy to set a maximum number of connections per stream, they can control how much (if any) packing they want OkHttp to perform.