### PR TITLE
Prevent flaky tests by adding sleep in HttpOverHttp2Test

### DIFF
--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HttpOverHttp2Test.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HttpOverHttp2Test.kt
@@ -1215,6 +1215,8 @@ class HttpOverHttp2Test(
       .isEqualTo(expectedSequenceNumber)
     responseDequeuedLatch!!.await()
     call.cancel()
+    // Avoid flaky race conditions
+    Thread.sleep(100)
     requestCanceledLatch!!.countDown()
     latch.await()
   }


### PR DESCRIPTION
Added a sleep to avoid flaky race conditions in test.