### PR TITLE
Promote Path.asRequestBody()

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
@@ -181,7 +181,6 @@ abstract class RequestBody {
     /** Returns a new request body that transmits the content of this. */
     @JvmStatic
     @JvmName("create")
-    @ExperimentalOkHttpApi
     fun Path.asRequestBody(
       fileSystem: FileSystem,
       contentType: MediaType? = null,


### PR DESCRIPTION
It's reasonable and it's tested.