### PR TITLE
Remove JDK 8 ALPN runs of module-specific tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run Checks
-        run: ./gradlew test -Dtest.java.version=8 -Dokhttp.platform=jdk8alpn -Dalpn.boot.version=8.1.13.v20181017 -Dorg.gradle.java.installations.paths=/opt/hostedtoolcache/Java_Adopt_jdk/8.0.242-8.1/x64
+        run: ./gradlew okhttp:test -Dtest.java.version=8 -Dokhttp.platform=jdk8alpn -Dalpn.boot.version=8.1.13.v20181017 -Dorg.gradle.java.installations.paths=/opt/hostedtoolcache/Java_Adopt_jdk/8.0.242-8.1/x64
 
   testopenjsse:
     runs-on: ubuntu-latest
@@ -252,7 +252,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run Checks
-        run: ./gradlew test -Dtest.java.version=8 -Dokhttp.platform=openjsse
+        run: ./gradlew okhttp:test -Dtest.java.version=8 -Dokhttp.platform=openjsse
 
   testconscrypt:
     runs-on: ubuntu-latest
@@ -280,7 +280,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run Checks
-        run: ./gradlew test -Dokhttp.platform=conscrypt
+        run: ./gradlew okhttp:test -Dokhttp.platform=conscrypt
 
   testbouncycastle:
     runs-on: ubuntu-latest
@@ -308,7 +308,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run Checks
-        run: ./gradlew test -Dokhttp.platform=bouncycastle
+        run: ./gradlew okhttp:test -Dokhttp.platform=bouncycastle
 
   testcorretto:
     runs-on: ubuntu-latest
@@ -337,12 +337,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run Checks
-        run: ./gradlew test -Dokhttp.platform=corretto
+        run: ./gradlew okhttp:test -Dokhttp.platform=corretto
 
   testopenjdk17:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'jdkversions') || contains(github.event.pull_request.labels.*.name, 'renovate')
-
 
     steps:
       - name: Checkout

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jetbrains.kotlin.gradle.utils.addExtendsFromRelation
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSnifferExtension
 import java.net.URI
 
@@ -240,21 +239,6 @@ subprojects {
   }
   tasks.withType<KotlinJvmTest>().configureEach {
     environment("OKHTTP_ROOT", rootDir)
-  }
-
-  if (project.name != "okhttp") {
-    if (platform == "jdk8alpn") {
-      // Add alpn-boot on Java 8 so we can use HTTP/2 without a stable API.
-      val alpnBootVersion = alpnBootVersion()
-      if (alpnBootVersion != null) {
-        val alpnBootJar = configurations.detachedConfiguration(
-          dependencies.create("org.mortbay.jetty.alpn:alpn-boot:$alpnBootVersion")
-        ).singleFile
-        tasks.withType<Test> {
-          jvmArgs("-Xbootclasspath/p:${alpnBootJar}")
-        }
-      }
-    }
   }
 
   tasks.withType<JavaCompile> {

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -101,7 +101,7 @@ kotlin {
       dependsOn(commonJvmAndroid)
 
       dependencies {
-        // These compileOnly dependencies must also be listed in the OSGi configuration above.
+        // These compileOnly dependencies must also be listed as optional in the OSGi manifest entries below.
         compileOnly(libs.conscrypt.openjdk)
         compileOnly(libs.bouncycastle.bcprov)
         compileOnly(libs.bouncycastle.bctls)

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Locks.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Locks.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(ExperimentalContracts::class, ExperimentalContracts::class)
+@file:OptIn(ExperimentalContracts::class)
 
 package okhttp3.internal.connection
 


### PR DESCRIPTION
For ALPN and other niche workflows, run only the core tests.