### PR TITLE
Add a reset method to MockWebServer

### DIFF
--- a/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
+++ b/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/MockWebServer.kt
@@ -183,6 +183,10 @@ class MockWebServer :
   @Throws(IOException::class)
   override fun close() = delegate.close()
 
+  fun reset() {
+    delegate.reset()
+  }
+
   companion object {
     private val logger = Logger.getLogger(MockWebServer::class.java.name)
   }

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -1269,6 +1269,18 @@ public class MockWebServer : Closeable {
     }
   }
 
+  /**
+   * Resets the request queue and count to their initial state.
+   *
+   * This is useful for test suites which start the `MockWebServer` once at the beginning, shut it down at the end,
+   * and reuse it across tests. This can be called in a `BeforeEach` or `AfterEach` method  for the request queue
+   * and count to be reset in between tests.
+   */
+  public fun reset() {
+    requestQueue.clear()
+    atomicRequestCount.set(0)
+  }
+
   private companion object {
     private const val CLIENT_AUTH_NONE = 0
     private const val CLIENT_AUTH_REQUESTED = 1


### PR DESCRIPTION
This is useful for test suites which start the `MockWebServer` once at the beginning, shut it down at the end, and reuse it across tests. This can be called in a `BeforeEach` or `AfterEach` method  for the request queue and count to be reset in between tests.