### PR TITLE
Avoid a ClassCastException in ResponseBodySource.close

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Exchange.kt
@@ -184,12 +184,13 @@ class Exchange(
     codec.carrier.trackFailure(call, e)
   }
 
-  fun <E : IOException?> bodyComplete(
+  /** If [e] is non-null, this will return a non-null value. */
+  fun bodyComplete(
     bytesRead: Long = -1L,
     responseDone: Boolean = false,
     requestDone: Boolean = false,
-    e: E,
-  ): E {
+    e: IOException?,
+  ): IOException? {
     if (e != null) {
       trackFailure(e)
     }
@@ -248,7 +249,7 @@ class Exchange(
         super.write(source, byteCount)
         this.bytesReceived += byteCount
       } catch (e: IOException) {
-        throw complete(e)
+        throw complete(e)!!
       }
     }
 
@@ -257,7 +258,7 @@ class Exchange(
       try {
         super.flush()
       } catch (e: IOException) {
-        throw complete(e)
+        throw complete(e)!!
       }
     }
 
@@ -272,11 +273,12 @@ class Exchange(
         super.close()
         complete(null)
       } catch (e: IOException) {
-        throw complete(e)
+        throw complete(e)!!
       }
     }
 
-    private fun <E : IOException?> complete(e: E): E {
+    /** If [e] is non-null, this will return a non-null value. */
+    private fun complete(e: IOException?): IOException? {
       if (completed) return e
       completed = true
       return bodyComplete(
@@ -334,7 +336,7 @@ class Exchange(
 
         return read
       } catch (e: IOException) {
-        throw complete(e)
+        throw complete(e)!!
       }
     }
 
@@ -346,11 +348,12 @@ class Exchange(
         super.close()
         complete(null)
       } catch (e: IOException) {
-        throw complete(e)
+        throw complete(e)!!
       }
     }
 
-    fun <E : IOException?> complete(e: E): E {
+    /** If [e] is non-null, this will return a non-null value. */
+    fun complete(e: IOException?): IOException? {
       if (completed) return e
       completed = true
       // If the body is closed without reading any bytes send a responseBodyStart() now.

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -307,12 +307,12 @@ class RealCall(
    * If the exchange was canceled or timed out, this will wrap [e] in an exception that provides
    * that additional context. Otherwise [e] is returned as-is.
    */
-  internal fun <E : IOException?> messageDone(
+  internal fun messageDone(
     exchange: Exchange,
     requestDone: Boolean = false,
     responseDone: Boolean = false,
-    e: E,
-  ): E {
+    e: IOException?,
+  ): IOException? {
     if (exchange != this.exchange) return e // This exchange was detached violently!
 
     var bothStreamsDone = false
@@ -366,7 +366,7 @@ class RealCall(
    * If the call was canceled or timed out, this will wrap [e] in an exception that provides that
    * additional context. Otherwise [e] is returned as-is.
    */
-  private fun <E : IOException?> callDone(e: E): E {
+  private fun callDone(e: IOException?): IOException? {
     assertLockNotHeld()
 
     val connection = this.connection
@@ -423,14 +423,13 @@ class RealCall(
     return null
   }
 
-  private fun <E : IOException?> timeoutExit(cause: E): E {
+  private fun timeoutExit(cause: IOException?): IOException? {
     if (timeoutEarlyExit) return cause
     if (!timeout.exit()) return cause
 
     val e = InterruptedIOException("timeout")
     if (cause != null) e.initCause(cause)
-    @Suppress("UNCHECKED_CAST") // E is either IOException or IOException?
-    return e as E
+    return e
   }
 
   /**

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -298,7 +298,7 @@ class RealConnection internal constructor(
     noNewExchanges()
     return object : RealWebSocket.Streams(true, source, sink) {
       override fun close() {
-        exchange.bodyComplete<IOException?>(
+        exchange.bodyComplete(
           bytesRead = -1L,
           responseDone = true,
           requestDone = true,


### PR DESCRIPTION
Closes: https://github.com/square/okhttp/issues/8960