### PR TITLE
[For discussion] Connection Listener

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/ConnectionEvent.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/ConnectionEvent.kt
@@ -13,11 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress(
-  "CANNOT_OVERRIDE_INVISIBLE_MEMBER",
-  "INVISIBLE_MEMBER",
-  "INVISIBLE_REFERENCE",
-)
 
 package okhttp3
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/OkHttpClientTestRule.kt
@@ -60,7 +60,7 @@ class OkHttpClientTestRule :
   private lateinit var testName: String
   private var defaultUncaughtExceptionHandler: Thread.UncaughtExceptionHandler? = null
   private var taskQueuesWereIdle: Boolean = false
-  private val connectionListener = RecordingConnectionListener()
+  val connectionListener = RecordingConnectionListener()
 
   var logger: Logger? = null
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingConnectionListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingConnectionListener.kt
@@ -13,12 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress(
-  "CANNOT_OVERRIDE_INVISIBLE_MEMBER",
-  "INVISIBLE_MEMBER",
-  "INVISIBLE_REFERENCE",
-)
-
 package okhttp3
 
 import assertk.assertThat
@@ -30,12 +24,11 @@ import java.util.Deque
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.TimeUnit
 import okhttp3.ConnectionEvent.NoNewExchanges
-import okhttp3.internal.connection.ConnectionListener
 import okhttp3.internal.connection.RealConnection
 import okio.IOException
 import org.junit.jupiter.api.Assertions
 
-internal open class RecordingConnectionListener(
+open class RecordingConnectionListener(
   /**
    * An override to ignore the normal order that is enforced.
    * EventListeners added by Interceptors will not see all events.

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
@@ -36,7 +36,6 @@ import okhttp3.internal.concurrent.TaskFaker
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.concurrent.withLock
 import okhttp3.internal.connection.CallConnectionUser
-import okhttp3.internal.connection.ConnectionListener
 import okhttp3.internal.connection.FastFallbackExchangeFinder
 import okhttp3.internal.connection.RealCall
 import okhttp3.internal.connection.RealConnection

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/http2/Http2FlowControlConnectionListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/http2/Http2FlowControlConnectionListener.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.http2
+
+import okhttp3.ConnectionListener
+import okhttp3.internal.http2.flowcontrol.WindowCounter
+
+/**
+ * ConnectionListener that outputs CSV for flow control of client receiving streams.
+ */
+class Http2FlowControlConnectionListener :
+  ConnectionListener(),
+  FlowControlListener {
+  val start = System.currentTimeMillis()
+
+  override fun receivingStreamWindowChanged(
+    streamId: Int,
+    windowCounter: WindowCounter,
+    bufferSize: Long,
+  ) {
+    println("${System.currentTimeMillis() - start},$streamId,${windowCounter.unacknowledged},$bufferSize")
+  }
+
+  override fun receivingConnectionWindowChanged(windowCounter: WindowCounter) {
+    println("${System.currentTimeMillis() - start},0,${windowCounter.unacknowledged},")
+  }
+}

--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -344,9 +344,27 @@ public abstract interface class okhttp3/Connection {
 	public abstract fun socket ()Ljava/net/Socket;
 }
 
+public abstract class okhttp3/ConnectionListener {
+	public static final field Companion Lokhttp3/ConnectionListener$Companion;
+	public fun <init> ()V
+	public fun connectEnd (Lokhttp3/Connection;Lokhttp3/Route;Lokhttp3/Call;)V
+	public fun connectFailed (Lokhttp3/Route;Lokhttp3/Call;Ljava/io/IOException;)V
+	public fun connectStart (Lokhttp3/Route;Lokhttp3/Call;)V
+	public fun connectionAcquired (Lokhttp3/Connection;Lokhttp3/Call;)V
+	public fun connectionClosed (Lokhttp3/Connection;)V
+	public fun connectionReleased (Lokhttp3/Connection;Lokhttp3/Call;)V
+	public fun noNewExchanges (Lokhttp3/Connection;)V
+}
+
+public final class okhttp3/ConnectionListener$Companion {
+	public final fun getNONE ()Lokhttp3/ConnectionListener;
+}
+
 public final class okhttp3/ConnectionPool {
 	public fun <init> ()V
 	public fun <init> (IJLjava/util/concurrent/TimeUnit;)V
+	public fun <init> (IJLjava/util/concurrent/TimeUnit;Lokhttp3/ConnectionListener;)V
+	public synthetic fun <init> (IJLjava/util/concurrent/TimeUnit;Lokhttp3/ConnectionListener;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun connectionCount ()I
 	public final fun evictAll ()V
 	public final fun idleConnectionCount ()I

--- a/okhttp/api/jvm/okhttp.api
+++ b/okhttp/api/jvm/okhttp.api
@@ -344,9 +344,27 @@ public abstract interface class okhttp3/Connection {
 	public abstract fun socket ()Ljava/net/Socket;
 }
 
+public abstract class okhttp3/ConnectionListener {
+	public static final field Companion Lokhttp3/ConnectionListener$Companion;
+	public fun <init> ()V
+	public fun connectEnd (Lokhttp3/Connection;Lokhttp3/Route;Lokhttp3/Call;)V
+	public fun connectFailed (Lokhttp3/Route;Lokhttp3/Call;Ljava/io/IOException;)V
+	public fun connectStart (Lokhttp3/Route;Lokhttp3/Call;)V
+	public fun connectionAcquired (Lokhttp3/Connection;Lokhttp3/Call;)V
+	public fun connectionClosed (Lokhttp3/Connection;)V
+	public fun connectionReleased (Lokhttp3/Connection;Lokhttp3/Call;)V
+	public fun noNewExchanges (Lokhttp3/Connection;)V
+}
+
+public final class okhttp3/ConnectionListener$Companion {
+	public final fun getNONE ()Lokhttp3/ConnectionListener;
+}
+
 public final class okhttp3/ConnectionPool {
 	public fun <init> ()V
 	public fun <init> (IJLjava/util/concurrent/TimeUnit;)V
+	public fun <init> (IJLjava/util/concurrent/TimeUnit;Lokhttp3/ConnectionListener;)V
+	public synthetic fun <init> (IJLjava/util/concurrent/TimeUnit;Lokhttp3/ConnectionListener;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun connectionCount ()I
 	public final fun evictAll ()V
 	public final fun idleConnectionCount ()I

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionListener.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Square, Inc.
+ * Copyright (C) 2025 Block, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import okio.IOException
  * attempt to mutate the event parameters, or be reentrant back into the client.
  * Any IO - writing to files or network should be done asynchronously.
  */
-@ExperimentalOkHttpApi
 abstract class ConnectionListener {
   /**
    * Invoked as soon as a call causes a connection to be started.
@@ -78,7 +77,6 @@ abstract class ConnectionListener {
    */
   open fun noNewExchanges(connection: Connection) {}
 
-  @ExperimentalOkHttpApi
   companion object {
     val NONE: ConnectionListener = object : ConnectionListener() {}
   }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionListener.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionListener.kt
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3.internal.connection
+package okhttp3
 
-import okhttp3.Call
-import okhttp3.Connection
-import okhttp3.Route
 import okio.IOException
 
 /**
@@ -27,7 +24,8 @@ import okio.IOException
  * attempt to mutate the event parameters, or be reentrant back into the client.
  * Any IO - writing to files or network should be done asynchronously.
  */
-internal abstract class ConnectionListener {
+@ExperimentalOkHttpApi
+abstract class ConnectionListener {
   /**
    * Invoked as soon as a call causes a connection to be started.
    */
@@ -80,6 +78,7 @@ internal abstract class ConnectionListener {
    */
   open fun noNewExchanges(connection: Connection) {}
 
+  @ExperimentalOkHttpApi
   companion object {
     val NONE: ConnectionListener = object : ConnectionListener() {}
   }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionPool.kt
@@ -83,7 +83,6 @@ class ConnectionPool internal constructor(
   )
 
   // Public API
-  @ExperimentalOkHttpApi
   constructor(
     maxIdleConnections: Int = 5,
     keepAliveDuration: Long = 5,

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionPool.kt
@@ -18,7 +18,6 @@ package okhttp3
 
 import java.util.concurrent.TimeUnit
 import okhttp3.internal.concurrent.TaskRunner
-import okhttp3.internal.connection.ConnectionListener
 import okhttp3.internal.connection.FastFallbackExchangeFinder
 import okhttp3.internal.connection.ForceConnectRoutePlanner
 import okhttp3.internal.connection.RealConnectionPool
@@ -83,8 +82,9 @@ class ConnectionPool internal constructor(
     ),
   )
 
-  // Internal until we promote ConnectionListener to be a public API.
-  internal constructor(
+  // Public API
+  @ExperimentalOkHttpApi
+  constructor(
     maxIdleConnections: Int = 5,
     keepAliveDuration: Long = 5,
     timeUnit: TimeUnit = TimeUnit.MINUTES,

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/CallConnectionUser.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/CallConnectionUser.kt
@@ -20,6 +20,7 @@ import java.net.InetAddress
 import java.net.Proxy
 import java.net.Socket
 import okhttp3.Connection
+import okhttp3.ConnectionListener
 import okhttp3.EventListener
 import okhttp3.Handshake
 import okhttp3.HttpUrl

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -27,6 +27,7 @@ import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSocket
 import okhttp3.Address
 import okhttp3.Connection
+import okhttp3.ConnectionListener
 import okhttp3.Handshake
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -59,7 +60,7 @@ import okio.Buffer
  * Connections are shared in a connection pool. Accesses to the connection's state must be guarded
  * by holding a lock on the connection.
  */
-class RealConnection internal constructor(
+class RealConnection(
   val taskRunner: TaskRunner,
   val connectionPool: RealConnectionPool,
   override val route: Route,

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -22,6 +22,7 @@ import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
 import okhttp3.Address
+import okhttp3.ConnectionListener
 import okhttp3.ConnectionPool
 import okhttp3.Route
 import okhttp3.internal.closeQuietly
@@ -35,7 +36,7 @@ import okhttp3.internal.okHttpName
 import okhttp3.internal.platform.Platform
 import okio.IOException
 
-class RealConnectionPool internal constructor(
+class RealConnectionPool(
   private val taskRunner: TaskRunner,
   /**
    * The maximum number of idle connections across all addresses.

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/internal.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/internal.kt
@@ -24,6 +24,7 @@ import java.nio.charset.Charset
 import javax.net.ssl.SSLSocket
 import okhttp3.Cache
 import okhttp3.CipherSuite
+import okhttp3.ConnectionListener
 import okhttp3.ConnectionPool
 import okhttp3.ConnectionSpec
 import okhttp3.Cookie
@@ -35,7 +36,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.internal.concurrent.TaskRunner
-import okhttp3.internal.connection.ConnectionListener
 import okhttp3.internal.connection.RealConnection
 
 internal fun parseCookie(

--- a/okhttp/src/jvmTest/kotlin/okhttp3/ConnectionListenerTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/ConnectionListenerTest.kt
@@ -13,12 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress(
-  "CANNOT_OVERRIDE_INVISIBLE_MEMBER",
-  "INVISIBLE_MEMBER",
-  "INVISIBLE_REFERENCE",
-)
-
 package okhttp3
 
 import assertk.assertThat

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/RouteSelectorTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/RouteSelectorTest.kt
@@ -31,6 +31,7 @@ import java.net.URI
 import java.net.UnknownHostException
 import kotlin.test.assertFailsWith
 import okhttp3.Address
+import okhttp3.ConnectionListener
 import okhttp3.FakeDns
 import okhttp3.OkHttpClientTestRule
 import okhttp3.Request


### PR DESCRIPTION
Reverts #8831

> I'd like to update the API to improve observability into things like ConnecitonPool, RoutePlanner, ConnectPlan, and ReusePlan. And also into HTTP/2 internals like flow-control.
> 
> As-is this is more coupled to Call lifecycles and is somewhat duplicative with ConnectionPool.
> 
> We'll do that work and make it a new public API, but we won't have it in the public API at all for the 5.0 release.