### PR TITLE
Fix a flake in TrailersTest

### DIFF
--- a/okhttp/src/jvmTest/kotlin/okhttp3/TrailersTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/TrailersTest.kt
@@ -610,16 +610,16 @@ open class TrailersTest {
           OKHTTP_CLIENT_WINDOW_SIZE.toLong(),
           DISCARD_STREAM_TIMEOUT_MILLIS.toLong() + 1L,
           TimeUnit.MILLISECONDS,
-        )
-        .build(),
+        ).build(),
     )
 
-    val call = client.newCall(
-      Request(
-        url = server.url("/"),
-        headers = headersOf("Cache-Control", "no-store"),
+    val call =
+      client.newCall(
+        Request(
+          url = server.url("/"),
+          headers = headersOf("Cache-Control", "no-store"),
+        ),
       )
-    )
     call.execute().use { response ->
       val source = response.body.source()
       assertThat(response.header("h1")).isEqualTo("v1")


### PR DESCRIPTION
We weren't testing what we wanted to be testing because the cache was on, and that impacts how Response.body.close() works.