### PR TITLE
Disable flaky test assertion in ConnectionPoolTest

### DIFF
--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -200,7 +200,8 @@ class ConnectionPoolTest {
         maxIdleConnections = 2,
       )
     factory.newConnection(pool, routeA1)
-    assertThat(taskRunner.activeQueues()).isNotEmpty()
+    // Racy causing flaky tests
+    // assertThat(taskRunner.activeQueues()).isNotEmpty()
     assertThat(taskRunnerThreads).isNotEmpty()
     Thread.sleep(100)
     for (t in taskRunnerThreads) {


### PR DESCRIPTION
The assertion `taskRunner.activeQueues()` was commented out due to a race condition causing flaky tests. This ensures more consistent test results while the underlying issue is investigated.

It's trivial to turn it from flaky to permanently failing by adding delay such as printlns.

```
    assertThat(taskRunner.activeQueues()).isNotEmpty()
    val qq = taskRunner.activeQueues()
    println(qq)
    println(qq.first().activeTask)
    println(qq.first().scheduledTasks)
    assertThat(taskRunner.activeQueues()).isNotEmpty() <-- Fails here
```