### PR TITLE
Fix pymdownx.emoji extension warning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,8 +45,8 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.caret
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.magiclink
   - pymdownx.smartsymbols


### PR DESCRIPTION
## Description
 - Fix pymdownx.emoji extension warning

## Repro
 - `mkdocs build`

## Warning
```
❯ mkdocs build
INFO    -  DeprecationWarning: 'materialx.emoji.twemoji' is deprecated.
           Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.

             File "/opt/homebrew/lib/python3.12/site-packages/materialx/emoji.py", line 118, in twemoji
               return _patch_index(options)
             File "/opt/homebrew/lib/python3.12/site-packages/materialx/emoji.py", line 68, in _deprecated_func
               warnings.warn(
WARNING -  Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /Users/<>/Downloads/site
INFO    -  Documentation built in 0.13 seconds
```

@JakeWharton @swankjesse 