### PR TITLE
Support @StartStop fields in nested tests

### DIFF
--- a/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/StartStopExtension.kt
+++ b/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/StartStopExtension.kt
@@ -51,24 +51,24 @@ internal class StartStopExtension :
   }
 
   override fun beforeEach(context: ExtensionContext) {
-    // Requires API 24
-    val testInstance = context.testInstance.get()
     val store = context.getStore(Namespace.create(StartStop::class.java))
 
-    val instanceFields =
-      findAnnotatedFields(
-        context.requiredTestClass,
-        StartStop::class.java,
-      ) { !Modifier.isStatic(it.modifiers) }
+    for (testInstance in context.requiredTestInstances.allInstances) {
+      val instanceFields =
+        findAnnotatedFields(
+          testInstance.javaClass,
+          StartStop::class.java,
+        ) { !Modifier.isStatic(it.modifiers) }
 
-    for (field in instanceFields) {
-      field.setAccessible(true)
-      val server = field.get(testInstance) as? MockWebServer ?: continue
+      for (field in instanceFields) {
+        field.setAccessible(true)
+        val server = field.get(testInstance) as? MockWebServer ?: continue
 
-      // Put the instance in the store, so JUnit closes it for us in afterEach.
-      store.put(field, server)
+        // Put the instance in the store, so JUnit closes it for us in afterEach.
+        store.put(server, server)
 
-      server.start()
+        server.start()
+      }
     }
   }
 }

--- a/mockwebserver-junit5/src/test/java/mockwebserver3/junit5/StartStopTest.kt
+++ b/mockwebserver-junit5/src/test/java/mockwebserver3/junit5/StartStopTest.kt
@@ -23,6 +23,7 @@ import mockwebserver3.Dispatcher
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.RecordedRequest
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -60,6 +61,18 @@ class StartStopTest {
     assertThat(serverD.started).isTrue()
     assertThat(serverE.started).isTrue()
     assertThat(serverF.started).isFalse()
+  }
+
+  @Nested
+  inner class NestedTest {
+    @Test
+    fun happyPath() {
+      testInstances += this@StartStopTest
+
+      assertThat(serverA.started).isTrue()
+      assertThat(serverB.started).isTrue()
+      assertThat(serverC.started).isFalse()
+    }
   }
 
   private companion object {


### PR DESCRIPTION
Fixes #9546

## Summary

- start `@StartStop` servers declared on enclosing instances for JUnit 5 `@Nested` tests
- discover fields from each matching test instance and retain each server independently in the extension store
- cover startup, non-annotated fields, and after-test cleanup for a nested test

## Validation

- focused `StartStopTest` regression
- `./gradlew :mockwebserver3-junit5:check`
- `git diff --check`
