### PR TITLE
Acquire fewer locks in TaskRunner

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
@@ -83,9 +83,10 @@ class TaskRunner(
         try {
           while (true) {
             currentThread.name = task.name
-            val delayNanos = logger.logElapsed(task, task.queue!!) {
-              task.runOnce()
-            }
+            val delayNanos =
+              logger.logElapsed(task, task.queue!!) {
+                task.runOnce()
+              }
 
             // A task ran successfully. Update the execution state and take the next task.
             task = withLock {

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
@@ -73,7 +73,8 @@ class TaskRunner(
   private val runnable: Runnable =
     object : Runnable {
       override fun run() {
-        var task: Task = withLock {
+        var task: Task =
+          withLock {
             runCallCount++
             awaitTaskToRun()
           } ?: return

--- a/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
@@ -30,7 +30,6 @@ import okhttp3.internal.connection.Locks.newLockCondition
 import okhttp3.internal.connection.Locks.withLock
 import okhttp3.internal.okHttpName
 import okhttp3.internal.threadFactory
-import okhttp3.internal.threadName
 
 /**
  * A set of worker threads that are shared among a set of task queues.
@@ -74,31 +73,34 @@ class TaskRunner(
   private val runnable: Runnable =
     object : Runnable {
       override fun run() {
-        var incrementedRunCallCount = false
-        while (true) {
-          val task =
-            this@TaskRunner.withLock {
-              if (!incrementedRunCallCount) {
-                incrementedRunCallCount = true
-                runCallCount++
-              }
+        var task: Task = withLock {
+            runCallCount++
+            awaitTaskToRun()
+          } ?: return
+
+        val currentThread = Thread.currentThread()
+        val oldName = currentThread.name
+        try {
+          while (true) {
+            currentThread.name = task.name
+            val delayNanos = logger.logElapsed(task, task.queue!!) {
+              task.runOnce()
+            }
+
+            // A task ran successfully. Update the execution state and take the next task.
+            task = withLock {
+              afterRun(task, delayNanos, true)
               awaitTaskToRun()
             } ?: return
-
-          logger.logElapsed(task, task.queue!!) {
-            var completedNormally = false
-            try {
-              runTask(task)
-              completedNormally = true
-            } finally {
-              // If the task is crashing start another thread to service the queues.
-              if (!completedNormally) {
-                this@TaskRunner.withLock {
-                  startAnotherThread()
-                }
-              }
-            }
           }
+        } catch (thrown: Throwable) {
+          // A task failed. Update execution state and re-throw the exception.
+          withLock {
+            afterRun(task, -1L, false)
+          }
+          throw thrown
+        } finally {
+          currentThread.name = oldName
         }
       }
     }
@@ -132,22 +134,10 @@ class TaskRunner(
     busyQueues.add(queue)
   }
 
-  private fun runTask(task: Task) {
-    threadName(task.name) {
-      var delayNanos = -1L
-      try {
-        delayNanos = task.runOnce()
-      } finally {
-        this.withLock {
-          afterRun(task, delayNanos)
-        }
-      }
-    }
-  }
-
   private fun afterRun(
     task: Task,
     delayNanos: Long,
+    completedNormally: Boolean,
   ) {
     lock.assertHeld()
 
@@ -165,6 +155,11 @@ class TaskRunner(
 
     if (queue.futureTasks.isNotEmpty()) {
       readyQueues.add(queue)
+
+      // If the task crashed, start another thread to run the next task.
+      if (!completedNormally) {
+        startAnotherThread()
+      }
     }
   }
 

--- a/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
+++ b/okhttp/src/test/java/okhttp3/internal/concurrent/TaskRunnerTest.kt
@@ -95,11 +95,11 @@ class TaskRunnerTest {
     assertThat(testLogHandler.takeAll()).containsExactly(
       "FINE: Q10000 scheduled after 100 µs: task",
       "FINE: Q10000 starting              : task",
+      "FINE: Q10000 finished run in   0 µs: task",
       "FINE: Q10000 run again after  50 µs: task",
-      "FINE: Q10000 finished run in   0 µs: task",
       "FINE: Q10000 starting              : task",
-      "FINE: Q10000 run again after 150 µs: task",
       "FINE: Q10000 finished run in   0 µs: task",
+      "FINE: Q10000 run again after 150 µs: task",
       "FINE: Q10000 starting              : task",
       "FINE: Q10000 finished run in   0 µs: task",
     )
@@ -137,8 +137,8 @@ class TaskRunnerTest {
       "FINE: Q10000 scheduled after 100 µs: task",
       "FINE: Q10000 starting              : task",
       "FINE: Q10000 scheduled after  50 µs: task",
-      "FINE: Q10000 already scheduled     : task",
       "FINE: Q10000 finished run in   0 µs: task",
+      "FINE: Q10000 already scheduled     : task",
       "FINE: Q10000 starting              : task",
       "FINE: Q10000 finished run in   0 µs: task",
     )
@@ -176,8 +176,8 @@ class TaskRunnerTest {
       "FINE: Q10000 scheduled after 100 µs: task",
       "FINE: Q10000 starting              : task",
       "FINE: Q10000 scheduled after 200 µs: task",
-      "FINE: Q10000 run again after  50 µs: task",
       "FINE: Q10000 finished run in   0 µs: task",
+      "FINE: Q10000 run again after  50 µs: task",
       "FINE: Q10000 starting              : task",
       "FINE: Q10000 finished run in   0 µs: task",
     )
@@ -306,8 +306,8 @@ class TaskRunnerTest {
     assertThat(testLogHandler.takeAll()).containsExactly(
       "FINE: Q10000 scheduled after 100 µs: task",
       "FINE: Q10000 starting              : task",
-      "FINE: Q10000 run again after  50 µs: task",
       "FINE: Q10000 finished run in   0 µs: task",
+      "FINE: Q10000 run again after  50 µs: task",
       "FINE: Q10000 starting              : task",
       "FINE: Q10000 finished run in   0 µs: task",
     )


### PR DESCRIPTION
Previously each run did this:

 - acquire a lock to take a task
 - acquire a lock to finish a task
 - if crashed, acquire a lock to start a new thread

So to run 10 tasks without any crashes, we'd acquire the lock 20 times.

With this update, we do this:

 - acquire a lock to take the first task
 - acquire a lock to release task N and take task N + 1

So to run 10 tasks without any crashes, we now acquire the lock 11 times.