### PR TITLE
Revert "Add QUERY method support"

### DIFF
--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -1040,7 +1040,6 @@ public class okhttp3/Request$Builder {
 	public fun patch (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
 	public fun post (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
 	public fun put (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
-	public fun query (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
 	public fun removeHeader (Ljava/lang/String;)Lokhttp3/Request$Builder;
 	public fun tag (Ljava/lang/Class;Ljava/lang/Object;)Lokhttp3/Request$Builder;
 	public fun tag (Ljava/lang/Object;)Lokhttp3/Request$Builder;

--- a/okhttp/api/jvm/okhttp.api
+++ b/okhttp/api/jvm/okhttp.api
@@ -1039,7 +1039,6 @@ public class okhttp3/Request$Builder {
 	public fun patch (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
 	public fun post (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
 	public fun put (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
-	public fun query (Lokhttp3/RequestBody;)Lokhttp3/Request$Builder;
 	public fun removeHeader (Ljava/lang/String;)Lokhttp3/Request$Builder;
 	public fun tag (Ljava/lang/Class;Ljava/lang/Object;)Lokhttp3/Request$Builder;
 	public fun tag (Ljava/lang/Object;)Lokhttp3/Request$Builder;

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt
@@ -228,10 +228,9 @@ class Cache internal constructor(
       return null
     }
 
-    if (requestMethod != "GET" && requestMethod != "QUERY") {
-      // Don't cache non-GET and non-QUERY responses. We're technically allowed to cache HEAD
-      // requests and some POST requests, but the complexity of doing so is high and the benefit
-      // is low.
+    if (requestMethod != "GET") {
+      // Don't cache non-GET responses. We're technically allowed to cache HEAD requests and some
+      // POST requests, but the complexity of doing so is high and the benefit is low.
       return null
     }
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Request.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Request.kt
@@ -317,8 +317,6 @@ class Request internal constructor(
 
     open fun patch(body: RequestBody): Builder = method("PATCH", body)
 
-    open fun query(body: RequestBody): Builder = method("QUERY", body)
-
     open fun method(
       method: String,
       body: RequestBody?,

--- a/okhttp/src/jvmTest/kotlin/okhttp3/RequestTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/RequestTest.kt
@@ -244,15 +244,6 @@ class RequestTest {
         .build()
     assertThat(patch.method).isEqualTo("PATCH")
     assertThat(patch.body).isEqualTo(body)
-
-    val query =
-      Request
-        .Builder()
-        .url("http://localhost/api")
-        .query(body)
-        .build()
-    assertThat(query.method).isEqualTo("QUERY")
-    assertThat(query.body).isEqualTo(body)
   }
 
   @Test


### PR DESCRIPTION
Reverts square/okhttp#8550

> Shouldn't this include the request body as part of the cache key somewhere?

