### PR TITLE
[WIP] Call.Decorator

### DIFF
--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
   "friendsImplementation"(projects.okhttpDnsoverhttps)
 
   testImplementation(projects.okhttp)
+  testImplementation(projects.okhttpCoroutines)
   testImplementation(libs.junit)
   testImplementation(libs.junit.ktx)
   testImplementation(libs.assertk)

--- a/android-test/src/androidTest/java/okhttp/android/test/AlwaysHttps.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/AlwaysHttps.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp.android.test
+
+import android.os.Build
+import android.security.NetworkSecurityPolicy
+import okhttp3.Call
+import okhttp3.Request
+
+class AlwaysHttps(
+  policy: Policy,
+) : Call.Decorator {
+  val hostPolicy: HostPolicy = policy.hostPolicy
+
+  override fun newCall(
+    chain: Call.Factory,
+    request: Request,
+  ): Call {
+    println("AlwaysHttps")
+
+    val updatedRequest =
+      if (request.url.scheme == "http" && !hostPolicy.isCleartextTrafficPermitted(request)) {
+        request
+          .newBuilder()
+          .url(
+            request.url
+              .newBuilder()
+              .scheme("https")
+              .build(),
+          ).build()
+      } else {
+        request
+      }
+
+    return chain.newCall(updatedRequest)
+  }
+
+  fun interface HostPolicy {
+    fun isCleartextTrafficPermitted(request: Request): Boolean
+  }
+
+  enum class Policy {
+    Always {
+      override val hostPolicy: HostPolicy
+        get() = HostPolicy { true }
+    },
+    Manifest {
+      override val hostPolicy: HostPolicy
+        get() =
+          if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+            val networkSecurityPolicy = NetworkSecurityPolicy.getInstance()
+
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+              HostPolicy { networkSecurityPolicy.isCleartextTrafficPermitted(it.url.host) }
+            } else {
+              HostPolicy { networkSecurityPolicy.isCleartextTrafficPermitted }
+            }
+          } else {
+            HostPolicy { true }
+          }
+    }, ;
+
+    abstract val hostPolicy: HostPolicy
+  }
+}

--- a/android-test/src/androidTest/java/okhttp/android/test/CallDecoratorTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/CallDecoratorTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp.android.test
+
+import java.util.logging.Logger
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp.android.test.AlwaysHttps.Policy
+import okhttp3.OkHttpClient
+import okhttp3.OkHttpClientTestRule
+import okhttp3.Request
+import okhttp3.tls.internal.TlsUtil.localhost
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@Tag("Slow")
+class CallDecoratorTest {
+  @Suppress("RedundantVisibilityModifier")
+  @JvmField
+  @RegisterExtension
+  public val clientTestRule =
+    OkHttpClientTestRule().apply {
+      logger = Logger.getLogger(CallDecoratorTest::class.java.name)
+    }
+
+  private var client: OkHttpClient =
+    clientTestRule
+      .newClientBuilder()
+      .addCallDecorator(AlwaysHttps(Policy.Always))
+      .addCallDecorator(OffMainThread)
+      .build()
+
+  private lateinit var server: MockWebServer
+
+  private val handshakeCertificates = localhost()
+
+  @BeforeEach
+  fun setup(server: MockWebServer) {
+    this.server = server
+  }
+
+  @Test
+  fun testSecureRequest() {
+    enableTls()
+
+    server.enqueue(MockResponse())
+
+    val request = Request.Builder().url(server.url("/")).build()
+
+    client.newCall(request).execute().use {
+      assertEquals(200, it.code)
+    }
+  }
+
+  @Test
+  fun testInsecureRequestChangedToSecure() {
+    enableTls()
+
+    val request =
+      Request
+        .Builder()
+        .url(
+          server
+            .url("/")
+            .newBuilder()
+            .scheme("http")
+            .build(),
+        ).build()
+
+    client.newCall(request).execute().use {
+      assertEquals(200, it.code)
+      assertEquals("https", it.request.url.scheme)
+    }
+  }
+
+  private fun enableTls() {
+    client =
+      client
+        .newBuilder()
+        .sslSocketFactory(
+          handshakeCertificates.sslSocketFactory(),
+          handshakeCertificates.trustManager,
+        ).build()
+    server.useHttps(handshakeCertificates.sslSocketFactory())
+  }
+}

--- a/android-test/src/androidTest/java/okhttp/android/test/OffMainThread.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OffMainThread.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp.android.test
+
+import android.os.Looper
+import okhttp3.Call
+import okhttp3.Request
+import okhttp3.Response
+
+object OffMainThread : Call.Decorator {
+  override fun newCall(
+    chain: Call.Factory,
+    request: Request,
+  ): Call = StrictModeCall(chain.newCall(request))
+
+  private class StrictModeCall(
+    private val delegate: Call,
+  ) : Call by delegate {
+    init {
+      println("StrictModeCall")
+    }
+
+    override fun execute(): Response {
+      if (Looper.getMainLooper().isCurrentThread) {
+        throw IllegalStateException("Network on main thread")
+      }
+
+      return delegate.execute()
+    }
+
+    override fun clone(): Call = StrictModeCall(delegate.clone())
+  }
+}

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -94,6 +94,7 @@ kotlin {
         compileOnly(libs.conscrypt.openjdk)
         implementation(libs.androidx.annotation)
         implementation(libs.androidx.startup.runtime)
+        implementation(libs.kotlinx.coroutines.core)
       }
     }
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Call.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Call.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3
 
+import okhttp3.Interceptor.Chain
 import okio.IOException
 import okio.Timeout
 
@@ -95,5 +96,9 @@ interface Call : Cloneable {
 
   fun interface Factory {
     fun newCall(request: Request): Call
+  }
+
+  fun interface Decorator {
+    fun newCall(chain: Call.Factory, request: Request): Call
   }
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Call.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Call.kt
@@ -15,7 +15,6 @@
  */
 package okhttp3
 
-import okhttp3.Interceptor.Chain
 import okio.IOException
 import okio.Timeout
 
@@ -99,6 +98,9 @@ interface Call : Cloneable {
   }
 
   fun interface Decorator {
-    fun newCall(chain: Call.Factory, request: Request): Call
+    fun newCall(
+      chain: Call.Factory,
+      request: Request,
+    ): Call
   }
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
@@ -150,7 +150,6 @@ open class OkHttpClient internal constructor(
    * the connection is established (if any) until after the response source is selected (either the
    * origin server, cache, or both).
    */
-  @get:JvmName("interceptors")
   val callDecorators: List<Call.Decorator> =
     builder.callDecorators.toImmutableList()
 
@@ -369,18 +368,24 @@ open class OkHttpClient internal constructor(
 
   /** Prepares the [request] to be executed at some point in the future. */
   override fun newCall(request: Request): Call {
-    if (callDecorators.isEmpty())
-      return RealCall(this, request, forWebSocket = false)
+    if (callDecorators.isNotEmpty()) {
+      return DecoratedCallFactory().newCall(request)
+    }
 
-    return newCall(request, decoratorOrder = callDecorators.listIterator())
+    return RealCall(this, request, forWebSocket = false)
   }
 
-  internal fun newCall(request: Request, decoratorOrder: ListIterator<Call.Decorator>): Call {
-    val decorator = decoratorOrder.next()
+  private inner class DecoratedCallFactory(
+    private val index: Int = 0,
+  ) : Call.Factory {
+    init {
+      println("DecoratedCallFactory index: $index")
+    }
 
-    val
-
-    return decorator.newCall(chain, request)
+    override fun newCall(request: Request): Call {
+      val next = if (index > callDecorators.lastIndex) this@OkHttpClient else DecoratedCallFactory(index + 1)
+      return callDecorators[index].newCall(next, request)
+    }
   }
 
   /** Uses [request] to connect a new web socket. */
@@ -654,6 +659,7 @@ open class OkHttpClient internal constructor(
       this.dispatcher = okHttpClient.dispatcher
       this.connectionPool = okHttpClient.connectionPool
       this.interceptors += okHttpClient.interceptors
+      this.callDecorators += okHttpClient.callDecorators
       this.networkInterceptors += okHttpClient.networkInterceptors
       this.eventListenerFactory = okHttpClient.eventListenerFactory
       this.retryOnConnectionFailure = okHttpClient.retryOnConnectionFailure
@@ -756,6 +762,11 @@ open class OkHttpClient internal constructor(
     fun eventListenerFactory(eventListenerFactory: EventListener.Factory) =
       apply {
         this.eventListenerFactory = eventListenerFactory
+      }
+
+    fun addCallDecorator(decorator: Call.Decorator) =
+      apply {
+        callDecorators += decorator
       }
 
     /**

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
@@ -146,6 +146,15 @@ open class OkHttpClient internal constructor(
     builder.interceptors.toImmutableList()
 
   /**
+   * Returns an immutable list of interceptors that observe the full span of each call: from before
+   * the connection is established (if any) until after the response source is selected (either the
+   * origin server, cache, or both).
+   */
+  @get:JvmName("interceptors")
+  val callDecorators: List<Call.Decorator> =
+    builder.callDecorators.toImmutableList()
+
+  /**
    * Returns an immutable list of interceptors that observe a single network request and response.
    * These interceptors must call [Interceptor.Chain.proceed] exactly once: it is an error for
    * a network interceptor to short-circuit or repeat a network request.
@@ -359,7 +368,20 @@ open class OkHttpClient internal constructor(
   }
 
   /** Prepares the [request] to be executed at some point in the future. */
-  override fun newCall(request: Request): Call = RealCall(this, request, forWebSocket = false)
+  override fun newCall(request: Request): Call {
+    if (callDecorators.isEmpty())
+      return RealCall(this, request, forWebSocket = false)
+
+    return newCall(request, decoratorOrder = callDecorators.listIterator())
+  }
+
+  internal fun newCall(request: Request, decoratorOrder: ListIterator<Call.Decorator>): Call {
+    val decorator = decoratorOrder.next()
+
+    val
+
+    return decorator.newCall(chain, request)
+  }
 
   /** Uses [request] to connect a new web socket. */
   override fun newWebSocket(
@@ -596,6 +618,7 @@ open class OkHttpClient internal constructor(
     internal var dispatcher: Dispatcher = Dispatcher()
     internal var connectionPool: ConnectionPool? = null
     internal val interceptors: MutableList<Interceptor> = mutableListOf()
+    internal val callDecorators: MutableList<Call.Decorator> = mutableListOf()
     internal val networkInterceptors: MutableList<Interceptor> = mutableListOf()
     internal var eventListenerFactory: EventListener.Factory = EventListener.NONE.asFactory()
     internal var retryOnConnectionFailure = true


### PR DESCRIPTION
Demonstrate a possible Call.Decorator API that handles some of the following cases, without forcing clients to deal exclusively with Call.Factory.

- Intercept Call creation on the callers thread - for example associating trace information
- Modifying the request - adding tags 
- Platform specific checks, such as Android Main thread or insecure URL checks
- Switching between clients, such as Network Pinning

Todo

- [ ] Agree correct API
- [ ] Add tests