### PR TITLE
Reject hostnames with unpaired UTF-16 surrogates

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/tls/OkHostnameVerifier.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/tls/OkHostnameVerifier.kt
@@ -24,7 +24,6 @@ import javax.net.ssl.SSLException
 import javax.net.ssl.SSLSession
 import okhttp3.internal.canParseAsIpAddress
 import okhttp3.internal.toCanonicalHost
-import okio.utf8Size
 
 /**
  * A HostnameVerifier consistent with [RFC 2818][rfc_2818].
@@ -96,7 +95,13 @@ object OkHostnameVerifier : HostnameVerifier {
     }
 
   /** Returns true if the [String] is ASCII encoded (0-127). */
-  private fun String.isAscii() = length == utf8Size().toInt()
+  private fun String.isAscii(): Boolean {
+    for (i in 0 until length) {
+      val c = this[i]
+      if (c >= '\u0080') return false
+    }
+    return true
+  }
 
   /**
    * Returns true if [hostname] matches the domain name [pattern].

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/tls/HostnameVerifierTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/tls/HostnameVerifierTest.kt
@@ -803,6 +803,21 @@ class HostnameVerifierTest {
     assertThat(localVerifier.verify("\uD83D\uDCA9.com", session)).isFalse()
   }
 
+  @Test fun verifyMalformedSurrogateHostname() {
+    // A hostname with an unpaired UTF-16 surrogate is not ASCII and must be rejected, not
+    // matched against the wildcard. https://github.com/square/okhttp/issues/6357
+    val heldCertificate =
+      HeldCertificate
+        .Builder()
+        .commonName("Foo Corp")
+        .addSubjectAlternativeName("*.com")
+        .build()
+    val session = session(heldCertificate.certificatePem())
+    assertThat(verifier.verify("example.com", session)).isTrue()
+    assertThat(verifier.verify("\uD800.com", session)).isFalse()
+    assertThat(verifier.verify("\uDC00.com", session)).isFalse()
+  }
+
   @Test fun verifyAsIpAddress() {
     // IPv4
     assertThat("127.0.0.1".canParseAsIpAddress()).isTrue()


### PR DESCRIPTION
`OkHostnameVerifier.isAscii()` used `length == utf8Size()` to decide whether a hostname is ASCII. That breaks on unpaired UTF-16 surrogates. okio encodes a lone surrogate as a single `?` byte, so its UTF-8 size equals its length and `isAscii()` wrongly returns true. A hostname that starts with an unpaired surrogate such as U+D800 then slips past the ASCII guard in `verify()` and can match a wildcard certificate like `*.com`.

The fix scans the string and returns false as soon as a code unit falls outside the ASCII range, so any unpaired surrogate counts as non-ASCII. I added a test that builds a `*.com` certificate and checks a surrogate hostname is rejected while a normal one still matches.

Fixes #6357
