### PR TITLE
ci: declare contents:read on publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: macos-15


### PR DESCRIPTION
The `publish` workflow runs on tag push and invokes `./gradlew publish`. The actual authentication for Maven Central + GPG signing flows through `ORG_GRADLE_PROJECT_*` secrets (`SONATYPE_CENTRAL_USERNAME`, `SONATYPE_CENTRAL_PASSWORD`, `GPG_SECRET_KEY`, `GPG_SECRET_PASSPHRASE`), not the workflow `GITHUB_TOKEN`. There's no other GitHub API call beyond `actions/checkout`.

This patch adds `permissions: contents: read` at workflow scope, matching the workflow-level block already used in `build.yml` and the per-job blocks in `containers.yml` and `docs.yml`. With it set:

- the workflow token can't be widened by a future change to the repository default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check goes green for this file
- if `actions/setup-java` or any other third-party dependency reachable from this workflow is ever compromised (cf. tj-actions/changed-files CVE-2025-30066), the explicit read-only scope keeps it boxed away from the publish secrets

No behavioural change.