### PR TITLE
Reject malformed UTCTime and GeneralizedTime in DER parsing

### DIFF
--- a/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/Adapters.kt
+++ b/okhttp-tls/src/main/kotlin/okhttp3/tls/internal/der/Adapters.kt
@@ -17,7 +17,7 @@ package okhttp3.tls.internal.der
 
 import java.math.BigInteger
 import java.net.ProtocolException
-import java.text.ParseException
+import java.text.ParsePosition
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
@@ -235,15 +235,16 @@ internal object Adapters {
     val dateFormat =
       SimpleDateFormat("yyMMddHHmmss'Z'").apply {
         timeZone = utc
+        isLenient = false
         set2DigitYearStart(Date(-631152000000L)) // 1950-01-01T00:00:00Z.
       }
 
-    try {
-      val parsed = dateFormat.parse(string)
-      return parsed.time
-    } catch (e: ParseException) {
+    val position = ParsePosition(0)
+    val parsed = dateFormat.parse(string, position)
+    if (parsed == null || position.index != string.length) {
       throw ProtocolException("Failed to parse UTCTime $string")
     }
+    return parsed.time
   }
 
   internal fun formatUtcTime(date: Long): String {
@@ -317,14 +318,15 @@ internal object Adapters {
     val dateFormat =
       SimpleDateFormat("yyyyMMddHHmmss'Z'").apply {
         timeZone = utc
+        isLenient = false
       }
 
-    try {
-      val parsed = dateFormat.parse(string)
-      return parsed.time
-    } catch (e: ParseException) {
+    val position = ParsePosition(0)
+    val parsed = dateFormat.parse(string, position)
+    if (parsed == null || position.index != string.length) {
       throw ProtocolException("Failed to parse GeneralizedTime $string")
     }
+    return parsed.time
   }
 
   internal fun formatGeneralizedTime(date: Long): String {

--- a/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
+++ b/okhttp-tls/src/test/java/okhttp3/tls/internal/der/DerTest.kt
@@ -691,6 +691,36 @@ internal class DerTest {
     }
   }
 
+  @Test fun `cannot decode utc time with out of range field`() {
+    // "191316030210Z" carries month 13.
+    val bytes = "170d3139313331363033303231305a".decodeHex()
+    assertFailsWith<ProtocolException> {
+      Adapters.UTC_TIME.fromDer(bytes)
+    }.also { expected ->
+      assertThat(expected).hasMessage("Failed to parse UTCTime 191316030210Z")
+    }
+  }
+
+  @Test fun `cannot decode utc time with trailing data`() {
+    // A valid "191216030210Z" followed by a stray '0' inside the declared length.
+    val bytes = "170e3139313231363033303231305a30".decodeHex()
+    assertFailsWith<ProtocolException> {
+      Adapters.UTC_TIME.fromDer(bytes)
+    }.also { expected ->
+      assertThat(expected).hasMessage("Failed to parse UTCTime 191216030210Z0")
+    }
+  }
+
+  @Test fun `cannot decode generalized time with out of range field`() {
+    // "20191316030210Z" carries month 13.
+    val bytes = "180f32303139313331363033303231305a".decodeHex()
+    assertFailsWith<ProtocolException> {
+      Adapters.GENERALIZED_TIME.fromDer(bytes)
+    }.also { expected ->
+      assertThat(expected).hasMessage("Failed to parse GeneralizedTime 20191316030210Z")
+    }
+  }
+
   @Test fun `parse utc time`() {
     assertThat(Adapters.parseUtcTime("920521000000Z"))
       .isEqualTo(date("1992-05-21T00:00:00.000+0000").time)


### PR DESCRIPTION
The DER reader decodes UTCTime and GeneralizedTime through SimpleDateFormat, but it leaves the formatter in its default lenient mode and parses with the single-argument parse(), which only anchors at the start of the string. Because these value bytes come straight off a certificate, an out-of-range field like a month of 13 gets silently rolled over into a neighboring month instead of being rejected, and any bytes after the trailing 'Z' that still sit inside the element's declared length are quietly ignored. So two different encodings can decode to the same instant, and a malformed timestamp comes back looking like a real one, which is the same shape of problem as accepting an over-long OID arc. I noticed it while comparing these two functions against the HTTP date parser in the same codebase, which already sets isLenient=false and confirms the whole string was consumed. This switches lenience off and uses a ParsePosition so the parse has to reach the end of the value, matching that existing pattern. Valid canonical times still decode exactly as before, including the two-digit-year cutoff at 1950, and I added regression tests for the out-of-range and trailing-byte cases.
