### PR TITLE
Enabling logging for Brotli encoding

### DIFF
--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -347,7 +347,8 @@ class HttpLoggingInterceptor
     private fun bodyHasUnknownEncoding(headers: Headers): Boolean {
       val contentEncoding = headers["Content-Encoding"] ?: return false
       return !contentEncoding.equals("identity", ignoreCase = true) &&
-        !contentEncoding.equals("gzip", ignoreCase = true)
+        !contentEncoding.equals("gzip", ignoreCase = true) &&
+        !contentEncoding.equals("br", ignoreCase = true)
     }
 
     private fun bodyIsStreaming(response: Response): Boolean {


### PR DESCRIPTION
This change aims to enable the log of the response body when using Brotli content-encoding. 