### PR TITLE
Fix breaking change from alpha.17 release

### DIFF
--- a/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/DeprecationBridge.kt
+++ b/mockwebserver-deprecated/src/main/kotlin/okhttp3/mockwebserver/DeprecationBridge.kt
@@ -112,7 +112,7 @@ internal fun mockwebserver3.RecordedRequest.unwrap(): RecordedRequest =
     sequenceNumber = exchangeIndex,
     failure = failure,
     method = method,
-    path = url.encodedPath,
+    path = target,
     handshake = handshake,
     requestUrl = url,
   )

--- a/mockwebserver-deprecated/src/test/java/okhttp3/mockwebserver/MockWebServerTest.kt
+++ b/mockwebserver-deprecated/src/test/java/okhttp3/mockwebserver/MockWebServerTest.kt
@@ -513,6 +513,7 @@ class MockWebServerTest {
     assertThat(request.requestLine).isEqualTo(
       "GET /a/deep/path?key=foo%20bar HTTP/1.1",
     )
+    assertThat(request.path).isEqualTo("/a/deep/path?key=foo%20bar")
     val requestUrl = request.requestUrl
     assertThat(requestUrl!!.scheme).isEqualTo("http")
     assertThat(requestUrl.host).isEqualTo(server.hostName)


### PR DESCRIPTION
The semantics of the old path property included the query string, and should be mapped from the new `target` which is the equivalent field in the new recorded request. Using url.encodedPath only provides the path component and omits the query component, resulting in a breaking change.