### PR TITLE
`Empty` constant of Headers, RequestBody, ResponseBody

### DIFF
--- a/mockwebserver/src/test/java/mockwebserver3/RecordedRequestTest.kt
+++ b/mockwebserver/src/test/java/mockwebserver3/RecordedRequestTest.kt
@@ -23,14 +23,13 @@ import java.net.InetAddress
 import java.net.Socket
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
-import okhttp3.internal.EMPTY_HEADERS
 import okio.Buffer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 
 @Timeout(30)
 class RecordedRequestTest {
-  private val headers: Headers = EMPTY_HEADERS
+  private val headers: Headers = Headers.Empty
 
   @Test fun testIPv4() {
     val socket =

--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -624,6 +624,7 @@ public final class okhttp3/Handshake$Companion {
 
 public final class okhttp3/Headers : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
 	public static final field Companion Lokhttp3/Headers$Companion;
+	public static final field Empty Lokhttp3/Headers;
 	public final fun -deprecated_size ()I
 	public final fun byteCount ()J
 	public fun equals (Ljava/lang/Object;)Z
@@ -1088,6 +1089,7 @@ public class okhttp3/Request$Builder {
 
 public abstract class okhttp3/RequestBody {
 	public static final field Companion Lokhttp3/RequestBody$Companion;
+	public static final field Empty Lokhttp3/RequestBody;
 	public fun <init> ()V
 	public fun contentLength ()J
 	public abstract fun contentType ()Lokhttp3/MediaType;
@@ -1202,6 +1204,7 @@ public class okhttp3/Response$Builder {
 
 public abstract class okhttp3/ResponseBody : java/io/Closeable {
 	public static final field Companion Lokhttp3/ResponseBody$Companion;
+	public static final field Empty Lokhttp3/ResponseBody;
 	public fun <init> ()V
 	public final fun byteStream ()Ljava/io/InputStream;
 	public final fun byteString ()Lokio/ByteString;

--- a/okhttp/api/jvm/okhttp.api
+++ b/okhttp/api/jvm/okhttp.api
@@ -624,6 +624,7 @@ public final class okhttp3/Handshake$Companion {
 
 public final class okhttp3/Headers : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
 	public static final field Companion Lokhttp3/Headers$Companion;
+	public static final field Empty Lokhttp3/Headers;
 	public final fun -deprecated_size ()I
 	public final fun byteCount ()J
 	public fun equals (Ljava/lang/Object;)Z
@@ -1088,6 +1089,7 @@ public class okhttp3/Request$Builder {
 
 public abstract class okhttp3/RequestBody {
 	public static final field Companion Lokhttp3/RequestBody$Companion;
+	public static final field Empty Lokhttp3/RequestBody;
 	public fun <init> ()V
 	public fun contentLength ()J
 	public abstract fun contentType ()Lokhttp3/MediaType;
@@ -1202,6 +1204,7 @@ public class okhttp3/Response$Builder {
 
 public abstract class okhttp3/ResponseBody : java/io/Closeable {
 	public static final field Companion Lokhttp3/ResponseBody$Companion;
+	public static final field Empty Lokhttp3/ResponseBody;
 	public fun <init> ()V
 	public final fun byteStream ()Ljava/io/InputStream;
 	public final fun byteString ()Lokio/ByteString;

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt
@@ -26,7 +26,6 @@ import java.security.cert.CertificateFactory
 import java.util.TreeSet
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.internal.EMPTY_HEADERS
 import okhttp3.internal.cache.CacheRequest
 import okhttp3.internal.cache.CacheStrategy
 import okhttp3.internal.cache.DiskLruCache
@@ -823,7 +822,7 @@ class Cache internal constructor(
       responseHeaders: Headers,
     ): Headers {
       val varyFields = responseHeaders.varyFields()
-      if (varyFields.isEmpty()) return EMPTY_HEADERS
+      if (varyFields.isEmpty()) return Headers.Empty
 
       val result = Headers.Builder()
       for (i in 0 until requestHeaders.size) {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Headers.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Headers.kt
@@ -322,6 +322,10 @@ class Headers internal constructor(
   }
 
   companion object {
+    /** Empty headers. */
+    @JvmField
+    val Empty = Headers(emptyArray())
+
     /**
      * Returns headers for the alternating header names and values. There must be an even number of
      * arguments, and they must alternate between header names and values.

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Request.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Request.kt
@@ -24,7 +24,6 @@ import okhttp3.internal.canonicalUrl
 import okhttp3.internal.commonAddHeader
 import okhttp3.internal.commonCacheControl
 import okhttp3.internal.commonDelete
-import okhttp3.internal.commonEmptyRequestBody
 import okhttp3.internal.commonGet
 import okhttp3.internal.commonHead
 import okhttp3.internal.commonHeader
@@ -270,7 +269,7 @@ class Request internal constructor(
     open fun post(body: RequestBody): Builder = commonPost(body)
 
     @JvmOverloads
-    open fun delete(body: RequestBody? = commonEmptyRequestBody): Builder = commonDelete(body)
+    open fun delete(body: RequestBody? = RequestBody.Empty): Builder = commonDelete(body)
 
     open fun put(body: RequestBody): Builder = commonPut(body)
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
@@ -19,8 +19,11 @@ import java.io.File
 import java.io.FileDescriptor
 import java.io.FileInputStream
 import java.io.IOException
-import okhttp3.internal.*
 import okhttp3.internal.chooseCharset
+import okhttp3.internal.commonContentLength
+import okhttp3.internal.commonIsDuplex
+import okhttp3.internal.commonIsOneShot
+import okhttp3.internal.commonToRequestBody
 import okio.BufferedSink
 import okio.ByteString
 import okio.FileSystem
@@ -107,7 +110,7 @@ abstract class RequestBody {
 
       override fun contentLength() = 0L
 
-      override fun writeTo(sink: BufferedSink) { /** write nothing */ }
+      override fun writeTo(sink: BufferedSink) {}
     }
 
     /**

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
@@ -19,11 +19,8 @@ import java.io.File
 import java.io.FileDescriptor
 import java.io.FileInputStream
 import java.io.IOException
+import okhttp3.internal.*
 import okhttp3.internal.chooseCharset
-import okhttp3.internal.commonContentLength
-import okhttp3.internal.commonIsDuplex
-import okhttp3.internal.commonIsOneShot
-import okhttp3.internal.commonToRequestBody
 import okio.BufferedSink
 import okio.ByteString
 import okio.FileSystem
@@ -101,6 +98,18 @@ abstract class RequestBody {
   open fun isOneShot(): Boolean = commonIsOneShot()
 
   companion object {
+    /** Empty request body. */
+    @JvmField
+    val Empty: RequestBody = EmptyRequestBody()
+
+    private class EmptyRequestBody : RequestBody() {
+      override fun contentType() = null
+
+      override fun contentLength() = 0L
+
+      override fun writeTo(sink: BufferedSink) { /** write nothing */ }
+    }
+
     /**
      * Returns a new request body that transmits this string. If [contentType] is non-null and lacks
      * a charset, this will use UTF-8.

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Response.kt
@@ -26,7 +26,6 @@ import okhttp3.internal.commonCacheControl
 import okhttp3.internal.commonCacheResponse
 import okhttp3.internal.commonClose
 import okhttp3.internal.commonCode
-import okhttp3.internal.commonEmptyResponse
 import okhttp3.internal.commonHeader
 import okhttp3.internal.commonHeaders
 import okhttp3.internal.commonIsRedirect
@@ -320,7 +319,7 @@ class Response internal constructor(
     internal var message: String? = null
     internal var handshake: Handshake? = null
     internal var headers: Headers.Builder
-    internal var body: ResponseBody = commonEmptyResponse
+    internal var body: ResponseBody = ResponseBody.Empty
     internal var networkResponse: Response? = null
     internal var cacheResponse: Response? = null
     internal var priorResponse: Response? = null

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ResponseBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ResponseBody.kt
@@ -213,6 +213,20 @@ abstract class ResponseBody : Closeable {
   }
 
   companion object {
+    /** Empty response body. */
+    @JvmField
+    val Empty: ResponseBody = EmptyResponseBody()
+
+    private class EmptyResponseBody : ResponseBody() {
+      private val source = Buffer()
+
+      override fun contentType() = null
+
+      override fun contentLength() = 0L
+
+      override fun source() = source
+    }
+
     /**
      * Returns a new response body that transmits this string. If [contentType] is non-null and
      * has a charset other than utf-8 the behaviour differs by platform.

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ResponseBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ResponseBody.kt
@@ -218,13 +218,11 @@ abstract class ResponseBody : Closeable {
     val Empty: ResponseBody = EmptyResponseBody()
 
     private class EmptyResponseBody : ResponseBody() {
-      private val source = Buffer()
-
       override fun contentType() = null
 
       override fun contentLength() = 0L
 
-      override fun source() = source
+      override fun source() = Buffer()
     }
 
     /**

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilCommon.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilCommon.kt
@@ -17,11 +17,6 @@
 
 package okhttp3.internal
 
-import okhttp3.Headers
-import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.ResponseBody
-import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.ArrayIndexOutOfBoundsException
 import okio.Buffer
 import okio.BufferedSink
@@ -393,10 +388,6 @@ internal fun checkOffsetAndCount(
     throw ArrayIndexOutOfBoundsException("length=$arrayLength, offset=$offset, count=$offset")
   }
 }
-
-val commonEmptyHeaders: Headers = Headers.headersOf()
-val commonEmptyRequestBody: RequestBody = EMPTY_BYTE_ARRAY.toRequestBody()
-val commonEmptyResponse: ResponseBody = EMPTY_BYTE_ARRAY.toResponseBody()
 
 internal fun <T> interleave(
   a: Iterable<T>,

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
@@ -41,22 +41,11 @@ import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.defaultPort
 import okhttp3.OkHttpClient
-import okhttp3.RequestBody
 import okhttp3.Response
-import okhttp3.ResponseBody
 import okhttp3.internal.http2.Header
 import okio.Buffer
 import okio.BufferedSource
 import okio.Source
-
-@JvmField
-internal val EMPTY_HEADERS: Headers = commonEmptyHeaders
-
-@JvmField
-internal val EMPTY_REQUEST: RequestBody = commonEmptyRequestBody
-
-@JvmField
-internal val EMPTY_RESPONSE: ResponseBody = commonEmptyResponse
 
 /** GMT and UTC are equivalent for our purposes. */
 @JvmField

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -24,7 +24,6 @@ import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.internal.EMPTY_HEADERS
 import okhttp3.internal.checkOffsetAndCount
 import okhttp3.internal.discard
 import okhttp3.internal.headersContentLength
@@ -144,7 +143,7 @@ class Http1ExchangeCodec(
 
   override fun trailers(): Headers {
     check(state == STATE_CLOSED) { "too early; can't read the trailers yet" }
-    return trailers ?: EMPTY_HEADERS
+    return trailers ?: Headers.Empty
   }
 
   override fun flushRequest() {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Connection.kt
@@ -22,8 +22,8 @@ import java.net.Socket
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
+import okhttp3.Headers
 import okhttp3.internal.EMPTY_BYTE_ARRAY
-import okhttp3.internal.EMPTY_HEADERS
 import okhttp3.internal.assertThreadDoesntHoldLock
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.TaskRunner
@@ -674,7 +674,7 @@ class Http2Connection internal constructor(
       }
       dataStream.receiveData(source, length)
       if (inFinished) {
-        dataStream.receiveHeaders(EMPTY_HEADERS, true)
+        dataStream.receiveHeaders(Headers.Empty, true)
       }
     }
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Stream.kt
@@ -23,7 +23,6 @@ import java.util.ArrayDeque
 import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
 import okhttp3.Headers
-import okhttp3.internal.EMPTY_HEADERS
 import okhttp3.internal.assertNotHeld
 import okhttp3.internal.connection.Locks.newLockCondition
 import okhttp3.internal.connection.Locks.withLock
@@ -174,7 +173,7 @@ class Http2Stream internal constructor(
   fun trailers(): Headers {
     this.withLock {
       if (source.finished && source.receiveBuffer.exhausted() && source.readBuffer.exhausted()) {
-        return source.trailers ?: EMPTY_HEADERS
+        return source.trailers ?: Headers.Empty
       }
       if (errorCode != null) {
         throw errorException ?: StreamResetException(errorCode!!)

--- a/okhttp/src/jvmTest/kotlin/okhttp3/HeadersJvmTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/HeadersJvmTest.kt
@@ -22,12 +22,11 @@ import java.time.Instant
 import java.util.Date
 import kotlin.test.assertFailsWith
 import okhttp3.Headers.Companion.toHeaders
-import okhttp3.internal.EMPTY_HEADERS
 import org.junit.jupiter.api.Test
 
 class HeadersJvmTest {
   @Test fun byteCount() {
-    assertThat(EMPTY_HEADERS.byteCount()).isEqualTo(0L)
+    assertThat(Headers.Empty.byteCount()).isEqualTo(0L)
     assertThat(
       Headers
         .Builder()

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
@@ -31,11 +31,11 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertFailsWith
+import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.TestUtil.headerEntries
 import okhttp3.TestUtil.repeat
 import okhttp3.internal.EMPTY_BYTE_ARRAY
-import okhttp3.internal.EMPTY_HEADERS
 import okhttp3.internal.concurrent.TaskFaker
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.connection.Locks.withLock
@@ -557,7 +557,7 @@ class Http2ConnectionTest {
     val stream = connection.newStream(headerEntries("a", "artichaut"), false)
     connection.writePingAndAwaitPong()
     assertThat(stream.takeHeaders()).isEqualTo(headersOf("headers", "bam"))
-    assertThat(stream.trailers()).isEqualTo(EMPTY_HEADERS)
+    assertThat(stream.trailers()).isEqualTo(Headers.Empty)
     assertThat(connection.openStreamCount()).isEqualTo(0)
 
     // Verify the peer received what was expected.
@@ -808,7 +808,7 @@ class Http2ConnectionTest {
     connection.writePingAndAwaitPong()
     assertThat(stream.takeHeaders()).isEqualTo(headersOf("headers", "bam"))
     assertThat(source.readUtf8(5)).isEqualTo("robot")
-    assertThat(stream.trailers()).isEqualTo(EMPTY_HEADERS)
+    assertThat(stream.trailers()).isEqualTo(Headers.Empty)
     assertThat(connection.openStreamCount()).isEqualTo(0)
 
     // Verify the peer received what was expected.

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -76,7 +76,6 @@ import okhttp3.TestUtil.assumeNotWindows
 import okhttp3.TestUtil.repeat
 import okhttp3.TestUtil.threadFactory
 import okhttp3.internal.DoubleInetAddressDns
-import okhttp3.internal.EMPTY_REQUEST
 import okhttp3.internal.RecordingOkAuthenticator
 import okhttp3.internal.connection.RealConnection
 import okhttp3.internal.discard
@@ -1623,7 +1622,7 @@ class HttpOverHttp2Test {
         Request
           .Builder()
           .url(server.url("/"))
-          .method("DELETE", EMPTY_REQUEST)
+          .method("DELETE", RequestBody.Empty)
           .build(),
       )
     val response = call.execute()


### PR DESCRIPTION
removed informal internal constants

closes #8670
