### PR TITLE
Bump JDK for maven build

### DIFF
--- a/maven-tests/pom.xml
+++ b/maven-tests/pom.xml
@@ -13,8 +13,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Not needed, just matches CI.