### PR TITLE
Avoid flakes

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/FakeDns.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/FakeDns.kt
@@ -19,11 +19,13 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import java.net.InetAddress
 import java.net.UnknownHostException
+import java.util.Collections
 import okio.Buffer
 
 class FakeDns : Dns {
-  private val hostAddresses: MutableMap<String, List<InetAddress>> = mutableMapOf()
-  private val requestedHosts: MutableList<String> = mutableListOf()
+  private val hostAddresses: MutableMap<String, List<InetAddress>> =
+    Collections.synchronizedMap(mutableMapOf())
+  private val requestedHosts: MutableList<String> = Collections.synchronizedList(mutableListOf())
   private var nextAddress = 0xff000064L // 255.0.0.100 in IPv4; ::ff00:64 in IPv6.
 
   /** Sets the results for `hostname`.  */


### PR DESCRIPTION
Saw this in CI

```
ConnectionCoalescingTest[jvm] > coalescedConnectionDestroyedAfterAcquire()[jvm] FAILED
    java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
        at java.base/java.util.ArrayList.add(ArrayList.java:484)
        at java.base/java.util.ArrayList.add(ArrayList.java:496)
        at okhttp3.FakeDns.lookup(FakeDns.kt:52)
        at okhttp3.internal.connection.RouteSelector.resetNextInetSocketAddress(RouteSelector.kt:170)
        at okhttp3.internal.connection.RouteSelector.nextProxy(RouteSelector.kt:132)
        at okhttp3.internal.connection.RouteSelector.next(RouteSelector.kt:70)
        at okhttp3.internal.connection.RealRoutePlanner.planConnect$okhttp(RealRoutePlanner.kt:168)
        at okhttp3.internal.connection.RealRoutePlanner.plan(RealRoutePlanner.kt:75)
        at okhttp3.internal.connection.SequentialExchangeFinder.find(SequentialExchangeFinder.kt:30)
        at okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:304)
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:332)
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:98)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:332)
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:332)
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:72)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:332)
        at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:232)
        at okhttp3.internal.connection.RealCall.execute(RealCall.kt:187)
        at okhttp3.ConnectionCoalescingTest.coalescedConnectionDestroyedAfterAcquire(ConnectionCoalescingTest.kt:289)
```