### PR TITLE
[4.x] Handle multiple 1xx responses

### DIFF
--- a/okhttp/src/main/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
+++ b/okhttp/src/main/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
@@ -104,7 +104,7 @@ class CallServerInterceptor(private val forWebSocket: Boolean) : Interceptor {
           .build()
       var code = response.code
 
-      if (shouldIgnoreAndWaitForRealResponse(code)) {
+      while (shouldIgnoreAndWaitForRealResponse(code)) {
         responseBuilder = exchange.readResponseHeaders(expectContinue = false)!!
         if (invokeStartEvent) {
           exchange.responseHeadersStart()


### PR DESCRIPTION
Cherry pick of https://github.com/square/okhttp/pull/8569

Fixes https://github.com/square/okhttp/issues/8568 on 4.x branch