### PR TITLE
docs: update README Maven version guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Maven projects.
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp-bom</artifactId>
-      <version>5.2.0</version>
+      <version>5.3.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -171,8 +171,6 @@ Maven projects.
 <dependency>
   <groupId>com.squareup.okhttp3</groupId>
   <artifactId>okhttp-jvm</artifactId>
-  <!-- Remove after OkHttp 5.2.0 with updated BOM. -->
-  <version>5.1.0</version>
 </dependency>
 
 <dependency>


### PR DESCRIPTION

**Repo:** square/okhttp (⭐ 46000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-3

## What
Updated the README's Maven setup example so it matches the release version advertised elsewhere in the document. The change bumps the `okhttp-bom` example from `5.2.0` to `5.3.0` and removes the obsolete explicit `okhttp-jvm` version override from the sample dependency block.

## Why
The README previously mixed current and stale Maven guidance in the same section, which could lead users to copy an outdated BOM version or unnecessarily pin `okhttp-jvm` to `5.1.0`. The repository's own `maven-tests/pom.xml` shows the BOM is intended to supply that version, so the override is no longer appropriate in user-facing documentation.

## Testing
Verified the README diff locally and confirmed there are no remaining stale `5.2.0` / `5.1.0` references in the updated Maven snippet. No code or test execution was needed because this is a documentation-only change.

## Risk
Low + documentation-only change that aligns examples with the current release and existing Maven usage in the repo.
