### PR TITLE
Split the state machine out of DnsOverHttps

### DIFF
--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/DnsOverHttps.kt
@@ -17,20 +17,12 @@ package okhttp3.dnsoverhttps
 
 import java.net.InetAddress
 import java.net.UnknownHostException
-import okhttp3.Call
 import okhttp3.Dns
 import okhttp3.HttpUrl
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.dnsoverhttps.internal.DnsMessage
 import okhttp3.dnsoverhttps.internal.DnsOverHttpsCall
-import okhttp3.dnsoverhttps.internal.QueryRequestBody
-import okhttp3.dnsoverhttps.internal.TYPE_A
-import okhttp3.dnsoverhttps.internal.TYPE_AAAA
-import okhttp3.dnsoverhttps.internal.TYPE_HTTPS
-import okhttp3.dnsoverhttps.internal.asQueryParameter
 import okhttp3.internal.dns.execute
 import okhttp3.internal.publicsuffix.PublicSuffixDatabase
 
@@ -54,18 +46,14 @@ class DnsOverHttps internal constructor(
   @get:JvmName("resolvePublicAddresses") val resolvePublicAddresses: Boolean,
 ) : Dns {
   override fun newCall(request: Dns.Request): Dns.Call {
-    val calls = callsList(request.hostname)
-
     val canceledException = validate(request.hostname)
-    if (canceledException != null) {
-      for (call in calls) {
-        call.cancel()
-      }
-    }
-
     return DnsOverHttpsCall(
       request = request,
-      calls = calls,
+      client = client,
+      dnsUrl = url,
+      post = post,
+      includeIPv6 = includeIPv6,
+      includeServiceMetadata = includeServiceMetadata,
       canceledException = canceledException,
     )
   }
@@ -107,54 +95,6 @@ class DnsOverHttps internal constructor(
       .filterIsInstance<Dns.Record.IpAddress>()
       .map { it.address }
   }
-
-  internal fun createCall(
-    hostname: String,
-    type: Int,
-  ): Call =
-    client.newCall(
-      request =
-        Request
-          .Builder()
-          .header("Accept", DNS_MESSAGE.toString())
-          .apply {
-            val dnsUrl = this@DnsOverHttps.url
-            if (post) {
-              url(dnsUrl)
-              cacheUrlOverride(
-                dnsUrl
-                  .newBuilder()
-                  .addQueryParameter("hostname", hostname)
-                  .build(),
-              )
-              post(QueryRequestBody(DnsMessage.query(hostname, type)))
-            } else {
-              val queryParameter = DnsMessage.query(hostname, type).asQueryParameter()
-              val requestUrl =
-                dnsUrl
-                  .newBuilder()
-                  .addQueryParameter("dns", queryParameter)
-                  .build()
-              url(requestUrl)
-            }
-          }.build(),
-    )
-
-  private fun callsList(
-    hostname: String,
-    inetAddressesOnly: Boolean = false,
-  ): List<Call> =
-    buildList {
-      if (includeServiceMetadata && !inetAddressesOnly) {
-        add(createCall(hostname, TYPE_HTTPS))
-      }
-
-      if (includeIPv6) {
-        add(createCall(hostname, TYPE_AAAA))
-      }
-
-      add(createCall(hostname, TYPE_A))
-    }
 
   class Builder {
     internal var client: OkHttpClient? = null

--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/-DnsMessage.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/-DnsMessage.kt
@@ -20,7 +20,6 @@ package okhttp3.dnsoverhttps.internal
 import java.io.IOException
 import java.net.InetAddress
 import java.net.ProtocolException
-import java.net.UnknownHostException
 import okhttp3.Protocol
 import okhttp3.RequestBody
 import okhttp3.Response
@@ -186,7 +185,7 @@ internal class QueryRequestBody(
 }
 
 @Throws(IOException::class)
-internal fun decodeResponse(response: Response): List<ResourceRecord> {
+internal fun decodeResponse(response: Response): DnsMessage {
   if (
     response.cacheResponse == null &&
     response.protocol !== Protocol.HTTP_2 &&
@@ -207,11 +206,6 @@ internal fun decodeResponse(response: Response): List<ResourceRecord> {
       )
     }
 
-    val dnsResponse = DnsMessageReader(body.source()).read()
-    when (dnsResponse.responseCode) {
-      RESPONSE_CODE_SUCCESS -> return dnsResponse.answers
-      RESPONSE_CODE_SERVER_FAILURE -> throw UnknownHostException("DNS server failure")
-      else -> throw UnknownHostException()
-    }
+    return DnsMessageReader(body.source()).read()
   }
 }

--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/-DnsOverHttpsCall.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/-DnsOverHttpsCall.kt
@@ -18,266 +18,108 @@
 package okhttp3.dnsoverhttps.internal
 
 import java.io.IOException
-import java.util.concurrent.atomic.AtomicReference
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Dns
-import okhttp3.Protocol
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.Response
+import okhttp3.dnsoverhttps.DnsOverHttps.Companion.DNS_MESSAGE
 import okhttp3.internal.OkHttpInternalApi
-import okhttp3.internal.testAndSet
 
 // TODO: in-memory caching that uses timeToLive.
 // TODO: honor Https.priority and Https.targetName. Create new calls!
 
 /**
  * Implements [Dns.Call] by making multiple HTTPS calls.
- *
- * Concurrency
- * -----------
- *
- * A few things conspire to make concurrency tricky:
- *
- *  * Each DNS record type is queried in parallel; [onResponse] and [onFailure] may be called
- *    concurrently.
- *  * Calls to [Dns.Callback] must be serialized.
- *  * We don't want to use locks to guard access to [Dns.Callback] functions.
- *
- * Each time we receive data for the callback (in the form of records or an exception), we either
- * immediately call the callback with that data (on a dispatcher thread), or queue it for the thread
- * that's busy calling the callback.
- *
- * After calling a callback, the caller must check to see if there's more data queued to deliver,
- * and deliver that also.
- *
- * The potentially surprising outcome of this strategy is the thread that performed the `TYPE_AAAA`
- * DNS request may also deliver the `TYPE_A` records to the callback, or vice versa.
- *
- * If a thread is intending to call the callback, it sets [State.Running.lockHeld] to true while
- * that call is executing.
  */
 @OkHttpInternalApi
 internal class DnsOverHttpsCall(
   override val request: Dns.Request,
-  private val calls: List<Call>,
-  private val canceledException: IOException?,
+  private val client: OkHttpClient,
+  private val dnsUrl: HttpUrl,
+  private val post: Boolean,
+  includeIPv6: Boolean,
+  includeServiceMetadata: Boolean,
+  canceledException: IOException?,
 ) : Dns.Call,
+  DnsCallStateMachine.Transport<Call>,
   Callback {
-  @Volatile
-  private var canceled = false
-  private val state = AtomicReference<State>(State.Idle)
+  private val stateMachine =
+    DnsCallStateMachine(
+      transport = this,
+      call = this,
+      canceledException = canceledException,
+      includeIPv6 = includeIPv6,
+      includeServiceMetadata = includeServiceMetadata,
+    )
 
-  override fun enqueue(callback: Dns.Callback) {
-    val running =
-      State.Running(
-        callback = callback,
-        runningCalls = calls,
-      )
-
-    val previous = state.testAndSet(running) { it is State.Idle }
-    check(previous is State.Idle) {
-      "already enqueued"
-    }
-
-    for (call in calls) {
-      call.enqueue(this)
-    }
+  override fun newQuery(dnsMessage: DnsMessage): Call {
+    val queryParameter = dnsMessage.asQueryParameter()
+    return client.newCall(
+      request =
+        Request
+          .Builder()
+          .header("Accept", DNS_MESSAGE.toString())
+          .apply {
+            if (post) {
+              url(dnsUrl)
+              cacheUrlOverride(
+                dnsUrl
+                  .newBuilder()
+                  .addQueryParameter("query", queryParameter)
+                  .build(),
+              )
+              post(QueryRequestBody(dnsMessage))
+            } else {
+              val requestUrl =
+                dnsUrl
+                  .newBuilder()
+                  .addQueryParameter("dns", queryParameter)
+                  .build()
+              url(requestUrl)
+            }
+          }.build(),
+    )
   }
 
-  /**
-   * If this is the last DNS call, call [Callback.onFailure]. Otherwise, hold that call until the
-   * last DNS call completes.
-   */
+  override fun enqueue(query: Call) {
+    query.enqueue(this)
+  }
+
+  override fun cancel(query: Call) {
+    query.cancel()
+  }
+
   override fun onFailure(
     call: Call,
     e: IOException,
   ) {
-    updateStateAndCallCallbacks(
-      completedCall = call,
-      newException = e,
-    )
+    stateMachine.onQueryFailure(call, e)
   }
 
   override fun onResponse(
     call: Call,
     response: Response,
   ) {
-    val resourceRecords =
+    val dnsMessage =
       try {
         decodeResponse(response)
       } catch (e: IOException) {
-        return updateStateAndCallCallbacks(
-          completedCall = call,
-          newException = e,
-        )
+        return stateMachine.onQueryFailure(call, e)
       }
 
-    val dnsRecords =
-      resourceRecords.map { resourceRecord ->
-        when (resourceRecord) {
-          is ResourceRecord.Https -> {
-            Dns.Record.ServiceMetadata(
-              hostname = resourceRecord.targetName.takeIf { it != "" } ?: request.hostname,
-              alpnIds =
-                resourceRecord.alpnIds?.mapNotNull { alpnId ->
-                  try {
-                    Protocol.get(alpnId)
-                  } catch (_: IOException) {
-                    null // Skip unrecognized ALPN ID.
-                  }
-                },
-              port = resourceRecord.port,
-              ipAddressHints = resourceRecord.ipAddressHints,
-              echConfigList = resourceRecord.echConfigList,
-            )
-          }
-
-          is ResourceRecord.IpAddress -> {
-            Dns.Record.IpAddress(
-              hostname = request.hostname,
-              address = resourceRecord.address,
-            )
-          }
-        }
-      }
-
-    updateStateAndCallCallbacks(
-      completedCall = call,
-      newRecords = dnsRecords,
-    )
+    stateMachine.onQueryResponse(call, dnsMessage)
   }
 
-  private tailrec fun updateStateAndCallCallbacks(
-    completedCall: Call? = null,
-    newRecords: List<Dns.Record> = listOf(),
-    newException: IOException? = null,
-    lockHeldByThisThread: Boolean = false,
-  ) {
-    while (true) {
-      val previous =
-        state.get() as? State.Running
-          ?: return // Already complete or canceled; nothing to do.
-
-      val newRunningCalls =
-        when {
-          completedCall != null -> previous.runningCalls - completedCall
-          else -> previous.runningCalls
-        }
-
-      val allExceptions =
-        when {
-          canceledException != null -> listOf(canceledException)
-          newException != null -> previous.pendingExceptions + newException
-          else -> previous.pendingExceptions
-        }
-
-      val allRecords =
-        when {
-          newRecords.isNotEmpty() -> previous.pendingRecords + newRecords
-          else -> previous.pendingRecords
-        }
-
-      val last = newRunningCalls.isEmpty()
-      val lockHeldByAnotherThread = !lockHeldByThisThread && previous.lockHeld
-
-      // There's a few reasons why we might not call any callbacks:
-      //  - There's no more records or failures to emit immediately
-      //  - Another thread is already calling the callbacks.
-      // In such cases, hand off any new work to that other thread and be done.
-      if ((!last && allRecords.isEmpty()) || lockHeldByAnotherThread) {
-        val next =
-          State.Running(
-            callback = previous.callback,
-            runningCalls = newRunningCalls,
-            lockHeld = lockHeldByAnotherThread,
-            pendingRecords = allRecords,
-            pendingExceptions = allExceptions,
-          )
-        if (!state.compareAndSet(previous, next)) continue // Lost a race, retry.
-        return
-      }
-
-      // We need to call a callback. Take the lock and the records.
-      val next =
-        when {
-          last -> {
-            State.Complete
-          }
-
-          else -> {
-            State.Running(
-              callback = previous.callback,
-              runningCalls = newRunningCalls,
-              lockHeld = true,
-              pendingRecords = listOf(),
-              pendingExceptions = allExceptions,
-            )
-          }
-        }
-      if (!state.compareAndSet(previous, next)) continue // Lost a race, retry.
-
-      val lastAndNoExceptions = last && allExceptions.isEmpty()
-      if (allRecords.isNotEmpty() || lastAndNoExceptions) {
-        previous.callback.onRecords(
-          call = this,
-          last = lastAndNoExceptions,
-          records = allRecords,
-        )
-      }
-
-      if (last && allExceptions.isNotEmpty()) {
-        previous.callback.onFailure(
-          call = this,
-          exceptions = allExceptions,
-        )
-      }
-
-      // Success, attempt to release the held lock. This might also process more events if some
-      // were enqueued while the callback was executing.
-      return updateStateAndCallCallbacks(
-        lockHeldByThisThread = true,
-      )
-    }
+  override fun enqueue(callback: Dns.Callback) {
+    stateMachine.start(callback)
   }
 
   override fun cancel() {
-    if (canceled) return // Already canceled.
-
-    canceled = true
-    for (call in calls) {
-      call.cancel()
-    }
+    stateMachine.cancel()
   }
 
-  override fun isCanceled() = canceled
-
-  private sealed interface State {
-    object Idle : State
-
-    class Running(
-      val callback: Dns.Callback,
-      val lockHeld: Boolean = false,
-      val runningCalls: List<Call>,
-      val pendingRecords: List<Dns.Record> = listOf(),
-      val pendingExceptions: List<IOException> = listOf(),
-    ) : State {
-      init {
-        check(pendingRecords.isEmpty() || lockHeld)
-      }
-    }
-
-    object Complete : State
-  }
-}
-
-internal fun Dns.Callback.onFailure(
-  call: DnsOverHttpsCall,
-  exceptions: List<IOException>,
-) {
-  val firstException = exceptions.first()
-  for (i in 1 until exceptions.size) {
-    firstException.addSuppressed(exceptions[i])
-  }
-
-  onFailure(call, firstException)
+  override fun isCanceled() = stateMachine.canceled
 }

--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/DnsCallStateMachine.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/DnsCallStateMachine.kt
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.dnsoverhttps.internal
+
+import java.io.IOException
+import java.net.UnknownHostException
+import java.util.concurrent.atomic.AtomicReference
+import okhttp3.Dns
+import okhttp3.Protocol
+
+/**
+ * State machine for DNS calls. This is intended for use with any transport for the queries, such
+ * as UDP or DNS over HTTPS.
+ *
+ * Concurrency
+ * -----------
+ *
+ * A few things conspire to make concurrency tricky:
+ *
+ *  * Each DNS record type is queried in parallel; [onQueryResponse] and [onQueryFailure] may be called
+ *    concurrently.
+ *  * Calls to [okhttp3.Dns.Callback] must be serialized.
+ *  * We don't want to use locks to guard access to [okhttp3.Dns.Callback] functions.
+ *
+ * Each time we receive data for the callback (in the form of records or an exception), we either
+ * immediately call the callback with that data (on a dispatcher thread), or queue it for the thread
+ * that's busy calling the callback.
+ *
+ * After calling a callback, the caller must check to see if there's more data queued to deliver,
+ * and deliver that also.
+ *
+ * The potentially surprising outcome of this strategy is the thread that performed the `TYPE_AAAA`
+ * DNS request may also deliver the `TYPE_A` records to the callback, or vice versa.
+ *
+ * If a thread is intending to call the callback, it sets [State.Running.lockHeld] to true while
+ * that call is executing.
+ */
+internal class DnsCallStateMachine<Q>(
+  private val transport: Transport<Q>,
+  private val call: Dns.Call,
+  private val canceledException: IOException?,
+  private val includeIPv6: Boolean,
+  private val includeServiceMetadata: Boolean,
+) {
+  private val state = AtomicReference<State<Q>>(State.Idle())
+
+  val canceled: Boolean
+    get() = state.get().canceled
+
+  fun start(callback: Dns.Callback) {
+    val queryMessages =
+      buildList {
+        if (includeServiceMetadata) {
+          add(DnsMessage.query(call.request.hostname, TYPE_HTTPS))
+        }
+        if (includeIPv6) {
+          add(DnsMessage.query(call.request.hostname, TYPE_AAAA))
+        }
+        add(DnsMessage.query(call.request.hostname, TYPE_A))
+      }
+
+    val queries =
+      queryMessages.map { dnsMessage ->
+        transport.newQuery(dnsMessage)
+      }
+
+    while (true) {
+      val previous =
+        state.get() as? State.Idle
+          ?: error("already enqueued")
+
+      val next =
+        State.Running<Q>(
+          canceled = previous.canceled,
+          callback = callback,
+          runningQueries = queries,
+        )
+
+      if (!state.compareAndSet(previous, next)) continue // Lost a race, retry.
+
+      for (query in queries) {
+        if (previous.canceled || canceledException != null) {
+          transport.cancel(query)
+        }
+        transport.enqueue(query)
+      }
+
+      return
+    }
+  }
+
+  fun cancel() {
+    while (true) {
+      val previous = state.get()
+      val next = previous.cancel()
+      if (!state.compareAndSet(previous, next)) continue // Lost a race, retry.
+
+      if (previous is State.Running) {
+        for (query in previous.runningQueries) {
+          transport.cancel(query)
+        }
+      }
+      return
+    }
+  }
+
+  fun onQueryFailure(
+    query: Q,
+    e: IOException,
+  ) {
+    updateStateAndCallCallbacks(
+      completedQuery = query,
+      newException = e,
+    )
+  }
+
+  fun onQueryResponse(
+    query: Q,
+    dnsResponse: DnsMessage,
+  ) {
+    val resourceRecords =
+      try {
+        when (dnsResponse.responseCode) {
+          RESPONSE_CODE_SUCCESS -> dnsResponse.answers
+          RESPONSE_CODE_SERVER_FAILURE -> throw UnknownHostException("DNS server failure")
+          else -> throw UnknownHostException()
+        }
+      } catch (e: IOException) {
+        return updateStateAndCallCallbacks(
+          completedQuery = query,
+          newException = e,
+        )
+      }
+
+    val dnsRecords =
+      resourceRecords.map { resourceRecord ->
+        when (resourceRecord) {
+          is ResourceRecord.Https -> {
+            Dns.Record.ServiceMetadata(
+              hostname = resourceRecord.targetName.takeIf { it != "" } ?: call.request.hostname,
+              alpnIds =
+                resourceRecord.alpnIds?.mapNotNull { alpnId ->
+                  try {
+                    Protocol.get(alpnId)
+                  } catch (_: IOException) {
+                    null // Skip unrecognized ALPN ID.
+                  }
+                },
+              port = resourceRecord.port,
+              ipAddressHints = resourceRecord.ipAddressHints,
+              echConfigList = resourceRecord.echConfigList,
+            )
+          }
+
+          is ResourceRecord.IpAddress -> {
+            Dns.Record.IpAddress(
+              hostname = call.request.hostname,
+              address = resourceRecord.address,
+            )
+          }
+        }
+      }
+
+    updateStateAndCallCallbacks(
+      completedQuery = query,
+      newRecords = dnsRecords,
+    )
+  }
+
+  private tailrec fun updateStateAndCallCallbacks(
+    completedQuery: Q? = null,
+    newRecords: List<Dns.Record> = listOf(),
+    newException: IOException? = null,
+    lockHeldByThisThread: Boolean = false,
+  ) {
+    while (true) {
+      val previous =
+        state.get() as? State.Running
+          ?: return // Already complete or canceled; nothing to do.
+
+      val newRunningQueries =
+        when {
+          completedQuery != null -> previous.runningQueries - completedQuery
+          else -> previous.runningQueries
+        }
+
+      val allExceptions =
+        when {
+          canceledException != null -> listOf(canceledException)
+          newException != null -> previous.pendingExceptions + newException
+          else -> previous.pendingExceptions
+        }
+
+      val allRecords =
+        when {
+          newRecords.isNotEmpty() -> previous.pendingRecords + newRecords
+          else -> previous.pendingRecords
+        }
+
+      val last = newRunningQueries.isEmpty()
+      val lockHeldByAnotherThread = !lockHeldByThisThread && previous.lockHeld
+
+      // There's a few reasons why we might not call any callbacks:
+      //  - There's no more records or failures to emit immediately
+      //  - Another thread is already calling the callbacks.
+      // In such cases, hand off any new work to that other thread and be done.
+      if ((!last && allRecords.isEmpty()) || lockHeldByAnotherThread) {
+        val next =
+          State.Running<Q>(
+            canceled = previous.canceled,
+            callback = previous.callback,
+            runningQueries = newRunningQueries,
+            lockHeld = lockHeldByAnotherThread,
+            pendingRecords = allRecords,
+            pendingExceptions = allExceptions,
+          )
+        if (!state.compareAndSet(previous, next)) continue // Lost a race, retry.
+        return
+      }
+
+      // We need to call a callback. Take the lock and the records.
+      val next =
+        when {
+          last -> {
+            State.Complete(previous.canceled)
+          }
+
+          else -> {
+            State.Running(
+              canceled = previous.canceled,
+              callback = previous.callback,
+              runningQueries = newRunningQueries,
+              lockHeld = true,
+              pendingRecords = listOf(),
+              pendingExceptions = allExceptions,
+            )
+          }
+        }
+      if (!state.compareAndSet(previous, next)) continue // Lost a race, retry.
+
+      val lastAndNoExceptions = last && allExceptions.isEmpty()
+      if (allRecords.isNotEmpty() || lastAndNoExceptions) {
+        previous.callback.onRecords(
+          call = call,
+          last = lastAndNoExceptions,
+          records = allRecords,
+        )
+      }
+
+      if (last && allExceptions.isNotEmpty()) {
+        previous.callback.onFailure(
+          call = call,
+          exceptions = allExceptions,
+        )
+      }
+
+      // Success, attempt to release the held lock. This might also process more events if some
+      // were enqueued while the callback was executing.
+      return updateStateAndCallCallbacks(
+        lockHeldByThisThread = true,
+      )
+    }
+  }
+
+  private sealed interface State<out Q> {
+    val canceled: Boolean
+
+    class Idle(
+      override val canceled: Boolean = false,
+    ) : State<Nothing> {
+      override fun cancel() = Idle(canceled = true)
+    }
+
+    class Running<Q>(
+      override val canceled: Boolean,
+      val callback: Dns.Callback,
+      val lockHeld: Boolean = false,
+      val runningQueries: List<Q>,
+      val pendingRecords: List<Dns.Record> = listOf(),
+      val pendingExceptions: List<IOException> = listOf(),
+    ) : State<Q> {
+      init {
+        check(pendingRecords.isEmpty() || lockHeld)
+      }
+
+      override fun cancel() =
+        Running(
+          canceled = true,
+          callback = callback,
+          lockHeld = lockHeld,
+          runningQueries = runningQueries,
+          pendingRecords = pendingRecords,
+          pendingExceptions = pendingExceptions,
+        )
+    }
+
+    class Complete(
+      override val canceled: Boolean,
+    ) : State<Nothing> {
+      override fun cancel() = Idle(canceled = true)
+    }
+
+    fun cancel(): State<Q>
+  }
+
+  interface Transport<Q> {
+    fun newQuery(dnsMessage: DnsMessage): Q
+
+    fun enqueue(query: Q)
+
+    fun cancel(query: Q)
+  }
+}
+
+internal fun Dns.Callback.onFailure(
+  call: Dns.Call,
+  exceptions: List<IOException>,
+) {
+  val firstException = exceptions.first()
+  for (i in 1 until exceptions.size) {
+    firstException.addSuppressed(exceptions[i])
+  }
+
+  onFailure(call, firstException)
+}

--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/DnsCallStateMachine.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/DnsCallStateMachine.kt
@@ -30,8 +30,8 @@ import okhttp3.Protocol
  *
  * A few things conspire to make concurrency tricky:
  *
- *  * Each DNS record type is queried in parallel; [onQueryResponse] and [onQueryFailure] may be called
- *    concurrently.
+ *  * Each DNS record type is queried in parallel; [onQueryResponse] and [onQueryFailure] may be
+ *    called concurrently.
  *  * Calls to [okhttp3.Dns.Callback] must be serialized.
  *  * We don't want to use locks to guard access to [okhttp3.Dns.Callback] functions.
  *

--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
@@ -85,7 +85,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 @Tag("Slowish")
 @Burst
 class DnsOverHttpsTest(
-  private val entryPoint: EntryPoint = EntryPoint.Lookup,
+  private val entryPoint: EntryPoint = EntryPoint.NewCall,
 ) {
   @RegisterExtension
   val platform = PlatformRule()

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-ExecuteDns.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-ExecuteDns.kt
@@ -63,7 +63,9 @@ fun Dns.Call.execute(): List<Dns.Record> {
         val result =
           when {
             allRecords.any { it is Dns.Record.IpAddress } -> Result.success(allRecords)
-            else -> Result.failure(e ?: UnknownHostException())
+            else -> Result.failure(
+              e ?: UnknownHostException("DNS returned no addresses for ${request.hostname}")
+            )
           }
         queue.put(result)
       }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-ExecuteDns.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-ExecuteDns.kt
@@ -62,10 +62,15 @@ fun Dns.Call.execute(): List<Dns.Record> {
       private fun complete(e: IOException? = null) {
         val result =
           when {
-            allRecords.any { it is Dns.Record.IpAddress } -> Result.success(allRecords)
-            else -> Result.failure(
-              e ?: UnknownHostException("DNS returned no addresses for ${request.hostname}")
-            )
+            allRecords.any { it is Dns.Record.IpAddress } -> {
+              Result.success(allRecords)
+            }
+
+            else -> {
+              Result.failure(
+                e ?: UnknownHostException("DNS returned no addresses for ${request.hostname}"),
+              )
+            }
           }
         queue.put(result)
       }

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
@@ -3677,7 +3677,7 @@ open class CallTest {
           .host("android.com")
           .build(),
       )
-    executeSynchronously(request).assertFailure("$dns returned no addresses for android.com")
+    executeSynchronously(request).assertFailure("DNS returned no addresses for android.com")
     dns.assertRequests("android.com")
   }
 


### PR DESCRIPTION
There's a few things that are a bit awkward, but overall it seems like it'll afford swapping in UDP or Android's resolver.