### PR TITLE
Add RFC 1008 (QUERY Method) support

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/HttpMethod.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/HttpMethod.kt
@@ -43,9 +43,9 @@ object HttpMethod {
   @JvmStatic // Despite being 'internal', this method is called by popular 3rd party SDKs.
   fun permitsRequestBody(method: String): Boolean = !(method == "GET" || method == "HEAD")
 
-  fun redirectsWithBody(method: String): Boolean = method == "PROPFIND"
+  fun redirectsWithBody(method: String): Boolean = method == "PROPFIND" || method == "QUERY"
 
-  fun redirectsToGet(method: String): Boolean = method != "PROPFIND"
+  fun redirectsToGet(method: String): Boolean = method != "PROPFIND" && method != "QUERY"
 
   fun isCacheable(requestMethod: String): Boolean = requestMethod == "GET" || requestMethod == "QUERY"
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/HttpMethod.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/HttpMethod.kt
@@ -15,6 +15,7 @@
  */
 package okhttp3.internal.http
 
+import java.net.HttpURLConnection.HTTP_SEE_OTHER
 import kotlin.jvm.JvmStatic
 
 object HttpMethod {
@@ -43,9 +44,14 @@ object HttpMethod {
   @JvmStatic // Despite being 'internal', this method is called by popular 3rd party SDKs.
   fun permitsRequestBody(method: String): Boolean = !(method == "GET" || method == "HEAD")
 
-  fun redirectsWithBody(method: String): Boolean = method == "PROPFIND" || method == "QUERY"
-
-  fun redirectsToGet(method: String): Boolean = method != "PROPFIND" && method != "QUERY"
+  fun redirectsToGet(
+    method: String,
+    responseCode: Int,
+  ): Boolean {
+    if (responseCode == HTTP_SEE_OTHER) return method != "PROPFIND"
+    if (responseCode == HTTP_TEMP_REDIRECT || responseCode == HTTP_PERM_REDIRECT) return false
+    return method != "PROPFIND" && method != "QUERY"
+  }
 
   fun isCacheable(requestMethod: String): Boolean = requestMethod == "GET" || requestMethod == "QUERY"
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
@@ -315,9 +315,11 @@ class RetryAndFollowUpInterceptor : Interceptor {
       val responseCode = userResponse.code
       val isQueryAndSeeOther = method == "QUERY" && responseCode == HTTP_SEE_OTHER
       val maintainBody =
-        (HttpMethod.redirectsWithBody(method) ||
-          responseCode == HTTP_PERM_REDIRECT ||
-          responseCode == HTTP_TEMP_REDIRECT) && !isQueryAndSeeOther
+        (
+          HttpMethod.redirectsWithBody(method) ||
+            responseCode == HTTP_PERM_REDIRECT ||
+            responseCode == HTTP_TEMP_REDIRECT
+        ) && !isQueryAndSeeOther
       if ((HttpMethod.redirectsToGet(method) || isQueryAndSeeOther) &&
         responseCode != HTTP_PERM_REDIRECT && responseCode != HTTP_TEMP_REDIRECT
       ) {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
@@ -313,11 +313,14 @@ class RetryAndFollowUpInterceptor : Interceptor {
     val requestBuilder = userResponse.request.newBuilder()
     if (HttpMethod.permitsRequestBody(method)) {
       val responseCode = userResponse.code
+      val isQueryAndSeeOther = method == "QUERY" && responseCode == HTTP_SEE_OTHER
       val maintainBody =
-        HttpMethod.redirectsWithBody(method) ||
+        (HttpMethod.redirectsWithBody(method) ||
           responseCode == HTTP_PERM_REDIRECT ||
-          responseCode == HTTP_TEMP_REDIRECT
-      if (HttpMethod.redirectsToGet(method) && responseCode != HTTP_PERM_REDIRECT && responseCode != HTTP_TEMP_REDIRECT) {
+          responseCode == HTTP_TEMP_REDIRECT) && !isQueryAndSeeOther
+      if ((HttpMethod.redirectsToGet(method) || isQueryAndSeeOther) &&
+        responseCode != HTTP_PERM_REDIRECT && responseCode != HTTP_TEMP_REDIRECT
+      ) {
         requestBuilder.method("GET", null)
       } else {
         val requestBody = if (maintainBody) userResponse.request.body else null

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/RetryAndFollowUpInterceptor.kt
@@ -313,25 +313,13 @@ class RetryAndFollowUpInterceptor : Interceptor {
     val requestBuilder = userResponse.request.newBuilder()
     if (HttpMethod.permitsRequestBody(method)) {
       val responseCode = userResponse.code
-      val isQueryAndSeeOther = method == "QUERY" && responseCode == HTTP_SEE_OTHER
-      val maintainBody =
-        (
-          HttpMethod.redirectsWithBody(method) ||
-            responseCode == HTTP_PERM_REDIRECT ||
-            responseCode == HTTP_TEMP_REDIRECT
-        ) && !isQueryAndSeeOther
-      if ((HttpMethod.redirectsToGet(method) || isQueryAndSeeOther) &&
-        responseCode != HTTP_PERM_REDIRECT && responseCode != HTTP_TEMP_REDIRECT
-      ) {
+      if (HttpMethod.redirectsToGet(method, responseCode)) {
         requestBuilder.method("GET", null)
-      } else {
-        val requestBody = if (maintainBody) userResponse.request.body else null
-        requestBuilder.method(method, requestBody)
-      }
-      if (!maintainBody) {
         requestBuilder.removeHeader("Transfer-Encoding")
         requestBuilder.removeHeader("Content-Length")
         requestBuilder.removeHeader("Content-Type")
+      } else {
+        requestBuilder.method(method, userResponse.request.body)
       }
     }
 

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
@@ -2491,6 +2491,96 @@ open class CallTest {
   }
 
   @Test
+  fun queryRedirectsToQueryAndMaintainsRequestBodyOnMovedTemp() {
+    server.enqueue(
+      MockResponse(
+        code = HttpURLConnection.HTTP_MOVED_TEMP,
+        headers = headersOf("Location", "/page2"),
+        body = "This page has moved!",
+      ),
+    )
+    server.enqueue(MockResponse(body = "Page 2"))
+
+    val response =
+      client
+        .newCall(
+          Request
+            .Builder()
+            .url(server.url("/page1"))
+            .query("Query Body".toRequestBody("text/plain".toMediaType()))
+            .build(),
+        ).execute()
+
+    assertThat(response.body.string()).isEqualTo("Page 2")
+    val page1 = server.takeRequest()
+    assertThat(page1.requestLine).isEqualTo("QUERY /page1 HTTP/1.1")
+    assertThat(page1.body?.utf8()).isEqualTo("Query Body")
+    val page2 = server.takeRequest()
+    assertThat(page2.requestLine).isEqualTo("QUERY /page2 HTTP/1.1")
+    assertThat(page2.body?.utf8()).isEqualTo("Query Body")
+  }
+
+  @Test
+  fun queryRedirectsToQueryAndMaintainsRequestBodyOnMovedPerm() {
+    server.enqueue(
+      MockResponse(
+        code = HttpURLConnection.HTTP_MOVED_PERM,
+        headers = headersOf("Location", "/page2"),
+        body = "This page has moved!",
+      ),
+    )
+    server.enqueue(MockResponse(body = "Page 2"))
+
+    val response =
+      client
+        .newCall(
+          Request
+            .Builder()
+            .url(server.url("/page1"))
+            .query("Query Body".toRequestBody("text/plain".toMediaType()))
+            .build(),
+        ).execute()
+
+    assertThat(response.body.string()).isEqualTo("Page 2")
+    val page1 = server.takeRequest()
+    assertThat(page1.requestLine).isEqualTo("QUERY /page1 HTTP/1.1")
+    assertThat(page1.body?.utf8()).isEqualTo("Query Body")
+    val page2 = server.takeRequest()
+    assertThat(page2.requestLine).isEqualTo("QUERY /page2 HTTP/1.1")
+    assertThat(page2.body?.utf8()).isEqualTo("Query Body")
+  }
+
+  @Test
+  fun queryRedirectsToGetAndDropsRequestBodyOnSeeOther() {
+    server.enqueue(
+      MockResponse(
+        code = HttpURLConnection.HTTP_SEE_OTHER,
+        headers = headersOf("Location", "/page2"),
+        body = "See other page!",
+      ),
+    )
+    server.enqueue(MockResponse(body = "Page 2"))
+
+    val response =
+      client
+        .newCall(
+          Request
+            .Builder()
+            .url(server.url("/page1"))
+            .query("Query Body".toRequestBody("text/plain".toMediaType()))
+            .build(),
+        ).execute()
+
+    assertThat(response.body.string()).isEqualTo("Page 2")
+    val page1 = server.takeRequest()
+    assertThat(page1.requestLine).isEqualTo("QUERY /page1 HTTP/1.1")
+    assertThat(page1.body?.utf8()).isEqualTo("Query Body")
+    val page2 = server.takeRequest()
+    assertThat(page2.requestLine).isEqualTo("GET /page2 HTTP/1.1")
+    assertThat(page2.body).isNull()
+  }
+
+  @Test
   fun responseCookies() {
     server.enqueue(
       MockResponse(


### PR DESCRIPTION
Now that QUERY method graduated to a proper RFC, this change fixes the missing bits for conformance, which is redirect handling. This change allows QUERY requests to be automatically redirected reusing the body, as well as allowing redirect to GET. Fortunately, this library already implemented these behaviours for PROPFIND so it's just adding QUERY into the list of methods.