### PR TITLE
Reject overflowing HPACK integers

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Hpack.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Hpack.kt
@@ -365,19 +365,25 @@ object Hpack {
         }
 
         // This is a multibyte value. Read 7 bits at a time.
-        var result = prefixMask
+        var result = prefixMask.toLong()
         var shift = 0
+        var byteCount = 0
         while (true) {
-          val b = readByte()
-          if (b and 0x80 != 0) { // Equivalent to (b >= 128) since b is in [0..255].
-            result += b and 0x7f shl shift
-            shift += 7
-          } else {
-            result += b shl shift // Last byte.
-            break
+          // An Int.MAX_VALUE payload needs at most 5 continuation bytes after the prefix.
+          if (byteCount == 5) {
+            throw IOException("HPACK integer overflow")
           }
+          val b = readByte()
+          byteCount++
+          val increment = (b and 0x7f).toLong() shl shift
+          if (increment > Int.MAX_VALUE.toLong() - result) {
+            throw IOException("HPACK integer overflow")
+          }
+          result += increment
+          if (b and 0x80 == 0) break
+          shift += 7
         }
-        return result
+        return result.toInt()
       }
 
       /** Reads a potentially Huffman encoded byte string. */

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HpackTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HpackTest.kt
@@ -375,7 +375,7 @@ class HpackTest {
     assertFailsWith<IOException> {
       hpackReader!!.readHeaders()
     }.also { expected ->
-      assertThat(expected.message).isEqualTo("Header index too large -2147483521")
+      assertThat(expected.message).isEqualTo("HPACK integer overflow")
     }
   }
 
@@ -413,8 +413,18 @@ class HpackTest {
     assertFailsWith<IOException> {
       hpackReader!!.readHeaders()
     }.also { expected ->
-      assertThat(expected.message)
-        .isEqualTo("Invalid dynamic table size update -2147483648")
+      assertThat(expected.message).isEqualTo("HPACK integer overflow")
+    }
+  }
+
+  @Test
+  fun dynamicTableSizeUpdateRejectsWrappedSmallPositive() {
+    bytesIn.writeByte(0x3f)
+    bytesIn.write("ffffffff8f00".decodeHex())
+    assertFailsWith<IOException> {
+      hpackReader!!.readHeaders()
+    }.also { expected ->
+      assertThat(expected.message).isEqualTo("HPACK integer overflow")
     }
   }
 
@@ -821,6 +831,38 @@ class HpackTest {
     assertBytes(31, 224, 255, 255, 255, 7)
     assertThat(newReader(byteStream(224, 255, 255, 255, 7)).readInt(31, 31))
       .isEqualTo(0x7fffffff)
+  }
+
+  @Test
+  fun overflowingValueRejected() {
+    assertFailsWith<IOException> {
+      newReader(Buffer().write("8080808008".decodeHex())).readInt(0xff, 0x7f)
+    }.also { expected ->
+      assertThat(expected.message).isEqualTo("HPACK integer overflow")
+    }
+  }
+
+  @Test
+  fun tooManyContinuationBytesRejected() {
+    assertFailsWith<IOException> {
+      newReader(Buffer().write("808080808001".decodeHex())).readInt(0x1f, 0x1f)
+    }.also { expected ->
+      assertThat(expected.message).isEqualTo("HPACK integer overflow")
+    }
+  }
+
+  @Test
+  fun stringLengthOverflowRejected() {
+    val source = Buffer()
+    source.writeByte(0x00)
+    source.writeByte(0x7f)
+    source.write("8080808008".decodeHex())
+
+    assertFailsWith<IOException> {
+      newReader(source).readHeaders()
+    }.also { expected ->
+      assertThat(expected.message).isEqualTo("HPACK integer overflow")
+    }
   }
 
   @Test


### PR DESCRIPTION
**Summary**. Reject malformed HPACK integers before they overflow in `Hpack.Reader.readInt()`.

**Problem**. `readInt()` decodes HPACK continuation bytes into a signed 32-bit Int without bounding the number of continuation bytes or checking for overflow. An overlong HPACK integer can therefore wrap into a negative or unrelated small positive value, and malformed input is only rejected later by downstream parsing logic.

 **Impact**. An HTTP/2 peer can use those malformed HPACK integers to cause connection-level DoS or to make OkHttp accept invalid HPACK state transitions that a compliant decoder should reject.



**Fix**. This change hardens `readInt()` by:

  - decoding into Long
  - rejecting more than 5 continuation bytes after the prefix
  - rejecting any increment that would exceed `Int.MAX_VALUE`
  - surfacing malformed values as `IOException("HPACK integer overflow")`

  Valid HPACK integers are unchanged, including the existing max 31-bit case.

**Tests**. Added regression coverage in HpackTest for malformed HPACK integers that previously overflowed or wrapped:

  - direct integer overflow
  - too many continuation bytes
  - overflow in HPACK string lengths
  - overflow that previously wrapped into a small dynamic table size

  Also updated the existing “insidious” HPACK tests to assert the new fail-fast behavior.