### PR TITLE
Add a test and fix for non-robolectric android test.

### DIFF
--- a/android-test/src/test/kotlin/okhttp/android/test/BaseOkHttpClientUnitTest.kt
+++ b/android-test/src/test/kotlin/okhttp/android/test/BaseOkHttpClientUnitTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package okhttp.android.test
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import java.net.InetAddress
+import java.net.UnknownHostException
+import okhttp3.Cache
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.AssumptionViolatedException
+import org.junit.Before
+import org.junit.Test
+
+abstract class BaseOkHttpClientUnitTest {
+  private lateinit var client: OkHttpClient
+
+  @Before
+  fun setUp() {
+    client =
+      OkHttpClient
+        .Builder()
+        .cache(Cache(FakeFileSystem(), "/cache".toPath(), 10_000_000))
+        .build()
+  }
+
+  @Test
+  fun testRequestExternal() {
+    assumeNetwork()
+
+    val request = Request("https://www.google.com/robots.txt".toHttpUrl())
+
+    val networkRequest =
+      request
+        .newBuilder()
+        .build()
+
+    val call = client.newCall(networkRequest)
+
+    call.execute().use { response ->
+      assertThat(response.code).isEqualTo(200)
+      assertThat(response.cacheResponse).isNull()
+    }
+
+    val cachedCall = client.newCall(request)
+
+    cachedCall.execute().use { response ->
+      assertThat(response.code).isEqualTo(200)
+      assertThat(response.cacheResponse).isNotNull()
+    }
+  }
+
+  private fun assumeNetwork() {
+    try {
+      InetAddress.getByName("www.google.com")
+    } catch (uhe: UnknownHostException) {
+      throw AssumptionViolatedException(uhe.message, uhe)
+    }
+  }
+}

--- a/android-test/src/test/kotlin/okhttp/android/test/NonRobolectricOkHttpClientTest.kt
+++ b/android-test/src/test/kotlin/okhttp/android/test/NonRobolectricOkHttpClientTest.kt
@@ -17,11 +17,10 @@
 package okhttp.android.test
 
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.junit.runners.JUnit4
 
-@RunWith(RobolectricTestRunner::class)
-@Config(
-  sdk = [21, 26, 30, 33, 35],
-)
-class RobolectricOkHttpClientTest : BaseOkHttpClientUnitTest()
+/**
+ * Android test running with only stubs.
+ */
+@RunWith(JUnit4::class)
+class NonRobolectricOkHttpClientTest : BaseOkHttpClientUnitTest()

--- a/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
+++ b/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
@@ -104,8 +104,13 @@ object AndroidLog {
   }
 
   fun enable() {
-    for ((logger, tag) in knownLoggers) {
-      enableLogging(logger, tag)
+    try {
+      for ((logger, tag) in knownLoggers) {
+        enableLogging(logger, tag)
+      }
+    } catch (re: RuntimeException) {
+      // Possibly running android unit test without robolectric
+      re.printStackTrace()
     }
   }
 


### PR DESCRIPTION
If Robolectric not active, then unit tests for Android will fail annoyingly.