### PR TITLE
Handle null return from ExtendedSSLSession.getRequestedServerNames on Android SDK 27/28

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/platform/Platform.kt
@@ -132,7 +132,7 @@ open class Platform {
   open fun getHandshakeServerNames(sslSocket: SSLSocket): List<String> {
     val session = sslSocket.session as? ExtendedSSLSession ?: return listOf()
     return try {
-      session.requestedServerNames.mapNotNull { (it as? SNIHostName)?.asciiName }
+      (session.requestedServerNames ?: emptyList()).mapNotNull { (it as? SNIHostName)?.asciiName }
     } catch (_: UnsupportedOperationException) {
       // UnsupportedOperationException – if the underlying provider does not implement the operation
       // https://github.com/bcgit/bc-java/issues/1773


### PR DESCRIPTION
Fixes #9523.

On Android SDK 27 and 28, `ExtendedSSLSession.getRequestedServerNames()` can return `null` instead of an empty list (upstream bug: google/conscrypt#977). This causes a `NullPointerException` in `MockWebServer` when recording `requestedServerNames` on a `RecordedRequest`.

**Change:** one-line null guard in `Platform.getHandshakeServerNames` — replace direct `.mapNotNull` call with `(session.requestedServerNames ?: emptyList()).mapNotNull { ... }`. Already catches `UnsupportedOperationException` in the same block, so the null case fits the same defensive pattern.