### PR TITLE
Fix RouteFailureTest and use RepeatedTest

### DIFF
--- a/okhttp/src/jvmTest/kotlin/okhttp3/RouteFailureTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/RouteFailureTest.kt
@@ -33,6 +33,7 @@ import okhttp3.internal.http.RecordingProxySelector
 import okhttp3.internal.http2.ErrorCode
 import okhttp3.testing.PlatformRule
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -82,7 +83,7 @@ class RouteFailureTest {
         .build()
   }
 
-  @Test
+  @RepeatedTest(100)
   fun http2OneBadHostOneGoodNoRetryOnConnectionFailure() {
     enableProtocol(Protocol.HTTP_2)
 
@@ -107,6 +108,7 @@ class RouteFailureTest {
       .assertFailureMatches("stream was reset: REFUSED_STREAM")
 
     assertThat(client.routeDatabase.failedRoutes).isEmpty()
+    server1.takeRequest()
     assertThat(server1.requestCount).isEqualTo(1)
     assertThat(server2.requestCount).isEqualTo(0)
 
@@ -162,7 +164,7 @@ class RouteFailureTest {
     )
   }
 
-  @Test
+  @RepeatedTest(100)
   fun http2OneBadHostOneGoodNoRetryOnConnectionFailureFastFallback() {
     enableProtocol(Protocol.HTTP_2)
 
@@ -187,6 +189,7 @@ class RouteFailureTest {
       .assertFailureMatches("stream was reset: REFUSED_STREAM")
 
     assertThat(client.routeDatabase.failedRoutes).isEmpty()
+    server1.takeRequest()
     assertThat(server1.requestCount).isEqualTo(1)
     assertThat(server2.requestCount).isEqualTo(0)
 
@@ -242,7 +245,7 @@ class RouteFailureTest {
     )
   }
 
-  @Test
+  @RepeatedTest(100)
   fun http2OneBadHostRetryOnConnectionFailure() {
     enableProtocol(Protocol.HTTP_2)
 
@@ -266,6 +269,7 @@ class RouteFailureTest {
       .assertFailureMatches("stream was reset: REFUSED_STREAM")
 
     assertThat(client.routeDatabase.failedRoutes).isEmpty()
+    server1.takeRequest()
     assertThat(server1.requestCount).isEqualTo(1)
 
     assertThat(clientTestRule.recordedConnectionEventTypes()).containsExactly(
@@ -276,7 +280,7 @@ class RouteFailureTest {
     )
   }
 
-  @Test
+  @RepeatedTest(100)
   fun http2OneBadHostRetryOnConnectionFailureFastFallback() {
     enableProtocol(Protocol.HTTP_2)
 
@@ -300,6 +304,7 @@ class RouteFailureTest {
       .assertFailureMatches("stream was reset: REFUSED_STREAM")
 
     assertThat(client.routeDatabase.failedRoutes).isEmpty()
+    server1.takeRequest()
     assertThat(server1.requestCount).isEqualTo(1)
 
     assertThat(clientTestRule.recordedConnectionEventTypes()).containsExactly(


### PR DESCRIPTION
Updated tests to use @RepeatedTest annotation for consistency and performance.

Also fixes a cause of flakiness

full disclosure: fix suggested by AI from https://github.com/square/okhttp/pull/9246
but seems appropriate.