### PR TITLE
Added Android API check and dump tasks for the okhttp project.

### DIFF
--- a/build-logic/src/main/kotlin/okhttp.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/okhttp.publish-conventions.gradle.kts
@@ -55,13 +55,10 @@ configure<ApiValidationExtension> {
 }
 
 if (project.name == "okhttp") {
-//  dependencies {
-//    "bcv-rt-jvm-cp"("org.jetbrains.kotlin:kotlin-metadata-jvm:2.2.21")
-//  }
+  // Workaround for https://github.com/Kotlin/binary-compatibility-validator/issues/312
   val apiBuild = tasks.register<KotlinApiBuildTask>("androidApiBuild") {
     outputApiFile = project.layout.buildDirectory.file("${this.name}/okhttp.api")
     inputClassesDirs.from(tasks.getByName("compileAndroidMain").outputs)
-//    runtimeClasspath.from(project.configurations.named("bcv-rt-jvm-cp-resolver"))
   }
   val apiCheck = tasks.register<KotlinApiCompareTask>("androidApiCheck") {
     group = "verification"

--- a/build-logic/src/main/kotlin/okhttp.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/okhttp.publish-conventions.gradle.kts
@@ -3,6 +3,8 @@ import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import kotlinx.validation.ApiValidationExtension
+import kotlinx.validation.KotlinApiBuildTask
+import kotlinx.validation.KotlinApiCompareTask
 
 plugins {
   id("com.vanniktech.maven.publish.base")
@@ -50,4 +52,27 @@ configure<ApiValidationExtension> {
   ignoredPackages += "okhttp3.brotli.internal"
   ignoredPackages += "okhttp3.sse.internal"
   ignoredPackages += "okhttp3.tls.internal"
+}
+
+if (project.name == "okhttp") {
+//  dependencies {
+//    "bcv-rt-jvm-cp"("org.jetbrains.kotlin:kotlin-metadata-jvm:2.2.21")
+//  }
+  val apiBuild = tasks.register<KotlinApiBuildTask>("androidApiBuild") {
+    outputApiFile = project.layout.buildDirectory.file("${this.name}/okhttp.api")
+    inputClassesDirs.from(tasks.getByName("compileAndroidMain").outputs)
+//    runtimeClasspath.from(project.configurations.named("bcv-rt-jvm-cp-resolver"))
+  }
+  val apiCheck = tasks.register<KotlinApiCompareTask>("androidApiCheck") {
+    group = "verification"
+    projectApiFile = project.file("api/android/okhttp.api")
+    generatedApiFile = apiBuild.flatMap(KotlinApiBuildTask::outputApiFile)
+  }
+  val apiDump = tasks.register<Copy>("androidApiDump") {
+    from(apiBuild.flatMap(KotlinApiBuildTask::outputApiFile))
+    destinationDir = project.file("api/android")
+  }
+
+  tasks.named("apiDump").configure { dependsOn(apiDump) }
+  tasks.named("apiCheck").configure { dependsOn(apiCheck) }
 }


### PR DESCRIPTION
Workaround for https://github.com/Kotlin/binary-compatibility-validator/issues/312

Came up in https://github.com/square/okhttp/pull/9360