### PR TITLE
Migrate Android instrumented tests to JUnit 4

### DIFF
--- a/android-test/build.gradle.kts
+++ b/android-test/build.gradle.kts
@@ -3,7 +3,6 @@
 plugins {
   id("com.android.library")
   kotlin("android")
-  id("de.mannodermaus.android-junit5")
 }
 
 val androidBuild = property("androidBuild").toString().toBoolean()
@@ -16,12 +15,10 @@ android {
   defaultConfig {
     minSdk = 21
 
-    // Make sure to use the AndroidJUnitRunner (or a sub-class) in order to hook in the JUnit 5 Test Builder
+    // Use standard AndroidJUnitRunner for JUnit 4 tests (compatible with API 21+)
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     testInstrumentationRunnerArguments += mapOf(
-      "runnerBuilder" to "de.mannodermaus.junit5.AndroidJUnit5Builder",
-      "notPackage" to "org.bouncycastle",
-      "configurationParameters" to "junit.jupiter.extensions.autodetection.enabled=true"
+      "notPackage" to "org.bouncycastle"
     )
   }
 
@@ -107,13 +104,6 @@ dependencies {
   androidTestImplementation(libs.squareup.okio.fakefilesystem)
 
   androidTestImplementation(libs.androidx.test.runner)
-  androidTestImplementation(libs.junit.jupiter.api)
-  androidTestImplementation(libs.junit5android.core)
-  androidTestRuntimeOnly(libs.junit5android.runner)
-}
-
-junitPlatform {
-  filters {
-    excludeTags("Remote")
-  }
+  // Use JUnit 4 for Android instrumented tests (compatible with API 21+)
+  androidTestImplementation(libs.junit)
 }

--- a/android-test/src/androidTest/java/okhttp/android/test/SingleAndroidTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/SingleAndroidTest.kt
@@ -23,7 +23,7 @@ import okhttp3.ConnectionPool
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.tls.internal.TlsUtil.localhost
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 /**
  * This single Junit 4 test is our Android test suite on API 21-25.

--- a/android-test/src/androidTest/java/okhttp/android/test/StrictModeTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/StrictModeTest.kt
@@ -27,16 +27,17 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.internal.platform.Platform
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.parallel.Isolated
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
-@Isolated
+@RunWith(AndroidJUnit4::class)
 @SdkSuppress(minSdkVersion = 28)
 class StrictModeTest {
   private val violations = mutableListOf<Violation>()
 
-  @AfterEach
+  @After
   fun cleanup() {
     StrictMode.setThreadPolicy(
       ThreadPolicy

--- a/android-test/src/androidTest/java/okhttp/android/test/alpn/AlpnOverrideTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/alpn/AlpnOverrideTest.kt
@@ -28,13 +28,14 @@ import okhttp3.DelegatingSSLSocketFactory
 import okhttp3.EventListener
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Test
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 /**
  * Tests for ALPN overriding on Android.
  */
-@Tag("Remote")
+@RunWith(AndroidJUnit4::class)
 class AlpnOverrideTest {
   class CustomSSLSocketFactory(
     delegate: SSLSocketFactory,

--- a/android-test/src/androidTest/java/okhttp/android/test/letsencrypt/LetsEncryptClientTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/letsencrypt/LetsEncryptClientTest.kt
@@ -24,13 +24,14 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.decodeCertificatePem
-import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Test
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 /**
  * Test for new Let's Encrypt Root Certificate.
  */
-@Tag("Remote")
+@RunWith(AndroidJUnit4::class)
 class LetsEncryptClientTest {
   @Test fun get() {
     // These tests wont actually run before Android 8.0 as per

--- a/android-test/src/androidTest/java/okhttp/android/test/sni/SniOverrideTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/sni/SniOverrideTest.kt
@@ -30,14 +30,15 @@ import okhttp3.Dns
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
-import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.Tag
-import org.junit.jupiter.api.Test
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 /**
  * Tests for SNI overriding on Android.
  */
-@Tag("Remote")
+@RunWith(AndroidJUnit4::class)
 class SniOverrideTest {
   var client =
     OkHttpClient


### PR DESCRIPTION
## Summary

Migrate the android-test module from JUnit 5 to JUnit 4 to enable tests to run on Android API 21-25.

The JUnit 5 tests weren't running on older Android versions due to limitations of the android-junit5 plugin (requires API 26+).

## Changes

**Annotation migrations:**
- `@BeforeEach` → `@Before`
- `@AfterEach` → `@After`
- `@Disabled` → `@Ignore`
- `@Tag` → removed
- `@RegisterExtension` → removed

**Import changes:**
- `org.junit.jupiter.api.*` → `org.junit.*`
- `TestAbortedException` → `AssumptionViolatedException`

**Build changes:**
- Removed `de.mannodermaus.android-junit5` plugin
- Simplified test instrumentation runner configuration
- Use standard `AndroidJUnitRunner`

**Test infrastructure:**
- Added `@RunWith(AndroidJUnit4::class)` to test classes
- Manually manage MockWebServer lifecycle with `@Before`/`@After`
- Simplified client creation without `OkHttpClientTestRule`

## Test Plan

These tests should now run on all supported Android versions (API 21+).

Fixes #9134