### PR TITLE
Gradle and vscode tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,6 @@ pom.xml.*
 release.properties
 local.properties
 
-.vscode
-
 .idea
 *.iml
 *.ipr

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.import.gradle.wrapper.enabled": true
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -10,6 +10,7 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
   }
   kotlinGradle {
     target("*.kts")
+    targetExclude("build/**/*.kts")
     ktlint()
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,12 @@ org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
 org.gradle.configuration-cache.parallel=true
 
+# Only configure projects reachable from the requested tasks, skipping unrelated subprojects
+org.gradle.isolated-projects=true
+
+# Watch the file system between builds to avoid full rescans on every invocation
+org.gradle.vfs.watch=true
+
 android.useAndroidX=true
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 
@@ -16,7 +22,8 @@ containerTests=false
 okhttpModuleTests=false
 okhttpDokka=false
 
-org.gradle.jvmargs='-Dfile.encoding=UTF-8'
+# Increase heap and metaspace to reduce GC pressure when loading 30+ plugin classpaths
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 
 # AGP 9.0 Settings
 android.builtInKotlin=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,6 @@ org.gradle.configuration-cache.parallel=true
 # Only configure projects reachable from the requested tasks, skipping unrelated subprojects
 org.gradle.isolated-projects=true
 
-# Watch the file system between builds to avoid full rescans on every invocation
-org.gradle.vfs.watch=true
-
 android.useAndroidX=true
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 


### PR DESCRIPTION
With this running commands with VS Code gradle tasks, and a terminal or agent doesn't destroy the configuration cache. So something like `./gradlew okcurl:apiCheck` runs in 300ms