### PR TITLE
Fix UTF-32 BOM

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/-UtilCommon.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/-UtilCommon.kt
@@ -58,9 +58,9 @@ internal val UNICODE_BOMS =
     // UTF-16LE.
     "fffe".decodeHex(),
     // UTF-32BE.
-    "0000ffff".decodeHex(),
+    "0000feff".decodeHex(),
     // UTF-32LE.
-    "ffff0000".decodeHex(),
+    "fffe0000".decodeHex(),
   )
 
 /**

--- a/okhttp/src/main/kotlin/okhttp3/internal/-UtilCommon.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/-UtilCommon.kt
@@ -61,7 +61,7 @@ internal val UNICODE_BOMS =
     "0000feff".decodeHex(),
     // UTF-32LE.
     "fffe0000".decodeHex(),
-  )
+  ).sortedByDescending { it.size }
 
 /**
  * Returns an array containing only elements found in this array and also in [other]. The returned

--- a/okhttp/src/test/java/okhttp3/ResponseBodyJvmTest.kt
+++ b/okhttp/src/test/java/okhttp3/ResponseBodyJvmTest.kt
@@ -62,7 +62,7 @@ class ResponseBodyJvmTest {
 
   @Test
   fun stringBomOverridesExplicitCharset() {
-    val body = body("0000ffff00000068000000650000006c0000006c0000006f", "utf-8")
+    val body = body("0000feff00000068000000650000006c0000006c0000006f", "utf-8")
     assertThat(body.string()).isEqualTo("hello")
   }
 
@@ -86,13 +86,13 @@ class ResponseBodyJvmTest {
 
   @Test
   fun stringBomUtf32Be() {
-    val body = body("0000ffff00000068000000650000006c0000006c0000006f")
+    val body = body("0000feff00000068000000650000006c0000006c0000006f")
     assertThat(body.string()).isEqualTo("hello")
   }
 
   @Test
   fun stringBomUtf32Le() {
-    val body = body("ffff000068000000650000006c0000006c0000006f000000")
+    val body = body("fffe000068000000650000006c0000006c0000006f000000")
     assertThat(body.string()).isEqualTo("hello")
   }
 
@@ -168,13 +168,13 @@ class ResponseBodyJvmTest {
 
   @Test
   fun readerBomUtf32Be() {
-    val body = body("0000ffff00000068000000650000006c0000006c0000006f")
+    val body = body("0000feff00000068000000650000006c0000006c0000006f")
     assertThat(exhaust(body.charStream())).isEqualTo("hello")
   }
 
   @Test
   fun readerBomUtf32Le() {
-    val body = body("ffff000068000000650000006c0000006c0000006f000000")
+    val body = body("fffe000068000000650000006c0000006c0000006f000000")
     assertThat(exhaust(body.charStream())).isEqualTo("hello")
   }
 


### PR DESCRIPTION
The UTF-32 BOM is `0000feff`, not `0000ffff`

https://en.wikipedia.org/wiki/Byte_order_mark#Byte-order_marks_by_encoding

Noticed by @JakeWharton [in kotlinlang Slack](https://slack-chats.kotlinlang.org/t/18797847/demo-kt-cpp#30b8a4c1-d483-4cbd-a0bd-4143efe5b1a1)


See also: https://github.com/square/wire/pull/2935