### PR TITLE
Introduce events for the dispatcher queue

### DIFF
--- a/okhttp-logging-interceptor/api/logging-interceptor.api
+++ b/okhttp-logging-interceptor/api/logging-interceptor.api
@@ -58,6 +58,8 @@ public final class okhttp3/logging/LoggingEventListener : okhttp3/EventListener 
 	public fun connectStart (Lokhttp3/Call;Ljava/net/InetSocketAddress;Ljava/net/Proxy;)V
 	public fun connectionAcquired (Lokhttp3/Call;Lokhttp3/Connection;)V
 	public fun connectionReleased (Lokhttp3/Call;Lokhttp3/Connection;)V
+	public fun dispatcherQueueEnd (Lokhttp3/Call;Lokhttp3/Dispatcher;)V
+	public fun dispatcherQueueStart (Lokhttp3/Call;Lokhttp3/Dispatcher;)V
 	public fun dnsEnd (Lokhttp3/Call;Ljava/lang/String;Ljava/util/List;)V
 	public fun dnsStart (Lokhttp3/Call;Ljava/lang/String;)V
 	public fun proxySelectEnd (Lokhttp3/Call;Lokhttp3/HttpUrl;Ljava/util/List;)V

--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/LoggingEventListener.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/LoggingEventListener.kt
@@ -22,6 +22,7 @@ import java.net.Proxy
 import java.util.concurrent.TimeUnit
 import okhttp3.Call
 import okhttp3.Connection
+import okhttp3.Dispatcher
 import okhttp3.EventListener
 import okhttp3.Handshake
 import okhttp3.HttpUrl
@@ -46,6 +47,20 @@ class LoggingEventListener private constructor(
     startNs = System.nanoTime()
 
     logWithTime("callStart: ${call.request()}")
+  }
+
+  override fun dispatcherQueueStart(
+    call: Call,
+    dispatcher: Dispatcher,
+  ) {
+    logWithTime("dispatcherQueueStart: $call queuedCallsCount=${dispatcher.queuedCallsCount()}")
+  }
+
+  override fun dispatcherQueueEnd(
+    call: Call,
+    dispatcher: Dispatcher,
+  ) {
+    logWithTime("dispatcherQueueEnd: $call queuedCallsCount=${dispatcher.queuedCallsCount()}")
   }
 
   override fun proxySelectStart(

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/CallEvent.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/CallEvent.kt
@@ -34,6 +34,20 @@ sealed class CallEvent {
   /** Returns if the event closes this event, or null if this is no open event. */
   open fun closes(event: CallEvent): Boolean? = null
 
+  data class DispatcherQueueStart(
+    override val timestampNs: Long,
+    override val call: Call,
+    val dispatcher: Dispatcher,
+  ) : CallEvent()
+
+  data class DispatcherQueueEnd(
+    override val timestampNs: Long,
+    override val call: Call,
+    val dispatcher: Dispatcher,
+  ) : CallEvent() {
+    override fun closes(event: CallEvent): Boolean = event is DispatcherQueueStart && call == event.call
+  }
+
   data class ProxySelectStart(
     override val timestampNs: Long,
     override val call: Call,

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/ClientRuleEventListener.kt
@@ -38,6 +38,24 @@ class ClientRuleEventListener(
     delegate.callStart(call)
   }
 
+  override fun dispatcherQueueStart(
+    call: Call,
+    dispatcher: Dispatcher,
+  ) {
+    logWithTime("dispatcherQueueStart: queuedCallsCount=${dispatcher.queuedCallsCount()}")
+
+    delegate.dispatcherQueueStart(call, dispatcher)
+  }
+
+  override fun dispatcherQueueEnd(
+    call: Call,
+    dispatcher: Dispatcher,
+  ) {
+    logWithTime("dispatcherQueueEnd: queuedCallsCount=${dispatcher.queuedCallsCount()}")
+
+    delegate.dispatcherQueueEnd(call, dispatcher)
+  }
+
   override fun proxySelectStart(
     call: Call,
     url: HttpUrl,

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/RecordingEventListener.kt
@@ -39,6 +39,8 @@ import okhttp3.CallEvent.ConnectFailed
 import okhttp3.CallEvent.ConnectStart
 import okhttp3.CallEvent.ConnectionAcquired
 import okhttp3.CallEvent.ConnectionReleased
+import okhttp3.CallEvent.DispatcherQueueEnd
+import okhttp3.CallEvent.DispatcherQueueStart
 import okhttp3.CallEvent.DnsEnd
 import okhttp3.CallEvent.DnsStart
 import okhttp3.CallEvent.FollowUpDecision
@@ -166,6 +168,16 @@ open class RecordingEventListener(
       fail<Any>("event $e without matching start event")
     }
   }
+
+  override fun dispatcherQueueStart(
+    call: Call,
+    dispatcher: Dispatcher,
+  ) = logEvent(DispatcherQueueStart(System.nanoTime(), call, dispatcher))
+
+  override fun dispatcherQueueEnd(
+    call: Call,
+    dispatcher: Dispatcher,
+  ) = logEvent(DispatcherQueueEnd(System.nanoTime(), call, dispatcher))
 
   override fun proxySelectStart(
     call: Call,

--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -496,6 +496,8 @@ public abstract class okhttp3/EventListener {
 	public fun connectStart (Lokhttp3/Call;Ljava/net/InetSocketAddress;Ljava/net/Proxy;)V
 	public fun connectionAcquired (Lokhttp3/Call;Lokhttp3/Connection;)V
 	public fun connectionReleased (Lokhttp3/Call;Lokhttp3/Connection;)V
+	public fun dispatcherQueueEnd (Lokhttp3/Call;Lokhttp3/Dispatcher;)V
+	public fun dispatcherQueueStart (Lokhttp3/Call;Lokhttp3/Dispatcher;)V
 	public fun dnsEnd (Lokhttp3/Call;Ljava/lang/String;Ljava/util/List;)V
 	public fun dnsStart (Lokhttp3/Call;Ljava/lang/String;)V
 	public fun followUpDecision (Lokhttp3/Call;Lokhttp3/Response;Lokhttp3/Request;)V

--- a/okhttp/api/jvm/okhttp.api
+++ b/okhttp/api/jvm/okhttp.api
@@ -496,6 +496,8 @@ public abstract class okhttp3/EventListener {
 	public fun connectStart (Lokhttp3/Call;Ljava/net/InetSocketAddress;Ljava/net/Proxy;)V
 	public fun connectionAcquired (Lokhttp3/Call;Lokhttp3/Connection;)V
 	public fun connectionReleased (Lokhttp3/Call;Lokhttp3/Connection;)V
+	public fun dispatcherQueueEnd (Lokhttp3/Call;Lokhttp3/Dispatcher;)V
+	public fun dispatcherQueueStart (Lokhttp3/Call;Lokhttp3/Dispatcher;)V
 	public fun dnsEnd (Lokhttp3/Call;Ljava/lang/String;Ljava/util/List;)V
 	public fun dnsStart (Lokhttp3/Call;Ljava/lang/String;)V
 	public fun followUpDecision (Lokhttp3/Call;Lokhttp3/Response;Lokhttp3/Request;)V

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/EventListener.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/EventListener.kt
@@ -33,6 +33,7 @@ import java.net.Proxy
  * Events are typically nested with this structure:
  *
  *  * call ([callStart], [callEnd], [callFailed])
+ *    * dispatcher queue ([dispatcherQueueStart], [dispatcherQueueEnd])
  *    * proxy selection ([proxySelectStart], [proxySelectEnd])
  *    * dns ([dnsStart], [dnsEnd])
  *    * connect ([connectStart], [connectEnd], [connectFailed])
@@ -68,6 +69,30 @@ abstract class EventListener {
    * will be handled within the boundaries of a single [callStart] and [callEnd]/[callFailed] pair.
    */
   open fun callStart(call: Call) {
+  }
+
+  /**
+   * Invoked for calls that were not executed immediately because resources weren't available. The
+   * call will remain in the queue until resources are available.
+   *
+   * Use [Dispatcher.maxRequests] and [Dispatcher.maxRequestsPerHost] to configure how many calls
+   * OkHttp performs concurrently.
+   */
+  open fun dispatcherQueueStart(
+    call: Call,
+    dispatcher: Dispatcher,
+  ) {
+  }
+
+  /**
+   * Invoked when [call] will be executed immediately.
+   *
+   * This method is invoked after [dispatcherQueueStart].
+   */
+  open fun dispatcherQueueEnd(
+    call: Call,
+    dispatcher: Dispatcher,
+  ) {
   }
 
   /**


### PR DESCRIPTION
So event listeners can see how long calls are waiting for resources to become available.

This is the API only. I'll do the implementation in follow-up.

Also note that I'm going to try my best to implement this event pair to only fire for calls that actually spend time in the queue. Calls that are immediately promoted out of the queue should not get events.