### PR TITLE
Fix flaky preferCallConnectionOverDeferredConnection test

### DIFF
--- a/okhttp/src/jvmTest/kotlin/okhttp3/FastFallbackTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/FastFallbackTest.kt
@@ -23,7 +23,9 @@ import java.io.IOException
 import java.net.Inet4Address
 import java.net.Inet6Address
 import java.net.InetAddress
+import java.net.InetSocketAddress
 import java.net.Socket
+import java.net.SocketAddress
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.net.SocketFactory
@@ -280,18 +282,23 @@ class FastFallbackTest {
     serverIpv4.protocols = listOf(Protocol.H2_PRIOR_KNOWLEDGE)
     serverIpv6.protocols = listOf(Protocol.H2_PRIOR_KNOWLEDGE)
 
-    // Yield the first IP address so the second IP address completes first.
-    val firstConnectLatch = CountDownLatch(1)
+    // Stall IPv6 so the IPv4 address completes first.
+    val ipv6ConnectLatch = CountDownLatch(1)
     val socketFactory =
       object : DelegatingSocketFactory(SocketFactory.getDefault()) {
-        var first = true
-
         override fun createSocket(): Socket {
-          if (first) {
-            first = false
-            firstConnectLatch.await()
+          return object : Socket() {
+            override fun connect(
+              endpoint: SocketAddress,
+              timeout: Int,
+            ) {
+              val address = (endpoint as? InetSocketAddress)?.address
+              if (address == localhostIpv6) {
+                ipv6ConnectLatch.await()
+              }
+              super.connect(endpoint, timeout)
+            }
           }
-          return super.createSocket()
         }
       }
 
@@ -305,7 +312,7 @@ class FastFallbackTest {
             try {
               chain.proceed(chain.request())
             } finally {
-              firstConnectLatch.countDown()
+              ipv6ConnectLatch.countDown()
             }
           },
         ).build()

--- a/okhttp/src/jvmTest/kotlin/okhttp3/FastFallbackTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/FastFallbackTest.kt
@@ -286,8 +286,8 @@ class FastFallbackTest {
     val ipv6ConnectLatch = CountDownLatch(1)
     val socketFactory =
       object : DelegatingSocketFactory(SocketFactory.getDefault()) {
-        override fun createSocket(): Socket {
-          return object : Socket() {
+        override fun createSocket(): Socket =
+          object : Socket() {
             override fun connect(
               endpoint: SocketAddress,
               timeout: Int,
@@ -299,7 +299,6 @@ class FastFallbackTest {
               super.connect(endpoint, timeout)
             }
           }
-        }
       }
 
     client =


### PR DESCRIPTION
Fixes #9369.

`preferCallConnectionOverDeferredConnection` tries to force IPv4 to win the Happy Eyeballs race by stalling the competing connect, so IPv6 becomes a deferred plan and a `REFUSED_STREAM` retry reuses the call connection. It did that by stalling the first `createSocket()` call.

That was racy. Fast fallback launches connect work on separate threads, so under load the IPv4 thread could claim the stall while IPv6 proceeded. The request then hit IPv6 and failed with:

```
expected: "this was the 2nd request on IPv4"
but was: "unexpected call to IPv6"
```

This stalls IPv6 specifically in `Socket.connect()` when the destination is `localhostIpv6`, so the right address is delayed no matter which thread runs first.