### PR TITLE
Clarify Dispatcher custom executor requirements

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dispatcher.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dispatcher.kt
@@ -31,8 +31,12 @@ import okhttp3.internal.unmodifiable
  * Policy on when async requests are executed.
  *
  * Each dispatcher uses an [ExecutorService] to run calls internally. If you supply your own
- * executor, it should be able to run [the configured maximum][maxRequests] number of calls
- * concurrently.
+ * executor, it must accept new tasks while up to [the configured maximum][maxRequests] calls
+ * are already running. A pool sized exactly to [maxRequests] is not sufficient with a
+ * [SynchronousQueue], because the dispatcher may submit the next call from a worker that has
+ * not yet returned to the queue. Prefer the default pattern (`corePoolSize=0`,
+ * `maxPoolSize=Int.MAX_VALUE`, [SynchronousQueue]), a bound of about `2 * maxRequests`, or a
+ * queueing executor.
  */
 class Dispatcher() {
   /**


### PR DESCRIPTION
## Summary
Fixes #9443

The existing Dispatcher docs say a custom executor only needs to run `maxRequests` calls concurrently. That understates the real requirement: promotion can submit the next call from a worker thread that has not yet returned to the pool, so a pool sized exactly to `maxRequests` with a `SynchronousQueue` can reject work.

This updates the class KDoc to describe that constraint and point at safe sizing patterns (the default unbounded max pool, roughly `2 * maxRequests`, or a queueing executor).

## Test plan
- [x] Docs-only change; no behavior change
- [ ] Skim `Dispatcher.kt` KDoc for accuracy against `promoteAndExecute` / default executor