### PR TITLE
Quote the multipart boundary when it isn't a token

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/MultipartBody.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/MultipartBody.kt
@@ -35,7 +35,12 @@ class MultipartBody internal constructor(
   @get:JvmName("type") val type: MediaType,
   @get:JvmName("parts") val parts: List<Part>,
 ) : RequestBody() {
-  private val contentType: MediaType = "$type; boundary=$boundary".toMediaType()
+  private val contentType: MediaType =
+    buildString {
+      append(type)
+      append("; boundary=")
+      appendBoundary(boundary)
+    }.toMediaType()
   private var contentLength = -1L
 
   @get:JvmName("boundary")
@@ -353,6 +358,35 @@ class MultipartBody internal constructor(
     private val COLONSPACE = byteArrayOf(':'.code.toByte(), ' '.code.toByte())
     private val CRLF = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte())
     private val DASHDASH = byteArrayOf('-'.code.toByte(), '-'.code.toByte())
+
+    private const val TOKEN_SPECIALS = "-!#\$%&'*+.^_`{|}~"
+
+    /**
+     * Appends [boundary] to this StringBuilder, unchanged if it's a valid RFC 2045 token or as a
+     * quoted-string otherwise. A boundary that contains a character like `:` isn't a token, so it
+     * must be quoted for the `Content-Type` to parse. See RFC 2045 section 5.1. A `"` or `\` can't
+     * round-trip through the quoted-string that `MediaType` reads back, so those are rejected.
+     */
+    private fun StringBuilder.appendBoundary(boundary: String) {
+      var quoted = boundary.isEmpty()
+      for (c in boundary) {
+        require(c != '"' && c != '\\') { "boundary contains a character that can't be quoted: $boundary" }
+        if (!quoted && !c.isTokenChar()) quoted = true
+      }
+      if (quoted) {
+        append('"')
+        append(boundary)
+        append('"')
+      } else {
+        append(boundary)
+      }
+    }
+
+    private fun Char.isTokenChar(): Boolean =
+      this in 'a'..'z' ||
+        this in 'A'..'Z' ||
+        this in '0'..'9' ||
+        this in TOKEN_SPECIALS
 
     /**
      * Appends a quoted-string to a StringBuilder.

--- a/okhttp/src/jvmTest/kotlin/okhttp3/MultipartBodyTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/MultipartBodyTest.kt
@@ -103,6 +103,33 @@ class MultipartBodyTest {
   }
 
   @Test
+  fun boundaryWithNonTokenCharacterIsQuoted() {
+    val body =
+      MultipartBody
+        .Builder("abc:def")
+        .addPart("Hello, World!".toRequestBody(null))
+        .build()
+    assertThat(body.boundary).isEqualTo("abc:def")
+    assertThat(body.contentType().toString())
+      .isEqualTo("multipart/mixed; boundary=\"abc:def\"")
+    assertThat(body.contentType().parameter("boundary")).isEqualTo("abc:def")
+  }
+
+  @Test
+  fun boundaryContainingQuoteIsRejected() {
+    val builder =
+      MultipartBody
+        .Builder("a\"; charset=\"evil")
+        .addPart("Hello, World!".toRequestBody(null))
+    assertFailsWith<IllegalArgumentException> {
+      builder.build()
+    }.also { expected ->
+      assertThat(expected.message)
+        .isEqualTo("boundary contains a character that can't be quoted: a\"; charset=\"evil")
+    }
+  }
+
+  @Test
   fun fieldAndTwoFiles() {
     val expected =
       """


### PR DESCRIPTION
Fixes #8068.

`MultipartBody` builds its `Content-Type` without quoting the boundary. A boundary with a non-token character, like the colon in `abc:def`, isn't a valid token, so `toMediaType()` rejects it and `build()` throws.

This quotes the boundary when it isn't a token, per RFC 2045 section 5.1, so the Content-Type parses and round-trips through `parameter("boundary")`. A boundary containing a quote or backslash can't round-trip through the quoted-string, so it's rejected instead. Added a test for the colon boundary and one for the rejected case.
