### PR TITLE
Change the locking mechanism to 'synchronized'

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskFaker.kt
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+@file:Suppress(
+  "CANNOT_OVERRIDE_INVISIBLE_MEMBER",
+  "INVISIBLE_MEMBER",
+  "INVISIBLE_REFERENCE",
+)
+
 package okhttp3.internal.concurrent
 
 import assertk.assertThat
@@ -24,7 +30,6 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
-import okhttp3.OkHttpClient
 import okhttp3.TestUtil.threadFactory
 import okhttp3.internal.connection.Locks.withLock
 
@@ -43,20 +48,6 @@ import okhttp3.internal.connection.Locks.withLock
  *  * By completing.
  */
 class TaskFaker : Closeable {
-  @Suppress("NOTHING_TO_INLINE")
-  internal inline fun Any.assertThreadHoldsLock() {
-    if (assertionsEnabled && !taskRunner.lock.isHeldByCurrentThread) {
-      throw AssertionError("Thread ${Thread.currentThread().name} MUST hold lock on $this")
-    }
-  }
-
-  @Suppress("NOTHING_TO_INLINE")
-  internal inline fun Any.assertThreadDoesntHoldLock() {
-    if (assertionsEnabled && taskRunner.lock.isHeldByCurrentThread) {
-      throw AssertionError("Thread ${Thread.currentThread().name} MUST NOT hold lock on $this")
-    }
-  }
-
   val logger = Logger.getLogger("TaskFaker." + instance++)
 
   /** Though this executor service may hold many threads, they are not executed concurrently. */
@@ -100,7 +91,7 @@ class TaskFaker : Closeable {
           taskRunner: TaskRunner,
           runnable: Runnable,
         ) {
-          taskRunner.assertThreadHoldsLock()
+          taskRunner.lock.assertThreadHoldsLock()
 
           val queuedTask = RunnableSerialTask(runnable)
           serialTaskQueue += queuedTask
@@ -111,14 +102,14 @@ class TaskFaker : Closeable {
         override fun nanoTime() = nanoTime
 
         override fun coordinatorNotify(taskRunner: TaskRunner) {
-          taskRunner.assertThreadHoldsLock()
+          taskRunner.lock.assertThreadHoldsLock()
           check(waitingCoordinatorTask != null)
 
           // Queue a task to resume the waiting coordinator.
           serialTaskQueue +=
             object : SerialTask {
               override fun start() {
-                taskRunner.assertThreadHoldsLock()
+                taskRunner.lock.assertThreadHoldsLock()
                 val coordinatorTask = waitingCoordinatorTask
                 if (coordinatorTask != null) {
                   waitingCoordinatorNotified = true
@@ -135,7 +126,7 @@ class TaskFaker : Closeable {
           taskRunner: TaskRunner,
           nanos: Long,
         ) {
-          taskRunner.assertThreadHoldsLock()
+          taskRunner.lock.assertThreadHoldsLock()
           check(waitingCoordinatorTask == null)
           if (nanos == 0L) return
 
@@ -169,7 +160,7 @@ class TaskFaker : Closeable {
 
   /** Advance the simulated clock, then runs tasks that are ready. Used by the test thread only. */
   fun advanceUntil(newTime: Long) {
-    taskRunner.assertThreadDoesntHoldLock()
+    taskRunner.lock.assertThreadDoesntHoldLock()
 
     taskRunner.withLock {
       check(currentTask == TestThreadSerialTask)
@@ -180,7 +171,7 @@ class TaskFaker : Closeable {
 
   /** Confirm all tasks have completed. Used by the test thread only. */
   fun assertNoMoreTasks() {
-    taskRunner.assertThreadDoesntHoldLock()
+    taskRunner.lock.assertThreadDoesntHoldLock()
 
     taskRunner.withLock {
       assertThat(activeThreads).isEqualTo(0)
@@ -189,14 +180,14 @@ class TaskFaker : Closeable {
 
   /** Unblock a waiting task thread. Used by the test thread only. */
   fun interruptCoordinatorThread() {
-    taskRunner.assertThreadDoesntHoldLock()
+    taskRunner.lock.assertThreadDoesntHoldLock()
     require(currentTask == TestThreadSerialTask)
 
     // Queue a task to interrupt the waiting coordinator.
     serialTaskQueue +=
       object : SerialTask {
         override fun start() {
-          taskRunner.assertThreadHoldsLock()
+          taskRunner.lock.assertThreadHoldsLock()
           waitingCoordinatorInterrupted = true
           val coordinatorTask = waitingCoordinatorTask ?: error("no coordinator waiting")
           currentTask = coordinatorTask
@@ -210,7 +201,7 @@ class TaskFaker : Closeable {
 
   /** Ask a single task to proceed. Used by the test thread only. */
   fun runNextTask() {
-    taskRunner.assertThreadDoesntHoldLock()
+    taskRunner.lock.assertThreadDoesntHoldLock()
 
     taskRunner.withLock {
       val contextSwitchCountBefore = contextSwitchCount
@@ -233,7 +224,7 @@ class TaskFaker : Closeable {
    * simulate races in tasks that doesn't have a deterministic sequence.
    */
   fun yield() {
-    taskRunner.assertThreadDoesntHoldLock()
+    taskRunner.lock.assertThreadDoesntHoldLock()
     taskRunner.withLock {
       yieldUntil()
     }
@@ -244,7 +235,7 @@ class TaskFaker : Closeable {
     strategy: ResumePriority = ResumePriority.AfterEnqueuedTasks,
     condition: () -> Boolean = { true },
   ) {
-    taskRunner.assertThreadHoldsLock()
+    taskRunner.lock.assertThreadHoldsLock()
     val self = currentTask
 
     val yieldCompleteTask =
@@ -252,7 +243,7 @@ class TaskFaker : Closeable {
         override fun isReady() = condition()
 
         override fun start() {
-          taskRunner.assertThreadHoldsLock()
+          taskRunner.lock.assertThreadHoldsLock()
           currentTask = self
           taskRunner.condition.signalAll()
         }
@@ -294,7 +285,7 @@ class TaskFaker : Closeable {
 
   /** Returns the task that was started, or null if there were no tasks to start. */
   private fun startNextTask(): SerialTask? {
-    taskRunner.assertThreadHoldsLock()
+    taskRunner.lock.assertThreadHoldsLock()
 
     val index = serialTaskQueue.indexOfFirst { it.isReady() }
     if (index == -1) return null
@@ -322,12 +313,12 @@ class TaskFaker : Closeable {
     private val runnable: Runnable,
   ) : SerialTask {
     override fun start() {
-      taskRunner.assertThreadHoldsLock()
+      taskRunner.lock.assertThreadHoldsLock()
       require(currentTask == this)
       activeThreads++
 
       tasksExecutor.execute {
-        taskRunner.assertThreadDoesntHoldLock()
+        taskRunner.lock.assertThreadDoesntHoldLock()
         require(currentTask == this)
         try {
           runnable.run()
@@ -414,8 +405,5 @@ class TaskFaker : Closeable {
 
   companion object {
     var instance = 0
-
-    @JvmField
-    val assertionsEnabled: Boolean = OkHttpClient::class.java.desiredAssertionStatus()
   }
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dispatcher.kt
@@ -21,8 +21,8 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.ReentrantLock
-import okhttp3.internal.assertNotHeld
+import okhttp3.internal.concurrent.Lock
+import okhttp3.internal.concurrent.assertNotHeld
 import okhttp3.internal.connection.Locks.withLock
 import okhttp3.internal.connection.RealCall
 import okhttp3.internal.connection.RealCall.AsyncCall
@@ -38,7 +38,7 @@ import okhttp3.internal.unmodifiable
  * concurrently.
  */
 class Dispatcher() {
-  internal val lock: ReentrantLock = ReentrantLock()
+  internal val lock = Lock()
 
   /**
    * The maximum number of requests to execute concurrently. Above this requests queue in memory,

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
@@ -29,7 +29,6 @@ import java.util.Locale
 import java.util.TimeZone
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.ReentrantLock
 import kotlin.text.Charsets.UTF_16BE
 import kotlin.text.Charsets.UTF_16LE
 import kotlin.text.Charsets.UTF_32BE
@@ -289,15 +288,6 @@ internal fun Long.toHexString(): String = java.lang.Long.toHexString(this)
 
 internal fun Int.toHexString(): String = Integer.toHexString(this)
 
-@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
-internal inline fun Any.wait() = (this as Object).wait()
-
-@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
-internal inline fun Any.notify() = (this as Object).notify()
-
-@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
-internal inline fun Any.notifyAll() = (this as Object).notifyAll()
-
 internal fun <T> readFieldOrNull(
   instance: Any,
   fieldType: Class<T>,
@@ -340,31 +330,3 @@ internal val okHttpName: String =
   OkHttpClient::class.java.name
     .removePrefix("okhttp3.")
     .removeSuffix("Client")
-
-@Suppress("NOTHING_TO_INLINE")
-internal inline fun ReentrantLock.assertHeld() {
-  if (assertionsEnabled && !this.isHeldByCurrentThread) {
-    throw AssertionError("Thread ${Thread.currentThread().name} MUST hold lock on $this")
-  }
-}
-
-@Suppress("NOTHING_TO_INLINE")
-internal inline fun Any.assertThreadHoldsLock() {
-  if (assertionsEnabled && !Thread.holdsLock(this)) {
-    throw AssertionError("Thread ${Thread.currentThread().name} MUST hold lock on $this")
-  }
-}
-
-@Suppress("NOTHING_TO_INLINE")
-internal inline fun ReentrantLock.assertNotHeld() {
-  if (assertionsEnabled && this.isHeldByCurrentThread) {
-    throw AssertionError("Thread ${Thread.currentThread().name} MUST NOT hold lock on $this")
-  }
-}
-
-@Suppress("NOTHING_TO_INLINE")
-internal inline fun Any.assertThreadDoesntHoldLock() {
-  if (assertionsEnabled && Thread.holdsLock(this)) {
-    throw AssertionError("Thread ${Thread.currentThread().name} MUST NOT hold lock on $this")
-  }
-}

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/cache/DiskLruCache.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/cache/DiskLruCache.kt
@@ -19,11 +19,12 @@ import java.io.Closeable
 import java.io.EOFException
 import java.io.Flushable
 import java.io.IOException
-import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.cache.DiskLruCache.Editor
 import okhttp3.internal.closeQuietly
+import okhttp3.internal.concurrent.Lockable
 import okhttp3.internal.concurrent.Task
 import okhttp3.internal.concurrent.TaskRunner
+import okhttp3.internal.concurrent.assertThreadHoldsLock
 import okhttp3.internal.deleteContents
 import okhttp3.internal.deleteIfExists
 import okhttp3.internal.isCivilized
@@ -95,7 +96,8 @@ class DiskLruCache(
   /** Used for asynchronous journal rebuilds. */
   taskRunner: TaskRunner,
 ) : Closeable,
-  Flushable {
+  Flushable,
+  Lockable {
   internal val fileSystem: FileSystem =
     object : ForwardingFileSystem(fileSystem) {
       override fun sink(

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/cache2/Relay.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/cache2/Relay.kt
@@ -19,7 +19,8 @@ import java.io.File
 import java.io.IOException
 import java.io.RandomAccessFile
 import okhttp3.internal.closeQuietly
-import okhttp3.internal.notifyAll
+import okhttp3.internal.concurrent.Lockable
+import okhttp3.internal.concurrent.notifyAll
 import okio.Buffer
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
@@ -63,7 +64,7 @@ class Relay private constructor(
   private val metadata: ByteString,
   /** The maximum size of [buffer]. */
   val bufferMaxSize: Long,
-) {
+) : Lockable {
   /** The thread that currently has access to upstream. Possibly null. Guarded by this. */
   var upstreamReader: Thread? = null
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/Lockable.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/Lockable.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
+
+package okhttp3.internal.concurrent
+
+import okhttp3.internal.assertionsEnabled
+
+/**
+ * Marker interface for objects that use the JVM's `synchronized` mechanism and th related
+ * `wait()` and `notify()` functions.
+ */
+interface Lockable
+
+/**
+ * Returns a new anonymous object to lock on.
+ *
+ * Use this to encapsulate locking returned objects:
+ *
+ *  * So callers don't call `synchronized`, `wait()` or `notify()` on your object
+ *  * So the `Lockable` interface is not in the public API
+ */
+@Suppress("FunctionName")
+fun Lock(): Lockable =
+  object : Lockable {
+  }
+
+internal inline fun Lockable.wait() = (this as Object).wait()
+
+internal inline fun Lockable.notify() = (this as Object).notify()
+
+internal inline fun Lockable.notifyAll() = (this as Object).notifyAll()
+
+internal inline fun Lockable.awaitNanos(nanos: Long) {
+  val ms = nanos / 1_000_000L
+  val ns = nanos - (ms * 1_000_000L)
+  if (ms > 0L || nanos > 0) {
+    (this as Object).wait(ms, ns.toInt())
+  }
+}
+
+internal inline fun Lockable.assertNotHeld() {
+  if (assertionsEnabled && Thread.holdsLock(this)) {
+    throw AssertionError("Thread ${Thread.currentThread().name} MUST NOT hold lock on $this")
+  }
+}
+
+internal inline fun Lockable.assertHeld() {
+  if (assertionsEnabled && !Thread.holdsLock(this)) {
+    throw AssertionError("Thread ${Thread.currentThread().name} MUST hold lock on $this")
+  }
+}
+
+internal inline fun Lockable.await() = wait()
+
+internal inline fun Lockable.signal() = notify()
+
+internal inline fun Lockable.signalAll() = notifyAll()
+
+internal inline fun Lockable.assertThreadDoesntHoldLock() {
+  assertNotHeld()
+}
+
+internal inline fun Lockable.assertThreadHoldsLock() {
+  assertHeld()
+}

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/Lockable.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/Lockable.kt
@@ -20,7 +20,7 @@ package okhttp3.internal.concurrent
 import okhttp3.internal.assertionsEnabled
 
 /**
- * Marker interface for objects that use the JVM's `synchronized` mechanism and th related
+ * Marker interface for objects that use the JVM's `synchronized` mechanism and the related
  * `wait()` and `notify()` functions.
  */
 interface Lockable

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/TaskQueue.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/TaskQueue.kt
@@ -17,8 +17,6 @@ package okhttp3.internal.concurrent
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.locks.ReentrantLock
-import okhttp3.internal.assertNotHeld
 import okhttp3.internal.connection.Locks.withLock
 import okhttp3.internal.okHttpName
 
@@ -32,7 +30,7 @@ class TaskQueue internal constructor(
   internal val taskRunner: TaskRunner,
   internal val name: String,
 ) {
-  internal val lock: ReentrantLock = ReentrantLock()
+  internal val lock = Lock()
 
   internal var shutdown = false
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/TaskRunner.kt
@@ -20,13 +20,9 @@ import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.Condition
-import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Logger
 import okhttp3.internal.addIfAbsent
-import okhttp3.internal.assertHeld
 import okhttp3.internal.concurrent.TaskRunner.Companion.INSTANCE
-import okhttp3.internal.connection.Locks.newLockCondition
 import okhttp3.internal.connection.Locks.withLock
 import okhttp3.internal.okHttpName
 import okhttp3.internal.threadFactory
@@ -46,8 +42,9 @@ class TaskRunner(
   val backend: Backend,
   internal val logger: Logger = TaskRunner.logger,
 ) {
-  internal val lock: ReentrantLock = ReentrantLock()
-  val condition: Condition = lock.newLockCondition()
+  internal val lock = Lock()
+  val condition: Lockable
+    get() = lock
 
   private var nextQueueName = 10000
   private var coordinatorWaiting = false

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Locks.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Locks.kt
@@ -17,9 +17,6 @@
 
 package okhttp3.internal.connection
 
-import java.util.concurrent.locks.Condition
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -33,63 +30,47 @@ import okhttp3.internal.http2.Http2Writer
 /**
  * Centralisation of central locks according to docs/contribute/concurrency.md
  */
+@OptIn(ExperimentalContracts::class)
 internal object Locks {
   inline fun <T> Dispatcher.withLock(action: () -> T): T {
     contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    return lock.runWithLock(action)
+    return synchronized(lock, action)
   }
 
   inline fun <T> RealConnection.withLock(action: () -> T): T {
     contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    return lock.runWithLock(action)
+    return synchronized(lock, action)
   }
 
   inline fun <T> RealCall.withLock(action: () -> T): T {
     contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    return lock.runWithLock(action)
+    return synchronized(lock, action)
   }
 
   inline fun <T> Http2Connection.withLock(action: () -> T): T {
     contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    return lock.runWithLock(action)
+    return synchronized(lock, action)
   }
 
   inline fun <T> Http2Stream.withLock(action: () -> T): T {
     contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    return lock.runWithLock(action)
+    return synchronized(lock, action)
   }
 
   inline fun <T> TaskRunner.withLock(action: () -> T): T {
     contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    return lock.runWithLock(action)
+    return synchronized(lock, action)
   }
 
   inline fun <T> TaskQueue.withLock(action: () -> T): T {
     contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    return lock.runWithLock(action)
+    return synchronized(lock, action)
   }
 
   inline fun <T> Http2Writer.withLock(action: () -> T): T {
     // TODO can we assert we don't have the connection lock?
 
     contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    return lock.runWithLock(action)
-  }
-
-  /**
-   * A no cost (inlined) alias to [ReentrantLock#newCondition] for an OkHttp Lock.
-   * No function on its own but places a central place that all conditions go through to allow
-   * temporary debugging.
-   */
-  internal fun ReentrantLock.newLockCondition(): Condition = this.newCondition()
-
-  /**
-   * A no cost (inlined) alias to [ReentrantLock#withLock] for an OkHttp Lock.
-   * No function on its own but places a central place that all locks go through to allow
-   * temporary debugging.
-   */
-  inline fun <T> ReentrantLock.runWithLock(action: () -> T): T {
-    contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
-    return withLock(action)
+    return synchronized(lock, action)
   }
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -23,7 +23,6 @@ import java.net.Socket
 import java.net.SocketException
 import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit.MILLISECONDS
-import java.util.concurrent.locks.ReentrantLock
 import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSocket
 import okhttp3.Address
@@ -34,10 +33,11 @@ import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Route
-import okhttp3.internal.assertHeld
-import okhttp3.internal.assertNotHeld
 import okhttp3.internal.closeQuietly
+import okhttp3.internal.concurrent.Lock
 import okhttp3.internal.concurrent.TaskRunner
+import okhttp3.internal.concurrent.assertHeld
+import okhttp3.internal.concurrent.assertNotHeld
 import okhttp3.internal.connection.Locks.withLock
 import okhttp3.internal.http.ExchangeCodec
 import okhttp3.internal.http.RealInterceptorChain
@@ -89,7 +89,7 @@ class RealConnection(
   ExchangeCodec.Carrier {
   private var http2Connection: Http2Connection? = null
 
-  internal val lock: ReentrantLock = ReentrantLock()
+  internal val lock = Lock()
 
   // These properties are guarded by [lock].
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -25,11 +25,11 @@ import okhttp3.Address
 import okhttp3.ConnectionListener
 import okhttp3.ConnectionPool
 import okhttp3.Route
-import okhttp3.internal.assertHeld
 import okhttp3.internal.closeQuietly
 import okhttp3.internal.concurrent.Task
 import okhttp3.internal.concurrent.TaskQueue
 import okhttp3.internal.concurrent.TaskRunner
+import okhttp3.internal.concurrent.assertHeld
 import okhttp3.internal.connection.Locks.withLock
 import okhttp3.internal.connection.RealCall.CallReference
 import okhttp3.internal.okHttpName

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Writer.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Writer.kt
@@ -17,9 +17,9 @@ package okhttp3.internal.http2
 
 import java.io.Closeable
 import java.io.IOException
-import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level.FINE
 import java.util.logging.Logger
+import okhttp3.internal.concurrent.Lock
 import okhttp3.internal.connection.Locks.withLock
 import okhttp3.internal.format
 import okhttp3.internal.http2.Http2.CONNECTION_PREFACE
@@ -49,7 +49,7 @@ class Http2Writer(
   private val sink: BufferedSink,
   private val client: Boolean,
 ) : Closeable {
-  internal val lock: ReentrantLock = ReentrantLock()
+  internal val lock = Lock()
 
   private val hpackBuffer: Buffer = Buffer()
   private var maxFrameSize: Int = INITIAL_MAX_FRAME_SIZE

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/ws/RealWebSocket.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/ws/RealWebSocket.kt
@@ -32,10 +32,11 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
-import okhttp3.internal.assertThreadHoldsLock
 import okhttp3.internal.closeQuietly
+import okhttp3.internal.concurrent.Lockable
 import okhttp3.internal.concurrent.Task
 import okhttp3.internal.concurrent.TaskRunner
+import okhttp3.internal.concurrent.assertThreadHoldsLock
 import okhttp3.internal.connection.Exchange
 import okhttp3.internal.connection.RealCall
 import okhttp3.internal.okHttpName
@@ -66,7 +67,8 @@ class RealWebSocket(
   private var minimumDeflateSize: Long,
   private val webSocketCloseTimeout: Long,
 ) : WebSocket,
-  WebSocketReader.FrameCallback {
+  WebSocketReader.FrameCallback,
+  Lockable {
   private val key: String
 
   /** Non-null for client web sockets. These can be canceled. */

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
@@ -36,11 +36,12 @@ import okhttp3.Headers.Companion.headersOf
 import okhttp3.TestUtil.headerEntries
 import okhttp3.TestUtil.repeat
 import okhttp3.internal.EMPTY_BYTE_ARRAY
+import okhttp3.internal.concurrent.Lockable
 import okhttp3.internal.concurrent.TaskFaker
 import okhttp3.internal.concurrent.TaskRunner
+import okhttp3.internal.concurrent.notifyAll
+import okhttp3.internal.concurrent.wait
 import okhttp3.internal.connection.Locks.withLock
-import okhttp3.internal.notifyAll
-import okhttp3.internal.wait
 import okio.AsyncTimeout
 import okio.Buffer
 import okio.BufferedSource
@@ -1986,7 +1987,9 @@ class Http2ConnectionTest {
     return connection
   }
 
-  private class RecordingPushObserver : PushObserver {
+  private class RecordingPushObserver :
+    PushObserver,
+    Lockable {
     val events = mutableListOf<Any>()
 
     @Synchronized fun takeEvent(): Any {


### PR DESCRIPTION
We migrated to ReentrantReadWriteLock to better support Loom, but now we can use synchronized and still support Loom. This old mechanism may be faster than ReentrantReadWriteLock.