### PR TITLE
Fix JavaHttpClientTest

### DIFF
--- a/samples/compare/src/test/kotlin/okhttp3/compare/JavaHttpClientTest.kt
+++ b/samples/compare/src/test/kotlin/okhttp3/compare/JavaHttpClientTest.kt
@@ -28,7 +28,6 @@ import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.junit5.StartStop
 import okhttp3.testing.PlatformRule
-import okhttp3.testing.PlatformVersion
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -77,9 +76,6 @@ class JavaHttpClientTest {
     assertThat(recorded.headers["Accept"]).isEqualTo("text/plain")
     assertThat(recorded.headers["Accept-Encoding"]).isNull() // No built-in gzip.
     assertThat(recorded.headers["Connection"]).isEqualTo("Upgrade, HTTP2-Settings")
-    if (PlatformVersion.majorVersion < 19) {
-      assertThat(recorded.headers["Content-Length"]).isEqualTo("0")
-    }
     assertThat(recorded.headers["HTTP2-Settings"]).isNotNull()
     assertThat(recorded.headers["Upgrade"]).isEqualTo("h2c") // HTTP/2 over plaintext!
     assertThat(recorded.headers["User-Agent"]!!).matches(Regex("Java-http-client/.*"))


### PR DESCRIPTION
Don't check on content length, not critical.