### PR TITLE
chore: update a deprecated usage of resume function Kotlinx coroutines in okhttp-coroutines

### DIFF
--- a/okhttp-coroutines/src/main/kotlin/okhttp3/coroutines/ExecuteAsync.kt
+++ b/okhttp-coroutines/src/main/kotlin/okhttp3/coroutines/ExecuteAsync.kt
@@ -45,7 +45,7 @@ suspend fun Call.executeAsync(): Response =
           call: Call,
           response: Response,
         ) {
-          continuation.resume(response) {
+          continuation.resume(response) { _, _, _ ->
             response.closeQuietly()
           }
         }


### PR DESCRIPTION
It seems that the project uses a modern version of Kotlin

https://github.com/square/okhttp/blob/54238b4c713080c3fd32fb1a070fb5d6814c9a09/gradle/libs.versions.toml#L13

Which already supports using the new function

![image](https://github.com/square/okhttp/assets/73608287/d5d2ea5b-b178-42df-94dd-1d7d3e3fc0e0)

It seems the old function was experimental before Kotlin 1.9.0 which might be one reason why `executeAsync` requires `@ExperimentalCoroutinesApi` annotation