### PR TITLE
New @StartStop extension for JUnit 5

### DIFF
--- a/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/StartStop.kt
+++ b/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/StartStop.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package mockwebserver3.junit5
+
+import mockwebserver3.junit5.internal.StartStopExtension
+import okhttp3.ExperimentalOkHttpApi
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Runs MockWebServer for the duration of a test method or test class.
+ *
+ * In Java JUnit 5 tests (ie. tests annotated `@org.junit.jupiter.api.Test`), use this by defining a
+ * field with the `@StartStop` annotation:
+ *
+ * ```java
+ * @StartStop public final MockWebServer server = new MockWebServer();
+ * ```
+ *
+ * Or for Kotlin:
+ *
+ * ```kotlin
+ * @StartStop val server = MockWebServer()
+ * ```
+ */
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+@ExtendWith(StartStopExtension::class)
+@ExperimentalOkHttpApi
+annotation class StartStop

--- a/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/StartStopExtension.kt
+++ b/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/StartStopExtension.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package mockwebserver3.junit5.internal
+
+import java.lang.reflect.Modifier
+import mockwebserver3.MockWebServer
+import mockwebserver3.junit5.StartStop
+import okhttp3.ExperimentalOkHttpApi
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace
+import org.junit.platform.commons.support.AnnotationSupport.findAnnotatedFields
+
+/** Implements the policy specified by [StartStop]. */
+@ExperimentalOkHttpApi
+internal class StartStopExtension :
+  BeforeEachCallback,
+  BeforeAllCallback {
+  override fun beforeAll(context: ExtensionContext) {
+    val store = context.getStore(Namespace.create(StartStop::class.java))
+
+    val staticFields =
+      findAnnotatedFields(
+        context.requiredTestClass,
+        StartStop::class.java,
+      ) { Modifier.isStatic(it.modifiers) }
+
+    for (field in staticFields) {
+      field.setAccessible(true)
+      val server = field.get(null) as? MockWebServer ?: continue
+
+      // Put the instance in the store, so JUnit closes it for us in afterAll.
+      store.put(field, server)
+
+      server.start()
+    }
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    val testInstance = context.testInstance.get()
+    val store = context.getStore(Namespace.create(StartStop::class.java))
+
+    val instanceFields =
+      findAnnotatedFields(
+        context.requiredTestClass,
+        StartStop::class.java,
+      ) { !Modifier.isStatic(it.modifiers) }
+
+    for (field in instanceFields) {
+      field.setAccessible(true)
+      val server = field.get(testInstance) as? MockWebServer ?: continue
+
+      // Put the instance in the store, so JUnit closes it for us in afterEach.
+      store.put(field, server)
+
+      server.start()
+    }
+  }
+}

--- a/mockwebserver-junit5/src/test/java/mockwebserver3/junit5/StartStopTest.kt
+++ b/mockwebserver-junit5/src/test/java/mockwebserver3/junit5/StartStopTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package mockwebserver3.junit5
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import java.util.concurrent.CopyOnWriteArrayList
+import mockwebserver3.Dispatcher
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.RecordedRequest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class StartStopTest {
+  private val dispatcherA = ClosableDispatcher()
+
+  @StartStop val serverA =
+    MockWebServer().apply {
+      dispatcher = dispatcherA
+    }
+
+  private val dispatcherB = ClosableDispatcher()
+
+  @StartStop val serverB =
+    MockWebServer().apply {
+      dispatcher = dispatcherB
+    }
+
+  /** This one won't start because it isn't annotated. */
+  private val dispatcherC = ClosableDispatcher()
+  val serverC =
+    MockWebServer().apply {
+      dispatcher = dispatcherC
+    }
+
+  @Test
+  fun happyPath() {
+    testInstances += this
+
+    assertThat(serverA.started).isTrue()
+    assertThat(serverB.started).isTrue()
+    assertThat(serverC.started).isFalse()
+
+    assertThat(serverD.started).isTrue()
+    assertThat(serverE.started).isTrue()
+    assertThat(serverF.started).isFalse()
+  }
+
+  private companion object {
+    val testInstances = CopyOnWriteArrayList<StartStopTest>()
+
+    private val dispatcherD = ClosableDispatcher()
+
+    @StartStop @JvmStatic
+    val serverD =
+      MockWebServer().apply {
+        dispatcher = dispatcherD
+      }
+
+    private val dispatcherE = ClosableDispatcher()
+
+    @StartStop @JvmStatic
+    val serverE =
+      MockWebServer().apply {
+        dispatcher = dispatcherE
+      }
+
+    private val dispatcherF = ClosableDispatcher()
+
+    @JvmStatic val serverF =
+      MockWebServer().apply {
+        dispatcher = dispatcherF
+      }
+
+    @JvmStatic
+    @RegisterExtension
+    val checkClosed =
+      AfterAllCallback {
+        for (test in testInstances) {
+          assertThat(test.dispatcherA.closed).isTrue()
+          assertThat(test.dispatcherB.closed).isTrue()
+          assertThat(test.dispatcherC.closed).isFalse() // Never started.
+        }
+        testInstances.clear()
+
+        // No assertion that serverC and serverD are closed, because the MockWebServerExtension
+        // runs after this callback.
+        if (false) {
+          assertThat(dispatcherD.closed).isTrue()
+          assertThat(dispatcherE.closed).isTrue()
+          assertThat(dispatcherF.closed).isFalse() // Never started.
+        }
+      }
+  }
+
+  class ClosableDispatcher : Dispatcher() {
+    var closed = false
+
+    override fun dispatch(request: RecordedRequest) = MockResponse()
+
+    override fun close() {
+      closed = true
+    }
+  }
+}


### PR DESCRIPTION
This is a new take on our JUnit 5 extension. Rather than creating and managing the MockWebServer instance in the extension, we let the user create it and all the extension does is manage the lifecycle.

Note that this annotation doesn't require any external configuration - it doesn't need a system-property to opt-into 'automatic' extensions, and it doesn't require a class-level extension either.