### PR TITLE
read DNS RDLENGTH as an unsigned 16-bit value

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-DnsMessageReader.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-DnsMessageReader.kt
@@ -151,7 +151,7 @@ class DnsMessageReader(
     val type = readShort().toInt()
     val `class` = readShort().toInt()
     val timeToLive = readInt()
-    val recordDataLength = readShort().toLong()
+    val recordDataLength = readUShort().toLong()
 
     when {
       `class` == CLASS_IN && type == TYPE_A -> {

--- a/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/DnsMessageReaderWriterTest.kt
+++ b/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/DnsMessageReaderWriterTest.kt
@@ -157,6 +157,54 @@ class DnsMessageReaderWriterTest {
     assertThat(e).hasMessage("malformed DNS message")
   }
 
+  /**
+   * An RDLENGTH is a 16-bit unsigned field, so a record may legitimately declare up to 65535 bytes
+   * of data. A value with the high bit set must still be skipped for record types we don't decode,
+   * otherwise the reader loses sync with the stream.
+   */
+  @Test
+  fun `unsupported record with high-bit record length is skipped`() {
+    val buffer =
+      Buffer().apply {
+        writeShort(0x0000) // id
+        writeShort(0x8180) // flags
+        writeShort(1) // question count
+        writeShort(1) // answer count
+        writeShort(0) // authority record count
+        writeShort(0) // additional record count
+
+        // Question: "a", type A, class IN.
+        writeByte(1)
+        writeByte('a'.code)
+        writeByte(0)
+        writeShort(TYPE_A)
+        writeShort(CLASS_IN)
+
+        // Answer with an unsupported type and 0x8000 bytes of record data.
+        writeShort(0xc00c) // Name compressed to the question's name.
+        writeShort(16) // TYPE_TXT, which this reader doesn't decode.
+        writeShort(CLASS_IN)
+        writeInt(0) // time to live
+        writeShort(0x8000) // record data length, 32768
+        write(ByteArray(0x8000))
+      }
+
+    assertThat(DnsMessageReader(buffer).read()).isEqualTo(
+      DnsMessage(
+        id = 0,
+        flags = -32384,
+        questions =
+          listOf(
+            Question(
+              name = "a",
+              type = TYPE_A,
+            ),
+          ),
+        answers = listOf(),
+      ),
+    )
+  }
+
   @Test
   fun `rejects mandatory service parameter with unsupported key`() {
     // An HTTPS record whose mandatory value is the single 2-octet SvcParamKey 0x0101 (257), which


### PR DESCRIPTION
readResourceRecord pulls the record data length out of the RDLENGTH field, which RFC 1035 defines as an unsigned 16-bit integer, but it decodes that field with readShort().toLong(), so any length with the high bit set comes back negative. Every other 16-bit field in this reader already goes through toUShort(), so this one is the odd one out. For an A or AAAA record the wrong sign is caught by the exact-length check, but for a record type we don't decode the code falls into skip(recordDataLength), and okio's skip treats a negative count as a no-op rather than an error. That means a record legitimately carrying 32768 or more bytes never gets consumed, the reader stays parked in the middle of the message, and the leftover bytes either trip the trailing-data check or get read as the next record. I hit it while feeding the reader a response with a large unknown record sitting in front of an A record. Decoding the field as unsigned, the same way the counts and the HTTPS parameter lengths already are, keeps the stream in sync, and I added a regression test that reads a message with an oversized unsupported record.