### PR TITLE
Fix test execution on Robolectric

### DIFF
--- a/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
+++ b/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/AndroidPlatform.kt
@@ -178,19 +178,7 @@ class AndroidPlatform :
   companion object {
     val Tag = "OkHttp"
 
-    val isSupported: Boolean =
-      when {
-        !isAndroid -> false
-        Build.VERSION.SDK_INT >= 30 -> false // graylisted methods are banned
-        else -> {
-          // Fail Fast
-          check(
-            Build.VERSION.SDK_INT >= 21,
-          ) { "Expected Android API level 21+ but was ${Build.VERSION.SDK_INT}" }
-
-          true
-        }
-      }
+    val isSupported: Boolean = isAndroid && Build.VERSION.SDK_INT in 21 until 29
 
     fun buildIfSupported(): Platform? = if (isSupported) AndroidPlatform() else null
   }

--- a/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/PlatformRegistry.kt
+++ b/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/PlatformRegistry.kt
@@ -16,12 +16,26 @@
 package okhttp3.internal.platform
 
 import android.content.Context
+import android.os.Build
+import java.lang.IllegalStateException
 import okhttp3.internal.platform.android.AndroidLog
 
 actual object PlatformRegistry {
   actual fun findPlatform(): Platform {
     AndroidLog.enable()
-    return Android10Platform.buildIfSupported() ?: AndroidPlatform.buildIfSupported()!!
+
+    val androidPlatform = Android10Platform.buildIfSupported()
+      ?: AndroidPlatform.buildIfSupported()
+    if (androidPlatform != null) return androidPlatform
+
+    // If the API version is 0, assume this is the Android artifact, but running on the JVM.
+    // Robolectric?
+    if (Build.VERSION.SDK_INT == 0) {
+      return Jdk9Platform.buildIfSupported()
+        ?: Platform()
+    }
+
+    throw IllegalStateException("Expected Android API level 21+ but was ${Build.VERSION.SDK_INT}")
   }
 
   actual val isAndroid: Boolean

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/platform/Jdk9Platform.kt
@@ -23,7 +23,11 @@ import javax.net.ssl.X509TrustManager
 import okhttp3.Protocol
 import okhttp3.internal.SuppressSignatureCheck
 
-/** OpenJDK 9+. */
+/**
+ * OpenJDK 9+ and JDK8 build 252+.
+ *
+ * This may also be used for Android tests with Robolectric.
+ */
 open class Jdk9Platform : Platform() {
   @SuppressSignatureCheck
   override fun configureTlsExtensions(


### PR DESCRIPTION
We had a regression in 5.0.0-alpha.15 that broke test execution on Robolectric. Now that works again.

Closes: https://github.com/square/okhttp/issues/8821