### PR TITLE
Fix conditional cache updates on Windows filesystems

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt
@@ -263,7 +263,7 @@ class Cache internal constructor(
     val snapshot = (cached.body as CacheResponseBody).snapshot
     var editor: DiskLruCache.Editor? = null
     try {
-      editor = snapshot.edit() ?: return // edit() returns null if snapshot is not current.
+      editor = snapshot.editMetadata() ?: return // editMetadata() returns null if snapshot is not current.
       entry.writeTo(editor)
       editor.commit()
     } catch (_: IOException) {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/cache/DiskLruCache.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/cache/DiskLruCache.kt
@@ -864,8 +864,7 @@ class DiskLruCache(
     fun edit(): Editor? = this@DiskLruCache.edit(key, sequenceNumber)
 
     @Throws(IOException::class)
-    internal fun editMetadata(): Editor? =
-      this@DiskLruCache.edit(key, sequenceNumber, allowSourceLocks = true)
+    internal fun editMetadata(): Editor? = this@DiskLruCache.edit(key, sequenceNumber, allowSourceLocks = true)
 
     /** Returns the unbuffered stream with the value for [index]. */
     fun getSource(index: Int): Source = sources[index]

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/cache/DiskLruCache.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/cache/DiskLruCache.kt
@@ -479,6 +479,14 @@ class DiskLruCache(
   fun edit(
     key: String,
     expectedSequenceNumber: Long = ANY_SEQUENCE_NUMBER,
+  ): Editor? = edit(key, expectedSequenceNumber, allowSourceLocks = false)
+
+  @Synchronized
+  @Throws(IOException::class)
+  private fun edit(
+    key: String,
+    expectedSequenceNumber: Long,
+    allowSourceLocks: Boolean,
   ): Editor? {
     initialize()
 
@@ -495,7 +503,7 @@ class DiskLruCache(
       return null // Another edit is in progress.
     }
 
-    if (entry != null && entry.lockingSourceCount != 0) {
+    if (!allowSourceLocks && entry != null && entry.lockingSourceCount != 0) {
       return null // We can't write this file because a reader is still reading it.
     }
 
@@ -854,6 +862,10 @@ class DiskLruCache(
      */
     @Throws(IOException::class)
     fun edit(): Editor? = this@DiskLruCache.edit(key, sequenceNumber)
+
+    @Throws(IOException::class)
+    internal fun editMetadata(): Editor? =
+      this@DiskLruCache.edit(key, sequenceNumber, allowSourceLocks = true)
 
     /** Returns the unbuffered stream with the value for [index]. */
     fun getSource(index: Int): Source = sources[index]

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CacheTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CacheTest.kt
@@ -3138,6 +3138,16 @@ class CacheTest {
 
   @Test
   fun conditionalHitUpdatesCache() {
+    assertConditionalHitUpdatesCache()
+  }
+
+  @Test
+  fun conditionalHitUpdatesCacheOnWindowsFileSystem() {
+    fileSystem.emulateWindows()
+    assertConditionalHitUpdatesCache()
+  }
+
+  private fun assertConditionalHitUpdatesCache() {
     server.enqueue(
       MockResponse
         .Builder()


### PR DESCRIPTION
Fixes #9335.

On filesystems that cannot replace or delete open files, conditional cache hits were unable to update their cached metadata.

For a stale cached response, OkHttp sends a conditional request. If the server returns `304 Not Modified`, `Cache.update()` rewrites the cached metadata with the combined headers and refreshed sent/received timestamps. On Windows-like filesystems this silently failed because the cached response body source was still open, causing `DiskLruCache.Snapshot.edit()` to return null when `lockingSourceCount != 0`.

This keeps the regular edit path conservative, but adds a metadata-only edit path for `Snapshot`. `Cache.update()` uses that path because it only rewrites `ENTRY_METADATA`; it does not replace the cached response body file that is currently being read.

I verified the root cause with JDWP using the debug-bridge MCP tool (https://github.com/ittaigolde/java-debug-mcp): at the `Cache.update()` path for a `304` response, `DiskLruCache.edit()` was returning null because `entry.lockingSourceCount == 1`.

Test coverage:
- Adds `conditionalHitUpdatesCacheOnWindowsFileSystem()`, which reproduces the Windows fake-filesystem failure.
- Keeps the existing Unix-path test coverage by extracting the shared assertion.

Verification:
- `./gradlew :okhttp:jvmTest --tests okhttp3.CacheTest.conditionalHitUpdatesCache --tests okhttp3.CacheTest.conditionalHitUpdatesCacheOnWindowsFileSystem --tests okhttp3.CacheTest.conditionalMissUpdatesCache`
- `./gradlew :okhttp:jvmTest --tests okhttp3.CacheTest`
