### PR TITLE
refactor: simplify internal immutable list extensions

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Handshake.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Handshake.kt
@@ -21,7 +21,6 @@ import java.security.cert.Certificate
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSession
-import okhttp3.internal.immutableListOf
 import okhttp3.internal.toImmutableList
 
 /**
@@ -154,6 +153,7 @@ class Handshake internal constructor(
           "TLS_NULL_WITH_NULL_NULL", "SSL_NULL_WITH_NULL_NULL" -> {
             throw IOException("cipherSuite == $cipherSuiteString")
           }
+
           else -> CipherSuite.forJavaName(cipherSuiteString)
         }
 
@@ -174,13 +174,6 @@ class Handshake internal constructor(
         localCertificates.toImmutableList(),
       ) { peerCertificatesCopy }
     }
-
-    private fun Array<out Certificate>?.toImmutableList(): List<Certificate> =
-      if (this != null) {
-        immutableListOf(*this)
-      } else {
-        emptyList()
-      }
 
     @Throws(IOException::class)
     @JvmName("-deprecated_get")

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
@@ -251,7 +251,7 @@ internal inline fun <reified T> List<T>.toImmutableList(): List<T> = toTypedArra
 
 /** Returns an immutable list containing [elements]. */
 @SafeVarargs
-internal fun <T> immutableListOf(vararg elements: T): List<T> = elements.copyOf().asList()
+internal fun <T> immutableListOf(vararg elements: T): List<T> = elements.asList()
 
 /** Returns an immutable list from copy of this. */
 internal fun <T> Array<out T>?.toImmutableList(): List<T> = this?.copyOf()?.asList() ?: emptyList()

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
@@ -24,7 +24,6 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketTimeoutException
 import java.nio.charset.Charset
-import java.util.Collections
 import java.util.Locale
 import java.util.TimeZone
 import java.util.concurrent.ThreadFactory
@@ -248,11 +247,14 @@ internal inline fun threadName(
 internal fun Response.headersContentLength(): Long = headers["Content-Length"]?.toLongOrDefault(-1L) ?: -1L
 
 /** Returns an immutable copy of this. */
-internal fun <T> List<T>.toImmutableList(): List<T> = Collections.unmodifiableList(toMutableList())
+internal inline fun <reified T> List<T>.toImmutableList(): List<T> = toTypedArray().asList()
 
 /** Returns an immutable list containing [elements]. */
 @SafeVarargs
-internal fun <T> immutableListOf(vararg elements: T): List<T> = Collections.unmodifiableList(listOf(*elements.clone()))
+internal fun <T> immutableListOf(vararg elements: T): List<T> = elements.copyOf().asList()
+
+/** Returns an immutable list from copy of this. */
+internal fun <T> Array<out T>?.toImmutableList(): List<T> = this?.copyOf()?.asList() ?: emptyList()
 
 /** Closes this, ignoring any checked exceptions. */
 internal fun Socket.closeQuietly() {


### PR DESCRIPTION
`Arrays.asList` creates unmodifiable list, also, the new version creates fewer temp lists and arrays.