### PR TITLE
fix: avoid kotlin.time.Duration in CacheControl to fix Kotlin 2.3 compat

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-CacheControlCommon.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-CacheControlCommon.kt
@@ -17,7 +17,7 @@
 
 package okhttp3.internal
 
-import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.TimeUnit
 import okhttp3.CacheControl
 import okhttp3.Headers
 
@@ -62,7 +62,7 @@ internal fun CacheControl.Companion.commonForceCache() =
   CacheControl
     .Builder()
     .onlyIfCached()
-    .maxStale(Int.MAX_VALUE.seconds)
+    .maxStale(Int.MAX_VALUE, TimeUnit.SECONDS)
     .build()
 
 internal fun CacheControl.Builder.commonBuild(): CacheControl =


### PR DESCRIPTION
## Summary

Fixes #9347 — `NoSuchMethodError: Duration.Companion.fromRawValue-UwyO8pc` when OkHttp 5.x (compiled with Kotlin 2.2.x) runs against Kotlin 2.3 stdlib.

## Root cause

`commonForceCache()` in `-CacheControlCommon.kt` uses `Int.MAX_VALUE.seconds`, which calls `kotlin.time.Duration.Companion.seconds` → `toDuration` → `durationOfNanos` → `Duration.Companion.fromRawValue`. The `fromRawValue` method is `@PublishedApi internal` in stdlib, and its mangled name changed between Kotlin 2.2.x and 2.3.x. When Gradle resolves a single stdlib (2.3.x wins), the OkHttp bytecode referencing the old mangled name crashes.

## Fix

Replace:
```kotlin
.maxStale(Int.MAX_VALUE.seconds)          // uses kotlin.time.Duration
```
With:
```kotlin
.maxStale(Int.MAX_VALUE, TimeUnit.SECONDS)  // uses OkHttp's own TimeUnit overload
```

This avoids the `kotlin.time.Duration` code path entirely. The `TimeUnit`-based `maxStale` overload is OkHttp's own public API — no stdlib internals involved.

## Changes

- `-CacheControlCommon.kt`: Replace `kotlin.time.Duration.Companion.seconds` import with `java.util.concurrent.TimeUnit`, change `maxStale` call to use `TimeUnit` overload

## Testing

- Existing `CacheControlTest` and `CacheControlJvmTest` cover `FORCE_CACHE` behavior — the value of `maxStaleSeconds` is unchanged (`Int.MAX_VALUE`)
- The fix is a 2-line change with identical runtime semantics