### PR TITLE
Fix flaky platformTrustedCertificates test for non-Entrust platforms  

### DIFF
--- a/okhttp-tls/src/test/java/okhttp3/tls/HandshakeCertificatesTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/HandshakeCertificatesTest.kt
@@ -163,8 +163,18 @@ class HandshakeCertificatesTest {
         .toSet()
 
     // It's safe to assume all platforms will have a major Internet certificate issuer.
+    val majorIssuers = listOf(
+      "DigiCert",
+      "Let's Encrypt",
+      "ISRG",  // Internet Security Research Group (Let's Encrypt parent)
+      "GlobalSign",
+      "Comodo",
+      "Sectigo",
+      "GeoTrust",
+      "Entrust",
+    )
     assertThat(names).matchesPredicate { strings ->
-      strings.any { it.matches(Regex("[A-Z]+=Entrust.*")) }
+      strings.any { name -> majorIssuers.any { issuer -> name.contains(issuer, ignoreCase = true) } }
     }
   }
 


### PR DESCRIPTION
  The `platformTrustedCertificates` test assumes Entrust certificates are always present in the platform's trusted certificate store. However, following Google's decision 
  to distrust Entrust certificates in Chrome (announced in 2024), newer platforms may not include Entrust as a trusted CA.                                                 
                                                                                                                                                                           
  This change updates the test to check for any major certificate authority instead of specifically Entrust, which aligns with the test's original intent: verifying that  
  platform-trusted certificates include at least one major Internet certificate issuer.                                                                                    
                                                                                                                                                                           
  Major CAs now checked:                                                                                                                                                   
  - DigiCert                                                                                                                                                               
  - Let's Encrypt / ISRG                                                                                                                                                   
  - GlobalSign                                                                                                                                                             
  - Comodo / Sectigo                                                                                                                                                       
  - GeoTrust                                                                                                                                                               
  - Entrust (still included as fallback)                                                                                                                                   
                                                                                                                                                                           
  Fixes #9288      