### PR TITLE
Update junit5 monorepo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -194,8 +194,10 @@ subprojects {
   if (project.name != "okhttp") {
     val testRuntimeOnly: Configuration by configurations.getting
     dependencies {
+      // https://junit.org/junit5/docs/current/user-guide/#running-tests-build-gradle-bom
       testRuntimeOnly(rootProject.libs.junit.jupiter.engine)
       testRuntimeOnly(rootProject.libs.junit.vintage.engine)
+      testRuntimeOnly(libs.junit.platform.launcher)
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ com-squareup-moshi = "1.15.2"
 com-squareup-okio = "3.10.2"
 de-mannodermaus-junit5 = "1.7.0"
 graalvm = "24.1.1"
+junitPlatformLauncher = "1.12.1"
 kotlinx-serialization = "1.8.0"
 ksp = "2.1.0-1.0.29"
 lintGradle = "1.0.0-alpha03"
@@ -70,6 +71,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "org-junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "org-junit-jupiter" }
 junit-platform-console = "org.junit.platform:junit-platform-console:1.12.1"
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncher" }
 junit-vintage-engine = "org.junit.vintage:junit-vintage-engine:5.12.1"
 junit-pioneer = "org.junit-pioneer:junit-pioneer:1.9.1"
 junit5android-core = { module = "de.mannodermaus.junit5:android-test-core", version.ref = "de-mannodermaus-junit5" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ com-squareup-moshi = "1.15.2"
 com-squareup-okio = "3.10.2"
 de-mannodermaus-junit5 = "1.7.0"
 graalvm = "24.1.1"
-junitPlatformLauncher = "1.12.1"
+junit-platform = "1.12.1"
 kotlinx-serialization = "1.8.0"
 ksp = "2.1.0-1.0.29"
 lintGradle = "1.0.0-alpha03"
@@ -70,9 +70,9 @@ junit-ktx = "androidx.test.ext:junit-ktx:1.2.1"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "org-junit-jupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "org-junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "org-junit-jupiter" }
-junit-platform-console = "org.junit.platform:junit-platform-console:1.12.1"
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncher" }
-junit-vintage-engine = "org.junit.vintage:junit-vintage-engine:5.12.1"
+junit-platform-console = { module = "org.junit.platform:junit-platform-console", version.ref = "junit-platform" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "org-junit-jupiter" }
 junit-pioneer = "org.junit-pioneer:junit-pioneer:1.9.1"
 junit5android-core = { module = "de.mannodermaus.junit5:android-test-core", version.ref = "de-mannodermaus-junit5" }
 junit5android-runner = { module = "de.mannodermaus.junit5:android-test-runner", version.ref = "de-mannodermaus-junit5" }


### PR DESCRIPTION
Also adds junit-platform-launch explicit dependency and bump version

We could do more and use the BOM https://junit.org/junit5/docs/current/user-guide/#running-tests-build-gradle-bom

But making the minimal change for now