### PR TITLE
Handle UnreadableResponseBody in HttpLoggingInterceptor

### DIFF
--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -25,6 +25,7 @@ import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
+import okhttp3.internal.UnreadableResponseBody
 import okhttp3.internal.charsetOrUtf8
 import okhttp3.internal.http.promisesBody
 import okhttp3.internal.isProbablyUtf8
@@ -284,6 +285,8 @@ class HttpLoggingInterceptor
           logger.log("<-- END HTTP (encoded body omitted)")
         } else if (bodyIsStreaming(response)) {
           logger.log("<-- END HTTP (streaming)")
+        } else if (responseBody is UnreadableResponseBody) {
+          logger.log("<-- END HTTP (unreadable body)")
         } else {
           val source = responseBody.source()
           source.request(Long.MAX_VALUE) // Buffer the entire body.


### PR DESCRIPTION
If `HttpLoggingInterceptor` is present on a client that attempts a websocket upgrade, the logging interceptor crashes due to:
<details><summary>UnreadableResponseBody</summary>

```
java.lang.IllegalStateException: Unreadable ResponseBody! These Response objects have bodies that are stripped:
 * Response.cacheResponse
 * Response.networkResponse
 * Response.priorResponse
 * EventSourceListener
 * WebSocketListener
(It is safe to call contentType() and contentLength() on these response bodies.)
	at okhttp3.internal.UnreadableResponseBody.read(UnreadableResponseBody.kt:41)
	at okio.RealBufferedSource.request(RealBufferedSource.kt:232)
	at okhttp3.logging.HttpLoggingInterceptor.intercept(HttpLoggingInterceptor.kt:292)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at okhttp3.logging.HttpLoggingInterceptorTest.setUp$lambda$0(HttpLoggingInterceptorTest.kt:82)
```
</details>

This is understandably intentional, however, HttpLoggingInterceptor also makes intentional choices about what it will and will not log or attempt to log. This adds a simple check that also skips responseBody logging if it is `UnreadableResponseBody`.

If we apply the test first, without the fix in HttpLoggingInterceptor, the `bodyResponseIsUnreadable()` test fails as expected, as shown above. With the fix, the test passes.