### PR TITLE
Removing the limitation of 256KB for header size

### DIFF
--- a/okhttp/api/okhttp.api
+++ b/okhttp/api/okhttp.api
@@ -986,6 +986,7 @@ public final class okhttp3/OkHttpClient$Builder {
 	public final fun fastFallback (Z)Lokhttp3/OkHttpClient$Builder;
 	public final fun followRedirects (Z)Lokhttp3/OkHttpClient$Builder;
 	public final fun followSslRedirects (Z)Lokhttp3/OkHttpClient$Builder;
+	public final fun headerSizeLimit (J)Lokhttp3/OkHttpClient$Builder;
 	public final fun hostnameVerifier (Ljavax/net/ssl/HostnameVerifier;)Lokhttp3/OkHttpClient$Builder;
 	public final fun interceptors ()Ljava/util/List;
 	public final fun minWebSocketMessageToCompress (J)Lokhttp3/OkHttpClient$Builder;

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -1394,7 +1394,7 @@ open class OkHttpClient internal constructor(
     /**
      * Sets the maximum length (in characters, excluding line breaks) of the header.
      *
-     * Set to -1 to allow any size fot the header.
+     * Set to [HeadersReader.HEADER_NO_LIMIT] to allow any size fot the header.
      *
      * [HeadersReader.HEADER_LIMIT] by default.
      */

--- a/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/main/kotlin/okhttp3/OkHttpClient.kt
@@ -1401,7 +1401,7 @@ open class OkHttpClient internal constructor(
     fun headerSizeLimit(characters: Long) =
       apply {
         require(characters >= -1) {
-          "headerSizeLimit must me either positive or equals to -1: $characters"
+          "headerSizeLimit must be either positive or equals to -1: $characters"
         }
 
         this.headerSizeLimit = characters

--- a/okhttp/src/main/kotlin/okhttp3/internal/http1/HeadersReader.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http1/HeadersReader.kt
@@ -28,13 +28,13 @@ class HeadersReader(
 
   /** Read a single line counted against the header size limit. */
   fun readLine(): String {
-    val line = if(headerLimit == -1L)
+    val line = if(headerLimit == HEADER_NO_LIMIT)
         source.readUtf8LineStrict()
       else
         source.readUtf8LineStrict(headerLimit)
-    if(headerLimit != -1L) {
+    if(headerLimit != HEADER_NO_LIMIT) {
       if(line.length.toLong() > headerLimit) {
-        headerLimit = -2
+        headerLimit = HEADER_NO_LIMIT - 1L
       } else {
         headerLimit -= line.length.toLong()
       }
@@ -55,5 +55,6 @@ class HeadersReader(
 
   companion object {
     const val HEADER_LIMIT: Long = 256L * 1024L
+    const val HEADER_NO_LIMIT: Long = -1L
   }
 }

--- a/okhttp/src/main/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -68,7 +68,10 @@ class Http1ExchangeCodec(
   private val sink: BufferedSink,
 ) : ExchangeCodec {
   private var state = STATE_IDLE
-  private val headersReader = HeadersReader(source)
+  private val headersReader = HeadersReader(
+    source = source,
+    headerLimit = client?.headerSizeLimit?:HeadersReader.HEADER_LIMIT
+  )
 
   private val Response.isChunked: Boolean
     get() = "chunked".equals(header("Transfer-Encoding"), ignoreCase = true)


### PR DESCRIPTION
This allows users to not be restricted to the limitation of 256KB for the size of the header, in order to solve #8472 :

## How to reproduce

### Python3 server code

```python3
import socket
import random
import string

def generate_random_string(length):
    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))

random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=256 * 1024 - 48))

# Création d'un socket TCP
with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
    server_socket.bind(('127.0.0.1', 8080))
    server_socket.listen()

    while True:
        conn, addr = server_socket.accept()
        with conn:
            response = (
                "HTTP/1.1 200 OK\n"
                "Content-Type: text/plain\n"
                f"MyHeader:{random_string}\n"
                "Content-Length: 14\n"
                "\n"
                "Erreur de requête"
            )
            conn.sendall(response.encode('utf-8'))
```

## Kotlin Client code after/before the PR (Comment/Uncomment lines 10/11)

```kotlin
import okhttp3.OkHttpClient;
import okhttp3.Request;
import okhttp3.Response;
import okhttp3.ResponseBody;
import okhttp3.internal.http1.HeadersReader;

public class OkHttpTest {
  private static final String ENDPOINT = "http://127.0.0.1:8080";

  public static void main(String... args) {
    OkHttpClient client = new OkHttpClient.Builder().build();
    //OkHttpClient client = new OkHttpClient.Builder().headerSizeLimit(HeadersReader.HEADER_NO_LIMIT).build();

    try {
      Request request = new Request.Builder()
        .url(ENDPOINT)
        .build();
      try (Response response = client.newCall(request).execute()) {
        ResponseBody body = response.body();
        System.out.println(body.string());
      }
    } catch(Exception e) {
      e.printStackTrace();
    }
  }
}
```

Before, you will get an `EOFException`, after, everything works fine