### PR TITLE
Fix test with latest JDKs

### DIFF
--- a/mockwebserver-deprecated/src/test/java/okhttp3/mockwebserver/MockWebServerTest.kt
+++ b/mockwebserver-deprecated/src/test/java/okhttp3/mockwebserver/MockWebServerTest.kt
@@ -398,6 +398,9 @@ class MockWebServerTest {
     } catch (e: ProtocolException) {
       // On Android, HttpURLConnection is implemented by OkHttp v2. OkHttp
       // treats an incomplete response body as a ProtocolException.
+    } catch (ioe: IOException) {
+      // Change in https://bugs.openjdk.org/browse/JDK-8335135
+      assertThat(ioe.message).isEqualTo("Premature EOF")
     }
   }
 

--- a/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.kt
+++ b/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.kt
@@ -439,6 +439,7 @@ class MockWebServerTest {
 
   @Test
   fun disconnectResponseHalfway() {
+    println(System.getProperty("java.version"))
     server.enqueue(
       MockResponse
         .Builder()
@@ -457,6 +458,9 @@ class MockWebServerTest {
     } catch (e: ProtocolException) {
       // On Android, HttpURLConnection is implemented by OkHttp v2. OkHttp
       // treats an incomplete response body as a ProtocolException.
+    } catch (ioe: IOException) {
+      // Change in https://bugs.openjdk.org/browse/JDK-8335135
+      assertThat(ioe.message).isEqualTo("Premature EOF")
     }
   }
 

--- a/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.kt
+++ b/mockwebserver/src/test/java/mockwebserver3/MockWebServerTest.kt
@@ -439,7 +439,6 @@ class MockWebServerTest {
 
   @Test
   fun disconnectResponseHalfway() {
-    println(System.getProperty("java.version"))
     server.enqueue(
       MockResponse
         .Builder()


### PR DESCRIPTION
Change in https://bugs.openjdk.org/browse/JDK-8335135

> HttpInputStream does not throw IOException when response is truncated