### PR TITLE
Make tests fail on UnsupportedOperationException

### DIFF
--- a/android-test/src/androidTest/java/okhttp/android/test/SingleAndroidTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/SingleAndroidTest.kt
@@ -37,8 +37,7 @@ class SingleAndroidTest {
       .sslSocketFactory(
         handshakeCertificates.sslSocketFactory(),
         handshakeCertificates.trustManager,
-      )
-      .connectionPool(ConnectionPool(0, 1, TimeUnit.SECONDS))
+      ).connectionPool(ConnectionPool(0, 1, TimeUnit.SECONDS))
       .build()
 
   private val server =


### PR DESCRIPTION
Will fail without the okio fix.

```
09:14:49.703  E  FATAL EXCEPTION: MockWebServer TaskRunner (Ask Gemini)
                 Process: okhttp.android.test.test, PID: 10087
                 java.lang.UnsupportedOperationException
                 	at javax.net.ssl.SSLSocket.shutdownOutput(SSLSocket.java:851)
                 	at okio.internal.DefaultSocket$SocketSink.close(DefaultSocket.kt:95)
                 	at okio.ForwardingSink.close(ForwardingSink.kt:37)
                 	at mockwebserver3.internal.MockWebServerSocket$sink$1.close(MockWebServerSocket.kt:69)
                 	at okio.RealBufferedSink.close(RealBufferedSink.kt:287)
                 	at okhttp3.internal.http2.Http2Writer.close(Http2Writer.kt:331)
                 	at okhttp3.internal.http2.Http2Connection.close$okhttp(Http2Connection.kt:474)
                 	at okhttp3.internal.http2.Http2Connection$ReaderRunnable.invoke(Http2Connection.kt:638)
                 	at okhttp3.internal.http2.Http2Connection$ReaderRunnable.invoke(Http2Connection.kt:619)
                 	at okhttp3.internal.concurrent.TaskQueue$execute$1.runOnce(TaskQueue.kt:112)
                 	at okhttp3.internal.concurrent.TaskRunner$runnable$1.run(TaskRunner.kt:81)
                 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
                 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
                 	at java.lang.Thread.run(Thread.java:818)
```