### PR TITLE
Updated guidance for running API 37.0 emulators

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,6 +299,18 @@ jobs:
     # experimental fail without blocking the build until the image is stable on CI.
     continue-on-error: ${{ matrix.experimental || false }}
 
+    # No window, no audio, and dynamic GPU/memory for headless environments. Shared by both
+    # emulator steps below: the emulator only restores a cached snapshot when the boot options
+    # are identical, and the action's default includes -no-snapshot (a slow cold boot).
+    env:
+      EMULATOR_OPTIONS: >-
+        -no-window
+        -gpu ${{ matrix.gpu || 'swiftshader_indirect' }}
+        -noaudio
+        -no-boot-anim
+        -camera-back none
+        -memory ${{ matrix.memory || '2048' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -322,7 +334,7 @@ jobs:
             target: playstore_ps16k
             # API 37 needs more headroom than the other levels.
             memory: 4096
-            gpu: -gpu auto
+            gpu: auto
             # Pre-release emulator image; allowed to fail (see continue-on-error above).
             experimental: true
 
@@ -349,6 +361,24 @@ jobs:
           kvm-ok || echo "KVM is not accelerated"
           kvm-ok || exit 1
 
+      # The runner image ships an outdated avdmanager that writes target=android-0
+      # into the AVD root ini for minor-versioned packages (android-37.x); the
+      # emulator clamps that to API 3 and skips the Vulkan/GLDirectMem auto-enable,
+      # which previously had to be worked around with -feature GLDirectMem.
+      - name: Update SDK cmdline-tools
+        id: cmdline-tools
+        run: |
+          SDK="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}}"
+          yes | "$SDK/cmdline-tools/latest/bin/sdkmanager" --install "cmdline-tools;latest" > /dev/null
+          # sdkmanager won't overwrite the preinstalled dir; it installs to latest-2.
+          if [ -d "$SDK/cmdline-tools/latest-2" ]; then
+            rm -rf "$SDK/cmdline-tools/latest"
+            mv "$SDK/cmdline-tools/latest-2" "$SDK/cmdline-tools/latest"
+          fi
+          "$SDK/cmdline-tools/latest/bin/avdmanager" list device > /dev/null
+          # --version prints a trailing blank line; grab the numeric line.
+          echo "version=$("$SDK/cmdline-tools/latest/bin/sdkmanager" --version 2>/dev/null | grep -Eo '^[0-9][0-9.]*' | head -1)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
@@ -362,11 +392,12 @@ jobs:
         uses: actions/cache@v6
         id: avd-cache
         with:
-          key: avd-${{ runner.os }}-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}
+          # Keyed on the cmdline-tools version: AVDs created by an older avdmanager
+          # (broken target=android-0 root ini) are invalidated automatically.
+          key: avd-${{ runner.os }}-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}-tools${{ steps.cmdline-tools.outputs.version }}
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-            # Added the actual system image path
             ${{ env.ANDROID_HOME }}/system-images/android-${{ matrix.api-level }}
 
       - name: Create AVD and generate snapshot for caching
@@ -378,15 +409,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
           emulator-boot-timeout: 120
-          # No window, no audio, and use dynamic GPU and feature flags for headless environments
-          emulator-options: >
-            -no-window
-            ${{ matrix.gpu || '-gpu swiftshader_indirect' }}
-            -noaudio
-            -no-boot-anim
-            -camera-back none
-            -memory ${{ matrix.memory || '2048' }}
-            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
+          emulator-options: ${{ env.EMULATOR_OPTIONS }}
           disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
@@ -397,17 +420,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
           emulator-boot-timeout: 120
-          # These must match the options used to create the snapshot above: the emulator only
-          # restores a cached snapshot when the boot options are identical. The action default
-          # includes -no-snapshot, which would otherwise force a slow cold boot.
-          emulator-options: >
-            -no-window
-            ${{ matrix.gpu || '-gpu swiftshader_indirect' }}
-            -noaudio
-            -no-boot-anim
-            -camera-back none
-            -memory ${{ matrix.memory || '2048' }}
-            -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
+          emulator-options: ${{ env.EMULATOR_OPTIONS }}
           script: ./gradlew -PandroidBuild=true connectedCheck
         env:
           API_LEVEL: ${{ matrix.api-level }}


### PR DESCRIPTION
closes https://github.com/lysine-dev/okhttp/issues/9567

h/t to @jpcottin