### PR TITLE
Tear down AddressPolicy

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/TestValueFactory.kt
@@ -37,13 +37,10 @@ import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.concurrent.withLock
 import okhttp3.internal.connection.CallConnectionUser
 import okhttp3.internal.connection.ConnectionListener
-import okhttp3.internal.connection.FastFallbackExchangeFinder
 import okhttp3.internal.connection.RealCall
 import okhttp3.internal.connection.RealConnection
 import okhttp3.internal.connection.RealConnectionPool
 import okhttp3.internal.connection.RealRoutePlanner
-import okhttp3.internal.connection.RouteDatabase
-import okhttp3.internal.connection.RoutePlanner
 import okhttp3.internal.http.RealInterceptorChain
 import okhttp3.internal.http.RecordingProxySelector
 import okhttp3.tls.HandshakeCertificates
@@ -102,7 +99,6 @@ class TestValueFactory : Closeable {
   fun newConnectionPool(
     taskRunner: TaskRunner = this.taskRunner,
     maxIdleConnections: Int = Int.MAX_VALUE,
-    routePlanner: RoutePlanner? = null,
   ): RealConnectionPool =
     RealConnectionPool(
       taskRunner = taskRunner,
@@ -110,25 +106,6 @@ class TestValueFactory : Closeable {
       keepAliveDuration = 100L,
       timeUnit = TimeUnit.NANOSECONDS,
       connectionListener = ConnectionListener.NONE,
-      exchangeFinderFactory = { pool, address, user ->
-        FastFallbackExchangeFinder(
-          routePlanner ?: RealRoutePlanner(
-            taskRunner = taskRunner,
-            connectionPool = pool,
-            readTimeoutMillis = 10_000,
-            writeTimeoutMillis = 10_000,
-            socketConnectTimeoutMillis = 10_000,
-            socketReadTimeoutMillis = 10_000,
-            pingIntervalMillis = 10_000,
-            retryOnConnectionFailure = false,
-            fastFallback = true,
-            address = address,
-            routeDatabase = RouteDatabase(),
-            connectionUser = user,
-          ),
-          taskRunner,
-        )
-      },
     )
 
   /** Returns an address that's without an SSL socket factory or hostname verifier.  */

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionPool.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/ConnectionPool.kt
@@ -19,11 +19,7 @@ package okhttp3
 import java.util.concurrent.TimeUnit
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.connection.ConnectionListener
-import okhttp3.internal.connection.FastFallbackExchangeFinder
-import okhttp3.internal.connection.ForceConnectRoutePlanner
 import okhttp3.internal.connection.RealConnectionPool
-import okhttp3.internal.connection.RealRoutePlanner
-import okhttp3.internal.connection.RouteDatabase
 
 /**
  * Manages reuse of HTTP and HTTP/2 connections for reduced network latency. HTTP requests that
@@ -44,14 +40,6 @@ class ConnectionPool internal constructor(
     timeUnit: TimeUnit = TimeUnit.MINUTES,
     taskRunner: TaskRunner = TaskRunner.INSTANCE,
     connectionListener: ConnectionListener = ConnectionListener.NONE,
-    readTimeoutMillis: Int = 10_000,
-    writeTimeoutMillis: Int = 10_000,
-    socketConnectTimeoutMillis: Int = 10_000,
-    socketReadTimeoutMillis: Int = 10_000,
-    pingIntervalMillis: Int = 10_000,
-    retryOnConnectionFailure: Boolean = true,
-    fastFallback: Boolean = true,
-    routeDatabase: RouteDatabase = RouteDatabase(),
   ) : this(
     RealConnectionPool(
       taskRunner = taskRunner,
@@ -59,27 +47,6 @@ class ConnectionPool internal constructor(
       keepAliveDuration = keepAliveDuration,
       timeUnit = timeUnit,
       connectionListener = connectionListener,
-      exchangeFinderFactory = { pool, address, user ->
-        FastFallbackExchangeFinder(
-          ForceConnectRoutePlanner(
-            RealRoutePlanner(
-              taskRunner = taskRunner,
-              connectionPool = pool,
-              readTimeoutMillis = readTimeoutMillis,
-              writeTimeoutMillis = writeTimeoutMillis,
-              socketConnectTimeoutMillis = socketConnectTimeoutMillis,
-              socketReadTimeoutMillis = socketReadTimeoutMillis,
-              pingIntervalMillis = pingIntervalMillis,
-              retryOnConnectionFailure = retryOnConnectionFailure,
-              fastFallback = fastFallback,
-              address = address,
-              routeDatabase = routeDatabase,
-              connectionUser = user,
-            ),
-          ),
-          taskRunner,
-        )
-      },
     ),
   )
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
@@ -267,16 +267,7 @@ open class OkHttpClient internal constructor(
 
   @get:JvmName("connectionPool")
   val connectionPool: ConnectionPool =
-    builder.connectionPool ?: ConnectionPool(
-      readTimeoutMillis = readTimeoutMillis,
-      writeTimeoutMillis = writeTimeoutMillis,
-      socketConnectTimeoutMillis = connectTimeoutMillis,
-      socketReadTimeoutMillis = readTimeoutMillis,
-      pingIntervalMillis = pingIntervalMillis,
-      retryOnConnectionFailure = retryOnConnectionFailure,
-      fastFallback = fastFallback,
-      routeDatabase = routeDatabase,
-    ).also {
+    builder.connectionPool ?: ConnectionPool().also {
       // Cache the pool in the builder so that it will be shared with other clients
       builder.connectionPool = it
     }
@@ -295,14 +286,14 @@ open class OkHttpClient internal constructor(
       this.x509TrustManager = builder.x509TrustManagerOrNull!!
       this.certificatePinner =
         builder.certificatePinner
-          .withCertificateChainCleaner(certificateChainCleaner!!)
+          .withCertificateChainCleaner(certificateChainCleaner)
     } else {
       this.x509TrustManager = Platform.get().platformTrustManager()
-      this.sslSocketFactoryOrNull = Platform.get().newSslSocketFactory(x509TrustManager!!)
-      this.certificateChainCleaner = CertificateChainCleaner.get(x509TrustManager!!)
+      this.sslSocketFactoryOrNull = Platform.get().newSslSocketFactory(x509TrustManager)
+      this.certificateChainCleaner = CertificateChainCleaner.get(x509TrustManager)
       this.certificatePinner =
         builder.certificatePinner
-          .withCertificateChainCleaner(certificateChainCleaner!!)
+          .withCertificateChainCleaner(certificateChainCleaner)
     }
 
     verifyClientState()

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnection.kt
@@ -335,16 +335,7 @@ class RealConnection internal constructor(
     settings: Settings,
   ) {
     withLock {
-      val oldLimit = allocationLimit
       allocationLimit = settings.getMaxConcurrentStreams()
-
-      if (allocationLimit < oldLimit) {
-        // We might need new connections to keep policies satisfied
-        connectionPool.scheduleOpener(route.address)
-      } else if (allocationLimit > oldLimit) {
-        // We might no longer need some connections
-        connectionPool.scheduleCloser()
-      }
     }
   }
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -18,9 +18,7 @@ package okhttp3.internal.connection
 
 import java.net.Socket
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
 import okhttp3.Address
 import okhttp3.ConnectionPool
 import okhttp3.Route
@@ -33,38 +31,22 @@ import okhttp3.internal.concurrent.withLock
 import okhttp3.internal.connection.RealCall.CallReference
 import okhttp3.internal.okHttpName
 import okhttp3.internal.platform.Platform
-import okio.IOException
 
 class RealConnectionPool internal constructor(
-  private val taskRunner: TaskRunner,
-  /**
-   * The maximum number of idle connections across all addresses.
-   * Connections needed to satisfy a [ConnectionPool.AddressPolicy] are not considered idle.
-   */
+  taskRunner: TaskRunner,
+  /** The maximum number of idle connections across all addresses. */
   private val maxIdleConnections: Int,
   keepAliveDuration: Long,
   timeUnit: TimeUnit,
   internal val connectionListener: ConnectionListener,
-  private val exchangeFinderFactory: (RealConnectionPool, Address, ConnectionUser) -> ExchangeFinder,
 ) {
   internal val keepAliveDurationNs: Long = timeUnit.toNanos(keepAliveDuration)
-
-  @Volatile
-  private var addressStates: Map<Address, AddressState> = mapOf()
 
   private val cleanupQueue: TaskQueue = taskRunner.newQueue()
   private val cleanupTask =
     object : Task("$okHttpName ConnectionPool connection closer") {
       override fun runOnce(): Long = closeConnections(System.nanoTime())
     }
-
-  private fun AddressState.scheduleOpener() {
-    queue.schedule(
-      object : Task("$okHttpName ConnectionPool connection opener") {
-        override fun runOnce(): Long = openConnections(this@scheduleOpener)
-      },
-    )
-  }
 
   /**
    * Holding the lock of the connection being added or removed when mutating this, and check its
@@ -160,7 +142,6 @@ class RealConnectionPool internal constructor(
       connection.noNewExchanges = true
       connections.remove(connection)
       if (connections.isEmpty()) cleanupQueue.cancelAll()
-      scheduleOpener(connection.route.address)
       true
     } else {
       scheduleCloser()
@@ -189,10 +170,6 @@ class RealConnectionPool internal constructor(
     }
 
     if (connections.isEmpty()) cleanupQueue.cancelAll()
-
-    for (policy in addressStates.values) {
-      policy.scheduleOpener()
-    }
   }
 
   /**
@@ -203,19 +180,6 @@ class RealConnectionPool internal constructor(
    * Returns -1 if no further cleanups are required.
    */
   fun closeConnections(now: Long): Long {
-    // Compute the concurrent call capacity for each address. We won't close a connection if doing
-    // so would violate a policy, unless it's OLD.
-    val addressStates = this.addressStates
-    for (state in addressStates.values) {
-      state.concurrentCallCapacity = 0
-    }
-    for (connection in connections) {
-      val addressState = addressStates[connection.route.address] ?: continue
-      connection.withLock {
-        addressState.concurrentCallCapacity += connection.allocationLimit
-      }
-    }
-
     // Find the longest-idle connections in 2 categories:
     //
     //  1. OLD: Connections that have been idle for at least keepAliveDurationNs. We close these if
@@ -248,12 +212,10 @@ class RealConnectionPool internal constructor(
           earliestOldConnection = connection
         }
 
-        if (isEvictable(addressStates, connection)) {
-          evictableConnectionCount++
-          if (idleAtNs < earliestEvictableIdleAtNs) {
-            earliestEvictableIdleAtNs = idleAtNs
-            earliestEvictableConnection = connection
-          }
+        evictableConnectionCount++
+        if (idleAtNs < earliestEvictableIdleAtNs) {
+          earliestEvictableIdleAtNs = idleAtNs
+          earliestEvictableConnection = connection
         }
       }
     }
@@ -288,7 +250,6 @@ class RealConnectionPool internal constructor(
           toEvict.noNewExchanges = true
           connections.remove(toEvict)
         }
-        addressStates[toEvict.route.address]?.scheduleOpener()
         toEvict.socket().closeQuietly()
         connectionListener.connectionClosed(toEvict)
         if (connections.isEmpty()) cleanupQueue.cancelAll()
@@ -312,16 +273,6 @@ class RealConnectionPool internal constructor(
         return -1
       }
     }
-  }
-
-  /** Returns true if no address policies prevent [connection] from being evicted. */
-  private fun isEvictable(
-    addressStates: Map<Address, AddressState>,
-    connection: RealConnection,
-  ): Boolean {
-    val addressState = addressStates[connection.route.address] ?: return true
-    val capacityWithoutIt = addressState.concurrentCallCapacity - connection.allocationLimit
-    return capacityWithoutIt >= addressState.policy.minimumConcurrentCalls
   }
 
   /**
@@ -364,101 +315,11 @@ class RealConnectionPool internal constructor(
     return references.size
   }
 
-  /**
-   * Adds or replaces the policy for [address].
-   * This will trigger a background task to start creating connections as needed.
-   */
-  fun setPolicy(
-    address: Address,
-    policy: AddressPolicy,
-  ) {
-    val state = AddressState(address, taskRunner.newQueue(), policy)
-    val newConnectionsNeeded: Int
-
-    while (true) {
-      val oldMap = this.addressStates
-      val newMap = oldMap + (address to state)
-      if (addressStatesUpdater.compareAndSet(this, oldMap, newMap)) {
-        val oldPolicyMinimumConcurrentCalls = oldMap[address]?.policy?.minimumConcurrentCalls ?: 0
-        newConnectionsNeeded = policy.minimumConcurrentCalls - oldPolicyMinimumConcurrentCalls
-        break
-      }
-    }
-
-    when {
-      newConnectionsNeeded > 0 -> state.scheduleOpener()
-      newConnectionsNeeded < 0 -> scheduleCloser()
-    }
-  }
-
-  /** Open connections to [address], if required by the address policy. */
-  fun scheduleOpener(address: Address) {
-    addressStates[address]?.scheduleOpener()
-  }
-
   fun scheduleCloser() {
     cleanupQueue.schedule(cleanupTask)
   }
 
-  /**
-   * Ensure enough connections open to [address] to satisfy its [ConnectionPool.AddressPolicy].
-   * If there are already enough connections, we're done.
-   * If not, we create one and then schedule the task to run again immediately.
-   */
-  private fun openConnections(state: AddressState): Long {
-    // This policy does not require minimum connections, don't run again
-    if (state.policy.minimumConcurrentCalls == 0) return -1L
-
-    var concurrentCallCapacity = 0
-    for (connection in connections) {
-      if (state.address != connection.route.address) continue
-      connection.withLock {
-        concurrentCallCapacity += connection.allocationLimit
-      }
-
-      // The policy was satisfied by existing connections, don't run again
-      if (concurrentCallCapacity >= state.policy.minimumConcurrentCalls) return -1L
-    }
-
-    // If we got here then the policy was not satisfied -- open a connection!
-    try {
-      val connection = exchangeFinderFactory(this, state.address, PoolConnectionUser).find()
-
-      // RealRoutePlanner will add the connection to the pool itself, other RoutePlanners may not
-      // TODO: make all RoutePlanners consistent in this behavior
-      if (connection !in connections) {
-        connection.withLock { put(connection) }
-      }
-
-      return 0L // run again immediately to create more connections if needed
-    } catch (e: IOException) {
-      // No need to log, user.connectFailed() will already have been called. Just try again later.
-      return state.policy.backoffDelayMillis.jitterBy(state.policy.backoffJitterMillis) * 1_000_000
-    }
-  }
-
-  private fun Long.jitterBy(amount: Int): Long = this + ThreadLocalRandom.current().nextInt(amount * -1, amount)
-
-  class AddressState(
-    val address: Address,
-    val queue: TaskQueue,
-    var policy: AddressPolicy,
-  ) {
-    /**
-     * How many calls the pool can carry without opening new connections. This field must only be
-     * accessed by the connection closer task.
-     */
-    var concurrentCallCapacity: Int = 0
-  }
-
   companion object {
     fun get(connectionPool: ConnectionPool): RealConnectionPool = connectionPool.delegate
-
-    private var addressStatesUpdater =
-      AtomicReferenceFieldUpdater.newUpdater(
-        RealConnectionPool::class.java,
-        Map::class.java,
-        "addressStates",
-      )
   }
 }

--- a/okhttp/src/jvmTest/kotlin/okhttp3/FakeRoutePlanner.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/FakeRoutePlanner.kt
@@ -28,7 +28,7 @@ class FakeRoutePlanner(
   val taskFaker: TaskFaker = factory.taskFaker,
 ) : RoutePlanner,
   Closeable {
-  val pool = factory.newConnectionPool(routePlanner = this)
+  val pool = factory.newConnectionPool()
   val events = LinkedBlockingDeque<String>()
   var canceled = false
   var autoGeneratePlans = false

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/ConnectionPoolTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/ConnectionPoolTest.kt
@@ -21,7 +21,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isTrue
-import okhttp3.Address
 import okhttp3.ConnectionPool
 import okhttp3.FakeRoutePlanner
 import okhttp3.OkHttpClient
@@ -30,19 +29,13 @@ import okhttp3.TestUtil.awaitGarbageCollection
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.concurrent.TaskRunner.RealBackend
 import okhttp3.internal.concurrent.withLock
-import okhttp3.internal.http2.Http2
-import okhttp3.internal.http2.Http2Connection
-import okhttp3.internal.http2.Http2ConnectionTest
 import okhttp3.internal.http2.MockHttp2Peer
-import okhttp3.internal.http2.Settings
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class ConnectionPoolTest {
   private val routePlanner = FakeRoutePlanner()
   private val factory = routePlanner.factory
-  private val taskFaker = routePlanner.taskFaker
   private val peer = MockHttp2Peer()
 
   /** The fake task runner prevents the cleanup runnable from being started.  */
@@ -210,138 +203,6 @@ class ConnectionPoolTest {
     }
     Thread.sleep(100)
     assertThat(taskRunner.activeQueues()).isEmpty()
-  }
-
-  @Test fun connectionPreWarmingHttp1() {
-    taskFaker.advanceUntil(System.nanoTime())
-    val expireTime = taskFaker.nanoTime + 1_000_000_000_000
-
-    routePlanner.autoGeneratePlans = true
-    routePlanner.defaultConnectionIdleAtNanos = expireTime
-    val address = routePlanner.address
-    val pool = routePlanner.pool
-
-    // Connections are created as soon as a policy is set
-    setPolicy(pool, address, AddressPolicy(2))
-    assertThat(pool.connectionCount()).isEqualTo(2)
-
-    // Connections are replaced if they idle out or are evicted from the pool
-    evictAllConnections(pool)
-    assertThat(pool.connectionCount()).isEqualTo(2)
-    forceConnectionsToExpire(pool, expireTime)
-    assertThat(pool.connectionCount()).isEqualTo(2)
-
-    // Excess connections aren't removed until they idle out, even if no longer needed
-    setPolicy(pool, address, AddressPolicy(1))
-    assertThat(pool.connectionCount()).isEqualTo(2)
-    forceConnectionsToExpire(pool, expireTime)
-    assertThat(pool.connectionCount()).isEqualTo(1)
-  }
-
-  @Disabled("https://github.com/square/okhttp/issues/8451")
-  @Test
-  fun connectionPreWarmingHttp2() {
-    taskFaker.advanceUntil(System.nanoTime())
-    val expireSooner = taskFaker.nanoTime + 1_000_000_000_000
-    val expireLater = taskFaker.nanoTime + 2_000_000_000_000
-
-    routePlanner.autoGeneratePlans = true
-    val address = routePlanner.address
-    val pool = routePlanner.pool
-
-    // Add a connection to the pool that won't expire for a while
-    routePlanner.defaultConnectionIdleAtNanos = expireLater
-    setPolicy(pool, address, AddressPolicy(1))
-    assertThat(pool.connectionCount()).isEqualTo(1)
-
-    // All other connections created will expire sooner
-    routePlanner.defaultConnectionIdleAtNanos = expireSooner
-
-    // Turn it into an http/2 connection that supports 5 concurrent streams
-    // which can satisfy a larger policy
-    val connection = routePlanner.plans.first().connection
-    val http2Connection = connectHttp2(peer, connection, 5)
-    setPolicy(pool, address, AddressPolicy(5))
-    assertThat(pool.connectionCount()).isEqualTo(1)
-
-    // Decrease the connection's max so that another connection is needed
-    updateMaxConcurrentStreams(http2Connection, 4)
-    assertThat(pool.connectionCount()).isEqualTo(2)
-
-    // Increase the connection's max so that the new connection is no longer needed
-    updateMaxConcurrentStreams(http2Connection, 5)
-    forceConnectionsToExpire(pool, expireSooner)
-    assertThat(pool.connectionCount()).isEqualTo(1)
-  }
-
-  private fun setPolicy(
-    pool: RealConnectionPool,
-    address: Address,
-    policy: AddressPolicy,
-  ) {
-    pool.setPolicy(address, policy)
-    taskFaker.runTasks()
-  }
-
-  private fun evictAllConnections(pool: RealConnectionPool) {
-    pool.evictAll()
-    assertThat(pool.connectionCount()).isEqualTo(0)
-    taskFaker.runTasks()
-  }
-
-  private fun forceConnectionsToExpire(
-    pool: RealConnectionPool,
-    expireTime: Long,
-  ) {
-    val idleTimeNanos = expireTime + pool.keepAliveDurationNs
-    repeat(pool.connectionCount()) { pool.closeConnections(idleTimeNanos) }
-    taskFaker.runTasks()
-  }
-
-  private fun connectHttp2(
-    peer: MockHttp2Peer,
-    realConnection: RealConnection,
-    maxConcurrentStreams: Int,
-  ): Http2Connection {
-    // Write the mocking script.
-    val settings1 = Settings()
-    settings1[Settings.MAX_CONCURRENT_STREAMS] = maxConcurrentStreams
-    peer.sendFrame().settings(settings1)
-    peer.acceptFrame() // ACK
-    peer.sendFrame().ping(false, 2, 0)
-    peer.acceptFrame() // PING
-    peer.play()
-
-    // Play it back.
-    val connection =
-      Http2Connection
-        .Builder(true, TaskRunner.INSTANCE)
-        .socket(peer.openSocket().asBufferedSocket(), "peer")
-        .pushObserver(Http2ConnectionTest.IGNORE)
-        .listener(realConnection)
-        .build()
-    connection.start(sendConnectionPreface = false)
-
-    // verify the peer received the ACK
-    val ackFrame = peer.takeFrame()
-    assertThat(ackFrame.type).isEqualTo(Http2.TYPE_SETTINGS)
-    assertThat(ackFrame.streamId).isEqualTo(0)
-    assertThat(ackFrame.ack).isTrue()
-
-    taskFaker.runTasks()
-
-    return connection
-  }
-
-  private fun updateMaxConcurrentStreams(
-    connection: Http2Connection,
-    amount: Int,
-  ) {
-    val settings = Settings()
-    settings[Settings.MAX_CONCURRENT_STREAMS] = amount
-    connection.readerRunnable.applyAndAckSettings(true, settings)
-    assertThat(connection.peerSettings[Settings.MAX_CONCURRENT_STREAMS]).isEqualTo(amount)
-    taskFaker.runTasks()
   }
 
   /** Use a helper method so there's no hidden reference remaining on the stack.  */


### PR DESCRIPTION
It's currently unused.

I'd like to bring this feature back soon, but using regular Calls to make it happen rather than having Connections created without a Call object. That should avoid some special cases.