### PR TITLE
Revert a pessimization in Response.headersContentLength

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
@@ -234,7 +234,7 @@ internal inline fun threadName(
 }
 
 /** Returns the Content-Length as reported by the response headers. */
-internal fun Response.headersContentLength(): Long = headers["Content-Length"]?.toLongOrNull() ?: -1L
+internal fun Response.headersContentLength(): Long = headers["Content-Length"]?.toLongOrDefault(-1L) ?: -1L
 
 /** Returns an immutable wrap of this. */
 @Suppress("NOTHING_TO_INLINE")


### PR DESCRIPTION
We don't want to allocate unless we need to.