### PR TITLE
update javadoc for `Response#body`

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/main/kotlin/okhttp3/Response.kt
@@ -84,7 +84,7 @@ class Response internal constructor(
    * from [Call.execute]. Response bodies must be [closed][ResponseBody] and may
    * be consumed only once.
    *
-   * This always returns null on responses returned from [cacheResponse], [networkResponse],
+   * This always returns an unreadable [ResponseBody], which may implement [ResponseBody.contentType] and [ResponseBody.contentLength], on responses returned from [cacheResponse], [networkResponse],
    * and [priorResponse].
    */
   @get:JvmName("body") val body: ResponseBody,


### PR DESCRIPTION
Previous doc shows that body is always null for cacheResponse, networkResponse and priorResponse. It's confusing since the body property can't be null. This pull request updates the doc to show that we'll get an unreadable body from the listed responses.