### PR TITLE
Update MockServer container image to 7.5.0

### DIFF
--- a/container-tests/build.gradle.kts
+++ b/container-tests/build.gradle.kts
@@ -21,6 +21,7 @@ tasks.withType<Test> {
   jvmArgs(
     "-Dokhttp.platform=$platform",
   )
+  systemProperty("mockserver.version", libs.versions.mockserver.client.get())
 
   if (platform == "loom") {
     jvmArgs(

--- a/container-tests/src/test/java/okhttp3/containers/BasicMockServerTest.kt
+++ b/container-tests/src/test/java/okhttp3/containers/BasicMockServerTest.kt
@@ -78,10 +78,15 @@ class BasicMockServerTest {
   }
 
   companion object {
+    private val mockServerVersion =
+      checkNotNull(System.getProperty("mockserver.version")) {
+        "mockserver.version is not set"
+      }
+
     val MOCKSERVER_IMAGE: DockerImageName =
       DockerImageName
         .parse("mockserver/mockserver")
-        .withTag("mockserver-7.4.0")
+        .withTag("mockserver-$mockServerVersion")
 
     fun OkHttpClient.Builder.trustMockServer(): OkHttpClient.Builder =
       apply {


### PR DESCRIPTION
Updates the container image for MockServer from 7.4.0 to 7.5.0.

The client was bumped in #9622, but the server image stayed on 7.4.0.

Fixes #9629

Tested via:

./gradlew :container-tests:test -PcontainerTests=true

./gradlew :container-tests:test -PcontainerTests=true -Pokhttp.platform=loom -Ptest.java.version=24 (12/12 passed)