### PR TITLE
read HTTPS mandatory SvcParamKeys as 16-bit values

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-DnsMessageReader.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-DnsMessageReader.kt
@@ -208,8 +208,9 @@ class DnsMessageReader(
       val valueLength = readUShort().toLong()
       when (key) {
         SERVICE_PARAMETER_MANDATORY -> {
-          for (i in 0 until valueLength) {
-            val serviceParameterKey = readByte()
+          if (valueLength % 2 != 0L) throw ProtocolException("malformed HTTPS / mandatory")
+          for (i in 0 until valueLength step 2) {
+            val serviceParameterKey = readUShort().toInt()
             if (serviceParameterKey !in SERVICE_PARAMETER_MANDATORY..SERVICE_PARAMETER_IPV6_HINT) {
               throw ProtocolException("unsupported HTTPS mandatory parameter $serviceParameterKey")
             }

--- a/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/DnsMessageReaderWriterTest.kt
+++ b/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/DnsMessageReaderWriterTest.kt
@@ -157,6 +157,31 @@ class DnsMessageReaderWriterTest {
     assertThat(e).hasMessage("malformed DNS message")
   }
 
+  @Test
+  fun `rejects mandatory service parameter with unsupported key`() {
+    // An HTTPS record whose mandatory value is the single 2-octet SvcParamKey 0x0101 (257), which
+    // OkHttp does not support. RFC 9460 requires such a record be treated as malformed.
+    val buffer = Buffer()
+    buffer.write(
+      "0000818000000001000000000000410001000000000009000100000000020101".decodeHex(),
+    )
+    assertFailsWith<ProtocolException> {
+      DnsMessageReader(buffer).read()
+    }
+  }
+
+  @Test
+  fun `rejects odd length mandatory service parameter`() {
+    // The mandatory value has an odd length, so it can't be a list of 2-octet SvcParamKeys.
+    val buffer = Buffer()
+    buffer.write(
+      "00008180000000010000000000004100010000000000080001000000000103".decodeHex(),
+    )
+    assertFailsWith<ProtocolException> {
+      DnsMessageReader(buffer).read()
+    }
+  }
+
   private fun assertRoundTrip(message: DnsMessage) {
     val buffer = Buffer()
     DnsMessageWriter(buffer).write(message)


### PR DESCRIPTION
The new DNS reader parses SVCB and HTTPS resource records, and each SvcParam value is length-prefixed. For the mandatory parameter (key 0), RFC 9460 defines the value as a list of 2-octet SvcParamKeys, but readHttpsResourceRecord walks it one byte at a time and range-checks each byte against the supported keys. Since these records come straight off a DNS or DoH response, a resolver can send a mandatory list whose keys OkHttp doesn't support and have it slip through: a two-byte key like 0x0101 gets split into 0x01 and 0x01, both of which look like known keys, so the record is accepted when RFC 9460 says it should be treated as malformed. An odd-length value, which can't be a list of 16-bit keys at all, is likewise read without complaint. I noticed it while checking that every other 2-byte field in this reader already goes through readUShort, and this one call site still used readByte. Reading the keys as 16-bit values and requiring an even length lines the mandatory handling up with the rest of the parser and with the ipv4hint/ipv6hint length checks right next to it. Existing HTTPS records still decode unchanged, and the two new tests cover the unsupported-key and odd-length cases.
