### PR TITLE
Allow nullable executorService parameter in Dispatcher class constructor

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Dispatcher.kt
@@ -123,7 +123,7 @@ class Dispatcher() {
   /** Running synchronous calls. Includes canceled calls that haven't finished yet. */
   private val runningSyncCalls = ArrayDeque<RealCall>()
 
-  constructor(executorService: ExecutorService) : this() {
+  constructor(executorService: ExecutorService?) : this() {
     this.executorServiceOrNull = executorService
   }
 


### PR DESCRIPTION
Allow nullable executorService parameter in Dispatcher.kt constructor to maintain backwards compatibility with OkHttp 3.x migration to 4.x and beyond.

For some more context: 
In my internal company's library, there were some code snippets using OkHttp 3.x that passed null into the Dispatcher constructor for the `executorService` parameter. This worked with the Java implementation of OkHttp library, but with the migration to Kotlin in 4.x and the `executorService` parameter not being nullable in Dispatcher constructor, this caused some projects to fail after upgrading from OkHttp 3.x to 4.x