### PR TITLE
Expose metrics on Connection interface

### DIFF
--- a/okhttp/api/android/okhttp.api
+++ b/okhttp/api/android/okhttp.api
@@ -343,10 +343,15 @@ public abstract interface class okhttp3/CompressionInterceptor$DecompressionAlgo
 }
 
 public abstract interface class okhttp3/Connection {
+	public abstract fun callCount ()I
+	public abstract fun connectAtMillis ()J
 	public abstract fun handshake ()Lokhttp3/Handshake;
+	public abstract fun idleAtMillis ()Ljava/lang/Long;
+	public abstract fun noNewExchanges ()Z
 	public abstract fun protocol ()Lokhttp3/Protocol;
 	public abstract fun route ()Lokhttp3/Route;
 	public abstract fun socket ()Ljava/net/Socket;
+	public abstract fun successCount ()I
 }
 
 public final class okhttp3/ConnectionPool {

--- a/okhttp/api/jvm/okhttp.api
+++ b/okhttp/api/jvm/okhttp.api
@@ -343,10 +343,15 @@ public abstract interface class okhttp3/CompressionInterceptor$DecompressionAlgo
 }
 
 public abstract interface class okhttp3/Connection {
+	public abstract fun callCount ()I
+	public abstract fun connectAtMillis ()J
 	public abstract fun handshake ()Lokhttp3/Handshake;
+	public abstract fun idleAtMillis ()Ljava/lang/Long;
+	public abstract fun noNewExchanges ()Z
 	public abstract fun protocol ()Lokhttp3/Protocol;
 	public abstract fun route ()Lokhttp3/Route;
 	public abstract fun socket ()Ljava/net/Socket;
+	public abstract fun successCount ()I
 }
 
 public final class okhttp3/ConnectionPool {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Connection.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Connection.kt
@@ -89,4 +89,34 @@ interface Connection {
    * [Protocol.HTTP_1_0].
    */
   fun protocol(): Protocol
+
+  /**
+   * Returns the wall-clock time (epoch millis) when this connection was created. This is the time
+   * the TCP and TLS handshakes completed.
+   */
+  fun connectAtMillis(): Long
+
+  /**
+   * Returns the wall-clock time (epoch millis) when this connection became idle, or null if it is
+   * currently active (carrying one or more calls).
+   */
+  fun idleAtMillis(): Long?
+
+  /**
+   * Returns the number of exchanges successfully completed on this connection. Each completed
+   * request/response pair increments this count.
+   */
+  fun successCount(): Int
+
+  /**
+   * Returns the number of calls currently carried by this connection. This is 0 when the
+   * connection is idle, and may be greater than 1 for HTTP/2 connections.
+   */
+  fun callCount(): Int
+
+  /**
+   * Returns true if this connection will not accept new exchanges. This may be because the
+   * connection has been marked for closure, or because an error has occurred on this connection.
+   */
+  fun noNewExchanges(): Boolean
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/ConnectPlan.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/ConnectPlan.kt
@@ -527,7 +527,7 @@ class ConnectPlan internal constructor(
     // Do nothing.
   }
 
-  override fun noNewExchanges() {
+  override fun prohibitNewExchanges() {
     // Do nothing.
   }
 

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Exchange.kt
@@ -175,7 +175,7 @@ class Exchange(
   }
 
   fun noNewExchangesOnConnection() {
-    codec.carrier.noNewExchanges()
+    codec.carrier.prohibitNewExchanges()
   }
 
   fun cancel() {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealCall.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealCall.kt
@@ -321,6 +321,7 @@ class RealCall(
     check(this.connection == null)
     this.connection = connection
     connection.calls.add(CallReference(this, callStackTrace))
+    connection.idleAtEpochMillis = null
   }
 
   /**
@@ -452,6 +453,7 @@ class RealCall(
 
     if (calls.isEmpty()) {
       connection.idleAtNs = System.nanoTime()
+      connection.idleAtEpochMillis = System.currentTimeMillis()
       if (connectionPool.connectionBecameIdle(connection)) {
         return connection.socket()
       }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RealConnectionPool.kt
@@ -314,6 +314,7 @@ class RealConnectionPool internal constructor(
       // If this was the last allocation, the connection is eligible for immediate eviction.
       if (references.isEmpty()) {
         connection.idleAtNs = now - keepAliveDurationNs
+        connection.idleAtEpochMillis = System.currentTimeMillis()
         return 0
       }
     }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/ExchangeCodec.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/ExchangeCodec.kt
@@ -92,7 +92,7 @@ interface ExchangeCodec {
       e: IOException?,
     )
 
-    fun noNewExchanges()
+    fun prohibitNewExchanges()
 
     fun cancel()
   }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -283,7 +283,7 @@ class Http1ExchangeCodec(
   private fun newUnknownLengthSource(url: HttpUrl): Source {
     check(state == STATE_OPEN_RESPONSE_BODY) { "state: $state" }
     state = STATE_READING_RESPONSE_BODY
-    carrier.noNewExchanges()
+    carrier.prohibitNewExchanges()
     return UnknownLengthSource(url)
   }
 
@@ -396,7 +396,7 @@ class Http1ExchangeCodec(
       try {
         socket.source.read(sink, byteCount)
       } catch (e: IOException) {
-        carrier.noNewExchanges()
+        carrier.prohibitNewExchanges()
         responseBodyComplete(TRAILERS_RESPONSE_BODY_TRUNCATED)
         throw e
       }
@@ -440,7 +440,7 @@ class Http1ExchangeCodec(
 
       val read = super.read(sink, minOf(bytesRemaining, byteCount))
       if (read == -1L) {
-        carrier.noNewExchanges() // The server didn't supply the promised content length.
+        carrier.prohibitNewExchanges() // The server didn't supply the promised content length.
         val e = ProtocolException("unexpected end of stream")
         responseBodyComplete(TRAILERS_RESPONSE_BODY_TRUNCATED)
         throw e
@@ -459,7 +459,7 @@ class Http1ExchangeCodec(
       if (bytesRemaining != 0L &&
         !discard(ExchangeCodec.DISCARD_STREAM_TIMEOUT_MILLIS, MILLISECONDS)
       ) {
-        carrier.noNewExchanges() // Unread bytes remain on the stream.
+        carrier.prohibitNewExchanges() // Unread bytes remain on the stream.
         responseBodyComplete(TRAILERS_RESPONSE_BODY_TRUNCATED)
       }
 
@@ -489,7 +489,7 @@ class Http1ExchangeCodec(
 
       val read = super.read(sink, minOf(byteCount, bytesRemainingInChunk))
       if (read == -1L) {
-        carrier.noNewExchanges() // The server didn't supply the promised chunk length.
+        carrier.prohibitNewExchanges() // The server didn't supply the promised chunk length.
         val e = ProtocolException("unexpected end of stream")
         responseBodyComplete(TRAILERS_RESPONSE_BODY_TRUNCATED)
         throw e
@@ -528,7 +528,7 @@ class Http1ExchangeCodec(
       if (hasMoreChunks &&
         !discard(ExchangeCodec.DISCARD_STREAM_TIMEOUT_MILLIS, MILLISECONDS)
       ) {
-        carrier.noNewExchanges() // Unread bytes remain on the stream.
+        carrier.prohibitNewExchanges() // Unread bytes remain on the stream.
         responseBodyComplete(TRAILERS_RESPONSE_BODY_TRUNCATED)
       }
       closed = true

--- a/okhttp/src/jvmTest/kotlin/okhttp3/KotlinSourceModernTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/KotlinSourceModernTest.kt
@@ -292,6 +292,16 @@ class KotlinSourceModernTest {
         override fun handshake(): Handshake? = TODO()
 
         override fun protocol(): Protocol = TODO()
+
+        override fun connectAtMillis(): Long = TODO()
+
+        override fun idleAtMillis(): Long? = TODO()
+
+        override fun successCount(): Int = TODO()
+
+        override fun callCount(): Int = TODO()
+
+        override fun noNewExchanges(): Boolean = TODO()
       }
   }
 


### PR DESCRIPTION
## Summary                                                                                                                                                               
                                                                                                                                                                           
  - Add 5 new methods to the `Connection` interface: `connectAtMillis()`, `idleAtMillis()`, `successCount()`, `callCount()`, and `noNewExchanges()`
  - Rename internal `Carrier.noNewExchanges()` to `Carrier.prohibitNewExchanges()` to avoid JVM method signature clash
  - Track idle/active epoch transitions in `RealCall` and `RealConnectionPool`

  ## Test plan

  - [x] `./gradlew :okhttp:jvmTest --tests "okhttp3.KotlinSourceModernTest.connection"` (compile check)
  - [x] `./gradlew :okhttp:jvmTest --tests "okhttp3.ConnectionListenerTest"` (integration)
  - [x] `./gradlew apiCheck` (API compatibility)

  Closes #9219
