### PR TITLE
Don't force a response body read on all trailers

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Response.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Response.kt
@@ -28,7 +28,6 @@ import okhttp3.internal.connection.Exchange
 import okhttp3.internal.http.HTTP_PERM_REDIRECT
 import okhttp3.internal.http.HTTP_TEMP_REDIRECT
 import okhttp3.internal.http.parseChallenges
-import okhttp3.internal.skipAll
 import okio.Buffer
 
 /**
@@ -191,13 +190,7 @@ class Response internal constructor(
    *     dropped.
    */
   @Throws(IOException::class)
-  fun trailers(): Headers {
-    val source = body.source()
-    if (source.isOpen) {
-      source.skipAll()
-    }
-    return trailersSource.get()
-  }
+  fun trailers(): Headers = trailersSource.get()
 
   /**
    * Peeks up to [byteCount] bytes from the response body and returns them as a new response
@@ -478,7 +471,6 @@ class Response internal constructor(
 
     internal fun initExchange(exchange: Exchange) {
       this.exchange = exchange
-      this.trailersSource = TrailersSource { exchange.trailers() }
     }
 
     open fun build(): Response {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
@@ -21,6 +21,7 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import okhttp3.internal.connection.Exchange
 import okhttp3.internal.http2.ConnectionShutdownException
+import okhttp3.internal.skipAll
 import okhttp3.internal.stripBody
 import okio.buffer
 
@@ -129,10 +130,17 @@ class CallServerInterceptor(
           // Connection is upgrading, but we need to ensure interceptors see a non-null response body.
           response.stripBody()
         } else {
+          val responseBody = exchange.openResponseBody(response)
           response
             .newBuilder()
-            .body(exchange.openResponseBody(response))
-            .build()
+            .body(responseBody)
+            .trailers {
+              val source = responseBody.source()
+              if (source.isOpen) {
+                source.skipAll()
+              }
+              exchange.trailers()
+            }.build()
         }
       if ("close".equals(response.request.header("Connection"), ignoreCase = true) ||
         "close".equals(response.header("Connection"), ignoreCase = true)


### PR DESCRIPTION
We only need to read the response body if its coming from a real server.

Closes: https://github.com/square/okhttp/issues/8902