### PR TITLE
Add tags to calls, including computable tags

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/FailingCall.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/FailingCall.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3
 
+import kotlin.reflect.KClass
 import okio.Timeout
 
 open class FailingCall : Call {
@@ -31,6 +32,20 @@ open class FailingCall : Call {
   override fun isCanceled(): Boolean = error("unexpected")
 
   override fun timeout(): Timeout = error("unexpected")
+
+  override fun <T : Any> tag(type: KClass<T>): T? = error("unexpected")
+
+  override fun <T> tag(type: Class<out T>): T? = error("unexpected")
+
+  override fun <T : Any> tag(
+    type: KClass<T>,
+    computeIfAbsent: () -> T,
+  ): T = error("unexpected")
+
+  override fun <T : Any> tag(
+    type: Class<T>,
+    computeIfAbsent: () -> T,
+  ): T = error("unexpected")
 
   override fun clone(): Call = error("unexpected")
 }

--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -126,6 +126,10 @@ public abstract interface class okhttp3/Call : java/lang/Cloneable {
 	public abstract fun isCanceled ()Z
 	public abstract fun isExecuted ()Z
 	public abstract fun request ()Lokhttp3/Request;
+	public abstract fun tag (Ljava/lang/Class;)Ljava/lang/Object;
+	public abstract fun tag (Ljava/lang/Class;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun tag (Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public abstract fun tag (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public abstract fun timeout ()Lokio/Timeout;
 }
 

--- a/okhttp/api/jvm/okhttp.api
+++ b/okhttp/api/jvm/okhttp.api
@@ -126,6 +126,10 @@ public abstract interface class okhttp3/Call : java/lang/Cloneable {
 	public abstract fun isCanceled ()Z
 	public abstract fun isExecuted ()Z
 	public abstract fun request ()Lokhttp3/Request;
+	public abstract fun tag (Ljava/lang/Class;)Ljava/lang/Object;
+	public abstract fun tag (Ljava/lang/Class;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun tag (Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public abstract fun tag (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public abstract fun timeout ()Lokio/Timeout;
 }
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Call.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Call.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3
 
+import kotlin.reflect.KClass
 import okio.IOException
 import okio.Timeout
 
@@ -88,8 +89,78 @@ interface Call : Cloneable {
   fun timeout(): Timeout
 
   /**
+   * Returns the tag attached with [type] as a key, or null if no tag is attached with that key.
+   *
+   * The tags on a call are seeded from the [request tags][Request.tag]. This set will grow if new
+   * tags are computed.
+   */
+  fun <T : Any> tag(type: KClass<T>): T?
+
+  /**
+   * Returns the tag attached with [type] as a key, or null if no tag is attached with that key.
+   *
+   * The tags on a call are seeded from the [request tags][Request.tag]. This set will grow if new
+   * tags are computed.
+   */
+  fun <T> tag(type: Class<out T>): T?
+
+  /**
+   * Returns the tag attached with [type] as a key. If it is absent, then [computeIfAbsent] is
+   * called and that value is both inserted and returned.
+   *
+   * If multiple calls to this function are made concurrently with the same [type], multiple values
+   * may be computed. But only one value will be inserted, and that inserted value will be returned
+   * to all callers.
+   *
+   * If computing multiple values is problematic, use an appropriate concurrency mechanism in your
+   * [computeIfAbsent] implementation. No locks are held while calling this function.
+   */
+  fun <T : Any> tag(
+    type: KClass<T>,
+    computeIfAbsent: () -> T,
+  ): T
+
+  /**
+   * Returns the tag attached with [type] as a key. If it is absent, then [computeIfAbsent] is
+   * called and that value is both inserted and returned.
+   *
+   * If multiple calls to this function are made concurrently with the same [type], multiple values
+   * may be computed. But only one value will be inserted, and that inserted value will be returned
+   * to all callers.
+   *
+   * If computing multiple values is problematic, use an appropriate concurrency mechanism in your
+   * [computeIfAbsent] implementation. No locks are held while calling this function.
+   */
+  fun <T : Any> tag(
+    type: Class<T>,
+    computeIfAbsent: () -> T,
+  ): T
+
+  /**
    * Create a new, identical call to this one which can be enqueued or executed even if this call
    * has already been.
+   *
+   * The tags on the returned call will equal the tags as on [request]. Any tags that were computed
+   * for this call will not be included on the cloned call. If necessary you may manually copy over
+   * specific tags by re-computing them:
+   *
+   * ```kotlin
+   * val copy = original.clone()
+   *
+   * val myTag = original.tag(MyTag::class)
+   * if (myTag != null) {
+   *   copy.tag(MyTag::class) { myTag }
+   * }
+   * ```
+   *
+   * ```java
+   * Call copy = original.clone();
+   *
+   * MyTag myTag = original.tag(MyTag.class);
+   * if (myTag != null) {
+   *   copy.tag(MyTag.class, () -> myTag);
+   * }
+   * ```
    */
   public override fun clone(): Call
 

--- a/okhttp/src/jvmTest/java/okhttp3/CallJavaTest.java
+++ b/okhttp/src/jvmTest/java/okhttp3/CallJavaTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CallJavaTest {
+  @RegisterExtension
+  OkHttpClientTestRule clientTestRule = new OkHttpClientTestRule();
+
+  private OkHttpClient client = clientTestRule.newClient();
+
+  @Test
+  public void tagsSeededFromRequest() {
+    Request request = new Request.Builder()
+      .url(HttpUrl.get("https://square.com/"))
+      .tag(Integer.class, 5)
+      .tag(String.class, "hello")
+      .build();
+    Call call = client.newCall(request);
+
+    assertEquals(5, call.tag(Integer.class));
+    assertEquals("hello", call.tag(String.class));
+    assertEquals(null, call.tag(Boolean.class));
+    assertEquals(null, call.tag(Object.class));
+  }
+
+  @Test
+  public void tagsCanBeComputed() {
+    Request request = new Request.Builder()
+      .url(HttpUrl.get("https://square.com/"))
+      .build();
+    Call call = client.newCall(request);
+
+    assertEquals("a", call.tag(String.class, () -> "a"));
+    assertEquals("a", call.tag(String.class, () -> "b"));
+  }
+}

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CallTagsTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CallTagsTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class CallTagsTest {
+  @JvmField @RegisterExtension
+  val clientTestRule = OkHttpClientTestRule()
+
+  private var client = clientTestRule.newClient()
+
+  @Test
+  fun tagsSeededFromRequest() {
+    val request =
+      Request
+        .Builder()
+        .url("https://square.com/".toHttpUrl())
+        .tag(Integer::class, 5 as Integer)
+        .tag(String::class, "hello")
+        .build()
+    val call = client.newCall(request)
+
+    // Check the Kotlin-focused APIs.
+    assertThat(call.tag(String::class)).isEqualTo("hello")
+    assertThat(call.tag(Integer::class)).isEqualTo(5)
+    assertThat(call.tag(Boolean::class)).isNull()
+    assertThat(call.tag(Any::class)).isNull()
+
+    // Check the Java APIs too.
+    assertThat(call.tag(String::class.java)).isEqualTo("hello")
+    assertThat(call.tag(Integer::class.java)).isEqualTo(5)
+    assertThat(call.tag(Boolean::class.java)).isNull()
+    assertThat(call.tag(Any::class.java)).isNull()
+  }
+
+  @Test
+  fun tagsCanBeComputed() {
+    val request =
+      Request
+        .Builder()
+        .url("https://square.com")
+        .build()
+    val call = client.newCall(request)
+
+    // Check the Kotlin-focused APIs.
+    assertThat(call.tag(String::class) { "a" }).isEqualTo("a")
+    assertThat(call.tag(String::class) { "b" }).isEqualTo("a")
+    assertThat(call.tag(String::class)).isEqualTo("a")
+
+    // Check the Java-focused APIs.
+    assertThat(call.tag(Integer::class) { 1 as Integer }).isEqualTo(1)
+    assertThat(call.tag(Integer::class) { 2 as Integer }).isEqualTo(1)
+    assertThat(call.tag(Integer::class)).isEqualTo(1)
+  }
+
+  @Test
+  fun computedTagsAreNotRetainedInClone() {
+    val request =
+      Request
+        .Builder()
+        .url("https://square.com")
+        .build()
+    val callA = client.newCall(request)
+    assertThat(callA.tag(String::class) { "a" }).isEqualTo("a")
+    assertThat(callA.tag(String::class) { "b" }).isEqualTo("a")
+
+    val callB = callA.clone()
+    assertThat(callB.tag(String::class) { "c" }).isEqualTo("c")
+    assertThat(callB.tag(String::class) { "d" }).isEqualTo("c")
+  }
+}

--- a/okhttp/src/jvmTest/kotlin/okhttp3/KotlinSourceModernTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/KotlinSourceModernTest.kt
@@ -46,6 +46,7 @@ import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509KeyManager
 import javax.net.ssl.X509TrustManager
+import kotlin.reflect.KClass
 import okhttp3.Handshake.Companion.handshake
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.Headers.Companion.toHeaders
@@ -200,6 +201,20 @@ class KotlinSourceModernTest {
         override fun isCanceled(): Boolean = TODO()
 
         override fun timeout(): Timeout = TODO()
+
+        override fun <T : Any> tag(type: KClass<T>): T? = TODO()
+
+        override fun <T> tag(type: Class<out T>): T? = TODO()
+
+        override fun <T : Any> tag(
+          type: KClass<T>,
+          computeIfAbsent: () -> T,
+        ): T = TODO()
+
+        override fun <T : Any> tag(
+          type: Class<T>,
+          computeIfAbsent: () -> T,
+        ): T = TODO()
 
         override fun clone(): Call = TODO()
       }


### PR DESCRIPTION
Originally I was planning on implementing tags on
Request only, but that design broke as soon as any
interceptor used Request.newBuilder() to create a
copy of the Request - the instance that received the
tags might not be the instance that needed them.

Instead I'm introducing this behavior on the Call
object, which behaves less like a value. I expect
that users' expected lifetimes of tags will work
naturally this way.

It is an API hazard that we have tags on both
Requests and Calls. Perhaps if given the opportunity
to do it over, I'd omit support for tags on Requests.