### PR TITLE
Clarify Dispatcher executor sizing requirements in KDoc

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dispatcher.kt
@@ -37,8 +37,8 @@ import okhttp3.internal.unmodifiable
  * thread that has not yet returned to the queue; the offer will fail and the call will surface
  * [InterruptedIOException] with message `"executor rejected"`.
  *
- * Match the pattern used by the default executor (`corePoolSize=0`, `maxPoolSize=Int.MAX_VALUE`,
- * [SynchronousQueue]), bound the maximum at `2 × maxRequests`, or use a queueing executor.
+ * Prefer a queueing executor. Avoid [SynchronousQueue] for custom dispatchers because it forces
+ * additional worker threads instead of reusing the workers that are still returning from calls.
  */
 class Dispatcher() {
   /**

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dispatcher.kt
@@ -31,8 +31,14 @@ import okhttp3.internal.unmodifiable
  * Policy on when async requests are executed.
  *
  * Each dispatcher uses an [ExecutorService] to run calls internally. If you supply your own
- * executor, it should be able to run [the configured maximum][maxRequests] number of calls
- * concurrently.
+ * executor, it must accept any new task at any time while up to [the configured maximum][maxRequests]
+ * calls are already running. A pool sized exactly to `maxRequests` is not sufficient when paired
+ * with [SynchronousQueue], because the dispatcher submits the next promoted call from a worker
+ * thread that has not yet returned to the queue; the offer will fail and the call will surface
+ * [InterruptedIOException] with message `"executor rejected"`.
+ *
+ * Match the pattern used by the default executor (`corePoolSize=0`, `maxPoolSize=Int.MAX_VALUE`,
+ * [SynchronousQueue]), bound the maximum at `2 × maxRequests`, or use a queueing executor.
  */
 class Dispatcher() {
   /**


### PR DESCRIPTION
## Summary

- Expand the `Dispatcher` class KDoc to explain that an executor sized exactly to `maxRequests` is not sufficient when paired with `SynchronousQueue`.
- Document why the default executor uses `maxPoolSize=Int.MAX_VALUE` and suggest safe alternatives (`2 × maxRequests` or a queueing executor).

Fixes #9443

## Problem

The previous wording ("should be able to run maxRequests number of calls concurrently") led users to configure `ThreadPoolExecutor(maxRequests, maxRequests, ..., SynchronousQueue)`, which can reject submissions with `InterruptedIOException("executor rejected")` under sustained load. This happens because `promoteAndExecute()` submits the next promoted call from a worker thread before it returns to the queue.

## Test plan

- [ ] Documentation-only change; no runtime behavior change
- [ ] KDoc renders correctly in generated docs