### PR TITLE
use SecureRandom for web socket mask keys

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
@@ -18,8 +18,8 @@ package okhttp3
 import java.net.Proxy
 import java.net.ProxySelector
 import java.net.Socket
+import java.security.SecureRandom
 import java.time.Duration
-import java.util.Random
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -363,7 +363,7 @@ open class OkHttpClient internal constructor(
         taskRunner = taskRunner,
         originalRequest = request,
         listener = listener,
-        random = Random(),
+        random = SecureRandom(),
         pingIntervalMillis = pingIntervalMillis.toLong(),
         // extensions is always null for clients:
         extensions = null,


### PR DESCRIPTION
OkHttp masks every outbound web socket frame with a four-byte key taken from the java.util.Random that newWebSocket creates for each connection, and the Sec-WebSocket-Key nonce comes from that same instance. RFC 6455 section 5.3 asks for the mask to come from a strong source of entropy and says the key for one frame must not make it simple for a server or proxy to predict the key for a later one, which is the whole point of masking: it keeps a party who can influence message content from choosing the bytes an intermediary sees on a ws:// stream. java.util.Random is a 48-bit linear congruential generator, so the first mask a peer observes hands it the top 32 bits of state and the remaining 16 fall to a 65,536 candidate search that the next frame confirms. I drove WebSocketWriter with a plain Random to check, and after two frames it predicts the rest of the mask stream exactly, enough to read a later frame plaintext straight off the wire, so the property the spec rules out is the one we currently have. What made me look was that MockWebServer already builds its RealWebSocket with SecureRandom even though a server never masks, while the client that does mask does not. SecureRandom is a java.util.Random subclass so nothing downstream changes, and the writer tests that want deterministic masks pass their own Random in.