### PR TITLE
Fix HTTP/2 cancellation during stream creation

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Connection.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Connection.kt
@@ -444,6 +444,10 @@ class Http2Connection internal constructor(
     close(ErrorCode.NO_ERROR, ErrorCode.CANCEL, null)
   }
 
+  internal fun cancel() {
+    socket.cancel()
+  }
+
   internal fun close(
     connectionCode: ErrorCode,
     streamCode: ErrorCode,

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt
@@ -65,6 +65,9 @@ class Http2ExchangeCodec(
   @Volatile
   private var canceled = false
 
+  @Volatile
+  private var streamCreationInFlight = false
+
   override val isResponseComplete: Boolean
     get() = stream?.isSourceComplete == true
 
@@ -81,12 +84,17 @@ class Http2ExchangeCodec(
 
     val hasRequestBody = request.body != null
     val requestHeaders = http2HeadersList(request)
-    stream = http2Connection.newStream(requestHeaders, hasRequestBody)
-    // We may have been asked to cancel while creating the new stream and sending the request
-    // headers, but there was still no stream to close.
-    if (canceled) {
-      stream!!.closeLater(ErrorCode.CANCEL)
-      throw IOException("Canceled")
+    streamCreationInFlight = true
+    try {
+      stream = http2Connection.newStream(requestHeaders, hasRequestBody)
+      // We may have been asked to cancel while creating the new stream and sending the request
+      // headers, but there was still no stream to close.
+      if (canceled) {
+        stream!!.closeLater(ErrorCode.CANCEL)
+        throw IOException("Canceled")
+      }
+    } finally {
+      streamCreationInFlight = false
     }
     stream!!.readTimeout().timeout(chain.readTimeoutMillis.toLong(), TimeUnit.MILLISECONDS)
     stream!!.writeTimeout().timeout(chain.writeTimeoutMillis.toLong(), TimeUnit.MILLISECONDS)
@@ -123,7 +131,12 @@ class Http2ExchangeCodec(
 
   override fun cancel() {
     canceled = true
-    stream?.closeLater(ErrorCode.CANCEL)
+    val stream = stream
+    if (stream != null) {
+      stream.closeLater(ErrorCode.CANCEL)
+    } else if (streamCreationInFlight) {
+      http2Connection.cancel()
+    }
   }
 
   companion object {

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
@@ -33,14 +33,14 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertFailsWith
+import okhttp3.Headers
+import okhttp3.Headers.Companion.headersOf
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Route
-import okhttp3.Headers
-import okhttp3.Headers.Companion.headersOf
-import okhttp3.TestValueFactory
 import okhttp3.TestUtil.headerEntries
 import okhttp3.TestUtil.repeat
+import okhttp3.TestValueFactory
 import okhttp3.internal.EMPTY_BYTE_ARRAY
 import okhttp3.internal.concurrent.Lockable
 import okhttp3.internal.concurrent.TaskFaker
@@ -2154,8 +2154,7 @@ class Http2ConnectionTest {
         override fun close() {
           cancel()
         }
-      }
-        .buffer()
+      }.buffer()
 
     override fun cancel() {
       canceled.countDown()

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2ConnectionTest.kt
@@ -31,9 +31,14 @@ import java.io.InterruptedIOException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertFailsWith
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Route
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
+import okhttp3.TestValueFactory
 import okhttp3.TestUtil.headerEntries
 import okhttp3.TestUtil.repeat
 import okhttp3.internal.EMPTY_BYTE_ARRAY
@@ -43,10 +48,13 @@ import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.concurrent.notifyAll
 import okhttp3.internal.concurrent.wait
 import okhttp3.internal.concurrent.withLock
+import okhttp3.internal.connection.RealCall
 import okhttp3.internal.connection.asBufferedSocket
+import okhttp3.internal.http.ExchangeCodec
 import okio.AsyncTimeout
 import okio.Buffer
 import okio.BufferedSource
+import okio.Sink
 import okio.Source
 import okio.buffer
 import org.junit.jupiter.api.AfterEach
@@ -1924,6 +1932,50 @@ class Http2ConnectionTest {
     assertThat(queues).hasSize(1)
   }
 
+  @Test fun cancelHttp2ExchangeInterruptsBlockedStreamCreation() {
+    val socket = BlockingFlushSocket()
+    val connection =
+      Http2Connection
+        .Builder(true, TaskRunner.INSTANCE)
+        .socket(socket, "peer")
+        .build()
+    val client = OkHttpClient()
+    val request = Request.Builder().url("https://example.com/").build()
+    val call = RealCall(client, request, forWebSocket = false)
+    val factory = TestValueFactory()
+    val codec =
+      Http2ExchangeCodec(
+        client = client,
+        carrier = FakeCarrier(factory.newRoute()),
+        chain = factory.newChain(call),
+        http2Connection = connection,
+      )
+    val result = AtomicReference<Any?>()
+    val done = CountDownLatch(1)
+
+    val writer =
+      Thread {
+        try {
+          codec.writeRequestHeaders(request)
+        } catch (e: IOException) {
+          result.set(e)
+        } finally {
+          done.countDown()
+        }
+      }
+
+    writer.start()
+    assertThat(socket.flushStarted.await(1, TimeUnit.SECONDS)).isTrue()
+    codec.cancel()
+    val completed = done.await(1, TimeUnit.SECONDS)
+    if (!completed) {
+      socket.cancel()
+    }
+    assertThat(completed).isTrue()
+    writer.join()
+    assertThat(result.get() is IOException).isTrue()
+  }
+
   private fun data(byteCount: Int): Buffer = Buffer().write(ByteArray(byteCount))
 
   private fun assertStreamData(
@@ -2074,5 +2126,55 @@ class Http2ConnectionTest {
           errorCode: ErrorCode,
         ) {}
       }
+  }
+
+  private class BlockingFlushSocket : okhttp3.internal.connection.BufferedSocket {
+    val flushStarted = CountDownLatch(1)
+    private val canceled = CountDownLatch(1)
+
+    override val source: BufferedSource = Buffer()
+
+    override val sink =
+      object : Sink {
+        override fun write(
+          source: Buffer,
+          byteCount: Long,
+        ) {
+          source.skip(byteCount)
+        }
+
+        override fun flush() {
+          flushStarted.countDown()
+          canceled.await()
+          throw IOException("canceled")
+        }
+
+        override fun timeout(): okio.Timeout = okio.Timeout.NONE
+
+        override fun close() {
+          cancel()
+        }
+      }
+        .buffer()
+
+    override fun cancel() {
+      canceled.countDown()
+    }
+  }
+
+  private class FakeCarrier(
+    override val route: Route,
+  ) : ExchangeCodec.Carrier {
+    override fun trackFailure(
+      call: RealCall,
+      e: IOException?,
+    ) {
+    }
+
+    override fun noNewExchanges() {
+    }
+
+    override fun cancel() {
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fix HTTP/2 call cancellation when a call is blocked creating a new stream and flushing request headers.

When `Http2ExchangeCodec.writeRequestHeaders()` calls `Http2Connection.newStream()`, the new stream is not assigned to the codec until `newStream()` returns. If the underlying HTTP/2 writer blocks during that operation, `Http2ExchangeCodec.cancel()` currently only sets `canceled = true`; there is no stream reference yet, so it cannot send `RST_STREAM` or interrupt the blocked writer.

This means an overall `callTimeout` can fire, `RealCall.cancel()` can reach the codec, but the thread doing the HTTP/2 write can remain blocked in socket I/O.

This patch tracks when stream creation is in flight. If cancellation happens in that window before a stream is available to close, the codec cancels the underlying HTTP/2 connection socket to interrupt the blocked writer. Once a stream exists, cancellation continues to use the narrower stream-level `closeLater(CANCEL)` behavior.

Fixes https://github.com/square/okhttp/issues/8014

## Verification

Added `Http2ConnectionTest.cancelHttp2ExchangeInterruptsBlockedStreamCreation`, which uses a fake `BufferedSocket` whose sink blocks on `flush()`.

The regression exercises the existing `Http2ExchangeCodec.cancel()` path:

- Before the production fix, the test reproduces the bug: `codec.cancel()` does not unblock `writeRequestHeaders()`, and the test fails because the writer thread does not complete within the timeout.
- With the fix, `codec.cancel()` interrupts the blocked stream creation and the test completes with an `IOException`.

Commands run:

```bash
./gradlew :okhttp:jvmTest --tests okhttp3.internal.http2.Http2ConnectionTest.cancelHttp2ExchangeInterruptsBlockedStreamCreation
./gradlew :okhttp:jvmTest --tests okhttp3.internal.http2.Http2ConnectionTest
```

Both pass with the fix applied.

## Debugging Notes

Static analysis showed the cancellation gap in the `Http2ExchangeCodec.writeRequestHeaders()` -> `Http2Connection.newStream()` path: the stream can exist inside `Http2Connection`, while the codec still has `stream == null` until header write/flush returns.

We also verified the repro/fix behavior using the local JDWP debugging workflow with `debug-bridge` / `java-debug-mcp`:

https://github.com/ittaigolde/java-debug-mcp
