### PR TITLE
TrailersSource, a new public API for HTTP trailers

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockResponse.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockResponse.kt
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress(
+  "CANNOT_OVERRIDE_INVISIBLE_MEMBER",
+  "INVISIBLE_MEMBER",
+  "INVISIBLE_REFERENCE",
+)
 
 package mockwebserver3
 
@@ -63,8 +68,9 @@ class MockResponse {
 
   val socketPolicy: SocketPolicy
 
-  val bodyDelayNanos: Long
   val headersDelayNanos: Long
+  val bodyDelayNanos: Long
+  val trailersDelayNanos: Long
 
   val pushPromises: List<PushPromise>
 
@@ -100,8 +106,9 @@ class MockResponse {
     this.throttleBytesPerPeriod = builder.throttleBytesPerPeriod
     this.throttlePeriodNanos = builder.throttlePeriodNanos
     this.socketPolicy = builder.socketPolicy
-    this.bodyDelayNanos = builder.bodyDelayNanos
     this.headersDelayNanos = builder.headersDelayNanos
+    this.bodyDelayNanos = builder.bodyDelayNanos
+    this.trailersDelayNanos = builder.trailersDelayNanos
     this.pushPromises = builder.pushPromises.toList()
     this.settings =
       Settings().apply {
@@ -178,9 +185,9 @@ class MockResponse {
 
     var socketPolicy: SocketPolicy
 
-    internal var bodyDelayNanos: Long
-
     internal var headersDelayNanos: Long
+    internal var bodyDelayNanos: Long
+    internal var trailersDelayNanos: Long
 
     /** The streams the server will push with this response. */
     val pushPromises: MutableList<PushPromise>
@@ -202,8 +209,9 @@ class MockResponse {
       this.throttleBytesPerPeriod = Long.MAX_VALUE
       this.throttlePeriodNanos = 0L
       this.socketPolicy = KeepOpen
-      this.bodyDelayNanos = 0L
       this.headersDelayNanos = 0L
+      this.bodyDelayNanos = 0L
+      this.trailersDelayNanos = 0L
       this.pushPromises = mutableListOf()
       this.settings = Settings()
     }
@@ -220,8 +228,9 @@ class MockResponse {
       this.throttleBytesPerPeriod = mockResponse.throttleBytesPerPeriod
       this.throttlePeriodNanos = mockResponse.throttlePeriodNanos
       this.socketPolicy = mockResponse.socketPolicy
-      this.bodyDelayNanos = mockResponse.bodyDelayNanos
       this.headersDelayNanos = mockResponse.headersDelayNanos
+      this.bodyDelayNanos = mockResponse.bodyDelayNanos
+      this.trailersDelayNanos = mockResponse.trailersDelayNanos
       this.pushPromises = mockResponse.pushPromises.toMutableList()
       this.settings =
         Settings().apply {
@@ -317,7 +326,7 @@ class MockResponse {
      */
     fun chunkedBody(
       body: Buffer,
-      maxChunkSize: Int,
+      maxChunkSize: Int = Int.MAX_VALUE,
     ) = apply {
       removeHeader("Content-Length")
       headers.add(CHUNKED_BODY_HEADER)
@@ -340,7 +349,7 @@ class MockResponse {
      */
     fun chunkedBody(
       body: String,
-      maxChunkSize: Int,
+      maxChunkSize: Int = Int.MAX_VALUE,
     ): Builder = chunkedBody(Buffer().writeUtf8(body), maxChunkSize)
 
     /** Sets the headers and returns this. */
@@ -374,6 +383,13 @@ class MockResponse {
       throttlePeriodNanos = unit.toNanos(period)
     }
 
+    fun headersDelay(
+      delay: Long,
+      unit: TimeUnit,
+    ) = apply {
+      headersDelayNanos = unit.toNanos(delay)
+    }
+
     /**
      * Set the delayed time of the response body to [delay]. This applies to the response body
      * only; response headers are not affected.
@@ -385,11 +401,11 @@ class MockResponse {
       bodyDelayNanos = unit.toNanos(delay)
     }
 
-    fun headersDelay(
+    fun trailersDelay(
       delay: Long,
       unit: TimeUnit,
     ) = apply {
-      headersDelayNanos = unit.toNanos(delay)
+      trailersDelayNanos = unit.toNanos(delay)
     }
 
     /**

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/TrailersSource.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/TrailersSource.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import okio.IOException
+
+@ExperimentalOkHttpApi
+fun interface TrailersSource {
+  /** Returns the trailers, blocking if they need to be loaded. */
+  @Throws(IOException::class)
+  fun get(): Headers
+
+  companion object {
+    @JvmField
+    val EMPTY: TrailersSource = TrailersSource { Headers.EMPTY }
+  }
+}

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-UtilJvm.kt
@@ -175,6 +175,13 @@ internal fun Source.skipAll(
   }
 }
 
+@Throws(IOException::class)
+internal fun BufferedSource.skipAll() {
+  while (!exhausted()) {
+    skip(buffer.size)
+  }
+}
+
 /**
  * Attempts to exhaust this, returning true if successful. This is useful when reading a complete
  * source is helpful, such as when doing so completes a cache body or frees a socket connection for

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Exchange.kt
@@ -150,7 +150,11 @@ class Exchange(
   }
 
   fun webSocketUpgradeFailed() {
-    bodyComplete(-1L, responseDone = true, requestDone = true, e = null)
+    bodyComplete(
+      responseDone = true,
+      requestDone = true,
+      e = null,
+    )
   }
 
   fun noNewExchangesOnConnection() {
@@ -167,7 +171,12 @@ class Exchange(
    */
   fun detachWithViolence() {
     codec.cancel()
-    call.messageDone(this, requestDone = true, responseDone = true, e = null)
+    call.messageDone(
+      exchange = this,
+      requestDone = true,
+      responseDone = true,
+      e = null,
+    )
   }
 
   private fun trackFailure(e: IOException) {
@@ -176,9 +185,9 @@ class Exchange(
   }
 
   fun <E : IOException?> bodyComplete(
-    bytesRead: Long,
-    responseDone: Boolean,
-    requestDone: Boolean,
+    bytesRead: Long = -1L,
+    responseDone: Boolean = false,
+    requestDone: Boolean = false,
     e: E,
   ): E {
     if (e != null) {
@@ -198,11 +207,20 @@ class Exchange(
         eventListener.responseBodyEnd(call, bytesRead)
       }
     }
-    return call.messageDone(this, requestDone, responseDone, e)
+    return call.messageDone(
+      exchange = this,
+      requestDone = requestDone,
+      responseDone = responseDone,
+      e = e,
+    )
   }
 
   fun noRequestBody() {
-    call.messageDone(this, requestDone = true, responseDone = false, e = null)
+    call.messageDone(
+      exchange = this,
+      requestDone = true,
+      e = null,
+    )
   }
 
   /** A request body that fires events when it completes. */
@@ -261,7 +279,11 @@ class Exchange(
     private fun <E : IOException?> complete(e: E): E {
       if (completed) return e
       completed = true
-      return bodyComplete(bytesReceived, responseDone = false, requestDone = true, e = e)
+      return bodyComplete(
+        bytesRead = bytesReceived,
+        requestDone = true,
+        e = e,
+      )
     }
   }
 
@@ -306,9 +328,6 @@ class Exchange(
         }
 
         bytesReceived = newBytesReceived
-        if (newBytesReceived == contentLength) {
-          complete(null)
-        }
 
         return read
       } catch (e: IOException) {
@@ -336,7 +355,11 @@ class Exchange(
         invokeStartEvent = false
         eventListener.responseBodyStart(call)
       }
-      return bodyComplete(bytesReceived, responseDone = true, requestDone = false, e = e)
+      return bodyComplete(
+        bytesRead = bytesReceived,
+        responseDone = true,
+        e = e,
+      )
     }
   }
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -309,8 +309,8 @@ class RealCall(
    */
   internal fun <E : IOException?> messageDone(
     exchange: Exchange,
-    requestDone: Boolean,
-    responseDone: Boolean,
+    requestDone: Boolean = false,
+    responseDone: Boolean = false,
     e: E,
   ): E {
     if (exchange != this.exchange) return e // This exchange was detached violently!

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -299,7 +299,12 @@ class RealConnection(
     noNewExchanges()
     return object : RealWebSocket.Streams(true, source, sink) {
       override fun close() {
-        exchange.bodyComplete<IOException?>(-1L, responseDone = true, requestDone = true, e = null)
+        exchange.bodyComplete<IOException?>(
+          bytesRead = -1L,
+          responseDone = true,
+          requestDone = true,
+          e = null,
+        )
       }
 
       override fun cancel() {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -192,7 +192,6 @@ class Http1ExchangeCodec(
           .code(statusLine.code)
           .message(statusLine.message)
           .headers(headersReader.readHeaders())
-          .trailers { error("trailers not available") }
 
       return when {
         expectContinue && statusLine.code == HTTP_CONTINUE -> {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
@@ -205,7 +205,6 @@ class Http2ExchangeCodec(
         .code(statusLine.code)
         .message(statusLine.message)
         .headers(headersBuilder.build())
-        .trailers { error("trailers not available") }
     }
   }
 }

--- a/okhttp/src/jvmTest/kotlin/okhttp3/ResponseJvmTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/ResponseJvmTest.kt
@@ -37,19 +37,6 @@ class ResponseJvmTest {
   }
 
   @Test
-  fun testFailsIfTrailersNotSet() {
-    val response =
-      newResponse("".toResponseBody()) {
-        // All live paths (Http1, Http2) in OkHttp do this
-        trailers { error("trailers not available") }
-      }
-
-    assertFailsWith<IllegalStateException>(message = "trailers not available") {
-      response.trailers()
-    }
-  }
-
-  @Test
   fun worksIfTrailersSet() {
     val response =
       newResponse("".toResponseBody()) {

--- a/okhttp/src/jvmTest/kotlin/okhttp3/TrailersTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/TrailersTest.kt
@@ -1,0 +1,361 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isIn
+import assertk.assertions.isLessThan
+import java.lang.Thread.sleep
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTime
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.SocketPolicy
+import okhttp3.Headers.Companion.headersOf
+import okhttp3.testing.PlatformRule
+import okio.IOException
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import okio.use
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@Timeout(30)
+open class TrailersTest {
+  private val fileSystem = FakeFileSystem()
+
+  @JvmField
+  @RegisterExtension
+  val platform = PlatformRule()
+
+  @RegisterExtension
+  val clientTestRule = OkHttpClientTestRule()
+
+  private lateinit var server: MockWebServer
+
+  private var client =
+    clientTestRule
+      .newClientBuilder()
+      .cache(Cache(fileSystem, "/cache/".toPath(), Long.MAX_VALUE))
+      .build()
+
+  @BeforeEach
+  fun setUp(server: MockWebServer) {
+    this.server = server
+  }
+
+  @Test
+  fun trailersHttp1() {
+    trailers(Protocol.HTTP_1_1)
+  }
+
+  @Test
+  fun trailersHttp2() {
+    trailers(Protocol.HTTP_2)
+  }
+
+  private fun trailers(protocol: Protocol) {
+    enableProtocol(protocol)
+
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .addHeader("h1", "v1")
+        .trailers(headersOf("t1", "v2"))
+        .body(protocol, "Hello")
+        .build(),
+    )
+
+    val call = client.newCall(Request(server.url("/")))
+    call.execute().use { response ->
+      val source = response.body.source()
+      assertThat(response.header("h1")).isEqualTo("v1")
+      assertThat(source.readUtf8()).isEqualTo("Hello")
+      assertThat(response.trailers()).isEqualTo(headersOf("t1", "v2"))
+      assertThat(response.trailers()).isEqualTo(headersOf("t1", "v2")) // Idempotent.
+    }
+  }
+
+  @Test
+  fun trailersWithoutReadingFullResponseBodyHttp1() {
+    trailersWithoutReadingFullResponseBody(Protocol.HTTP_1_1)
+  }
+
+  @Test
+  fun trailersWithoutReadingFullResponseBodyHttp2() {
+    trailersWithoutReadingFullResponseBody(Protocol.HTTP_2)
+  }
+
+  private fun trailersWithoutReadingFullResponseBody(protocol: Protocol) {
+    enableProtocol(protocol)
+
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .addHeader("h1", "v1")
+        .trailers(headersOf("t1", "v2"))
+        .body(protocol, "Hello")
+        .build(),
+    )
+
+    val call = client.newCall(Request(server.url("/")))
+    call.execute().use { response ->
+      assertThat(response.header("h1")).isEqualTo("v1")
+      assertThat(response.trailers()).isEqualTo(headersOf("t1", "v2"))
+    }
+  }
+
+  @Test
+  @Disabled
+  fun trailersAndCacheHttp1() {
+    trailersAndCache(Protocol.HTTP_1_1)
+  }
+
+  @Test
+  @Disabled
+  fun trailersAndCacheHttp2() {
+    trailersAndCache(Protocol.HTTP_2)
+  }
+
+  private fun trailersAndCache(protocol: Protocol) {
+    enableProtocol(protocol)
+
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .addHeader("h1", "v1")
+        .addHeader("Cache-Control: max-age=30")
+        .body(protocol, "Hello")
+        .trailers(headersOf("t1", "v2"))
+        .build(),
+    )
+
+    val call1 = client.newCall(Request(server.url("/")))
+    call1.execute().use { response ->
+      val source = response.body.source()
+      assertThat(response.header("h1")).isEqualTo("v1")
+      assertThat(source.readUtf8()).isEqualTo("Hello")
+      assertThat(response.trailers()).isEqualTo(headersOf("t1", "v2"))
+    }
+
+    val call2 = client.newCall(Request(server.url("/")))
+    call2.execute().use { response ->
+      val source = response.body.source()
+      assertThat(response.header("h1")).isEqualTo("v1")
+      assertThat(source.readUtf8()).isEqualTo("Hello")
+      assertThat(response.trailers()).isEqualTo(headersOf("t1", "v2"))
+    }
+  }
+
+  @Test
+  fun delayBeforeTrailersHttp1() {
+    delayBeforeTrailers(Protocol.HTTP_1_1)
+  }
+
+  @Test
+  fun delayBeforeTrailersHttp2() {
+    trailers(Protocol.HTTP_2)
+  }
+
+  /** Confirm the client will block if necessary to consume trailers. */
+  private fun delayBeforeTrailers(protocol: Protocol) {
+    enableProtocol(protocol)
+
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .addHeader("h1", "v1")
+        .trailers(headersOf("t1", "v2"))
+        .body(protocol, "Hello")
+        .trailersDelay(500, TimeUnit.MILLISECONDS)
+        .build(),
+    )
+
+    val call = client.newCall(Request(server.url("/")))
+    call.execute().use { response ->
+      val source = response.body.source()
+      assertThat(response.header("h1")).isEqualTo("v1")
+      assertThat(source.readUtf8(5)).isEqualTo("Hello")
+      val trailersDelay =
+        measureTime {
+          val trailers = response.trailers()
+          assertThat(trailers).isEqualTo(headersOf("t1", "v2"))
+        }
+      assertThat(trailersDelay).isGreaterThan(250.milliseconds)
+    }
+  }
+
+  @Test
+  fun disconnectBeforeTrailersHttp1() {
+    disconnectBeforeTrailers(Protocol.HTTP_1_1)
+  }
+
+  @Test
+  fun disconnectBeforeTrailersHttp2() {
+    disconnectBeforeTrailers(Protocol.HTTP_2)
+  }
+
+  /** Confirm we can get an [IOException] reading trailers. */
+  private fun disconnectBeforeTrailers(protocol: Protocol) {
+    enableProtocol(protocol)
+
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .addHeader("h1", "v1")
+        .trailers(headersOf("t1", "v2"))
+        .body(protocol, "Hello")
+        .socketPolicy(SocketPolicy.DisconnectDuringResponseBody)
+        .build(),
+    )
+
+    val call = client.newCall(Request(server.url("/")))
+    call.execute().use { response ->
+      assertThat(response.header("h1")).isEqualTo("v1")
+      assertFailsWith<IOException> {
+        response.trailers()
+      }
+    }
+  }
+
+  @Test
+  fun cannotReadTrailersAfterEarlyResponseCloseHttp1() {
+    cannotReadTrailersAfterEarlyResponseClose(Protocol.HTTP_1_1)
+  }
+
+  @Test
+  fun cannotReadTrailersAfterEarlyResponseCloseHttp2() {
+    cannotReadTrailersAfterEarlyResponseClose(Protocol.HTTP_2)
+  }
+
+  private fun cannotReadTrailersAfterEarlyResponseClose(protocol: Protocol) {
+    enableProtocol(protocol)
+
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .addHeader("h1", "v1")
+        .trailers(headersOf("t1", "v2"))
+        .body(protocol, "Hello")
+        .build(),
+    )
+
+    val call = client.newCall(Request(server.url("/")))
+    call.execute().use { response ->
+      assertThat(response.header("h1")).isEqualTo("v1")
+      response.close()
+      assertFailsWith<IllegalStateException> {
+        response.trailers()
+      }
+    }
+  }
+
+  @Test
+  fun cancelWhileReadingTrailersHttp1() {
+    cancelWhileReadingTrailers(Protocol.HTTP_1_1)
+  }
+
+  @Test
+  fun cancelWhileReadingTrailersHttp2() {
+    cancelWhileReadingTrailers(Protocol.HTTP_2)
+  }
+
+  private fun cancelWhileReadingTrailers(protocol: Protocol) {
+    enableProtocol(protocol)
+
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .addHeader("h1", "v1")
+        .trailers(headersOf("t1", "v2"))
+        .body(protocol, "Hello")
+        .trailersDelay(1, TimeUnit.SECONDS)
+        .build(),
+    )
+
+    val call = client.newCall(Request(server.url("/")))
+    call.execute().use { response ->
+      val source = response.body.source()
+      assertThat(response.header("h1")).isEqualTo("v1")
+      assertThat(source.readUtf8(5)).isEqualTo("Hello")
+      call.cancelLater(500.milliseconds)
+      val trailersDelay =
+        measureTime {
+          val exception =
+            assertFailsWith<IOException> {
+              val trailers = response.trailers()
+              println(trailers)
+            }
+          assertThat(exception.message).isIn(
+            "Socket closed",
+            "stream was reset: CANCEL",
+          )
+        }
+      assertThat(trailersDelay).isGreaterThan(250.milliseconds)
+      assertThat(trailersDelay).isLessThan(750.milliseconds)
+    }
+  }
+
+  private fun MockResponse.Builder.body(
+    protocol: Protocol,
+    body: String,
+  ) = apply {
+    when (protocol) {
+      Protocol.HTTP_1_1 -> chunkedBody(body)
+      else -> body(body)
+    }
+  }
+
+  private fun enableProtocol(protocol: Protocol) {
+    if (protocol == Protocol.HTTP_2) {
+      enableTls()
+      client =
+        client
+          .newBuilder()
+          .protocols(listOf(protocol, Protocol.HTTP_1_1))
+          .build()
+      server.protocols = client.protocols
+    }
+  }
+
+  private fun enableTls() {
+    val handshakeCertificates = platform.localhostHandshakeCertificates()
+    client =
+      client
+        .newBuilder()
+        .sslSocketFactory(
+          handshakeCertificates.sslSocketFactory(),
+          handshakeCertificates.trustManager,
+        ).build()
+    server.useHttps(handshakeCertificates.sslSocketFactory())
+  }
+
+  private fun Call.cancelLater(delay: Duration) {
+    thread(name = "canceler") {
+      sleep(delay.inWholeMilliseconds)
+      cancel()
+    }
+  }
+}


### PR DESCRIPTION
This doesn't change much.

The new interface replaces a Kotlin lambda that had similar behavior, though that lambda wasn't specified as thoroughly.

We now permit calls to Response.trailers() before the entire response body is consumed. But when such calls are made the response body is discarded first. This could be a bit of a surprise to users, especially users who do an additional layer of buffering over their ResponseBody because it could yield latent failures.

But I think it's better behavior overall, especially since it's possible data binding layers might not consume the entire response body in all cases. For example, a JSON library might not read to the very end of the response if it has received a terminating '}' byte.

The riskiest part of this change is when ResponseBodySource self-reports as complete. Previously it would self-report as complete when it returned as many bytes as promised in the Content-Length. With this change it will now only report itself complete when it receives a definitive EOF on the stream, signaled by a -1 byte count on a read. This is because only when the EOF is received can we be sure that the trailers are received, and we must not unhook the Exchange from the Call until that happens. The previous behavior could make Call.cancel() no-op even if we were blocked waiting on trailers.