### PR TITLE
Don't crash route selection when the system proxy selector throws

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RouteSelector.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/RouteSelector.kt
@@ -104,8 +104,15 @@ class RouteSelector internal constructor(
       val uri = url.toUri()
       if (uri.host == null) return immutableListOf(Proxy.NO_PROXY)
 
-      // Try each of the ProxySelector choices until one connection succeeds.
-      val proxiesOrNull = address.proxySelector.select(uri)
+      // Try each of the ProxySelector choices until one connection succeeds. A misconfigured
+      // system proxy (such as one with no port set) can make ProxySelector.select() itself throw
+      // IllegalArgumentException; treat that as "no usable proxy" rather than letting it crash.
+      val proxiesOrNull =
+        try {
+          address.proxySelector.select(uri)
+        } catch (_: IllegalArgumentException) {
+          null
+        }
       if (proxiesOrNull.isNullOrEmpty()) return immutableListOf(Proxy.NO_PROXY)
 
       return proxiesOrNull.toImmutableList()

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/RouteSelectorTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/connection/RouteSelectorTest.kt
@@ -206,6 +206,35 @@ class RouteSelectorTest {
     assertThat(routeSelector.hasNext()).isFalse()
   }
 
+  @Test fun proxySelectorThrowingIllegalArgumentExceptionFallsBackToDirect() {
+    val brokenProxySelector: ProxySelector =
+      object : ProxySelector() {
+        override fun select(uri: URI): List<Proxy>? {
+          // A system proxy with an unset port makes the platform ProxySelector throw this.
+          throw IllegalArgumentException("port out of range:-1")
+        }
+
+        override fun connectFailed(
+          uri: URI,
+          socketAddress: SocketAddress,
+          e: IOException,
+        ): Unit = throw AssertionError()
+      }
+
+    val address =
+      factory.newAddress(
+        proxySelector = brokenProxySelector,
+      )
+    val routeSelector = newRouteSelector(address)
+    assertThat(routeSelector.hasNext()).isTrue()
+    dns[uriHost] = dns.allocate(1)
+    val selection = routeSelector.next()
+    assertRoute(selection.next(), address, Proxy.NO_PROXY, dns.lookup(uriHost, 0), uriPort)
+    dns.assertRequests(uriHost)
+    assertThat(selection.hasNext()).isFalse()
+    assertThat(routeSelector.hasNext()).isFalse()
+  }
+
   @Test fun proxySelectorReturnsNoProxies() {
     val address = factory.newAddress()
     val routeSelector = newRouteSelector(address)


### PR DESCRIPTION
Fixes #9469.

When no explicit proxy is configured, `RouteSelector` calls `address.proxySelector.select(uri)` and only handles a null/empty return. On Android the platform `DefaultProxySelector` can itself throw `IllegalArgumentException: port out of range:-1` when a system proxy is configured (via APN/MDM) with an unset port. That exception propagates out of `resetNextProxy` and crashes the call on the dispatcher thread, even though OkHttp already rejects out-of-range proxy ports elsewhere.

This treats a throwing `ProxySelector.select()` the same as a null/empty result and falls back to a direct connection, which matches how the surrounding code already handles "no usable proxy". Added a `RouteSelectorTest` case that fails on the current code and passes with the fix.
