### PR TITLE
Print URLs in HttpLoggingInterceptor when the call fails

### DIFF
--- a/android-test/src/test/kotlin/okhttp/android/test/AndroidLoggingTest.kt
+++ b/android-test/src/test/kotlin/okhttp/android/test/AndroidLoggingTest.kt
@@ -60,9 +60,16 @@ class AndroidLoggingTest {
 
     val logs = ShadowLog.getLogsForTag(AndroidPlatform.Tag)
     assertThat(logs.map { it.type }).containsOnly(Log.INFO)
-    assertThat(logs.map { it.msg }).containsExactly(
+    assertThat(
+      logs.map {
+        it.msg.replace(
+          "\\d+".toRegex(),
+          "",
+        )
+      },
+    ).containsExactly(
       "--> GET http://google.com/robots.txt",
-      "<-- HTTP FAILED: java.net.UnknownHostException: shortcircuit",
+      "<-- HTTP FAILED: java.net.UnknownHostException: shortcircuit. ${request.url} (ms)",
     )
     // We should consider if these logs should retain Exceptions
     assertThat(logs.last().throwable).isNull()

--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -247,7 +247,13 @@ class HttpLoggingInterceptor
       try {
         response = chain.proceed(request)
       } catch (e: Exception) {
-        logger.log("<-- HTTP FAILED: $e")
+        val tookMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs)
+        logger.log(
+          buildString {
+            append("<-- HTTP FAILED: $e.")
+            append(" ${redactUrl(request.url)} (${tookMs}ms)")
+          },
+        )
         throw e
       }
 

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
@@ -837,7 +837,7 @@ class HttpLoggingInterceptorTest {
     }
     applicationLogs
       .assertLogEqual("--> GET $url")
-      .assertLogEqual("<-- HTTP FAILED: java.net.UnknownHostException: reason")
+      .assertLogMatch(Regex("""<-- HTTP FAILED: java.net.UnknownHostException: reason. $url \(\d+ms\)"""))
       .assertNoMoreLogs()
   }
 


### PR DESCRIPTION
When there's lots of messages, it is difficult to map the failure messages to the start messages without the url.