### PR TITLE
Fix an environment-specific bug in RouteFailureTest

### DIFF
--- a/okhttp/src/test/java/okhttp3/RouteFailureTest.kt
+++ b/okhttp/src/test/java/okhttp3/RouteFailureTest.kt
@@ -316,7 +316,8 @@ class RouteFailureTest {
   fun proxyMoveTest(cleanShutdown: Boolean) {
     // Define a single Proxy at myproxy:8008 that will artificially move during the test
     val proxySelector = RecordingProxySelector()
-    proxySelector.proxies.add(Proxy(Proxy.Type.HTTP, InetSocketAddress("myproxy", 8008)))
+    val socketAddress = InetSocketAddress.createUnresolved("myproxy", 8008)
+    proxySelector.proxies.add(Proxy(Proxy.Type.HTTP, socketAddress))
 
     // Define two host names for the DNS routing of fake proxy servers
     val proxyServer1 = InetAddress.getByAddress("proxyServer1", byteArrayOf(127, 0, 0, 2))


### PR DESCRIPTION
InetSocketAddress's constructor will try to resolve the host to an IP address. As a result, if you're on a network that happens to have a resolvable `myproxy` host, this test would fail -- and as it turns out, my home network does.

Instead, use InetSocketAddress.createUnresolved().