### PR TITLE
Catch UnsatisfiedLinkError in AndroidLog

### DIFF
--- a/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
+++ b/okhttp/src/androidMain/kotlin/okhttp3/internal/platform/android/AndroidLog.kt
@@ -112,7 +112,7 @@ object AndroidLog {
       // Happens with non-robolectric unit tests
       System.err.println("Possibly running android unit test without robolectric")
       re.printStackTrace()
-    } catch (ule: Error) {
+    } catch (ule: UnsatisfiedLinkError) {
       // Happens with Paparazzi - with Android classes on the classpath
       System.err.println("Possibly running android unit test without robolectric")
       ule.printStackTrace()


### PR DESCRIPTION
Happens with Paparazzi. see https://github.com/square/okhttp/issues/9125