### PR TITLE
Incorrect protocol: quic

### DIFF
--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
@@ -223,7 +223,7 @@ class DnsOverHttps internal constructor(
     hostname: String,
     response: Response,
   ): List<InetAddress> {
-    if (response.cacheResponse == null && response.protocol !== Protocol.HTTP_2) {
+    if (response.cacheResponse == null && response.protocol !== Protocol.HTTP_2 && response.protocol !== Protocol.QUIC) {
       Platform.get().log("Incorrect protocol: ${response.protocol}", Platform.WARN)
     }
 


### PR DESCRIPTION
When using an interceptor to handle HTTP/3, this warning is constantly output in the log, which is unnecessary.