### PR TITLE
HttpLoggingInterceptor: Recognize "br" (Brotli) as a known encoding

### DIFF
--- a/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
+++ b/okhttp-logging-interceptor/src/main/kotlin/okhttp3/logging/HttpLoggingInterceptor.kt
@@ -358,7 +358,8 @@ class HttpLoggingInterceptor
     private fun bodyHasUnknownEncoding(headers: Headers): Boolean {
       val contentEncoding = headers["Content-Encoding"] ?: return false
       return !contentEncoding.equals("identity", ignoreCase = true) &&
-        !contentEncoding.equals("gzip", ignoreCase = true)
+        !contentEncoding.equals("gzip", ignoreCase = true) &&
+        !contentEncoding.equals("br", ignoreCase = true)
     }
 
     private fun bodyIsStreaming(response: Response): Boolean {

--- a/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
+++ b/okhttp-logging-interceptor/src/test/java/okhttp3/logging/HttpLoggingInterceptorTest.kt
@@ -661,7 +661,7 @@ class HttpLoggingInterceptorTest {
     server.enqueue(
       MockResponse
         .Builder() // It's invalid to return this if not requested, but the server might anyway
-        .setHeader("Content-Encoding", "br")
+        .setHeader("Content-Encoding", "xyz")
         .setHeader("Content-Type", PLAIN)
         .body(Buffer().write("iwmASGVsbG8sIEhlbGxvLCBIZWxsbwoD".decodeBase64()!!))
         .build(),
@@ -676,7 +676,7 @@ class HttpLoggingInterceptorTest {
       .assertLogMatch(Regex("""User-Agent: okhttp/.+"""))
       .assertLogEqual("--> END GET")
       .assertLogMatch(Regex("""<-- 200 OK $url \(\d+ms\)"""))
-      .assertLogEqual("Content-Encoding: br")
+      .assertLogEqual("Content-Encoding: xyz")
       .assertLogEqual("Content-Type: text/plain; charset=utf-8")
       .assertLogMatch(Regex("""Content-Length: \d+"""))
       .assertLogEqual("<-- END HTTP (encoded body omitted)")
@@ -685,7 +685,7 @@ class HttpLoggingInterceptorTest {
       .assertLogEqual("--> GET $url")
       .assertLogEqual("--> END GET")
       .assertLogMatch(Regex("""<-- 200 OK $url \(\d+ms\)"""))
-      .assertLogEqual("Content-Encoding: br")
+      .assertLogEqual("Content-Encoding: xyz")
       .assertLogEqual("Content-Type: text/plain; charset=utf-8")
       .assertLogMatch(Regex("""Content-Length: \d+"""))
       .assertLogEqual("<-- END HTTP (encoded body omitted)")


### PR DESCRIPTION
Previously, HttpLoggingInterceptor treated "br" (Brotli) as an unknown
content encoding and skipped logging the response body by emitting:
"<-- END HTTP (encoded body omitted)".

OkHttp supports Brotli via the optional BrotliInterceptor and includes
"br" in accepted encodings. Treating it as unknown is therefore inconsistent.

This change updates the interceptor to recognize "br" as a known encoding,
allowing it to follow the normal logging flow (similar to "gzip").

Note:
This change does not add Brotli decompression. If BrotliInterceptor is
not used, the response body may still be logged as binary.

Tests are updated to use a truly unknown encoding ("xyz") to preserve
the original intent of verifying unknown encoding handling.