### PR TITLE
Fix a liveness bug in MockWebServer

### DIFF
--- a/mockwebserver/src/main/kotlin/mockwebserver3/internal/SleepNanos.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/internal/SleepNanos.kt
@@ -30,7 +30,7 @@ internal fun Socket.sleepWhileOpen(nanos: Long) {
     ms -= 100L
   }
 
-  if (ms > 0L || nanos > 0) {
+  if (ms > 0L || ns > 0) {
     Thread.sleep(ms, ns.toInt())
   }
 }

--- a/mockwebserver/src/main/kotlin/mockwebserver3/internal/SleepNanos.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/internal/SleepNanos.kt
@@ -16,9 +16,20 @@
  */
 package mockwebserver3.internal
 
-internal fun sleepNanos(nanos: Long) {
-  val ms = nanos / 1_000_000L
+import java.io.InterruptedIOException
+import java.net.Socket
+
+/** Sleeps [nanos], throwing if the socket is closed before that period has elapsed. */
+internal fun Socket.sleepWhileOpen(nanos: Long) {
+  var ms = nanos / 1_000_000L
   val ns = nanos - (ms * 1_000_000L)
+
+  while (ms > 100) {
+    Thread.sleep(100)
+    if (isClosed) throw InterruptedIOException("socket closed")
+    ms -= 100L
+  }
+
   if (ms > 0L || nanos > 0) {
     Thread.sleep(ms, ns.toInt())
   }

--- a/mockwebserver/src/main/kotlin/mockwebserver3/internal/ThrottledSink.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/internal/ThrottledSink.kt
@@ -16,6 +16,7 @@
  */
 package mockwebserver3.internal
 
+import java.net.Socket
 import okio.Buffer
 import okio.Sink
 
@@ -24,6 +25,7 @@ import okio.Sink
  * this permits any interval to be used.
  */
 internal class ThrottledSink(
+  private val socket: Socket,
   private val delegate: Sink,
   private val bytesPerPeriod: Long,
   private val periodDelayNanos: Long,
@@ -39,7 +41,7 @@ internal class ThrottledSink(
     while (bytesLeft > 0) {
       if (bytesWrittenSinceLastDelay == bytesPerPeriod) {
         flush()
-        sleepNanos(periodDelayNanos)
+        socket.sleepWhileOpen(periodDelayNanos)
         bytesWrittenSinceLastDelay = 0
       }
 


### PR DESCRIPTION
It was possible to configure delays that would be honored after MockWebServer was shut down. With this fix any delay will be abandoned once the server is closed.