### PR TITLE
docs(readme): include a note about using okhttp-coroutines module

### DIFF
--- a/okhttp-coroutines/README.md
+++ b/okhttp-coroutines/README.md
@@ -21,3 +21,13 @@ Cancellation if implemented sensibly in both directions.
 Cancelling a coroutine scope, will cancel the call.
 Cancelling a call, will throw a CancellationException
 but not cancel the scope if caught.
+
+## Releases
+
+The latest release is available on [Maven Central](https://central.sonatype.com/artifact/com.squareup.okhttp3/okhttp-coroutines).
+
+```
+implementation("com.squareup.okhttp3:okhttp-coroutines:5.0.0-alpha.14")
+```
+
+**Notice** that the OkHttp coroutines artifact has a different version than [OkHttp](https://github.com/square/okhttp).


### PR DESCRIPTION
The `okhttp-coroutines` module is published with a different version than OkHttp and its other modules and won't work with the OkHttp BOM platform, The current `README.md` might suggest that this module is under early development and has not yet been published.

This PR updates the `README.md` file in the `okhttp-coroutines`, I noticed this module is not yet mentioned in `README.md` of the root project folder or at OkHttp docs website, except this link: https://square.github.io/okhttp/5.x/okhttp-coroutines/index.html

At the moment `5.0.0-alpha.14` is hardcoded in this PR, this repository might not have a script that will replace the hardcoded value in this folder yet. Let me know if I should replace it with something else like `<latest-version-here>` and include a GitHub badge that will show the latest version in Maven Central instead.