### PR TITLE
Allow HTTP/1.1 Upgrades with empty RequestBody

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Request.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Request.kt
@@ -82,8 +82,8 @@ class Request internal constructor(
 
   init {
     val connectionHeader = headers["Connection"]
-    require(body == null || !"upgrade".equals(connectionHeader, ignoreCase = true)) {
-      "expected a null request body with 'Connection: upgrade'"
+    require(body == null || !"upgrade".equals(connectionHeader, ignoreCase = true) || body.contentLength() == 0L) {
+      "expected a null or empty request body with 'Connection: upgrade'"
     }
   }
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/CallServerInterceptor.kt
@@ -40,9 +40,7 @@ object CallServerInterceptor : Interceptor {
     var responseBuilder: Response.Builder? = null
     var sendRequestException: IOException? = null
     val hasRequestBody = HttpMethod.permitsRequestBody(request.method) && requestBody != null
-    val isUpgradeRequest =
-      !hasRequestBody &&
-        "upgrade".equals(request.header("Connection"), ignoreCase = true)
+    val isUpgradeRequest = "upgrade".equals(request.header("Connection"), ignoreCase = true)
     try {
       exchange.writeRequestHeaders(request)
 


### PR DESCRIPTION
See https://docs.docker.com/reference/api/engine/version/v1.51/#tag/Container/operation/ContainerAttach