### PR TITLE
Fix isDotDot to recognize ..%2e and %2e.. path segments

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/HttpUrl.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/HttpUrl.kt
@@ -1594,7 +1594,9 @@ class HttpUrl private constructor(
       input == ".." ||
         input.equals("%2e.", ignoreCase = true) ||
         input.equals(".%2e", ignoreCase = true) ||
-        input.equals("%2e%2e", ignoreCase = true)
+        input.equals("%2e%2e", ignoreCase = true) ||
+        input.equals("..%2e", ignoreCase = true) ||
+        input.equals("%2e..", ignoreCase = true)
 
     /**
      * Cuts this string up into alternating parameter names and values. This divides a query string

--- a/okhttp/src/jvmTest/kotlin/okhttp3/HttpUrlTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/HttpUrlTest.kt
@@ -973,6 +973,10 @@ open class HttpUrlTest {
     assertThat(base.resolve("%2e.")).isEqualTo(parse("http://host/a/"))
     assertThat(base.resolve(".%2e")).isEqualTo(parse("http://host/a/"))
     assertThat(base.resolve("%2e%2e")).isEqualTo(parse("http://host/a/"))
+    assertThat(base.resolve("..%2e")).isEqualTo(parse("http://host/a/"))
+    assertThat(base.resolve("%2e..")).isEqualTo(parse("http://host/a/"))
+    assertThat(base.resolve("..%2E")).isEqualTo(parse("http://host/a/"))
+    assertThat(base.resolve("%2E..")).isEqualTo(parse("http://host/a/"))
     assertThat(base.resolve("%2E")).isEqualTo(parse("http://host/a/b/"))
     assertThat(base.resolve("%2e")).isEqualTo(parse("http://host/a/b/"))
   }


### PR DESCRIPTION
## Summary

- Extend `HttpUrl.Builder.isDotDot()` to treat `..%2e` and `%2e..` as dot-dot segments, matching RFC 3986 §6.2.2.3 normalization semantics already applied to `%2e.`, `.%2e`, and `%2e%2e`.
- Add regression tests in `HttpUrlTest.relativePath()` for the missing encoded forms (including uppercase `%2E` variants).

Fixes #9451

## Problem

`HttpUrl.resolve()` left `..%2e` and `%2e..` in the encoded path instead of collapsing them. Code that validates `encodedPath()` against a prefix (e.g. `/static/`) could be bypassed when downstream components percent-decode `%2e` later.

## Test plan

- [ ] `./gradlew :okhttp:jvmTest --tests "okhttp3.HttpUrlTest.relativePath"`
- [ ] Verify `base.resolve("..%2e")` and `base.resolve("%2e..")` normalize to the parent path instead of leaving literal encoded segments