### PR TITLE
fix: the requestbodycompression in RequestBodyCompression.java

### DIFF
--- a/samples/guide/src/main/java/okhttp3/recipes/RequestBodyCompression.java
+++ b/samples/guide/src/main/java/okhttp3/recipes/RequestBodyCompression.java
@@ -35,7 +35,7 @@ public final class RequestBodyCompression {
    *
    * https://console.developers.google.com/project
    */
-  public static final String GOOGLE_API_KEY = "AIzaSyAx2WZYe0My0i-uGurpvraYJxO7XNbwiGs";
+  public static final String GOOGLE_API_KEY = System.getenv("GOOGLE_API_KEY");
   public static final MediaType MEDIA_TYPE_JSON = MediaType.get("application/json");
 
   private final OkHttpClient client = new OkHttpClient.Builder()


### PR DESCRIPTION
## Summary
Fix high severity security issue in `samples/guide/src/main/java/okhttp3/recipes/RequestBodyCompression.java`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `samples/guide/src/main/java/okhttp3/recipes/RequestBodyCompression.java:38` |

**Description**: The RequestBodyCompression.java sample file contains hardcoded API key references at lines 38 and 54. If these are real, active API keys committed to version control, they are immediately accessible to anyone with repository read access — including the public if the repository is open source. Even if the keys are placeholders, the pattern teaches developers an insecure practice that may be replicated with real credentials in production applications.

## Changes
- `samples/guide/src/main/java/okhttp3/recipes/RequestBodyCompression.java`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
