### PR TITLE
Change some MockWebServer ergonomics

### DIFF
--- a/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
@@ -24,7 +24,6 @@ import java.util.logging.Level
 import java.util.logging.Logger
 import javax.net.ServerSocketFactory
 import javax.net.ssl.SSLSocketFactory
-import okhttp3.ExperimentalOkHttpApi
 import okhttp3.HttpUrl
 import okhttp3.Protocol
 import org.junit.rules.ExternalResource
@@ -32,7 +31,6 @@ import org.junit.rules.ExternalResource
 class MockWebServer :
   ExternalResource(),
   Closeable {
-  @ExperimentalOkHttpApi
   val delegate = mockwebserver3.MockWebServer()
 
   val requestCount: Int by delegate::requestCount
@@ -62,11 +60,7 @@ class MockWebServer :
   var protocolNegotiationEnabled: Boolean by delegate::protocolNegotiationEnabled
 
   @get:JvmName("protocols")
-  var protocols: List<Protocol>
-    get() = delegate.protocols
-    set(value) {
-      delegate.protocols = value
-    }
+  var protocols: List<Protocol> by delegate::protocols
 
   init {
     delegate.dispatcher = dispatcher.wrap()
@@ -84,27 +78,14 @@ class MockWebServer :
   }
 
   @JvmName("-deprecated_port")
-  @Deprecated(
-    message = "moved to val",
-    replaceWith = ReplaceWith(expression = "port"),
-    level = DeprecationLevel.ERROR,
-  )
   fun getPort(): Int = port
 
   fun toProxyAddress(): Proxy {
     before() // This implicitly starts the delegate.
-    return delegate.toProxyAddress()
+    return delegate.proxyAddress
   }
 
   @JvmName("-deprecated_serverSocketFactory")
-  @Deprecated(
-    message = "moved to var",
-    replaceWith =
-      ReplaceWith(
-        expression = "run { this.serverSocketFactory = serverSocketFactory }",
-      ),
-    level = DeprecationLevel.ERROR,
-  )
   fun setServerSocketFactory(serverSocketFactory: ServerSocketFactory) {
     delegate.serverSocketFactory = serverSocketFactory
   }
@@ -115,47 +96,21 @@ class MockWebServer :
   }
 
   @JvmName("-deprecated_bodyLimit")
-  @Deprecated(
-    message = "moved to var",
-    replaceWith =
-      ReplaceWith(
-        expression = "run { this.bodyLimit = bodyLimit }",
-      ),
-    level = DeprecationLevel.ERROR,
-  )
   fun setBodyLimit(bodyLimit: Long) {
     delegate.bodyLimit = bodyLimit
   }
 
   @JvmName("-deprecated_protocolNegotiationEnabled")
-  @Deprecated(
-    message = "moved to var",
-    replaceWith =
-      ReplaceWith(
-        expression = "run { this.protocolNegotiationEnabled = protocolNegotiationEnabled }",
-      ),
-    level = DeprecationLevel.ERROR,
-  )
   fun setProtocolNegotiationEnabled(protocolNegotiationEnabled: Boolean) {
     delegate.protocolNegotiationEnabled = protocolNegotiationEnabled
   }
 
   @JvmName("-deprecated_protocols")
-  @Deprecated(
-    message = "moved to var",
-    replaceWith = ReplaceWith(expression = "run { this.protocols = protocols }"),
-    level = DeprecationLevel.ERROR,
-  )
   fun setProtocols(protocols: List<Protocol>) {
     delegate.protocols = protocols
   }
 
   @JvmName("-deprecated_protocols")
-  @Deprecated(
-    message = "moved to var",
-    replaceWith = ReplaceWith(expression = "protocols"),
-    level = DeprecationLevel.ERROR,
-  )
   fun protocols(): List<Protocol> = delegate.protocols
 
   fun useHttps(
@@ -187,11 +142,6 @@ class MockWebServer :
   ): RecordedRequest? = delegate.takeRequest(timeout, unit)?.unwrap()
 
   @JvmName("-deprecated_requestCount")
-  @Deprecated(
-    message = "moved to val",
-    replaceWith = ReplaceWith(expression = "requestCount"),
-    level = DeprecationLevel.ERROR,
-  )
   fun getRequestCount(): Int = delegate.requestCount
 
   fun enqueue(response: MockResponse) {

--- a/mockwebserver/api/mockwebserver3.api
+++ b/mockwebserver/api/mockwebserver3.api
@@ -96,12 +96,13 @@ public final class mockwebserver3/MockWebServer : java/io/Closeable {
 	public final fun getBodyLimit ()J
 	public final fun getDispatcher ()Lmockwebserver3/Dispatcher;
 	public final fun getHostName ()Ljava/lang/String;
-	public final fun getInetSocketAddress ()Ljava/net/InetSocketAddress;
 	public final fun getPort ()I
 	public final fun getProtocolNegotiationEnabled ()Z
 	public final fun getProtocols ()Ljava/util/List;
+	public final fun getProxyAddress ()Ljava/net/Proxy;
 	public final fun getRequestCount ()I
 	public final fun getServerSocketFactory ()Ljavax/net/ServerSocketFactory;
+	public final fun getSocketAddress ()Ljava/net/InetSocketAddress;
 	public final fun getStarted ()Z
 	public final fun noClientAuth ()V
 	public final fun requestClientAuth ()V
@@ -111,14 +112,12 @@ public final class mockwebserver3/MockWebServer : java/io/Closeable {
 	public final fun setProtocolNegotiationEnabled (Z)V
 	public final fun setProtocols (Ljava/util/List;)V
 	public final fun setServerSocketFactory (Ljavax/net/ServerSocketFactory;)V
-	public final fun setStarted (Z)V
 	public final fun start ()V
 	public final fun start (I)V
 	public final fun start (Ljava/net/InetAddress;I)V
 	public static synthetic fun start$default (Lmockwebserver3/MockWebServer;IILjava/lang/Object;)V
 	public final fun takeRequest ()Lmockwebserver3/RecordedRequest;
 	public final fun takeRequest (JLjava/util/concurrent/TimeUnit;)Lmockwebserver3/RecordedRequest;
-	public final fun toProxyAddress ()Ljava/net/Proxy;
 	public fun toString ()Ljava/lang/String;
 	public final fun url (Ljava/lang/String;)Lokhttp3/HttpUrl;
 	public final fun useHttps (Ljavax/net/ssl/SSLSocketFactory;)V

--- a/mockwebserver/src/test/java/mockwebserver3/MockResponseSniTest.kt
+++ b/mockwebserver/src/test/java/mockwebserver3/MockResponseSniTest.kt
@@ -194,7 +194,7 @@ class MockResponseSniTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .build()
 
     server.enqueue(

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
@@ -877,21 +877,21 @@ open class CallTest {
       OkHttpClient
         .Builder()
         .connectionPool(client.connectionPool)
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
     executeSynchronously("/a").assertBody("abc")
     client =
       OkHttpClient
         .Builder()
         .connectionPool(client.connectionPool)
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
     executeSynchronously("/b").assertBody("def")
     client =
       OkHttpClient
         .Builder()
         .connectionPool(client.connectionPool)
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
     executeSynchronously("/c").assertBody("ghi")
     assertThat(server.takeRequest().sequenceNumber).isEqualTo(0)
@@ -904,7 +904,7 @@ open class CallTest {
     client =
       OkHttpClient
         .Builder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
     server.enqueue(MockResponse(body = "abc"))
     server.enqueue(MockResponse(body = "def"))
@@ -1039,7 +1039,7 @@ open class CallTest {
   fun connectTimeoutsAttemptsAlternateRoute() {
     val proxySelector = RecordingProxySelector()
     proxySelector.proxies.add(Proxy(Proxy.Type.HTTP, TestUtil.UNREACHABLE_ADDRESS_IPV4))
-    proxySelector.proxies.add(server.toProxyAddress())
+    proxySelector.proxies.add(server.proxyAddress)
     server.enqueue(MockResponse(body = "success!"))
     client =
       client
@@ -1121,8 +1121,8 @@ open class CallTest {
       MockResponse(body = "success!"),
     )
     val proxySelector = RecordingProxySelector()
-    proxySelector.proxies.add(server.toProxyAddress())
-    proxySelector.proxies.add(server2.toProxyAddress())
+    proxySelector.proxies.add(server.proxyAddress)
+    proxySelector.proxies.add(server2.proxyAddress)
     client =
       client
         .newBuilder()
@@ -3660,7 +3660,7 @@ open class CallTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .hostnameVerifier(hostnameVerifier)
         .build()
     val request =
@@ -3706,7 +3706,7 @@ open class CallTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .hostnameVerifier(hostnameVerifier)
         .build()
     val request = Request("https://android.com/foo".toHttpUrl())
@@ -3744,7 +3744,7 @@ open class CallTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .proxyAuthenticator(RecordingOkAuthenticator("password", "Basic"))
         .hostnameVerifier(RecordingHostnameVerifier())
         .build()
@@ -3777,7 +3777,7 @@ open class CallTest {
     client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .proxyAuthenticator(RecordingOkAuthenticator("password", "Basic"))
         .build()
     val request = Request("http://android.com/foo".toHttpUrl())
@@ -3828,7 +3828,7 @@ open class CallTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .proxyAuthenticator(RecordingOkAuthenticator("password", "Basic"))
         .hostnameVerifier(RecordingHostnameVerifier())
         .build()
@@ -3872,7 +3872,7 @@ open class CallTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .proxyAuthenticator(RecordingOkAuthenticator("password", "Basic"))
         .hostnameVerifier(RecordingHostnameVerifier())
         .build()
@@ -3903,7 +3903,7 @@ open class CallTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .hostnameVerifier(RecordingHostnameVerifier())
         .build()
     val request =
@@ -3938,7 +3938,7 @@ open class CallTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .hostnameVerifier(RecordingHostnameVerifier())
         .proxyAuthenticator { _: Route?, response: Response? ->
           assertThat(response!!.request.method).isEqualTo("CONNECT")
@@ -3990,7 +3990,7 @@ open class CallTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .hostnameVerifier(RecordingHostnameVerifier())
         .proxyAuthenticator { _: Route?, response: Response ->
           val challenges = response.challenges()
@@ -4029,7 +4029,7 @@ open class CallTest {
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
-        ).proxy(server.toProxyAddress())
+        ).proxy(server.proxyAddress)
         .build()
     val request = Request(server.url("/"))
     assertFailsWith<IOException> {
@@ -4174,7 +4174,7 @@ open class CallTest {
         .newBuilder()
         .proxySelector(
           FakeProxySelector()
-            .addProxy(server2.toProxyAddress())
+            .addProxy(server2.proxyAddress)
             .addProxy(Proxy.NO_PROXY),
         ).build()
     server2.close()
@@ -4443,7 +4443,7 @@ open class CallTest {
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
         ).hostnameVerifier(RecordingHostnameVerifier())
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
   }
 

--- a/okhttp/src/jvmTest/kotlin/okhttp3/ConnectionListenerTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/ConnectionListenerTest.kt
@@ -312,7 +312,7 @@ open class ConnectionListenerTest {
   @Throws(IOException::class)
   fun successfulHttpProxyConnect() {
     server!!.enqueue(MockResponse())
-    val proxy = server!!.toProxyAddress()
+    val proxy = server!!.proxyAddress
     client =
       client
         .newBuilder()

--- a/okhttp/src/jvmTest/kotlin/okhttp3/EventListenerTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/EventListenerTest.kt
@@ -916,7 +916,7 @@ class EventListenerTest {
     client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
     val call =
       client.newCall(
@@ -935,7 +935,7 @@ class EventListenerTest {
     assertThat(connectStart.call).isSameAs(call)
     assertThat(connectStart.inetSocketAddress).isEqualTo(expectedAddress)
     assertThat(connectStart.proxy).isEqualTo(
-      server.toProxyAddress(),
+      server.proxyAddress,
     )
     val connectEnd = listener.removeUpToEvent<CallEvent.ConnectEnd>()
     assertThat(connectEnd.call).isSameAs(call)
@@ -1001,7 +1001,7 @@ class EventListenerTest {
     client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .proxyAuthenticator(RecordingOkAuthenticator("password", "Basic"))
         .build()
     val call =
@@ -1081,7 +1081,7 @@ class EventListenerTest {
     client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
     val call =
       client.newCall(

--- a/okhttp/src/jvmTest/kotlin/okhttp3/EventListenerTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/EventListenerTest.kt
@@ -1890,6 +1890,7 @@ class EventListenerTest {
   @Test
   fun redirectUsingNewConnectionEventSequence() {
     val otherServer = MockWebServer()
+    otherServer.start()
     server.enqueue(
       MockResponse
         .Builder()
@@ -1937,6 +1938,7 @@ class EventListenerTest {
     assertThat(listener.findEvent<FollowUpDecision>()).all {
       prop(FollowUpDecision::nextRequest).isNotNull()
     }
+    otherServer.close()
   }
 
   @Test

--- a/okhttp/src/jvmTest/kotlin/okhttp3/RouteFailureTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/RouteFailureTest.kt
@@ -94,8 +94,8 @@ class RouteFailureTest {
     server2.enqueue(bodyResponse)
 
     dns[server1.hostName] = listOf(ipv6, ipv4)
-    socketFactory[ipv6] = server1.inetSocketAddress
-    socketFactory[ipv4] = server2.inetSocketAddress
+    socketFactory[ipv6] = server1.socketAddress
+    socketFactory[ipv4] = server2.socketAddress
 
     client =
       client
@@ -131,8 +131,8 @@ class RouteFailureTest {
     server2.enqueue(bodyResponse)
 
     dns[server1.hostName] = listOf(ipv6, ipv4)
-    socketFactory[ipv6] = server1.inetSocketAddress
-    socketFactory[ipv4] = server2.inetSocketAddress
+    socketFactory[ipv6] = server1.socketAddress
+    socketFactory[ipv4] = server2.socketAddress
 
     client =
       client
@@ -174,8 +174,8 @@ class RouteFailureTest {
     server2.enqueue(bodyResponse)
 
     dns[server1.hostName] = listOf(ipv6, ipv4)
-    socketFactory[ipv6] = server1.inetSocketAddress
-    socketFactory[ipv4] = server2.inetSocketAddress
+    socketFactory[ipv6] = server1.socketAddress
+    socketFactory[ipv4] = server2.socketAddress
 
     client =
       client
@@ -211,8 +211,8 @@ class RouteFailureTest {
     server2.enqueue(bodyResponse)
 
     dns[server1.hostName] = listOf(ipv6, ipv4)
-    socketFactory[ipv6] = server1.inetSocketAddress
-    socketFactory[ipv4] = server2.inetSocketAddress
+    socketFactory[ipv6] = server1.socketAddress
+    socketFactory[ipv4] = server2.socketAddress
 
     client =
       client
@@ -254,7 +254,7 @@ class RouteFailureTest {
     server1.enqueue(refusedStream)
 
     dns[server1.hostName] = listOf(ipv6)
-    socketFactory[ipv6] = server1.inetSocketAddress
+    socketFactory[ipv6] = server1.socketAddress
 
     client =
       client
@@ -288,7 +288,7 @@ class RouteFailureTest {
     server1.enqueue(refusedStream)
 
     dns[server1.hostName] = listOf(ipv6)
-    socketFactory[ipv6] = server1.inetSocketAddress
+    socketFactory[ipv6] = server1.socketAddress
 
     client =
       client
@@ -324,13 +324,13 @@ class RouteFailureTest {
     val proxyServer1 = InetAddress.getByAddress("proxyServer1", byteArrayOf(127, 0, 0, 2))
     val proxyServer2 = InetAddress.getByAddress("proxyServer2", byteArrayOf(127, 0, 0, 3))
 
-    println("Proxy Server 1 is ${server1.inetSocketAddress}")
-    println("Proxy Server 2 is ${server2.inetSocketAddress}")
+    println("Proxy Server 1 is ${server1.socketAddress}")
+    println("Proxy Server 2 is ${server2.socketAddress}")
 
     // Since myproxy:8008 won't resolve, redirect with DNS to proxyServer1
     // Then redirect socket connection to server1
     dns["myproxy"] = listOf(proxyServer1)
-    socketFactory[proxyServer1] = server1.inetSocketAddress
+    socketFactory[proxyServer1] = server1.socketAddress
 
     client = client.newBuilder().proxySelector(proxySelector).build()
 
@@ -340,7 +340,7 @@ class RouteFailureTest {
     server2.enqueue(MockResponse(200))
     server2.enqueue(MockResponse(200))
 
-    println("\n\nRequest to ${server1.inetSocketAddress}")
+    println("\n\nRequest to ${server1.socketAddress}")
     executeSynchronously(request)
       .assertSuccessful()
       .assertCode(200)
@@ -356,9 +356,9 @@ class RouteFailureTest {
     // Now redirect with DNS to proxyServer2
     // Then redirect socket connection to server2
     dns["myproxy"] = listOf(proxyServer2)
-    socketFactory[proxyServer2] = server2.inetSocketAddress
+    socketFactory[proxyServer2] = server2.socketAddress
 
-    println("\n\nRequest to ${server2.inetSocketAddress}")
+    println("\n\nRequest to ${server2.socketAddress}")
     executeSynchronously(request)
       .apply {
         // We may have a single failed request if not clean shutdown
@@ -372,7 +372,7 @@ class RouteFailureTest {
         }
       }
 
-    println("\n\nRequest to ${server2.inetSocketAddress}")
+    println("\n\nRequest to ${server2.socketAddress}")
     executeSynchronously(request)
       .assertSuccessful()
       .assertCode(200)

--- a/okhttp/src/jvmTest/kotlin/okhttp3/URLConnectionTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/URLConnectionTest.kt
@@ -298,7 +298,7 @@ class URLConnectionTest {
         .newBuilder()
         .proxySelector(
           FakeProxySelector()
-            .addProxy(server2.toProxyAddress())
+            .addProxy(server2.proxyAddress)
             .addProxy(Proxy.NO_PROXY),
         ).build()
     server2.close()
@@ -1028,7 +1028,7 @@ class URLConnectionTest {
           handshakeCertificates.trustManager,
         ).connectionSpecs(listOf(ConnectionSpec.MODERN_TLS))
         .hostnameVerifier(RecordingHostnameVerifier())
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
     val response =
       getResponse(
@@ -1069,7 +1069,7 @@ class URLConnectionTest {
     client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
@@ -1120,7 +1120,7 @@ class URLConnectionTest {
       client
         .newBuilder()
         .proxyAuthenticator(Authenticator.JAVA_NET_AUTHENTICATOR)
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
@@ -1161,7 +1161,7 @@ class URLConnectionTest {
     client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .sslSocketFactory(
           handshakeCertificates.sslSocketFactory(),
           handshakeCertificates.trustManager,
@@ -1194,7 +1194,7 @@ class URLConnectionTest {
     client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .sslSocketFactory(socketFactory, handshakeCertificates.trustManager)
         .hostnameVerifier(hostnameVerifier)
         .build()
@@ -1215,7 +1215,7 @@ class URLConnectionTest {
         .newBuilder()
         .proxySelector(
           object : ProxySelector() {
-            override fun select(uri: URI): List<Proxy> = listOf(server.toProxyAddress())
+            override fun select(uri: URI): List<Proxy> = listOf(server.proxyAddress)
 
             override fun connectFailed(
               uri: URI,
@@ -1887,7 +1887,7 @@ class URLConnectionTest {
       client =
         client
           .newBuilder()
-          .proxy(server.toProxyAddress())
+          .proxy(server.proxyAddress)
           .proxyAuthenticator(JavaNetAuthenticator())
           .build()
       response = getResponse(Request("http://android.com/".toHttpUrl()))
@@ -2540,7 +2540,7 @@ class URLConnectionTest {
             override fun select(uri: URI): List<Proxy> {
               proxySelectionRequests.add(uri)
               val proxyServer = if (uri.port == server.port) server else server2
-              return listOf(proxyServer.toProxyAddress())
+              return listOf(proxyServer.proxyAddress)
             }
 
             override fun connectFailed(
@@ -4396,7 +4396,7 @@ class URLConnectionTest {
       ): Call.Factory =
         client
           .newBuilder()
-          .proxy(server.toProxyAddress())
+          .proxy(server.proxyAddress)
           .build()
     },
     PROXY_SYSTEM_PROPERTY {

--- a/okhttp/src/jvmTest/kotlin/okhttp3/WholeOperationTimeoutTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/WholeOperationTimeoutTest.kt
@@ -340,6 +340,7 @@ class WholeOperationTimeoutTest {
   @Test
   fun timeoutFollowingRedirectOnNewConnection() {
     val otherServer = MockWebServer()
+    otherServer.start()
     server.enqueue(
       MockResponse
         .Builder()

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -2145,7 +2145,7 @@ class HttpOverHttp2Test {
     client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
     val call1 = client.newCall(Request("https://android.com/call1".toHttpUrl()))
     val response2 = call1.execute()
@@ -2334,7 +2334,7 @@ class HttpOverHttp2Test {
     val client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .build()
 
     val url = server.url("/").resolve("//android.com/foo")!!
@@ -2387,7 +2387,7 @@ class HttpOverHttp2Test {
     val client =
       client
         .newBuilder()
-        .proxy(server.toProxyAddress())
+        .proxy(server.proxyAddress)
         .proxyAuthenticator(RecordingOkAuthenticator("password", "Basic"))
         .build()
 


### PR DESCRIPTION
Now calling MockWebServer.port and similar functions will not implicity start the server. It is instead necessary to explicitly call the start() function.

The problem with the old behavior was that reading the port field could fail with an IOException, which is weird behavior for reading a property.