### PR TITLE
Start @StartStop MockWebServer for @Nested JUnit 5 tests

### DIFF
--- a/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/StartStopExtension.kt
+++ b/mockwebserver-junit5/src/main/kotlin/mockwebserver3/junit5/internal/StartStopExtension.kt
@@ -51,24 +51,26 @@ internal class StartStopExtension :
   }
 
   override fun beforeEach(context: ExtensionContext) {
-    // Requires API 24
-    val testInstance = context.testInstance.get()
     val store = context.getStore(Namespace.create(StartStop::class.java))
 
-    val instanceFields =
-      findAnnotatedFields(
-        context.requiredTestClass,
-        StartStop::class.java,
-      ) { !Modifier.isStatic(it.modifiers) }
+    // A @Nested test declares its @StartStop fields on an enclosing instance, so walk every
+    // instance in the hierarchy instead of just the innermost one from context.testInstance.
+    for (testInstance in context.requiredTestInstances.allInstances) {
+      val instanceFields =
+        findAnnotatedFields(
+          testInstance.javaClass,
+          StartStop::class.java,
+        ) { !Modifier.isStatic(it.modifiers) }
 
-    for (field in instanceFields) {
-      field.setAccessible(true)
-      val server = field.get(testInstance) as? MockWebServer ?: continue
+      for (field in instanceFields) {
+        field.setAccessible(true)
+        val server = field.get(testInstance) as? MockWebServer ?: continue
 
-      // Put the instance in the store, so JUnit closes it for us in afterEach.
-      store.put(field, server)
+        // Put the instance in the store, so JUnit closes it for us in afterEach.
+        store.put(field, server)
 
-      server.start()
+        server.start()
+      }
     }
   }
 }

--- a/mockwebserver-junit5/src/test/java/mockwebserver3/junit5/NestedStartStopTest.kt
+++ b/mockwebserver-junit5/src/test/java/mockwebserver3/junit5/NestedStartStopTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package mockwebserver3.junit5
+
+import assertk.assertThat
+import assertk.assertions.isTrue
+import mockwebserver3.MockWebServer
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class NestedStartStopTest {
+  @StartStop val outerServer = MockWebServer()
+
+  @Test
+  fun outerServerStartsForOuterTest() {
+    assertThat(outerServer.started).isTrue()
+  }
+
+  @Nested
+  inner class Group {
+    @StartStop val nestedServer = MockWebServer()
+
+    @Test
+    fun outerServerStartsForNestedTest() {
+      // Before the fix the outer @StartStop field was never started for @Nested tests.
+      assertThat(outerServer.started).isTrue()
+      assertThat(nestedServer.started).isTrue()
+    }
+  }
+}


### PR DESCRIPTION
Fixes #9546.

A `@StartStop MockWebServer` field declared on an outer class is never started when the test runs inside a `@Nested` inner class, so a nested test that uses the server fails with `IllegalStateException: call start() first`.

`StartStopExtension.beforeEach` resolved instance fields from `context.testInstance` (the innermost `@Nested` instance) and `context.requiredTestClass` (the nested class). A `@StartStop` field on an enclosing class is on neither, so it was never found or started. Top-level tests were unaffected because the test instance and its declaring class line up.

The fix walks `context.requiredTestInstances.allInstances`, which returns every instance in the enclosing hierarchy, and starts the annotated fields on each. Behavior is unchanged for non-nested tests, where `allInstances` is the single test instance.

Added `NestedStartStopTest`, which declares a `@StartStop` server on the outer class and one on a `@Nested` inner class and asserts both are started from a nested test. It fails before the change and passes after.