### PR TITLE
Limit proxy CONNECT auth retries without Connection: close

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/ConnectPlan.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/ConnectPlan.kt
@@ -416,6 +416,10 @@ class ConnectPlan internal constructor(
   /**
    * To make an HTTPS connection over an HTTP proxy, send an unencrypted CONNECT request to create
    * the proxy connection. This may need to be retried if the proxy requires authorization.
+   *
+   * Retries on the same connection (when the proxy does not send `Connection: close`) share the
+   * same [MAX_TUNNEL_ATTEMPTS] budget as reconnects after `Connection: close`, so a misbehaving
+   * proxy cannot trap this loop indefinitely. See https://github.com/square/okhttp/issues/9477.
    */
   @Throws(IOException::class)
   private fun createTunnel(): Request? {
@@ -423,6 +427,8 @@ class ConnectPlan internal constructor(
     // Make an SSL Tunnel on the first message pair of each SSL + proxy connection.
     val url = route.address.url
     val requestLine = "CONNECT ${url.toHostHeader(includeDefaultPort = true)} HTTP/1.1"
+    // Count prior reconnects so keep-alive and Connection: close retries share one budget.
+    var tunnelAttempts = attempt
     while (true) {
       val tunnelCodec =
         Http1ExchangeCodec(
@@ -453,6 +459,13 @@ class ConnectPlan internal constructor(
 
           if ("close".equals(response.header("Connection"), ignoreCase = true)) {
             return nextRequest
+          }
+
+          tunnelAttempts++
+          if (tunnelAttempts >= MAX_TUNNEL_ATTEMPTS) {
+            throw ProtocolException(
+              "Too many tunnel connections attempted: $MAX_TUNNEL_ATTEMPTS",
+            )
           }
         }
 

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
@@ -3870,7 +3870,85 @@ open class CallTest {
     val request = Request("https://android.com/foo".toHttpUrl())
     assertFailsWith<ProtocolException> {
       client.newCall(request).execute()
+    }.also { expected ->
+      assertThat(expected).hasMessage("Too many tunnel connections attempted: 21")
     }
+  }
+
+  /**
+   * A proxy that keeps the connection open and always returns 407 must not trap OkHttp in an
+   * infinite loop. https://github.com/square/okhttp/issues/9477
+   */
+  @Test
+  fun tooManyProxyAuthFailuresWithoutConnectionClose() {
+    server.useHttps(handshakeCertificates.sslSocketFactory())
+    server.protocols = listOf(Protocol.HTTP_1_1)
+    for (i in 0..20) {
+      server.enqueue(
+        MockResponse
+          .Builder()
+          .code(407)
+          .headers(headersOf("Proxy-Authenticate", "Basic realm=\"localhost\""))
+          .inTunnel()
+          .build(),
+      )
+    }
+    val authenticator = RecordingOkAuthenticator("password", "Basic")
+    client =
+      client
+        .newBuilder()
+        .sslSocketFactory(
+          handshakeCertificates.sslSocketFactory(),
+          handshakeCertificates.trustManager,
+        ).proxy(server.proxyAddress)
+        .proxyAuthenticator(authenticator)
+        .hostnameVerifier(RecordingHostnameVerifier())
+        .build()
+    val request = Request("https://android.com/foo".toHttpUrl())
+    assertFailsWith<ProtocolException> {
+      client.newCall(request).execute()
+    }.also { expected ->
+      assertThat(expected).hasMessage("Too many tunnel connections attempted: 21")
+    }
+    // Preemptive challenge + 21 reactive 407s, but only 21 CONNECT attempts are allowed.
+    assertThat(authenticator.responses.size).isEqualTo(22)
+  }
+
+  /** Confirm we still succeed after several keep-alive proxy auth challenges (under the limit). */
+  @Test
+  fun proxyAuthenticateOnConnectSucceedsAfterManyChallenges() {
+    server.useHttps(handshakeCertificates.sslSocketFactory())
+    server.protocols = listOf(Protocol.HTTP_1_1)
+    for (i in 0..19) {
+      server.enqueue(
+        MockResponse
+          .Builder()
+          .code(407)
+          .headers(headersOf("Proxy-Authenticate", "Basic realm=\"localhost\""))
+          .inTunnel()
+          .build(),
+      )
+    }
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .inTunnel()
+        .build(),
+    )
+    server.enqueue(MockResponse(body = "response body"))
+    client =
+      client
+        .newBuilder()
+        .sslSocketFactory(
+          handshakeCertificates.sslSocketFactory(),
+          handshakeCertificates.trustManager,
+        ).proxy(server.proxyAddress)
+        .proxyAuthenticator(RecordingOkAuthenticator("password", "Basic"))
+        .hostnameVerifier(RecordingHostnameVerifier())
+        .build()
+    val request = Request("https://android.com/foo".toHttpUrl())
+    val response = client.newCall(request).execute()
+    assertThat(response.body.string()).isEqualTo("response body")
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fixes an infinite loop in `ConnectPlan.createTunnel()` when an HTTP proxy repeatedly responds with `407 Proxy Authentication Required` without `Connection: close` ([#9477](https://github.com/square/okhttp/issues/9477)).
- Keep-alive proxy auth retries now share the existing `MAX_TUNNEL_ATTEMPTS` (21) budget already used for reconnects after `Connection: close`.
- After the limit is exceeded, OkHttp fails with `ProtocolException("Too many tunnel connections attempted: 21")` instead of looping forever.

### Background

`createTunnel()` only exited a `while (true)` loop when the proxy closed the connection, the authenticator returned null, or I/O failed. Unlike `RetryAndFollowUpInterceptor` (`MAX_FOLLOW_UPS = 20`) and the reconnect path (`MAX_TUNNEL_ATTEMPTS = 21`), keep-alive 407 handling had no iteration counter.

### Approach

Reuse `MAX_TUNNEL_ATTEMPTS` and seed the counter from the plan's existing `attempt` field so keep-alive retries and `Connection: close` reconnects share one budget (mixed cases cannot exceed 21 total either).

## Test plan

- [x] `CallTest.tooManyProxyAuthFailuresWithoutConnectionClose` — reproducer for #9477 (21 keep-alive 407s → `ProtocolException`)
- [x] `CallTest.proxyAuthenticateOnConnectSucceedsAfterManyChallenges` — 20 challenges then success still works
- [x] `CallTest.tooManyProxyAuthFailuresWithConnectionClose` — asserts the shared error message
- [x] Existing `proxyAuthenticateOnConnect` / `proxyAuthenticateOnConnectWithConnectionClose` still pass

Closes #9477