### PR TITLE
Remove Renovate schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard",
-    "schedule:daily"
+    ":dependencyDashboard"
   ],
   "semanticCommits": "disabled",
   "labels": [


### PR DESCRIPTION
We're fully caught up, and I do not like that these come in at like 9pm at night rather than just when noticed like every other repo.