### PR TITLE
Run most builds on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,6 @@ jobs:
 
   testzulu11:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'zulu')
 
     steps:
       - name: Checkout
@@ -160,7 +159,6 @@ jobs:
 
   testopenjdk8:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'jdkversions') || contains(github.event.pull_request.labels.*.name, 'renovate')
 
     steps:
       - name: Checkout
@@ -323,7 +321,6 @@ jobs:
 
   testopenjdk17:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'jdkversions') || contains(github.event.pull_request.labels.*.name, 'renovate')
 
     steps:
       - name: Checkout
@@ -349,7 +346,6 @@ jobs:
 
   testopenjdk21:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'jdkversions') || contains(github.event.pull_request.labels.*.name, 'renovate')
 
     steps:
       - name: Checkout
@@ -381,7 +377,6 @@ jobs:
 
   testopenjdklatest:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'jdkversions') || contains(github.event.pull_request.labels.*.name, 'renovate')
 
     steps:
       - name: Checkout
@@ -408,8 +403,6 @@ jobs:
 
   testopenjdkearlyaccess:
     runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'jdkversions') || contains(github.event.pull_request.labels.*.name, 'renovate')
-    if: false # https://youtrack.jetbrains.com/issue/KTOR-8489
 
     steps:
       - name: Checkout
@@ -436,8 +429,6 @@ jobs:
 
   testwindows:
     runs-on: windows-latest
-    # TODO add master build after fixing all tests in CI
-    if: contains(github.event.pull_request.labels.*.name, 'windows')
 
     steps:
       - name: Checkout
@@ -463,7 +454,6 @@ jobs:
 
   testgraal:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'graal')
 
     steps:
       - name: Checkout
@@ -504,7 +494,6 @@ jobs:
   testandroid:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'android') || contains(github.event.pull_request.labels.*.name, 'renovate')
 
     strategy:
       fail-fast: false
@@ -583,7 +572,6 @@ jobs:
 
   testloom:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'loom')
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,6 +403,7 @@ jobs:
 
   testopenjdkearlyaccess:
     runs-on: ubuntu-latest
+    if: false # https://youtrack.jetbrains.com/issue/KTOR-8489
 
     steps:
       - name: Checkout

--- a/okcurl/src/test/kotlin/okhttp3/curl/OkcurlTest.kt
+++ b/okcurl/src/test/kotlin/okhttp3/curl/OkcurlTest.kt
@@ -16,9 +16,18 @@
 package okhttp3.curl
 
 import com.github.ajalt.clikt.core.main
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import okhttp3.TestUtil.assumeNotWindows
 
 class OkcurlTest {
+  @BeforeTest
+  fun skipWindows() {
+    // Failing with
+    // org.gradle.internal.remote.internal.MessageIOException: Could not write '/127.0.0.1:16225'.
+    assumeNotWindows()
+  }
+
   @Test
   fun simple() {
     Main().main(listOf("--help"))


### PR DESCRIPTION
Seems that the filtered set is not a popular approach. Assuming we have mostly non flaky builds, run more things on all builds (main, branches, prs).