### PR TITLE
[for discussion] Make LoggingEventListener.logWithTime open

### DIFF
--- a/okhttp-logging-interceptor/api/logging-interceptor.api
+++ b/okhttp-logging-interceptor/api/logging-interceptor.api
@@ -34,9 +34,9 @@ public abstract interface class okhttp3/logging/HttpLoggingInterceptor$Logger {
 public final class okhttp3/logging/HttpLoggingInterceptor$Logger$Companion {
 }
 
-public final class okhttp3/logging/LoggingEventListener : okhttp3/EventListener {
+public class okhttp3/logging/LoggingEventListener : okhttp3/EventListener {
 	public static final field Companion Lokhttp3/logging/LoggingEventListener$Companion;
-	public synthetic fun <init> (Lokhttp3/logging/HttpLoggingInterceptor$Logger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lokhttp3/logging/HttpLoggingInterceptor$Logger;)V
 	public fun cacheConditionalHit (Lokhttp3/Call;Lokhttp3/Response;)V
 	public fun cacheHit (Lokhttp3/Call;Lokhttp3/Response;)V
 	public fun cacheMiss (Lokhttp3/Call;)V
@@ -51,6 +51,8 @@ public final class okhttp3/logging/LoggingEventListener : okhttp3/EventListener 
 	public fun connectionReleased (Lokhttp3/Call;Lokhttp3/Connection;)V
 	public fun dnsEnd (Lokhttp3/Call;Ljava/lang/String;Ljava/util/List;)V
 	public fun dnsStart (Lokhttp3/Call;Ljava/lang/String;)V
+	public final fun getLogger ()Lokhttp3/logging/HttpLoggingInterceptor$Logger;
+	public fun logWithTime (Ljava/lang/String;)V
 	public fun proxySelectEnd (Lokhttp3/Call;Lokhttp3/HttpUrl;Ljava/util/List;)V
 	public fun proxySelectStart (Lokhttp3/Call;Lokhttp3/HttpUrl;)V
 	public fun requestBodyEnd (Lokhttp3/Call;J)V
@@ -76,5 +78,6 @@ public class okhttp3/logging/LoggingEventListener$Factory : okhttp3/EventListene
 	public fun <init> (Lokhttp3/logging/HttpLoggingInterceptor$Logger;)V
 	public synthetic fun <init> (Lokhttp3/logging/HttpLoggingInterceptor$Logger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Lokhttp3/Call;)Lokhttp3/EventListener;
+	public final fun getLogger ()Lokhttp3/logging/HttpLoggingInterceptor$Logger;
 }
 

--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/LoggingEventListener.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/LoggingEventListener.kt
@@ -37,8 +37,8 @@ import okhttp3.Response
  * The format of the logs created by this class should not be considered stable and may change
  * slightly between releases. If you need a stable logging format, use your own event listener.
  */
-class LoggingEventListener private constructor(
-  private val logger: HttpLoggingInterceptor.Logger,
+open class LoggingEventListener(
+  val logger: HttpLoggingInterceptor.Logger,
 ) : EventListener() {
   private var startNs: Long = 0
 
@@ -228,7 +228,7 @@ class LoggingEventListener private constructor(
     logWithTime("cacheConditionalHit: $cachedResponse")
   }
 
-  private fun logWithTime(message: String) {
+  open fun logWithTime(message: String) {
     val timeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs)
     logger.log("[$timeMs ms] $message")
   }
@@ -236,7 +236,7 @@ class LoggingEventListener private constructor(
   open class Factory
     @JvmOverloads
     constructor(
-      private val logger: HttpLoggingInterceptor.Logger = HttpLoggingInterceptor.Logger.DEFAULT,
+      val logger: HttpLoggingInterceptor.Logger = HttpLoggingInterceptor.Logger.DEFAULT,
     ) : EventListener.Factory {
       override fun create(call: Call): EventListener = LoggingEventListener(logger)
     }

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.kt
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/LoggingEventListenerTest.kt
@@ -263,9 +263,10 @@ class LoggingEventListenerTest {
   @Test
   fun customLogger() {
     val logs = mutableListOf<String>()
-    val localLogger = HttpLoggingInterceptor.Logger {
-      logs.add(it)
-    }
+    val localLogger =
+      HttpLoggingInterceptor.Logger {
+        logs.add(it)
+      }
 
     client =
       OkHttpClient
@@ -286,13 +287,15 @@ class LoggingEventListenerTest {
       fail<Any>()
     } catch (expected: UnknownHostException) {
     }
-    assertThat(logs).isEqualTo(listOf(
-      """XXX callStart: Request{method=GET, url=$url}""",
-      """XXX proxySelectStart: $url""",
-      """XXX proxySelectEnd: [DIRECT]""",
-      """XXX dnsStart: ${url.host}""",
-      """XXX callFailed: java.net.UnknownHostException: reason"""
-    ))
+    assertThat(logs).isEqualTo(
+      listOf(
+        """XXX callStart: Request{method=GET, url=$url}""",
+        """XXX proxySelectStart: $url""",
+        """XXX proxySelectEnd: [DIRECT]""",
+        """XXX dnsStart: ${url.host}""",
+        """XXX callFailed: java.net.UnknownHostException: reason""",
+      ),
+    )
   }
 
   private fun request(): Request.Builder = Request.Builder().url(url)


### PR DESCRIPTION
Minimal API surface to allow customising logWithTime without rewriting.

fixes #8834

Based on past judgement calls, this may not land. So mainly for discussion at the moment. 