### PR TITLE
Disable Renovate semantic commits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
     ":dependencyDashboard",
     "schedule:daily"
   ],
+  "semanticCommits": "disabled",
   "labels": [
     "renovate"
   ],


### PR DESCRIPTION
Just because someone put a colon in their commit message doesn't mean we want this system.