### PR TITLE
Hide internal functions

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-ChallengeCommon.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-ChallengeCommon.kt
@@ -19,16 +19,16 @@ package okhttp3.internal
 
 import okhttp3.Challenge
 
-fun Challenge.commonEquals(other: Any?): Boolean =
+internal fun Challenge.commonEquals(other: Any?): Boolean =
   other is Challenge &&
     other.scheme == scheme &&
     other.authParams == authParams
 
-fun Challenge.commonHashCode(): Int {
+internal fun Challenge.commonHashCode(): Int {
   var result = 29
   result = 31 * result + scheme.hashCode()
   result = 31 * result + authParams.hashCode()
   return result
 }
 
-fun Challenge.commonToString(): String = "$scheme authParams=$authParams"
+internal fun Challenge.commonToString(): String = "$scheme authParams=$authParams"


### PR DESCRIPTION
Currently we have many public functions in `okhttp3.internal` package, some of them are for totally internal usages, but some of them might be widely used as a util. This PR will hide the previous ones. Maybe we should create a util file for public functions like `fun String.canParseAsIpAddress(): Boolean`.