### PR TITLE
Add Partitioned cookie attribute support

### DIFF
--- a/okhttp/src/jvmTest/kotlin/okhttp3/CookieTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CookieTest.kt
@@ -362,6 +362,18 @@ class CookieTest {
     assertThat(parse(url, "a=b; Secure")!!.secure).isTrue()
   }
 
+  @Test fun partitioned() {
+    assertThat(parse(url, "a=b")!!.partitioned).isFalse()
+    assertThat(parse(url, "a=b; Partitioned")!!.partitioned).isTrue()
+    assertThat(parse(url, "a=b; partitioned")!!.partitioned).isTrue()
+    assertThat(parse(url, "a=b; PARTITIONED")!!.partitioned).isTrue()
+  }
+
+  @Test fun partitionedToString() {
+    val cookie = parse(url, "a=b; Secure; Partitioned")
+    assertThat(cookie!!.toString()).isEqualTo("a=b; path=/; secure; partitioned")
+  }
+
   @Test fun maxAgeTakesPrecedenceOverExpires() {
     // Max-Age = 1, Expires = 2. In either order.
     assertThat(parseCookie(0L, url, "a=b; Max-Age=1; Expires=Thu, 01 Jan 1970 00:00:02 GMT")!!.expiresAt)
@@ -434,6 +446,7 @@ class CookieTest {
     assertThat(cookie.persistent).isFalse()
     assertThat(cookie.hostOnly).isFalse()
     assertThat(cookie.sameSite).isNull()
+    assertThat(cookie.partitioned).isFalse()
   }
 
   @Test fun newBuilder() {
@@ -565,6 +578,18 @@ class CookieTest {
     assertThat(cookie.httpOnly).isTrue()
   }
 
+  @Test fun builderPartitioned() {
+    val cookie =
+      Cookie
+        .Builder()
+        .name("a")
+        .value("b")
+        .hostOnlyDomain("example.com")
+        .partitioned()
+        .build()
+    assertThat(cookie.partitioned).isTrue()
+  }
+
   @Test fun builderIpv6() {
     val cookie =
       Cookie
@@ -658,6 +683,8 @@ class CookieTest {
         "a=b; Path=/c; Domain=example.com;            Secure; HttpOnly; SameSite=Lax",
         "a=b; Path=/c; Domain=example.com; Max-Age=5;         HttpOnly; SameSite=Lax",
         "a=b; Path=/c; Domain=example.com; Max-Age=5; Secure;         ; SameSite=Lax",
+        "a=b; Path=/c; Domain=example.com; Max-Age=5; Secure; HttpOnly; Partitioned",
+        "a=b; Path=/c; Domain=example.com; Max-Age=5; Secure; HttpOnly; SameSite=None; Partitioned",
       )
     for (stringA in cookieStrings) {
       val cookieA = parseCookie(0, url, stringA!!)


### PR DESCRIPTION
## Summary

Add support for parsing and exposing the `Partitioned` cookie attribute, which is part of the [CHIPS (Cookies Having Independent Partitioned State)](https://developers.google.com/privacy-sandbox/cookies/chips) proposal for improved privacy in cross-site contexts.

When set, partitioned cookies are only sent in requests where the top-level site matches the site that set the cookie, providing additional privacy protections for cross-site contexts.

## Changes

- Add `partitioned` boolean property to `Cookie` class with KDoc
- Add parsing for `Partitioned` attribute in Set-Cookie header (case-insensitive)
- Add `partitioned()` builder method
- Include `partitioned` in `equals()`, `hashCode()`, and `toString()`
- Add tests for parsing, builder, and serialization

## Browser Support

This attribute is already supported by:
- Chrome/Edge (since 2023)
- Firefox (since v131)
- Safari 18.4+

## Test Plan

- [x] Added `partitioned()` test for parsing
- [x] Added `partitionedToString()` test for serialization
- [x] Added `builderPartitioned()` test for builder
- [x] Updated `builder()` test to verify default is false
- [x] Updated `equalsAndHashCode()` test with partitioned variations
- [x] All existing CookieTest tests pass

Fixes #8705