### PR TITLE
Fix merge issue with modules and logging

### DIFF
--- a/okhttp/src/jvmMain/java9/module-info.java
+++ b/okhttp/src/jvmMain/java9/module-info.java
@@ -6,7 +6,7 @@ module okhttp3 {
   exports okhttp3;
   exports okhttp3.internal to okhttp3.logging, okhttp3.sse, okhttp3.java.net.cookiejar, okhttp3.dnsoverhttps, mockwebserver3, okhttp3.mockwebserver, okhttp3.coroutines, okhttp3.tls;
   exports okhttp3.internal.concurrent to mockwebserver3, okhttp3.mockwebserver;
-  exports okhttp3.internal.connection to mockwebserver3, okhttp3.mockwebserver;
+  exports okhttp3.internal.connection to mockwebserver3, okhttp3.mockwebserver, okhttp3.logging;
   exports okhttp3.internal.http to okhttp3.logging, okhttp3.brotli, mockwebserver3;
   exports okhttp3.internal.http2 to mockwebserver3, okhttp3.mockwebserver;
   exports okhttp3.internal.platform to okhttp3.logging, okhttp3.java.net.cookiejar, okhttp3.dnsoverhttps, mockwebserver3, okhttp3.mockwebserver, okhttp3.tls;


### PR DESCRIPTION
```
> Task :logging-interceptor:compileKotlin FAILED
e: file:///home/runner/work/okhttp/okhttp/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt:273:27 Symbol is declared in module 'okhttp3' which does not export package 'okhttp3.internal.connection'.
```