### PR TITLE
Temporarily remove AddressPolicy from the public API

### DIFF
--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -339,16 +339,6 @@ public final class okhttp3/ConnectionPool {
 	public final fun connectionCount ()I
 	public final fun evictAll ()V
 	public final fun idleConnectionCount ()I
-	public final fun setPolicy (Lokhttp3/Address;Lokhttp3/ConnectionPool$AddressPolicy;)V
-}
-
-public final class okhttp3/ConnectionPool$AddressPolicy {
-	public final field backoffDelayMillis J
-	public final field backoffJitterMillis I
-	public final field minimumConcurrentCalls I
-	public fun <init> ()V
-	public fun <init> (IJI)V
-	public synthetic fun <init> (IJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class okhttp3/ConnectionSpec {

--- a/okhttp/api/jvm/okhttp.api
+++ b/okhttp/api/jvm/okhttp.api
@@ -339,16 +339,6 @@ public final class okhttp3/ConnectionPool {
 	public final fun connectionCount ()I
 	public final fun evictAll ()V
 	public final fun idleConnectionCount ()I
-	public final fun setPolicy (Lokhttp3/Address;Lokhttp3/ConnectionPool$AddressPolicy;)V
-}
-
-public final class okhttp3/ConnectionPool$AddressPolicy {
-	public final field backoffDelayMillis J
-	public final field backoffJitterMillis I
-	public final field minimumConcurrentCalls I
-	public fun <init> ()V
-	public fun <init> (IJI)V
-	public synthetic fun <init> (IJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class okhttp3/ConnectionSpec {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionPool.kt
@@ -125,32 +125,4 @@ class ConnectionPool internal constructor(
   fun evictAll() {
     delegate.evictAll()
   }
-
-  /**
-   * Sets a policy that applies to [address].
-   * Overwrites any existing policy for that address.
-   */
-  @ExperimentalOkHttpApi
-  fun setPolicy(
-    address: Address,
-    policy: AddressPolicy,
-  ) {
-    delegate.setPolicy(address, policy)
-  }
-
-  /**
-   * A policy for how the pool should treat a specific address.
-   */
-  class AddressPolicy(
-    /**
-     * How many concurrent calls should be possible to make at any time.
-     * The pool will routinely try to pre-emptively open connections to satisfy this minimum.
-     * Connections will still be closed if they idle beyond the keep-alive but will be replaced.
-     */
-    @JvmField val minimumConcurrentCalls: Int = 0,
-    /** How long to wait to retry pre-emptive connection attempts that fail. */
-    @JvmField val backoffDelayMillis: Long = 60 * 1000,
-    /** How much jitter to introduce in connection retry backoff delays */
-    @JvmField val backoffJitterMillis: Int = 100,
-  )
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/AddressPolicy.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/AddressPolicy.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.connection
+
+/**
+ * A policy for how the pool should treat a specific address.
+ */
+class AddressPolicy(
+  /**
+   * How many concurrent calls should be possible to make at any time.
+   * The pool will routinely try to pre-emptively open connections to satisfy this minimum.
+   * Connections will still be closed if they idle beyond the keep-alive but will be replaced.
+   */
+  @JvmField val minimumConcurrentCalls: Int = 0,
+  /** How long to wait to retry pre-emptive connection attempts that fail. */
+  @JvmField val backoffDelayMillis: Long = 60 * 1000,
+  /** How much jitter to introduce in connection retry backoff delays */
+  @JvmField val backoffJitterMillis: Int = 100,
+)

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -370,7 +370,7 @@ class RealConnectionPool internal constructor(
    */
   fun setPolicy(
     address: Address,
-    policy: ConnectionPool.AddressPolicy,
+    policy: AddressPolicy,
   ) {
     val state = AddressState(address, taskRunner.newQueue(), policy)
     val newConnectionsNeeded: Int
@@ -442,7 +442,7 @@ class RealConnectionPool internal constructor(
   class AddressState(
     val address: Address,
     val queue: TaskQueue,
-    var policy: ConnectionPool.AddressPolicy,
+    var policy: AddressPolicy,
   ) {
     /**
      * How many calls the pool can carry without opening new connections. This field must only be

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -222,7 +222,7 @@ class ConnectionPoolTest {
     val pool = routePlanner.pool
 
     // Connections are created as soon as a policy is set
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(2))
+    setPolicy(pool, address, AddressPolicy(2))
     assertThat(pool.connectionCount()).isEqualTo(2)
 
     // Connections are replaced if they idle out or are evicted from the pool
@@ -232,7 +232,7 @@ class ConnectionPoolTest {
     assertThat(pool.connectionCount()).isEqualTo(2)
 
     // Excess connections aren't removed until they idle out, even if no longer needed
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(1))
+    setPolicy(pool, address, AddressPolicy(1))
     assertThat(pool.connectionCount()).isEqualTo(2)
     forceConnectionsToExpire(pool, expireTime)
     assertThat(pool.connectionCount()).isEqualTo(1)
@@ -251,7 +251,7 @@ class ConnectionPoolTest {
 
     // Add a connection to the pool that won't expire for a while
     routePlanner.defaultConnectionIdleAtNanos = expireLater
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(1))
+    setPolicy(pool, address, AddressPolicy(1))
     assertThat(pool.connectionCount()).isEqualTo(1)
 
     // All other connections created will expire sooner
@@ -261,7 +261,7 @@ class ConnectionPoolTest {
     // which can satisfy a larger policy
     val connection = routePlanner.plans.first().connection
     val http2Connection = connectHttp2(peer, connection, 5)
-    setPolicy(pool, address, ConnectionPool.AddressPolicy(5))
+    setPolicy(pool, address, AddressPolicy(5))
     assertThat(pool.connectionCount()).isEqualTo(1)
 
     // Decrease the connection's max so that another connection is needed
@@ -277,7 +277,7 @@ class ConnectionPoolTest {
   private fun setPolicy(
     pool: RealConnectionPool,
     address: Address,
-    policy: ConnectionPool.AddressPolicy,
+    policy: AddressPolicy,
   ) {
     pool.setPolicy(address, policy)
     taskFaker.runTasks()


### PR DESCRIPTION
I would like to do more work on the API and implementation before committing to this API, and I want to do that after we cut 5.0 final.