### PR TITLE
Add test demonstrating topPrivateDomain on Robolectric

### DIFF
--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -41,6 +41,7 @@ android {
 
   testOptions {
     targetSdk = 34
+    unitTests.isIncludeAndroidResources = true
   }
 
   kotlinOptions {

--- a/android-test/src/test/kotlin/okhttp/android/test/BaseOkHttpClientUnitTest.kt
+++ b/android-test/src/test/kotlin/okhttp/android/test/BaseOkHttpClientUnitTest.kt
@@ -71,7 +71,7 @@ abstract class BaseOkHttpClientUnitTest {
   }
 
   @Test
-  fun testPublicSuffixDb() {
+  open fun testPublicSuffixDb() {
     val httpUrl = "https://www.google.co.uk".toHttpUrl()
     assertThat(httpUrl.topPrivateDomain()).isEqualTo("google.co.uk")
   }

--- a/android-test/src/test/kotlin/okhttp/android/test/BaseOkHttpClientUnitTest.kt
+++ b/android-test/src/test/kotlin/okhttp/android/test/BaseOkHttpClientUnitTest.kt
@@ -70,6 +70,12 @@ abstract class BaseOkHttpClientUnitTest {
     }
   }
 
+  @Test
+  fun testPublicSuffixDb() {
+    val httpUrl = "https://www.google.co.uk".toHttpUrl()
+    assertThat(httpUrl.topPrivateDomain()).isEqualTo("google.co.uk")
+  }
+
   private fun assumeNetwork() {
     try {
       InetAddress.getByName("www.google.com")

--- a/android-test/src/test/kotlin/okhttp/android/test/NonRobolectricOkHttpClientTest.kt
+++ b/android-test/src/test/kotlin/okhttp/android/test/NonRobolectricOkHttpClientTest.kt
@@ -16,6 +16,8 @@
  */
 package okhttp.android.test
 
+import org.junit.Ignore
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -23,4 +25,10 @@ import org.junit.runners.JUnit4
  * Android test running with only stubs.
  */
 @RunWith(JUnit4::class)
-class NonRobolectricOkHttpClientTest : BaseOkHttpClientUnitTest()
+class NonRobolectricOkHttpClientTest : BaseOkHttpClientUnitTest() {
+  @Ignore("Requires an Asset")
+  @Test
+  override fun testPublicSuffixDb() {
+    super.testPublicSuffixDb()
+  }
+}

--- a/android-test/src/test/kotlin/okhttp/android/test/RobolectricOkHttpClientTest.kt
+++ b/android-test/src/test/kotlin/okhttp/android/test/RobolectricOkHttpClientTest.kt
@@ -31,6 +31,7 @@ class RobolectricOkHttpClientTest : BaseOkHttpClientUnitTest() {
   @Before
   fun setContext() {
     // This is awkward because Robolectric won't run our initializers and we don't want test deps
+    // https://github.com/robolectric/robolectric/issues/8461
     PlatformRegistry.applicationContext = ApplicationProvider.getApplicationContext()
   }
 }

--- a/android-test/src/test/kotlin/okhttp/android/test/RobolectricOkHttpClientTest.kt
+++ b/android-test/src/test/kotlin/okhttp/android/test/RobolectricOkHttpClientTest.kt
@@ -16,6 +16,9 @@
  */
 package okhttp.android.test
 
+import androidx.test.core.app.ApplicationProvider
+import okhttp3.internal.platform.PlatformRegistry
+import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -24,4 +27,10 @@ import org.robolectric.annotation.Config
 @Config(
   sdk = [21, 26, 30, 33, 35],
 )
-class RobolectricOkHttpClientTest : BaseOkHttpClientUnitTest()
+class RobolectricOkHttpClientTest : BaseOkHttpClientUnitTest() {
+  @Before
+  fun setContext() {
+    // This is awkward because Robolectric won't run our initializers and we don't want test deps
+    PlatformRegistry.applicationContext = ApplicationProvider.getApplicationContext()
+  }
+}

--- a/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/Android10Platform.kt
+++ b/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/Android10Platform.kt
@@ -21,12 +21,14 @@ import android.os.Build
 import android.os.StrictMode
 import android.security.NetworkSecurityPolicy
 import android.util.CloseGuard
+import android.util.Log
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
 import okhttp3.Protocol
 import okhttp3.internal.SuppressSignatureCheck
+import okhttp3.internal.platform.AndroidPlatform.Companion.Tag
 import okhttp3.internal.platform.android.Android10SocketAdapter
 import okhttp3.internal.platform.android.AndroidCertificateChainCleaner
 import okhttp3.internal.platform.android.AndroidSocketAdapter
@@ -109,6 +111,18 @@ class Android10Platform :
 
   override fun buildCertificateChainCleaner(trustManager: X509TrustManager): CertificateChainCleaner =
     AndroidCertificateChainCleaner.buildIfSupported(trustManager) ?: super.buildCertificateChainCleaner(trustManager)
+
+  override fun log(
+    message: String,
+    level: Int,
+    t: Throwable?,
+  ) {
+    if (level == WARN) {
+      Log.w(Tag, message, t)
+    } else {
+      Log.i(Tag, message, t)
+    }
+  }
 
   companion object {
     val isSupported: Boolean = isAndroid && Build.VERSION.SDK_INT >= 29

--- a/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
+++ b/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
@@ -109,7 +109,7 @@ object AndroidLog {
         enableLogging(logger, tag)
       }
     } catch (re: RuntimeException) {
-      // Possibly running android unit test without robolectric
+      System.err.println("Possibly running android unit test without robolectric")
       re.printStackTrace()
     }
   }


### PR DESCRIPTION
Part of an analysis of https://github.com/square/okhttp/issues/8927

Working with includeTestResources and use of an internal method `PlatformRegistry.applicationContext`