### PR TITLE
Use SHOUTY_CASE for static constants

### DIFF
--- a/mockwebserver/src/test/java/mockwebserver3/RecordedRequestTest.kt
+++ b/mockwebserver/src/test/java/mockwebserver3/RecordedRequestTest.kt
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Timeout
 
 @Timeout(30)
 class RecordedRequestTest {
-  private val headers: Headers = Headers.Empty
+  private val headers: Headers = Headers.EMPTY
 
   @Test fun testIPv4() {
     val socket =

--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -624,7 +624,7 @@ public final class okhttp3/Handshake$Companion {
 
 public final class okhttp3/Headers : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
 	public static final field Companion Lokhttp3/Headers$Companion;
-	public static final field Empty Lokhttp3/Headers;
+	public static final field EMPTY Lokhttp3/Headers;
 	public final fun -deprecated_size ()I
 	public final fun byteCount ()J
 	public fun equals (Ljava/lang/Object;)Z
@@ -1089,7 +1089,7 @@ public class okhttp3/Request$Builder {
 
 public abstract class okhttp3/RequestBody {
 	public static final field Companion Lokhttp3/RequestBody$Companion;
-	public static final field Empty Lokhttp3/RequestBody;
+	public static final field EMPTY Lokhttp3/RequestBody;
 	public fun <init> ()V
 	public fun contentLength ()J
 	public abstract fun contentType ()Lokhttp3/MediaType;
@@ -1204,7 +1204,7 @@ public class okhttp3/Response$Builder {
 
 public abstract class okhttp3/ResponseBody : java/io/Closeable {
 	public static final field Companion Lokhttp3/ResponseBody$Companion;
-	public static final field Empty Lokhttp3/ResponseBody;
+	public static final field EMPTY Lokhttp3/ResponseBody;
 	public fun <init> ()V
 	public final fun byteStream ()Ljava/io/InputStream;
 	public final fun byteString ()Lokio/ByteString;

--- a/okhttp/api/jvm/okhttp.api
+++ b/okhttp/api/jvm/okhttp.api
@@ -624,7 +624,7 @@ public final class okhttp3/Handshake$Companion {
 
 public final class okhttp3/Headers : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
 	public static final field Companion Lokhttp3/Headers$Companion;
-	public static final field Empty Lokhttp3/Headers;
+	public static final field EMPTY Lokhttp3/Headers;
 	public final fun -deprecated_size ()I
 	public final fun byteCount ()J
 	public fun equals (Ljava/lang/Object;)Z
@@ -1089,7 +1089,7 @@ public class okhttp3/Request$Builder {
 
 public abstract class okhttp3/RequestBody {
 	public static final field Companion Lokhttp3/RequestBody$Companion;
-	public static final field Empty Lokhttp3/RequestBody;
+	public static final field EMPTY Lokhttp3/RequestBody;
 	public fun <init> ()V
 	public fun contentLength ()J
 	public abstract fun contentType ()Lokhttp3/MediaType;
@@ -1204,7 +1204,7 @@ public class okhttp3/Response$Builder {
 
 public abstract class okhttp3/ResponseBody : java/io/Closeable {
 	public static final field Companion Lokhttp3/ResponseBody$Companion;
-	public static final field Empty Lokhttp3/ResponseBody;
+	public static final field EMPTY Lokhttp3/ResponseBody;
 	public fun <init> ()V
 	public final fun byteStream ()Ljava/io/InputStream;
 	public final fun byteString ()Lokio/ByteString;

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt
@@ -822,7 +822,7 @@ class Cache internal constructor(
       responseHeaders: Headers,
     ): Headers {
       val varyFields = responseHeaders.varyFields()
-      if (varyFields.isEmpty()) return Headers.Empty
+      if (varyFields.isEmpty()) return Headers.EMPTY
 
       val result = Headers.Builder()
       for (i in 0 until requestHeaders.size) {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Headers.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Headers.kt
@@ -324,7 +324,7 @@ class Headers internal constructor(
   companion object {
     /** Empty headers. */
     @JvmField
-    val Empty = Headers(emptyArray())
+    val EMPTY = Headers(emptyArray())
 
     /**
      * Returns headers for the alternating header names and values. There must be an even number of

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Request.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Request.kt
@@ -269,7 +269,7 @@ class Request internal constructor(
     open fun post(body: RequestBody): Builder = commonPost(body)
 
     @JvmOverloads
-    open fun delete(body: RequestBody? = RequestBody.Empty): Builder = commonDelete(body)
+    open fun delete(body: RequestBody? = RequestBody.EMPTY): Builder = commonDelete(body)
 
     open fun put(body: RequestBody): Builder = commonPut(body)
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
@@ -101,17 +101,9 @@ abstract class RequestBody {
   open fun isOneShot(): Boolean = commonIsOneShot()
 
   companion object {
-    /** Empty request body. */
+    /** Empty request body with no content-type. */
     @JvmField
-    val Empty: RequestBody = EmptyRequestBody()
-
-    private class EmptyRequestBody : RequestBody() {
-      override fun contentType() = null
-
-      override fun contentLength() = 0L
-
-      override fun writeTo(sink: BufferedSink) {}
-    }
+    val EMPTY: RequestBody = ByteString.EMPTY.toRequestBody()
 
     /**
      * Returns a new request body that transmits this string. If [contentType] is non-null and lacks

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Response.kt
@@ -322,7 +322,7 @@ class Response internal constructor(
     internal var message: String? = null
     internal var handshake: Handshake? = null
     internal var headers: Headers.Builder
-    internal var body: ResponseBody = ResponseBody.Empty
+    internal var body: ResponseBody = ResponseBody.EMPTY
     internal var networkResponse: Response? = null
     internal var cacheResponse: Response? = null
     internal var priorResponse: Response? = null

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ResponseBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ResponseBody.kt
@@ -213,17 +213,9 @@ abstract class ResponseBody : Closeable {
   }
 
   companion object {
-    /** Empty response body. */
+    /** Empty response body with no content-type. Closing this response body does nothing. */
     @JvmField
-    val Empty: ResponseBody = EmptyResponseBody()
-
-    private class EmptyResponseBody : ResponseBody() {
-      override fun contentType() = null
-
-      override fun contentLength() = 0L
-
-      override fun source() = Buffer()
-    }
+    val EMPTY: ResponseBody = ByteString.EMPTY.toResponseBody()
 
     /**
      * Returns a new response body that transmits this string. If [contentType] is non-null and

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -143,7 +143,7 @@ class Http1ExchangeCodec(
 
   override fun trailers(): Headers {
     check(state == STATE_CLOSED) { "too early; can't read the trailers yet" }
-    return trailers ?: Headers.Empty
+    return trailers ?: Headers.EMPTY
   }
 
   override fun flushRequest() {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Connection.kt
@@ -674,7 +674,7 @@ class Http2Connection internal constructor(
       }
       dataStream.receiveData(source, length)
       if (inFinished) {
-        dataStream.receiveHeaders(Headers.Empty, true)
+        dataStream.receiveHeaders(Headers.EMPTY, true)
       }
     }
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Stream.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Stream.kt
@@ -173,7 +173,7 @@ class Http2Stream internal constructor(
   fun trailers(): Headers {
     this.withLock {
       if (source.finished && source.receiveBuffer.exhausted() && source.readBuffer.exhausted()) {
-        return source.trailers ?: Headers.Empty
+        return source.trailers ?: Headers.EMPTY
       }
       if (errorCode != null) {
         throw errorException ?: StreamResetException(errorCode!!)

--- a/okhttp/src/jvmTest/kotlin/okhttp3/HeadersJvmTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/HeadersJvmTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test
 
 class HeadersJvmTest {
   @Test fun byteCount() {
-    assertThat(Headers.Empty.byteCount()).isEqualTo(0L)
+    assertThat(Headers.EMPTY.byteCount()).isEqualTo(0L)
     assertThat(
       Headers
         .Builder()

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
@@ -557,7 +557,7 @@ class Http2ConnectionTest {
     val stream = connection.newStream(headerEntries("a", "artichaut"), false)
     connection.writePingAndAwaitPong()
     assertThat(stream.takeHeaders()).isEqualTo(headersOf("headers", "bam"))
-    assertThat(stream.trailers()).isEqualTo(Headers.Empty)
+    assertThat(stream.trailers()).isEqualTo(Headers.EMPTY)
     assertThat(connection.openStreamCount()).isEqualTo(0)
 
     // Verify the peer received what was expected.
@@ -808,7 +808,7 @@ class Http2ConnectionTest {
     connection.writePingAndAwaitPong()
     assertThat(stream.takeHeaders()).isEqualTo(headersOf("headers", "bam"))
     assertThat(source.readUtf8(5)).isEqualTo("robot")
-    assertThat(stream.trailers()).isEqualTo(Headers.Empty)
+    assertThat(stream.trailers()).isEqualTo(Headers.EMPTY)
     assertThat(connection.openStreamCount()).isEqualTo(0)
 
     // Verify the peer received what was expected.

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -1622,7 +1622,7 @@ class HttpOverHttp2Test {
         Request
           .Builder()
           .url(server.url("/"))
-          .method("DELETE", RequestBody.Empty)
+          .method("DELETE", RequestBody.EMPTY)
           .build(),
       )
     val response = call.execute()


### PR DESCRIPTION
OkHttp has lots of constants defined from before it was a Kotlin library, and I'd rather the library be self-consistent than consistent with Kotlin idioms.

As a bonus we get to remain consistent with Java idioms. I'd love a Kotlin mechanism to use @JvmField and @JvmName at the same time, but I can't figure out how.