### PR TITLE
docs: redirect 4.x API doc URLs to 5.x

### DIFF
--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -26,6 +26,29 @@ cd $DIR
 
 mv ./build/dokka/htmlMultiModule docs/5.x
 
+# Redirect 4.x doc URLs to 5.x.
+# The 4.x API docs were never published to gh-pages, so all /4.x/ URLs 404.
+# Since 5.x is the direct successor, redirect there.
+mkdir -p docs/4.x
+cat > docs/4.x/index.html << 'REDIRECT'
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting to OkHttp 5.x API docs</title>
+  <script>
+    // Redirect /4.x/anything to /5.x/anything
+    var newPath = window.location.pathname.replace('/4.x/', '/5.x/');
+    window.location.replace(window.location.origin + newPath + window.location.hash);
+  </script>
+  <meta http-equiv="refresh" content="0; url=../5.x/">
+</head>
+<body>
+  <p>OkHttp 4.x API docs are no longer published separately. Redirecting to <a href="../5.x/">5.x API docs</a>.</p>
+</body>
+</html>
+REDIRECT
+
 # Copy in special files that GitHub wants in the project root.
 cat README.md | grep -v 'project website' > docs/index.md
 cp CHANGELOG.md docs/changelogs/changelog.md

--- a/test_docs.sh
+++ b/test_docs.sh
@@ -16,6 +16,29 @@ set -ex
 
 mv ./build/dokka/html docs/5.x
 
+# Redirect 4.x doc URLs to 5.x.
+# The 4.x API docs were never published to gh-pages, so all /4.x/ URLs 404.
+# Since 5.x is the direct successor, redirect there.
+mkdir -p docs/4.x
+cat > docs/4.x/index.html << 'REDIRECT'
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting to OkHttp 5.x API docs</title>
+  <script>
+    // Redirect /4.x/anything to /5.x/anything
+    var newPath = window.location.pathname.replace('/4.x/', '/5.x/');
+    window.location.replace(window.location.origin + newPath + window.location.hash);
+  </script>
+  <meta http-equiv="refresh" content="0; url=../5.x/">
+</head>
+<body>
+  <p>OkHttp 4.x API docs are no longer published separately. Redirecting to <a href="../5.x/">5.x API docs</a>.</p>
+</body>
+</html>
+REDIRECT
+
 # Copy in special files that GitHub wants in the project root.
 cat README.md | grep -v 'project website' > docs/index.md
 cp CHANGELOG.md docs/changelogs/changelog.md


### PR DESCRIPTION
## Summary

Fixes #9156 — all `/okhttp/4.x/` URLs on the project website return 404 because the 4.x API docs were never published to gh-pages. Pages like `/features/caching/` that link to `/okhttp/4.x/okhttp/okhttp3/-cache/` are broken.

## Changes

Both `deploy_website.sh` and `test_docs.sh` now generate a `docs/4.x/index.html` redirect page during the docs build. The redirect:

- Uses JavaScript `window.location.replace()` to map `/4.x/<path>` → `/5.x/<path>` (preserving sub-paths and hash fragments)
- Falls back to `<meta http-equiv="refresh">` for non-JS browsers
- Shows a user-friendly message with a manual link

This works because 5.x is the direct successor to 4.x with the same `okhttp3` package structure.

## What's on gh-pages today

```
1.x/  ✅ (cherry-picked in deploy_website.sh)
2.x/  ✅ (cherry-picked in deploy_website.sh)
3.x/  ✅ (cherry-picked in deploy_website.sh)
4.x/  ❌ 404 — no cherry-pick, no generated docs
5.x/  ✅ (generated by Dokka)
```

After this PR, `4.x/` will contain a redirect page pointing to `5.x/`.

## Testing

1. Verified `curl -s -o /dev/null -w "%{http_code}" https://square.github.io/okhttp/4.x/okhttp/okhttp3/-cache/` returns 404
2. Verified `curl -s -o /dev/null -w "%{http_code}" https://square.github.io/okhttp/5.x/okhttp/okhttp3/-cache/` returns 200
3. Confirmed `deploy_website.sh` and `test_docs.sh` both produce the redirect in `docs/4.x/`