### PR TITLE
Reduce flakes by not unit testing in check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Run Checks
-        run: ./gradlew check -PgraalBuild=true
+        run: ./gradlew check -PgraalBuild=true -x jvmTest -x test
 
   testopenjdk11:
     permissions:


### PR DESCRIPTION
These are run multiple times, but the check job, and windows seems anecdotally most flaky.