### PR TITLE
Apply androidx.lint:lint-gradle checks only to build-logic

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   `kotlin-dsl`
   id("com.diffplug.spotless") version "8.4.0"
-  id("com.android.lint")
+  id("com.android.lint") version "1.0.0-alpha05"
 }
 
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   `kotlin-dsl`
   id("com.diffplug.spotless") version "8.4.0"
+  id("com.android.lint")
 }
 
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {
@@ -36,6 +37,6 @@ dependencies {
   implementation(libs.gradlePlugin.ksp)
   implementation(libs.gradlePlugin.mrjar)
   implementation(libs.gradlePlugin.tapmoc)
-  implementation(libs.androidx.lint.gradle)
   implementation(libs.kotlin.gradle.plugin.api)
+  lintChecks(libs.androidx.lint.gradle)
 }

--- a/build-logic/src/main/kotlin/okhttp.quality-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/okhttp.quality-conventions.gradle.kts
@@ -71,7 +71,6 @@ dependencies {
   androidSignature(library("signature-android-apilevel21")) { artifact { type = "signature" } }
   jvmSignature(library("codehaus-signature-java18")) { artifact { type = "signature" } }
 
-  "lintChecks"(library("androidx-lint-gradle"))
 }
 
 configure<com.android.build.api.dsl.Lint> {


### PR DESCRIPTION
The Gradle-specific lint checks from androidx.lint:lint-gradle were being applied to all 27 library modules via quality-conventions, but they are designed for Gradle plugin code only. Move them to build-logic where they belong.