### PR TITLE
Fix flaky DuplexTest.duplexWithAuthChallenge

### DIFF
--- a/okhttp/src/jvmTest/kotlin/okhttp3/DuplexTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/DuplexTest.kt
@@ -496,14 +496,27 @@ class DuplexTest {
   fun duplexWithAuthChallenge() {
     enableProtocol(Protocol.HTTP_2)
     val credential = basic("jesse", "secret")
+    val duplexResponseSent = CountDownLatch(1)
+    val requestHeadersEndListener =
+      object : EventListener() {
+        override fun requestHeadersEnd(
+          call: Call,
+          request: Request,
+        ) {
+          // Wait for the server to send the duplex response before acting on the 401 response
+          // and resetting the stream.
+          duplexResponseSent.await()
+        }
+      }
     client =
       client
         .newBuilder()
         .authenticator(RecordingOkAuthenticator(credential, null))
+        .eventListener(eventRecorder.eventListener + requestHeadersEndListener)
         .build()
     val body1 =
       MockSocketHandler()
-        .sendResponse("please authenticate!\n")
+        .sendResponse("please authenticate!\n", duplexResponseSent)
         .requestIOException()
         .exhaustResponse()
     server.enqueue(


### PR DESCRIPTION
## Summary

Fixes #9370.

On Windows (and occasionally elsewhere), `duplexWithAuthChallenge` fails with:

```
StreamResetException: stream was reset: CANCEL
  at MockSocketHandler.sendResponse (flush)
  at MockSocketHandler.awaitSuccess
```

The client can act on the 401 and cancel the HTTP/2 stream while the server is still writing the duplex challenge body. That is the same race fixed for `duplexWithRedirect` in #4788.

### Change

Reuse that pattern:

1. `CountDownLatch` counted down after the server sends `"please authenticate!\n"`
2. `EventListener.requestHeadersEnd` awaits the latch so the client does not process the 401 (and reset the stream) until that write has finished

## Test plan

- [x] `./gradlew :okhttp:jvmTest --tests okhttp3.DuplexTest.duplexWithAuthChallenge` (×5)
- [x] `./gradlew :okhttp:jvmTest --tests okhttp3.DuplexTest.duplexWithRedirect`
- [x] spotlessCheck