### PR TITLE
Fix broken/outdated links

### DIFF
--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -6,7 +6,7 @@
 
 set -ex
 
-REPO="git@github.com:square/okhttp.git"
+REPO="git@github.com:lysine-dev/okhttp.git"
 DIR=temp-clone
 
 # Delete any existing temporary website clone

--- a/docs/changelogs/changelog_2x.md
+++ b/docs/changelogs/changelog_2x.md
@@ -542,7 +542,7 @@ in addition to synchronous blocking calls.
     `Headers` class offers full access to the HTTP headers.
 
  *  **Okio dependency added.** OkHttp now depends on
-    [Okio](https://github.com/square/okio), an I/O library that makes it easier
+    [Okio](https://github.com/lysine-dev/okio), an I/O library that makes it easier
     to access, store and process data. Using this library internally makes OkHttp
     faster while consuming less memory. You can write a `RequestBody` as an Okio
     `BufferedSink` and a `ResponseBody` as an Okio `BufferedSource`. Standard
@@ -626,5 +626,5 @@ in addition to synchronous blocking calls.
 
 
  [brick]: https://noncombatant.org/2015/05/01/about-http-public-key-pinning/
- [interceptors]: https://square.github.io/okhttp/interceptors/
+ [interceptors]: https://lysine.dev/okhttp/interceptors/
  [webdav]: https://tools.ietf.org/html/rfc4918

--- a/docs/changelogs/changelog_3x.md
+++ b/docs/changelogs/changelog_3x.md
@@ -1117,7 +1117,7 @@ stuck on the old version.
  [conscrypt]: https://github.com/google/conscrypt/
  [conscrypt_dependency]: https://github.com/google/conscrypt/#download
  [grpc_http2]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
- [https_server_sample]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/HttpsServer.java
+ [https_server_sample]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/HttpsServer.java
  [jetty_8_252]: https://webtide.com/jetty-alpn-java-8u252/
  [junit_5_rules]: https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4-rulesupport
  [major_versions]: https://jakewharton.com/java-interoperability-policy-for-major-version-updates/
@@ -1129,5 +1129,5 @@ stuck on the old version.
  [public_suffix]: https://publicsuffix.org/
  [remove_cbc_ecdsa]: https://developers.google.com/web/updates/2016/12/chrome-56-deprecations#remove_cbc-mode_ecdsa_ciphers_in_tls
  [require_android_5]: https://code.cash.app/okhttp-3-13-requires-android-5
- [tls_configuration_history]: https://square.github.io/okhttp/tls_configuration_history/
- [upgrading_to_okhttp_4]: https://square.github.io/okhttp/upgrading_to_okhttp_4/
+ [tls_configuration_history]: https://lysine.dev/okhttp/tls_configuration_history/
+ [upgrading_to_okhttp_4]: https://lysine.dev/okhttp/upgrading_to_okhttp_4/

--- a/docs/changelogs/upgrading_to_okhttp_4.md
+++ b/docs/changelogs/upgrading_to_okhttp_4.md
@@ -274,6 +274,6 @@ android {
  [java_sams]: https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions
  [kotlin_sams]: https://youtrack.jetbrains.com/issue/KT-11129
  [mockito]: https://site.mockito.org/
- [proguard_problems]: https://github.com/square/okhttp/issues/5167
+ [proguard_problems]: https://github.com/lysine-dev/okhttp/issues/5167
  [require_android_5]: https://code.cash.app/okhttp-3-13-requires-android-5
  [r8]: https://developer.android.com/studio/releases#r8-default

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -134,7 +134,7 @@ To visit all headers, use the `Headers` class which supports access by index.
 
       fun run() {
         val request = Request.Builder()
-            .url("https://api.github.com/repos/square/okhttp/issues")
+            .url("https://api.github.com/repos/lysine-dev/okhttp/issues")
             .header("User-Agent", "OkHttp Headers.java")
             .addHeader("Accept", "application/json; q=0.5")
             .addHeader("Accept", "application/vnd.github.v3+json")
@@ -156,7 +156,7 @@ To visit all headers, use the `Headers` class which supports access by index.
 
       public void run() throws Exception {
         Request request = new Request.Builder()
-            .url("https://api.github.com/repos/square/okhttp/issues")
+            .url("https://api.github.com/repos/lysine-dev/okhttp/issues")
             .header("User-Agent", "OkHttp Headers.java")
             .addHeader("Accept", "application/json; q=0.5")
             .addHeader("Accept", "application/vnd.github.v3+json")
@@ -237,7 +237,7 @@ Use an HTTP POST to send a request body to a service. This example posts a markd
 
 ### Post Streaming ([.kt][PostStreamingKotlin], [.java][PostStreamingJava])
 
-Here we `POST` a request body as a stream. The content of this request body is being generated as it's being written. This example streams directly into the [Okio](https://github.com/square/okio) buffered sink. Your programs may prefer an `OutputStream`, which you can get from `BufferedSink.outputStream()`.
+Here we `POST` a request body as a stream. The content of this request body is being generated as it's being written. This example streams directly into the [Okio](https://github.com/lysine-dev/okio) buffered sink. Your programs may prefer an `OutputStream`, which you can get from `BufferedSink.outputStream()`.
 
 === ":material-language-kotlin: Kotlin"
     ```kotlin
@@ -641,7 +641,7 @@ Response caching uses HTTP headers for all configuration. You can add request he
       }
     ```
 
-To prevent a response from using the cache, use [`CacheControl.FORCE_NETWORK`](https://square.github.io/okhttp/5.x/okhttp/okhttp3/-cache-control/-companion/-f-o-r-c-e_-n-e-t-w-o-r-k). To prevent it from using the network, use [`CacheControl.FORCE_CACHE`](https://square.github.io/okhttp/5.x/okhttp/okhttp3/-cache-control/-companion/-f-o-r-c-e_-c-a-c-h-e). Be warned: if you use `FORCE_CACHE` and the response requires the network, OkHttp will return a `504 Unsatisfiable Request` response.
+To prevent a response from using the cache, use [`CacheControl.FORCE_NETWORK`](https://lysine.dev/okhttp/5.x/okhttp/okhttp3/-cache-control/-companion/-f-o-r-c-e_-n-e-t-w-o-r-k). To prevent it from using the network, use [`CacheControl.FORCE_CACHE`](https://lysine.dev/okhttp/5.x/okhttp/okhttp3/-cache-control/-companion/-f-o-r-c-e_-c-a-c-h-e). Be warned: if you use `FORCE_CACHE` and the response requires the network, OkHttp will return a `504 Unsatisfiable Request` response.
 
 
 ### Canceling a Call ([.kt][CancelCallKotlin], [.java][CancelCallJava])
@@ -1151,33 +1151,33 @@ Upload a file to a server (for example, Imgur) and report progress as the reques
       }
     ```
 
- [SynchronousGetJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/SynchronousGet.java
- [SynchronousGetKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/SynchronousGet.kt
- [AsynchronousGetJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/AsynchronousGet.java
- [AsynchronousGetKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/AsynchronousGet.kt
- [AccessHeadersJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/AccessHeaders.java
- [AccessHeadersKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/AccessHeaders.kt
- [PostStringJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostString.java
- [PostStringKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostString.kt
- [PostStreamingJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostStreaming.java
- [PostStreamingKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostStreaming.kt
- [PostFileJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostFile.java
- [PostFileKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostFile.kt
- [PostFormJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostForm.java
- [PostFormKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostForm.kt
- [PostMultipartJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostMultipart.java
- [PostMultipartKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostMultipart.kt
- [ParseResponseWithMoshiJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/ParseResponseWithMoshi.java
- [ParseResponseWithMoshiKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/ParseResponseWithMoshi.kt
- [CacheResponseJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/CacheResponse.java
- [CacheResponseKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/CacheResponse.kt
- [CancelCallJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/CancelCall.java
- [CancelCallKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/CancelCall.kt
- [ConfigureTimeoutsJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/ConfigureTimeouts.java
- [ConfigureTimeoutsKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/ConfigureTimeouts.kt
- [PerCallSettingsJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PerCallSettings.java
- [PerCallSettingsKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PerCallSettings.kt
- [AuthenticateJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
- [AuthenticateKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/Authenticate.kt
- [UploadProgressJava]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/UploadProgress.java
- [UploadProgressKotlin]: https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/UploadProgress.kt
+ [SynchronousGetJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/SynchronousGet.java
+ [SynchronousGetKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/SynchronousGet.kt
+ [AsynchronousGetJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/AsynchronousGet.java
+ [AsynchronousGetKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/AsynchronousGet.kt
+ [AccessHeadersJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/AccessHeaders.java
+ [AccessHeadersKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/AccessHeaders.kt
+ [PostStringJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostString.java
+ [PostStringKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostString.kt
+ [PostStreamingJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostStreaming.java
+ [PostStreamingKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostStreaming.kt
+ [PostFileJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostFile.java
+ [PostFileKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostFile.kt
+ [PostFormJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostForm.java
+ [PostFormKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostForm.kt
+ [PostMultipartJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PostMultipart.java
+ [PostMultipartKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PostMultipart.kt
+ [ParseResponseWithMoshiJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/ParseResponseWithMoshi.java
+ [ParseResponseWithMoshiKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/ParseResponseWithMoshi.kt
+ [CacheResponseJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/CacheResponse.java
+ [CacheResponseKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/CacheResponse.kt
+ [CancelCallJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/CancelCall.java
+ [CancelCallKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/CancelCall.kt
+ [ConfigureTimeoutsJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/ConfigureTimeouts.java
+ [ConfigureTimeoutsKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/ConfigureTimeouts.kt
+ [PerCallSettingsJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/PerCallSettings.java
+ [PerCallSettingsKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/PerCallSettings.kt
+ [AuthenticateJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/Authenticate.java
+ [AuthenticateKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/Authenticate.kt
+ [UploadProgressJava]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/UploadProgress.java
+ [UploadProgressKotlin]: https://github.com/lysine-dev/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/kt/UploadProgress.kt

--- a/docs/security/security_providers.md
+++ b/docs/security/security_providers.md
@@ -25,5 +25,5 @@ All providers support HTTP/1.1 and TLSv1.2.
 [OpenJDK]: https://openjdk.java.net/groups/security/
 [OpenJSSE]: https://github.com/openjsse/openjsse
 [OpenSSL]: https://www.openssl.org/
-[bug5592]: https://github.com/square/okhttp/issues/5592
-[bug5698]: https://github.com/square/okhttp/issues/5698
+[bug5592]: https://github.com/lysine-dev/okhttp/issues/5592
+[bug5698]: https://github.com/lysine-dev/okhttp/issues/5698

--- a/docs/works_with_okhttp.md
+++ b/docs/works_with_okhttp.md
@@ -27,12 +27,12 @@ Here’s some libraries that work nicely with OkHttp.
  * [okhttp-staleiferror-interceptor](https://github.com/PeelTechnologies/okhttp-staleiferror-interceptor/): serve stale responses when the server isn’t reachable.
  * [okhttp-stats](https://github.com/flipkart-incubator/okhttp-stats): Get stats like average network speed.
  * [okhttp-system-keystore](https://github.com/charleskorn/okhttp-system-keystore): Use trusted certificates from the operating system keystore (Keychain on macOS, Certificate Store on Windows).
- * ⬜️ [Okio](https://github.com/square/okio/): A modern I/O API for Java.
+ * ⬜️ [Okio](https://github.com/lysine-dev/okio/): A modern I/O API for Java.
  * [OkLog](https://github.com/simonpercic/OkLog): Response logging interceptor for OkHttp. Logs a URL link with URL-encoded response for every OkHttp call.
  * [Okurl](https://github.com/yschimke/okurl/wiki) A curl-like client for social networks and other APIs.
  * [PersistentCookieJar](https://github.com/franmontiel/PersistentCookieJar): A persistent `CookieJar`.
  * ⬜️ [Picasso](https://github.com/square/picasso): A powerful image downloading and caching library for Android.
- * ⬜️ [Retrofit](https://github.com/square/retrofit): Type-safe HTTP client for Android and Java by Square.
+ * ⬜️ [Retrofit](https://github.com/lysine-dev/retrofit): Type-safe HTTP client for Android and Java by Square.
  * [ScribeJava](https://github.com/scribejava/scribejava): Simple OAuth library for Java
  * [Stetho](https://github.com/facebook/stetho): Stetho is a debug bridge for Android applications.
  * ⬜️ [Wire](https://github.com/square/wire): Clean, lightweight protocol buffers for Android and Java.

--- a/native-image-tests/build.gradle.kts
+++ b/native-image-tests/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.withType<JavaCompile> {
 }
 
 // TODO reenable other tests
-// https://github.com/square/okhttp/issues/8901
+// https://github.com/lysine-dev/okhttp/issues/8901
 // sourceSets {
 //  test {
 //    java.srcDirs(

--- a/okhttp-logging-interceptor/README.md
+++ b/okhttp-logging-interceptor/README.md
@@ -41,4 +41,4 @@ implementation("com.squareup.okhttp3:logging-interceptor:5.4.0")
 ```
 
 
-[interceptors]: https://square.github.io/okhttp/interceptors/
+[interceptors]: https://lysine.dev/okhttp/interceptors/

--- a/okhttp-tls/README.md
+++ b/okhttp-tls/README.md
@@ -228,7 +228,7 @@ Download
 implementation("com.squareup.okhttp3:okhttp-tls:5.4.0")
 ```
 
- [held_certificate]: https://square.github.io/okhttp/5.x/okhttp-tls/okhttp3.tls/-held-certificate/
- [held_certificate_builder]: https://square.github.io/okhttp/5.x/okhttp-tls/okhttp3.tls/-held-certificate/-builder/
- [handshake_certificates]: https://square.github.io/okhttp/5.x/okhttp-tls/okhttp3.tls/-handshake-certificates/
- [handshake_certificates_builder]: https://square.github.io/okhttp/5.x/okhttp-tls/okhttp3.tls/-handshake-certificates/-builder/
+ [held_certificate]: https://lysine.dev/okhttp/5.x/okhttp-tls/okhttp3.tls/-held-certificate/
+ [held_certificate_builder]: https://lysine.dev/okhttp/5.x/okhttp-tls/okhttp3.tls/-held-certificate/-builder/
+ [handshake_certificates]: https://lysine.dev/okhttp/5.x/okhttp-tls/okhttp3.tls/-handshake-certificates/
+ [handshake_certificates_builder]: https://lysine.dev/okhttp/5.x/okhttp-tls/okhttp3.tls/-handshake-certificates/-builder/

--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -340,7 +340,7 @@ afterEvaluate {
 
 // Work around issue 8826, where the Sentry SDK assumes that OkHttp's internal-visibility symbols
 // will be suffixed '$okhttp' in deployable artifacts. This isn't intended to be a published API,
-// but it's easy enough for us to keep it working. https://github.com/square/okhttp/issues/8826
+// but it's easy enough for us to keep it working. https://github.com/lysine-dev/okhttp/issues/8826
 tasks.withType<KotlinCompile> {
   compilerOptions {
     freeCompilerArgs.addAll("-module-name=okhttp", "-Xexpect-actual-classes")

--- a/regression-test/src/androidTest/java/okhttp/regression/compare/OkHttpClientTest.java
+++ b/regression-test/src/androidTest/java/okhttp/regression/compare/OkHttpClientTest.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 /**
  * OkHttp.
  *
- * https://square.github.io/okhttp/
+ * https://lysine.dev/okhttp/
  */
 @RunWith(AndroidJUnit4.class)
 public class OkHttpClientTest {


### PR DESCRIPTION
(The https://github.com/square/ links are not actually broken; GitHub simply redirects them. But might be better nonetheless to directly link to https://github.com/lysine-dev/.)

Similar to https://github.com/lysine-dev/okio/pull/1827 there are a few other (non-link) references to Square where you as maintainers might know best how to or if to update them.