### PR TITLE
Fix: Handle multiple 1xx responses

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
@@ -105,7 +105,7 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
           .build()
       var code = response.code
 
-      if (shouldIgnoreAndWaitForRealResponse(code, exchange)) {
+      while (shouldIgnoreAndWaitForRealResponse(code, exchange)) {
         responseBuilder = exchange.readResponseHeaders(expectContinue = false)!!
         if (invokeStartEvent) {
           exchange.responseHeadersStart()

--- a/okhttp/src/test/java/okhttp3/CallTest.kt
+++ b/okhttp/src/test/java/okhttp3/CallTest.kt
@@ -3235,6 +3235,33 @@ open class CallTest {
   }
 
   @Test
+  fun serverRespondsWithProcessingMultiple() {
+    server.enqueue(
+      MockResponse.Builder()
+        .apply {
+          repeat(10) {
+            addInformationalResponse(
+              MockResponse(
+                code = HTTP_PROCESSING,
+              ),
+            )
+          }
+        }
+        .build(),
+    )
+    val request =
+      Request(
+        url = server.url("/"),
+        body = "abc".toRequestBody("text/plain".toMediaType()),
+      )
+    executeSynchronously(request)
+      .assertCode(200)
+      .assertSuccessful()
+    val recordedRequest = server.takeRequest()
+    assertThat(recordedRequest.body.readUtf8()).isEqualTo("abc")
+  }
+
+  @Test
   fun serverRespondsWithUnsolicited100Continue_HTTP2() {
     enableProtocol(Protocol.HTTP_2)
     serverRespondsWithUnsolicited100Continue()


### PR DESCRIPTION
This change updates the client to handle multiple 1xx (Processing etc) responses from the server. The client now waits for the final response with a status code other than 1xx before proceeding.

From https://datatracker.ietf.org/doc/html/rfc7231#section-6.2

>    A client MUST be able to parse one or more 1xx responses received
   prior to a final response, even if the client does not expect one.  A
   user agent MAY ignore unexpected 1xx responses.

fixes #8568