### PR TITLE
Move gzip() from RequestBody to Request.Builder

### DIFF
--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
@@ -34,7 +34,6 @@ import okhttp3.Protocol
 import okhttp3.RecordingHostnameVerifier
 import okhttp3.Request
 import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.gzip
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.logging.HttpLoggingInterceptor.Level
 import okhttp3.testing.PlatformRule
@@ -586,8 +585,8 @@ class HttpLoggingInterceptorTest {
       client
         .newCall(
           request()
-            .addHeader("Content-Encoding", "gzip")
-            .post("Uncompressed".toRequestBody().gzip())
+            .post("Uncompressed".toRequestBody())
+            .gzip()
             .build(),
         ).execute()
     val responseBody = response.body

--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -1017,6 +1017,7 @@ public class okhttp3/Request$Builder {
 	public fun delete (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
 	public static synthetic fun delete$default (Lokhttp3/Request$Builder;Lokhttp3/RequestBody;ILjava/lang/Object;)Lokhttp3/Request$Builder;
 	public fun get ()Lokhttp3/Request$Builder;
+	public final fun gzip ()Lokhttp3/Request$Builder;
 	public fun head ()Lokhttp3/Request$Builder;
 	public fun header (Ljava/lang/String;Ljava/lang/String;)Lokhttp3/Request$Builder;
 	public fun headers (Lokhttp3/Headers;)Lokhttp3/Request$Builder;
@@ -1054,7 +1055,6 @@ public abstract class okhttp3/RequestBody {
 	public static final fun create ([BLokhttp3/MediaType;)Lokhttp3/RequestBody;
 	public static final fun create ([BLokhttp3/MediaType;I)Lokhttp3/RequestBody;
 	public static final fun create ([BLokhttp3/MediaType;II)Lokhttp3/RequestBody;
-	public static final fun gzip (Lokhttp3/RequestBody;)Lokhttp3/RequestBody;
 	public fun isDuplex ()Z
 	public fun isOneShot ()Z
 	public abstract fun writeTo (Lokio/BufferedSink;)V
@@ -1083,7 +1083,6 @@ public final class okhttp3/RequestBody$Companion {
 	public static synthetic fun create$default (Lokhttp3/RequestBody$Companion;Lokio/ByteString;Lokhttp3/MediaType;ILjava/lang/Object;)Lokhttp3/RequestBody;
 	public static synthetic fun create$default (Lokhttp3/RequestBody$Companion;Lokio/Path;Lokio/FileSystem;Lokhttp3/MediaType;ILjava/lang/Object;)Lokhttp3/RequestBody;
 	public static synthetic fun create$default (Lokhttp3/RequestBody$Companion;[BLokhttp3/MediaType;IIILjava/lang/Object;)Lokhttp3/RequestBody;
-	public final fun gzip (Lokhttp3/RequestBody;)Lokhttp3/RequestBody;
 }
 
 public final class okhttp3/Response : java/io/Closeable {

--- a/okhttp/api/jvm/okhttp.api
+++ b/okhttp/api/jvm/okhttp.api
@@ -1017,6 +1017,7 @@ public class okhttp3/Request$Builder {
 	public fun delete (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
 	public static synthetic fun delete$default (Lokhttp3/Request$Builder;Lokhttp3/RequestBody;ILjava/lang/Object;)Lokhttp3/Request$Builder;
 	public fun get ()Lokhttp3/Request$Builder;
+	public final fun gzip ()Lokhttp3/Request$Builder;
 	public fun head ()Lokhttp3/Request$Builder;
 	public fun header (Ljava/lang/String;Ljava/lang/String;)Lokhttp3/Request$Builder;
 	public fun headers (Lokhttp3/Headers;)Lokhttp3/Request$Builder;
@@ -1054,7 +1055,6 @@ public abstract class okhttp3/RequestBody {
 	public static final fun create ([BLokhttp3/MediaType;)Lokhttp3/RequestBody;
 	public static final fun create ([BLokhttp3/MediaType;I)Lokhttp3/RequestBody;
 	public static final fun create ([BLokhttp3/MediaType;II)Lokhttp3/RequestBody;
-	public static final fun gzip (Lokhttp3/RequestBody;)Lokhttp3/RequestBody;
 	public fun isDuplex ()Z
 	public fun isOneShot ()Z
 	public abstract fun writeTo (Lokio/BufferedSink;)V
@@ -1083,7 +1083,6 @@ public final class okhttp3/RequestBody$Companion {
 	public static synthetic fun create$default (Lokhttp3/RequestBody$Companion;Lokio/ByteString;Lokhttp3/MediaType;ILjava/lang/Object;)Lokhttp3/RequestBody;
 	public static synthetic fun create$default (Lokhttp3/RequestBody$Companion;Lokio/Path;Lokio/FileSystem;Lokhttp3/MediaType;ILjava/lang/Object;)Lokhttp3/RequestBody;
 	public static synthetic fun create$default (Lokhttp3/RequestBody$Companion;[BLokhttp3/MediaType;IIILjava/lang/Object;)Lokhttp3/RequestBody;
-	public final fun gzip (Lokhttp3/RequestBody;)Lokhttp3/RequestBody;
 }
 
 public final class okhttp3/Response : java/io/Closeable {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/RequestBody.kt
@@ -24,9 +24,7 @@ import okhttp3.internal.chooseCharset
 import okio.BufferedSink
 import okio.ByteString
 import okio.FileSystem
-import okio.GzipSink
 import okio.Path
-import okio.buffer
 import okio.source
 
 abstract class RequestBody {
@@ -257,35 +255,5 @@ abstract class RequestBody {
       contentType: MediaType?,
       file: File,
     ): RequestBody = file.asRequestBody(contentType)
-
-    /**
-     * Returns a gzip version of the RequestBody, with compressed payload.
-     * This is not automatic as not all servers support gzip compressed requests.
-     *
-     * ```
-     * val request = Request.Builder().url("...")
-     *  .addHeader("Content-Encoding", "gzip")
-     *  .post(uncompressedBody.gzip())
-     *  .build()
-     * ```
-     */
-    @JvmStatic
-    @ExperimentalOkHttpApi
-    fun RequestBody.gzip(): RequestBody {
-      return object : RequestBody() {
-        override fun contentType(): MediaType? = this@gzip.contentType()
-
-        override fun contentLength(): Long {
-          return -1 // We don't know the compressed length in advance!
-        }
-
-        @Throws(IOException::class)
-        override fun writeTo(sink: BufferedSink) {
-          GzipSink(sink).buffer().use(this@gzip::writeTo)
-        }
-
-        override fun isOneShot(): Boolean = this@gzip.isOneShot()
-      }
-    }
   }
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/GzipRequestBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/GzipRequestBody.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.http
+
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.GzipSink
+import okio.buffer
+
+internal class GzipRequestBody(
+  val delegate: RequestBody,
+) : RequestBody() {
+  override fun contentType() = delegate.contentType()
+
+  // We don't know the compressed length in advance!
+  override fun contentLength() = -1L
+
+  override fun writeTo(sink: BufferedSink) {
+    GzipSink(sink).buffer().use(delegate::writeTo)
+  }
+
+  override fun isOneShot() = delegate.isOneShot()
+}

--- a/samples/guide/src/main/java/okhttp3/recipes/RequestBodyCompression.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/RequestBodyCompression.java
@@ -27,9 +27,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okio.BufferedSink;
-import okio.GzipSink;
-import okio.Okio;
 
 public final class RequestBodyCompression {
   /**
@@ -78,28 +75,9 @@ public final class RequestBodyCompression {
       }
 
       Request compressedRequest = originalRequest.newBuilder()
-          .header("Content-Encoding", "gzip")
-          .method(originalRequest.method(), gzip(originalRequest.body()))
+          .gzip()
           .build();
       return chain.proceed(compressedRequest);
-    }
-
-    private RequestBody gzip(final RequestBody body) {
-      return new RequestBody() {
-        @Override public MediaType contentType() {
-          return body.contentType();
-        }
-
-        @Override public long contentLength() {
-          return -1; // We don't know the compressed length in advance!
-        }
-
-        @Override public void writeTo(BufferedSink sink) throws IOException {
-          BufferedSink gzipSink = Okio.buffer(new GzipSink(sink));
-          body.writeTo(gzipSink);
-          gzipSink.close();
-        }
-      };
     }
   }
 }


### PR DESCRIPTION
On Request.Builder the one function can add the header and apply compression. Otherwise the caller needs to keep those calls in sync.

One severe drawback of this approach is the calls to Request.Builder are now ordered. If you call gzip() before you call post(), it'll crash. Worse, if you call post() and then gzip() and then post() again
with a different body, it'll silently not compress the new body. I don't love this drawback but I think the mitigations aren't worth the effort.