### PR TITLE
Smoosh CI jobs together using matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ permissions:
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -21,12 +25,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
 
       - name: Configure JDK
         uses: actions/setup-java@v5
@@ -69,20 +67,15 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
+          java-version: |
+            11
+            21
 
       - uses: graalvm/setup-graalvm@v1
         with:
           distribution: 'graalvm'
           java-version: 21
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          cache: 'gradle'
           native-image-job-reports: true
 
       - name: Setup Gradle
@@ -91,10 +84,16 @@ jobs:
       - name: Run Checks
         run: ./gradlew check -PgraalBuild=true -x jvmTest -x test -x allTests -x java9Test
 
-  testopenjdk11:
-    permissions:
-      checks: write # for mikepenz/action-junit-report
+  test_jvm:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version:
+          - 8
+          - 11
+          - 17
+          - 21
 
     steps:
       - name: Checkout
@@ -104,22 +103,18 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
+          java-version: |
+            ${{ matrix.java-version }}
+            21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
       - name: Run Tests
-        run: ./gradlew test allTests -Ptest.java.version=11
+        run: ./gradlew test allTests -Ptest.java.version=${{ matrix.java-version }}
 
       - name: Publish Test Report
-        if: github.repository == 'square/okhttp' && github.ref == 'refs/heads/master'
+        if: github.repository == 'square/okhttp' && github.ref == 'refs/heads/master' && matrix.java-version == '11'
         uses: mikepenz/action-junit-report@v6
         with:
           report_paths: '**/build/test-results/*/TEST-*.xml'
@@ -127,60 +122,10 @@ jobs:
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: github.repository == 'square/okhttp' && github.ref == 'refs/heads/master'
+        if: github.repository == 'square/okhttp' && github.ref == 'refs/heads/master' && matrix.java-version == '11'
         with:
           files: |
             **/build/test-results/*/TEST-*.xml
-
-  testzulu11:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Run Tests
-        run: ./gradlew test allTests -Dtest.java.version=11
-
-  testopenjdk8:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Run Tests
-        run: ./gradlew test allTests -Ptest.java.version=8
 
   testopenjdk8alpn:
     runs-on: ubuntu-latest
@@ -200,12 +145,6 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
           java-version: 21
 
       - name: Setup Gradle
@@ -214,19 +153,20 @@ jobs:
       - name: Run Tests
         run: ./gradlew test allTests -Ptest.java.version=8 -Pokhttp.platform=jdk8alpn -Palpn.boot.version=8.1.13.v20181017 -Dorg.gradle.java.installations.paths=/opt/hostedtoolcache/Java_Adopt_jdk/8.0.242-8.1/x64
 
-  testopenjsse:
+  test_providers:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'providers')
+    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'providers')
+    strategy:
+      matrix:
+        provider:
+          - openjsse
+          - bouncycastle
+          - corretto
+          - conscrypt
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
 
       - name: Configure JDK
         uses: actions/setup-java@v5
@@ -238,142 +178,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Run Tests
-        run: ./gradlew test allTests -Ptest.java.version=8 -Pokhttp.platform=openjsse
-
-  testconscrypt:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'conscrypt')
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Run Tests
-        run: ./gradlew test allTests -Pokhttp.platform=conscrypt
-
-  testbouncycastle:
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'providers')
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Run Tests
-        run: ./gradlew test allTests -Pokhttp.platform=bouncycastle
-
-  testcorretto:
-    runs-on: ubuntu-latest
-    # TODO add master build after fixing all tests in CI
-    if: contains(github.event.pull_request.labels.*.name, 'providers')
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Run Tests
-        run: ./gradlew test allTests -Pokhttp.platform=corretto
-
-  testopenjdk17:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Run Tests
-        run: ./gradlew test allTests -Ptest.java.version=17
-
-  testopenjdk21:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Run Tests
-        run: ./gradlew test allTests -Ptest.java.version=21
+        run: ./gradlew test allTests -Pokhttp.platform=${{ matrix.provider }}
 
   testopenjdklatest:
     runs-on: ubuntu-latest
@@ -439,12 +244,6 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
           java-version: 21
 
       - name: Setup Gradle
@@ -464,12 +263,6 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
           java-version: 21
 
       - uses: graalvm/setup-graalvm@v1
@@ -477,7 +270,6 @@ jobs:
           distribution: 'graalvm'
           java-version: 24
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          cache: 'gradle'
           native-image-job-reports: true
 
       - name: Setup Gradle
@@ -508,12 +300,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
 
       - name: Configure JDK
         uses: actions/setup-java@v5
@@ -588,19 +374,9 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 24
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 21
+          java-version: |
+            21
+            24
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
@@ -624,12 +400,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Configure JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
 
       - name: Configure JDK
         uses: actions/setup-java@v5


### PR DESCRIPTION
Consolidates the GitHub Actions workflow by using matrix strategies for JVM and provider tests.

- Replaces separate `testopenjdk*` jobs with a single `test_jvm` job that runs tests against Java versions 8, 11, 17, and 21 using a matrix.
- Replaces separate provider test jobs (`testopenjsse`, `testconscrypt`, `testbouncycastle`, `testcorretto`) with a single `test_providers` job that uses a matrix for different security providers.
- Adds workflow concurrency to cancel in-progress runs on the same branch.
- Removes redundant JDK setup steps and cleans up Java version definitions.