### PR TITLE
Detect overflow when decoding DER variable-length integers

### DIFF
--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/DerReader.kt
@@ -305,12 +305,16 @@ internal class DerReader(
 
   /** Used for tags and subidentifiers. */
   private fun readVariableLengthLong(): Long {
-    // TODO(jwilson): detect overflow.
     var result = 0L
     while (true) {
       val byteN = source.readByte().toLong() and 0xff
       if ((byteN and 0b1000_0000L) == 0b1000_0000L) {
-        result = (result + (byteN and 0b0111_1111)) shl 7
+        result += byteN and 0b0111_1111
+        // Once more than 56 bits are used the following shift left by 7 would drop set bits and
+        // could flip the sign, so the encoded value doesn't fit in a Long. Fail instead of
+        // silently returning a truncated (possibly negative) number.
+        if (result ushr 56 != 0L) throw ProtocolException("variable length long > Long.MAX_VALUE")
+        result = result shl 7
       } else {
         return result + byteN
       }

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
@@ -405,6 +405,20 @@ internal class DerTest {
     assertThat(derReader.hasNext()).isFalse()
   }
 
+  @Test fun `decode object identifier with overflowing subidentifier`() {
+    val buffer =
+      Buffer()
+        .write("060a81808080808080808000".decodeHex())
+
+    val derReader = DerReader(buffer)
+
+    assertFailsWith<ProtocolException> {
+      derReader.read("test") { derReader.readObjectIdentifier() }
+    }.also { expected ->
+      assertThat(expected.message).isEqualTo("variable length long > Long.MAX_VALUE")
+    }
+  }
+
   @Test fun `encode object identifier without adapter`() {
     val buffer = Buffer()
     val derWriter = DerWriter(buffer)


### PR DESCRIPTION
DerReader decodes ASN.1 variable-length integers for OBJECT IDENTIFIER subidentifiers and high-number tags, building the value up with a shift left of 7 per continuation byte. That accumulation had no overflow guard (it carried a `// TODO: detect overflow`), so a subidentifier padded with enough continuation bytes silently wraps a Long and the shift can flip the sign. I ran into it decoding a certificate whose OID had an over-long arc: instead of rejecting the input, `readObjectIdentifier` handed back a bogus arc like `2.9223372036854775728` produced by the wrapped arithmetic. Since these bytes come straight off an untrusted certificate, quietly turning a malformed OID into a real-looking one seemed worth closing off. This throws a `ProtocolException` once the running value no longer fits in a Long, the same way the length decoder just above already rejects a length past `Long.MAX_VALUE`. Values up to `Long.MAX_VALUE` still decode exactly as before, and there's a regression test for the overflowing case.
