### PR TITLE
Rename includeHttps to includeServiceMetadata

### DIFF
--- a/okhttp-dnsoverhttps/api/okhttp-dnsoverhttps.api
+++ b/okhttp-dnsoverhttps/api/okhttp-dnsoverhttps.api
@@ -2,8 +2,8 @@ public final class okhttp3/dnsoverhttps/DnsOverHttps : okhttp3/Dns {
 	public static final field Companion Lokhttp3/dnsoverhttps/DnsOverHttps$Companion;
 	public static final field MAX_RESPONSE_SIZE I
 	public final fun client ()Lokhttp3/OkHttpClient;
-	public final fun includeHttps ()Z
 	public final fun includeIPv6 ()Z
+	public final fun includeServiceMetadata ()Z
 	public fun lookup (Ljava/lang/String;)Ljava/util/List;
 	public fun newCall (Lokhttp3/Dns$Request;)Lokhttp3/Dns$Call;
 	public final fun post ()Z
@@ -18,8 +18,8 @@ public final class okhttp3/dnsoverhttps/DnsOverHttps$Builder {
 	public final fun bootstrapDnsHosts ([Ljava/net/InetAddress;)Lokhttp3/dnsoverhttps/DnsOverHttps$Builder;
 	public final fun build ()Lokhttp3/dnsoverhttps/DnsOverHttps;
 	public final fun client (Lokhttp3/OkHttpClient;)Lokhttp3/dnsoverhttps/DnsOverHttps$Builder;
-	public final fun includeHttps (Z)Lokhttp3/dnsoverhttps/DnsOverHttps$Builder;
 	public final fun includeIPv6 (Z)Lokhttp3/dnsoverhttps/DnsOverHttps$Builder;
+	public final fun includeServiceMetadata (Z)Lokhttp3/dnsoverhttps/DnsOverHttps$Builder;
 	public final fun post (Z)Lokhttp3/dnsoverhttps/DnsOverHttps$Builder;
 	public final fun resolvePrivateAddresses (Z)Lokhttp3/dnsoverhttps/DnsOverHttps$Builder;
 	public final fun resolvePublicAddresses (Z)Lokhttp3/dnsoverhttps/DnsOverHttps$Builder;

--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
@@ -53,7 +53,7 @@ class DnsOverHttps internal constructor(
   @get:JvmName("client") val client: OkHttpClient,
   @get:JvmName("url") val url: HttpUrl,
   @get:JvmName("includeIPv6") val includeIPv6: Boolean,
-  @get:JvmName("includeHttps") val includeHttps: Boolean,
+  @get:JvmName("includeServiceMetadata") val includeServiceMetadata: Boolean,
   @get:JvmName("post") val post: Boolean,
   @get:JvmName("resolvePrivateAddresses") val resolvePrivateAddresses: Boolean,
   @get:JvmName("resolvePublicAddresses") val resolvePublicAddresses: Boolean,
@@ -230,7 +230,7 @@ class DnsOverHttps internal constructor(
     inetAddressesOnly: Boolean = false,
   ): List<Call> =
     buildList {
-      if (includeHttps && !inetAddressesOnly) {
+      if (includeServiceMetadata && !inetAddressesOnly) {
         add(createCall(hostname, TYPE_HTTPS))
       }
 
@@ -245,7 +245,7 @@ class DnsOverHttps internal constructor(
     internal var client: OkHttpClient? = null
     internal var url: HttpUrl? = null
     internal var includeIPv6 = true
-    internal var includeHttps = false
+    internal var includeServiceMetadata = true
     internal var post = false
     internal var systemDns = Dns.SYSTEM
     internal var bootstrapDnsHosts: List<InetAddress>? = null
@@ -258,7 +258,7 @@ class DnsOverHttps internal constructor(
         client.newBuilder().dns(buildBootstrapClient(this)).build(),
         checkNotNull(url) { "url not set" },
         includeIPv6,
-        includeHttps,
+        includeServiceMetadata,
         post,
         resolvePrivateAddresses,
         resolvePublicAddresses,
@@ -278,12 +278,10 @@ class DnsOverHttps internal constructor(
     /**
      * True to request [`HTTPS` DNS records](https://datatracker.ietf.org/doc/rfc9460/), which are
      * necessary for [Encrypted Client Hello (ECH)](https://datatracker.ietf.org/doc/rfc9849/).
-     *
-     * This is false by default, but that default is subject to change in 2026.
      */
-    fun includeHttps(includeHttps: Boolean) =
+    fun includeServiceMetadata(includeServiceMetadata: Boolean) =
       apply {
-        this.includeHttps = includeHttps
+        this.includeServiceMetadata = includeServiceMetadata
       }
 
     fun includeIPv6(includeIPv6: Boolean) =

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
@@ -797,7 +797,7 @@ class DnsOverHttpsTest(
       .Builder()
       .client(bootstrapClient)
       .includeIPv6(includeIPv6)
-      .includeHttps(includeHttps)
+      .includeServiceMetadata(includeHttps)
       .resolvePrivateAddresses(resolvePrivateAddresses)
       .resolvePublicAddresses(resolvePublicAddresses)
       .url(url)

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
@@ -354,7 +354,7 @@ class DnsOverHttpsTest(
   fun completeHttpsRecordsReturned() {
     assumeTrue(entryPoint == EntryPoint.NewCall)
 
-    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeHttps = true)
+    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeServiceMetadata = true)
     server["lysine.dev"] =
       listOf(
         ResourceRecord.IpAddress(
@@ -434,7 +434,7 @@ class DnsOverHttpsTest(
   fun serviceMetadataEmptyTargetNameAliasesToRequestHostname() {
     assumeTrue(entryPoint == EntryPoint.NewCall)
 
-    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeHttps = true)
+    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeServiceMetadata = true)
     server["lysine.dev"] =
       listOf(
         ResourceRecord.IpAddress(
@@ -484,7 +484,7 @@ class DnsOverHttpsTest(
   fun httpsFailureIsDeliveredAfterIpv6AndIpv4Records() {
     assumeTrue(entryPoint == EntryPoint.NewCall)
 
-    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeHttps = true)
+    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeServiceMetadata = true)
 
     // Fail the HTTPS call, which should have index 0.
     server.sequenceIndexToOverride[0] = overrideResponse("")
@@ -537,7 +537,7 @@ class DnsOverHttpsTest(
   fun ipv6FailureIsDeliveredAfterIpv4Records() {
     assumeTrue(entryPoint == EntryPoint.NewCall)
 
-    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeHttps = true)
+    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeServiceMetadata = true)
 
     // Fail the IPv6 call, which should have index 1.
     server.sequenceIndexToOverride[1] = overrideResponse("")
@@ -573,7 +573,7 @@ class DnsOverHttpsTest(
   fun emptyResultsAreSkipped() {
     assumeTrue(entryPoint == EntryPoint.NewCall)
 
-    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeHttps = true)
+    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeServiceMetadata = true)
     server["lysine.dev"] =
       listOf(
         ResourceRecord.IpAddress(
@@ -604,7 +604,7 @@ class DnsOverHttpsTest(
   fun lastEventIsDeliveredEventIfItIsEmpty() {
     assumeTrue(entryPoint == EntryPoint.NewCall)
 
-    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeHttps = true)
+    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeServiceMetadata = true)
 
     val call = dns.newCall(Dns.Request("lysine.dev"))
     val dnsEvents = call.toEventsQueue()
@@ -621,7 +621,7 @@ class DnsOverHttpsTest(
   fun callIsCanceledBeforeItIsStarted() {
     assumeTrue(entryPoint == EntryPoint.NewCall)
 
-    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeHttps = true)
+    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeServiceMetadata = true)
 
     val call = dns.newCall(Dns.Request("lysine.dev"))
     call.cancel()
@@ -635,7 +635,7 @@ class DnsOverHttpsTest(
   fun callIsCanceledBeforeItReachesTheNetwork() {
     assumeTrue(entryPoint == EntryPoint.NewCall)
 
-    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeHttps = true)
+    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeServiceMetadata = true)
     val call = dns.newCall(Dns.Request("lysine.dev"))
 
     interceptor =
@@ -717,7 +717,7 @@ class DnsOverHttpsTest(
   private fun callbackIsCalledSequentially() {
     assumeTrue(entryPoint == EntryPoint.NewCall)
 
-    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeHttps = true)
+    dns = buildLocalhost(bootstrapClient, includeIPv6 = true, includeServiceMetadata = true)
     server["lysine.dev"] =
       listOf(
         ResourceRecord.IpAddress(
@@ -787,7 +787,7 @@ class DnsOverHttpsTest(
   private fun buildLocalhost(
     bootstrapClient: OkHttpClient,
     includeIPv6: Boolean = false,
-    includeHttps: Boolean = false,
+    includeServiceMetadata: Boolean = false,
     post: Boolean = false,
     resolvePrivateAddresses: Boolean = true,
     resolvePublicAddresses: Boolean = true,
@@ -797,7 +797,7 @@ class DnsOverHttpsTest(
       .Builder()
       .client(bootstrapClient)
       .includeIPv6(includeIPv6)
-      .includeServiceMetadata(includeHttps)
+      .includeServiceMetadata(includeServiceMetadata)
       .resolvePrivateAddresses(resolvePrivateAddresses)
       .resolvePublicAddresses(resolvePublicAddresses)
       .url(url)


### PR DESCRIPTION
'HTTPS' is way too confusing for DnsOverHttps, because it's about a DNS record type and not the transport for which records are retrieved.