### PR TITLE
Completely fake out the network for simple tests

### DIFF
--- a/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/OkHttpTest.kt
@@ -72,8 +72,6 @@ import okhttp3.CallEvent.SecureConnectStart
 import okhttp3.CertificatePinner
 import okhttp3.CompressionInterceptor
 import okhttp3.Connection
-import okhttp3.DelegatingSSLSocket
-import okhttp3.DelegatingSSLSocketFactory
 import okhttp3.EventListener
 import okhttp3.EventRecorder
 import okhttp3.Gzip
@@ -93,6 +91,8 @@ import okhttp3.internal.platform.AndroidPlatform
 import okhttp3.internal.platform.Platform
 import okhttp3.internal.platform.PlatformRegistry
 import okhttp3.logging.LoggingEventListener
+import okhttp3.sockets.DelegatingSSLSocket
+import okhttp3.sockets.DelegatingSSLSocketFactory
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.internal.TlsUtil.localhost

--- a/android-test/src/androidTest/java/okhttp/android/test/alpn/AlpnOverrideTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/alpn/AlpnOverrideTest.kt
@@ -24,10 +24,10 @@ import javax.net.ssl.SSLSocketFactory
 import okhttp3.Call
 import okhttp3.Connection
 import okhttp3.ConnectionSpec
-import okhttp3.DelegatingSSLSocketFactory
 import okhttp3.EventListener
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.sockets.DelegatingSSLSocketFactory
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 

--- a/android-test/src/androidTest/java/okhttp/android/test/sni/SniOverrideTest.kt
+++ b/android-test/src/androidTest/java/okhttp/android/test/sni/SniOverrideTest.kt
@@ -25,11 +25,11 @@ import javax.net.ssl.SNIHostName
 import javax.net.ssl.SNIServerName
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
-import okhttp3.DelegatingSSLSocketFactory
 import okhttp3.Dns
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
+import okhttp3.sockets.DelegatingSSLSocketFactory
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test

--- a/android-test/src/test/kotlin/okhttp/android/test/AndroidSocketAdapterTest.kt
+++ b/android-test/src/test/kotlin/okhttp/android/test/AndroidSocketAdapterTest.kt
@@ -18,8 +18,6 @@ package okhttp.android.test
 import java.security.Provider
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
-import okhttp3.DelegatingSSLSocket
-import okhttp3.DelegatingSSLSocketFactory
 import okhttp3.Protocol.HTTP_1_1
 import okhttp3.Protocol.HTTP_2
 import okhttp3.internal.platform.android.AndroidSocketAdapter
@@ -27,6 +25,8 @@ import okhttp3.internal.platform.android.ConscryptSocketAdapter
 import okhttp3.internal.platform.android.DeferredSocketAdapter
 import okhttp3.internal.platform.android.SocketAdapter
 import okhttp3.internal.platform.android.StandardAndroidSocketAdapter
+import okhttp3.sockets.DelegatingSSLSocket
+import okhttp3.sockets.DelegatingSSLSocketFactory
 import org.conscrypt.Conscrypt
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull

--- a/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
+++ b/mockwebserver/src/main/kotlin/mockwebserver3/MockWebServer.kt
@@ -880,7 +880,7 @@ public class MockWebServer : Closeable {
           socket = socket,
         ).buffer()
     body.writeTo(responseBodySink)
-    responseBodySink.emit()
+    responseBodySink.flush()
 
     socket.sleepWhileOpen(response.trailersDelayNanos)
     if ("chunked".equals(response.headers["Transfer-Encoding"], ignoreCase = true)) {

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/SpecificHostSocketFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/SpecificHostSocketFactory.kt
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.SocketAddress
 import okhttp3.internal.platform.Platform
+import okhttp3.sockets.DelegatingSocketFactory
 
 /**
  * A [SocketFactory] that redirects connections to [defaultAddress] or specific overridden address via [set].

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingSSLSession.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingSSLSession.kt
@@ -15,7 +15,7 @@
  */
 @file:Suppress("DEPRECATION")
 
-package okhttp3
+package okhttp3.sockets
 
 import java.security.Principal
 import java.security.cert.Certificate

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingSSLSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingSSLSocket.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3
+package okhttp3.sockets
 
 import java.io.IOException
 import java.io.InputStream

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingSSLSocketFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingSSLSocketFactory.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3
+package okhttp3.sockets
 
 import java.io.IOException
 import java.net.InetAddress

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingServerSocketFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingServerSocketFactory.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3
+package okhttp3.sockets
 
 import java.io.IOException
 import java.net.InetAddress

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingSocketFactory.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/DelegatingSocketFactory.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package okhttp3
+package okhttp3.sockets
 
 import java.io.IOException
 import java.net.InetAddress

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
@@ -221,7 +221,7 @@ internal class BoundServer(
       attempts.removeFirst()
     }
 
-    val (clientSocket, serverSocket) = inMemorySocketPair(1024 * 1024)
+    val (clientSocket, serverSocket) = inMemorySocketPair(maxBufferSize = 1024 * 1024)
     val connection = FakeConnection(
       clientAddress = attempt.clientAddress,
       serverAddress = attempt.serverAddress,

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.sockets
+
+import java.net.ConnectException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.SocketAddress
+import java.net.SocketException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import javax.net.ServerSocketFactory
+import javax.net.SocketFactory
+import okhttp3.internal.concurrent.Lockable
+import okhttp3.internal.concurrent.notifyAll
+import okhttp3.internal.concurrent.wait
+import okhttp3.internal.concurrent.withLock
+import okhttp3.internal.connection.BufferedSocket
+import okhttp3.internal.connection.asBufferedSocket
+import okio.Buffer
+import okio.Timeout
+import okio.inMemorySocketPair
+
+/**
+ * A complete in-memory socket system, suitable for testing OkHttp without using any operating
+ * system TCP sockets.
+ */
+class FakeNetwork {
+  private val boundServers = ConcurrentHashMap<SocketAddress, BoundServer>()
+
+  private val nextClientIpv4Address = Buffer().run {
+    writeByte(192)
+    writeByte(168)
+    writeByte(0)
+    writeByte(1)
+    AtomicInteger(readInt())
+  }
+
+  private var nextClientPort = AtomicInteger(5_000)
+  private var nextServerPort = AtomicInteger(6_000)
+
+  internal val anyAddress: InetAddress
+    get() = InetAddress.getByAddress(byteArrayOf(0, 0, 0, 0))
+
+  /** Generate a new unique client address. */
+  internal fun nextClientAddress(): InetSocketAddress {
+    val ipv4AddressInt = nextClientIpv4Address.getAndIncrement()
+    val ipv4AddressBytes = Buffer()
+      .writeInt(ipv4AddressInt)
+      .readByteArray()
+    return InetSocketAddress(
+      InetAddress.getByAddress(ipv4AddressBytes),
+      nextClientPort.getAndIncrement(),
+    )
+  }
+
+  /** Generate a new unique server port. */
+  fun nextServerPort() = nextServerPort.getAndIncrement()
+
+  val serverSocketFactory = object : ServerSocketFactory() {
+    override fun createServerSocket() = FakeServerSocket(this@FakeNetwork)
+
+    override fun createServerSocket(port: Int) = error("unsupported")
+
+    override fun createServerSocket(port: Int, backlog: Int) = error("unsupported")
+
+    override fun createServerSocket(
+      port: Int,
+      backlog: Int,
+      ifAddress: InetAddress?
+    ) = error("unsupported")
+  }
+
+  val socketFactory = object : SocketFactory() {
+    override fun createSocket() = FakeSocket(this@FakeNetwork)
+
+    override fun createSocket(host: String, port: Int) = error("unsupported")
+
+    override fun createSocket(
+      host: String?,
+      port: Int,
+      localHost: InetAddress?,
+      localPort: Int
+    ) = error("unsupported")
+
+    override fun createSocket(host: InetAddress?, port: Int) = error("unsupported")
+
+    override fun createSocket(
+      address: InetAddress?,
+      port: Int,
+      localAddress: InetAddress?,
+      localPort: Int
+    ) = error("unsupported")
+  }
+
+  internal fun connect(
+    attempt: ConnectAttempt,
+    connectTimeoutMillis: Long,
+  ): FakeConnection {
+    val boundServer = boundServers[attempt.serverAddress]
+      ?: throw ConnectException("no server bound")
+
+    val timeout = Timeout()
+      .deadline(connectTimeoutMillis, TimeUnit.MILLISECONDS)
+    boundServer.enqueue(timeout, attempt)
+    return attempt.await(timeout)
+  }
+
+  /** Returns non-null if the bind was successful. */
+  internal fun bind(
+    endpoint: InetSocketAddress,
+    backlog: Int,
+  ): BoundServer? {
+    val serverAddress = when (endpoint.port) {
+      0 -> InetSocketAddress(endpoint.address, nextServerPort())
+      else -> endpoint
+    }
+
+    val result = BoundServer(serverAddress, backlog)
+    val collision = boundServers.putIfAbsent(serverAddress, result)
+    if (collision != null) return null
+    return result
+  }
+
+  internal fun cancel(server: BoundServer) {
+    boundServers.remove(server.serverAddress, server)
+    server.close()
+  }
+}
+
+/**
+ * Attempt to connect to a server.
+ *
+ * Either the client or the server can asynchronously cancel this attempt while the caller is
+ * awaiting its result.
+ *
+ * This uses `synchronized` to guard [result]. Calls to [await] wait on this lock until a result is
+ * sent.
+ */
+internal class ConnectAttempt(
+  val clientAddress: InetSocketAddress,
+  val serverAddress: InetSocketAddress,
+) : Lockable {
+  private var result: Result<FakeConnection>? = null
+
+  fun cancel(e: SocketException) {
+    withLock {
+      if (result != null) return
+      result = Result.failure(e)
+      notifyAll()
+    }
+  }
+
+  fun complete(connection: FakeConnection) {
+    withLock {
+      if (result != null) return
+      result = Result.success(connection)
+      notifyAll()
+    }
+  }
+
+  fun await(timeout: Timeout): FakeConnection {
+    withLock {
+      while (true) {
+        val result = result
+        if (result != null) return result.getOrThrow()
+
+        timeout.waitUntilNotified(this)
+      }
+    }
+  }
+
+  override fun toString() = "Connect@$serverAddress"
+}
+
+/**
+ * Matches inbound connection attempts with calls to [accept].
+ *
+ * This uses `synchronized` to guard [attempts] and [closed]. Calls to [accept] wait on this lock
+ * until a connection attempt is enqueued.
+ */
+internal class BoundServer(
+  val serverAddress: InetSocketAddress,
+  val maxBacklogSize: Int,
+) : Lockable {
+  private val attempts = ArrayDeque<ConnectAttempt>()
+  private var closed = false
+
+  fun enqueue(timeout: Timeout, attempt: ConnectAttempt) {
+    withLock {
+      while (attempts.size >= maxBacklogSize && !closed) {
+        timeout.waitUntilNotified(this) // Wait until there's room in the backlog.
+      }
+      if (closed) throw ConnectException("closed")
+      notifyAll()
+      attempts += attempt
+    }
+  }
+
+  fun accept(): FakeConnection {
+    val attempt = withLock {
+      while (attempts.isEmpty() && !closed) {
+        wait() // Wait for a connection attempt.
+      }
+      if (closed) throw SocketException("closed")
+      notifyAll()
+      attempts.removeFirst()
+    }
+
+    val (clientSocket, serverSocket) = inMemorySocketPair(1024 * 1024)
+    val connection = FakeConnection(
+      clientAddress = attempt.clientAddress,
+      serverAddress = attempt.serverAddress,
+      clientSocket = clientSocket.asBufferedSocket(),
+      serverSocket = serverSocket.asBufferedSocket(),
+    )
+
+    attempt.complete(connection)
+    return connection
+  }
+
+  fun close() {
+    val attemptsToCancel = withLock {
+      notifyAll()
+      closed = true
+      attempts.toList()
+        .also { attempts.clear() }
+    }
+    for (attempt in attemptsToCancel) {
+      attempt.cancel(SocketException("server closed"))
+    }
+  }
+
+  override fun toString() = "Server@$serverAddress"
+}
+
+internal class FakeConnection(
+  val clientAddress: InetSocketAddress,
+  val serverAddress: InetSocketAddress,
+  val clientSocket: BufferedSocket,
+  val serverSocket: BufferedSocket,
+) {
+  override fun toString() = "$clientAddress<->$serverAddress"
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
@@ -42,13 +42,14 @@ import okio.inMemorySocketPair
 class FakeNetwork {
   private val boundServers = ConcurrentHashMap<SocketAddress, BoundServer>()
 
-  private val nextClientIpv4Address = Buffer().run {
-    writeByte(192)
-    writeByte(168)
-    writeByte(0)
-    writeByte(1)
-    AtomicInteger(readInt())
-  }
+  private val nextClientIpv4Address =
+    Buffer().run {
+      writeByte(192)
+      writeByte(168)
+      writeByte(0)
+      writeByte(1)
+      AtomicInteger(readInt())
+    }
 
   private var nextClientPort = AtomicInteger(5_000)
   private var nextServerPort = AtomicInteger(6_000)
@@ -59,9 +60,10 @@ class FakeNetwork {
   /** Generate a new unique client address. */
   internal fun nextClientAddress(): InetSocketAddress {
     val ipv4AddressInt = nextClientIpv4Address.getAndIncrement()
-    val ipv4AddressBytes = Buffer()
-      .writeInt(ipv4AddressInt)
-      .readByteArray()
+    val ipv4AddressBytes =
+      Buffer()
+        .writeInt(ipv4AddressInt)
+        .readByteArray()
     return InetSocketAddress(
       InetAddress.getByAddress(ipv4AddressBytes),
       nextClientPort.getAndIncrement(),
@@ -71,51 +73,64 @@ class FakeNetwork {
   /** Generate a new unique server port. */
   fun nextServerPort() = nextServerPort.getAndIncrement()
 
-  val serverSocketFactory = object : ServerSocketFactory() {
-    override fun createServerSocket() = FakeServerSocket(this@FakeNetwork)
+  val serverSocketFactory =
+    object : ServerSocketFactory() {
+      override fun createServerSocket() = FakeServerSocket(this@FakeNetwork)
 
-    override fun createServerSocket(port: Int) = error("unsupported")
+      override fun createServerSocket(port: Int) = error("unsupported")
 
-    override fun createServerSocket(port: Int, backlog: Int) = error("unsupported")
+      override fun createServerSocket(
+        port: Int,
+        backlog: Int,
+      ) = error("unsupported")
 
-    override fun createServerSocket(
-      port: Int,
-      backlog: Int,
-      ifAddress: InetAddress?
-    ) = error("unsupported")
-  }
+      override fun createServerSocket(
+        port: Int,
+        backlog: Int,
+        ifAddress: InetAddress?,
+      ) = error("unsupported")
+    }
 
-  val socketFactory = object : SocketFactory() {
-    override fun createSocket() = FakeSocket(this@FakeNetwork)
+  val socketFactory =
+    object : SocketFactory() {
+      override fun createSocket() = FakeSocket(this@FakeNetwork)
 
-    override fun createSocket(host: String, port: Int) = error("unsupported")
+      override fun createSocket(
+        host: String,
+        port: Int,
+      ) = error("unsupported")
 
-    override fun createSocket(
-      host: String?,
-      port: Int,
-      localHost: InetAddress?,
-      localPort: Int
-    ) = error("unsupported")
+      override fun createSocket(
+        host: String?,
+        port: Int,
+        localHost: InetAddress?,
+        localPort: Int,
+      ) = error("unsupported")
 
-    override fun createSocket(host: InetAddress?, port: Int) = error("unsupported")
+      override fun createSocket(
+        host: InetAddress?,
+        port: Int,
+      ) = error("unsupported")
 
-    override fun createSocket(
-      address: InetAddress?,
-      port: Int,
-      localAddress: InetAddress?,
-      localPort: Int
-    ) = error("unsupported")
-  }
+      override fun createSocket(
+        address: InetAddress?,
+        port: Int,
+        localAddress: InetAddress?,
+        localPort: Int,
+      ) = error("unsupported")
+    }
 
   internal fun connect(
     attempt: ConnectAttempt,
     connectTimeoutMillis: Long,
   ): FakeConnection {
-    val boundServer = boundServers[attempt.serverAddress]
-      ?: throw ConnectException("no server bound")
+    val boundServer =
+      boundServers[attempt.serverAddress]
+        ?: throw ConnectException("no server bound")
 
-    val timeout = Timeout()
-      .deadline(connectTimeoutMillis, TimeUnit.MILLISECONDS)
+    val timeout =
+      Timeout()
+        .deadline(connectTimeoutMillis, TimeUnit.MILLISECONDS)
     boundServer.enqueue(timeout, attempt)
     return attempt.await(timeout)
   }
@@ -125,10 +140,11 @@ class FakeNetwork {
     endpoint: InetSocketAddress,
     backlog: Int,
   ): BoundServer? {
-    val serverAddress = when (endpoint.port) {
-      0 -> InetSocketAddress(endpoint.address, nextServerPort())
-      else -> endpoint
-    }
+    val serverAddress =
+      when (endpoint.port) {
+        0 -> InetSocketAddress(endpoint.address, nextServerPort())
+        else -> endpoint
+      }
 
     val result = BoundServer(serverAddress, backlog)
     val collision = boundServers.putIfAbsent(serverAddress, result)
@@ -200,7 +216,10 @@ internal class BoundServer(
   private val attempts = ArrayDeque<ConnectAttempt>()
   private var closed = false
 
-  fun enqueue(timeout: Timeout, attempt: ConnectAttempt) {
+  fun enqueue(
+    timeout: Timeout,
+    attempt: ConnectAttempt,
+  ) {
     withLock {
       while (attempts.size >= maxBacklogSize && !closed) {
         timeout.waitUntilNotified(this) // Wait until there's room in the backlog.
@@ -212,34 +231,38 @@ internal class BoundServer(
   }
 
   fun accept(): FakeConnection {
-    val attempt = withLock {
-      while (attempts.isEmpty() && !closed) {
-        wait() // Wait for a connection attempt.
+    val attempt =
+      withLock {
+        while (attempts.isEmpty() && !closed) {
+          wait() // Wait for a connection attempt.
+        }
+        if (closed) throw SocketException("closed")
+        notifyAll()
+        attempts.removeFirst()
       }
-      if (closed) throw SocketException("closed")
-      notifyAll()
-      attempts.removeFirst()
-    }
 
     val (clientSocket, serverSocket) = inMemorySocketPair(maxBufferSize = 1024 * 1024)
-    val connection = FakeConnection(
-      clientAddress = attempt.clientAddress,
-      serverAddress = attempt.serverAddress,
-      clientSocket = clientSocket.asBufferedSocket(),
-      serverSocket = serverSocket.asBufferedSocket(),
-    )
+    val connection =
+      FakeConnection(
+        clientAddress = attempt.clientAddress,
+        serverAddress = attempt.serverAddress,
+        clientSocket = clientSocket.asBufferedSocket(),
+        serverSocket = serverSocket.asBufferedSocket(),
+      )
 
     attempt.complete(connection)
     return connection
   }
 
   fun close() {
-    val attemptsToCancel = withLock {
-      notifyAll()
-      closed = true
-      attempts.toList()
-        .also { attempts.clear() }
-    }
+    val attemptsToCancel =
+      withLock {
+        notifyAll()
+        closed = true
+        attempts
+          .toList()
+          .also { attempts.clear() }
+      }
     for (attempt in attemptsToCancel) {
       attempt.cancel(SocketException("server closed"))
     }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("Since15")
+
+package okhttp3.sockets
+
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketAddress
+import java.net.SocketException
+import java.net.SocketOption
+import java.util.concurrent.atomic.AtomicReference
+
+internal class FakeServerSocket(
+  val network: FakeNetwork,
+) : ServerSocket() {
+  private val atomicState = AtomicReference<State>(State.New)
+  private val state: State
+    get() = atomicState.get()
+
+  private var reuseAddress = false
+
+  override fun bind(endpoint: SocketAddress, backlog: Int) {
+    check(endpoint is InetSocketAddress)
+
+    while (true) {
+      val previous = state
+      if (previous !is State.New) throw SocketException("cannot bind")
+
+      if (!atomicState.compareAndSet(previous, State.Binding)) continue // Lost a race, retry.
+
+      val boundServer = network.bind(endpoint, backlog)
+
+      if (boundServer == null) {
+        check(atomicState.compareAndSet(State.Binding, previous))
+        throw SocketException("bind collision")
+      }
+
+      val next = State.Bound(
+        boundServer = boundServer,
+      )
+      check(atomicState.compareAndSet(State.Binding, next))
+      break
+    }
+  }
+
+  override fun getInetAddress() = (state.endpoint as? InetSocketAddress)?.address
+
+  override fun getLocalPort() = (state.endpoint as? InetSocketAddress)?.port ?: -1
+
+  override fun getLocalSocketAddress() = state.endpoint
+
+  override fun accept(): Socket {
+    val boundAddress = (state as? State.Bound)?.boundServer
+      ?: throw SocketException("not bound")
+
+    val connection = boundAddress.accept()
+    val socket = FakeSocket(
+      network = network,
+      initialState = FakeSocket.State.Connected(
+        localAddress = connection.serverAddress,
+        remoteAddress = connection.clientAddress,
+        bufferedSocket = connection.serverSocket,
+      )
+    )
+
+    return socket
+  }
+
+  override fun close() {
+    while (true) {
+      val previous = state
+      val next = State.Closed(previous)
+      if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
+
+      if (previous is State.Bound) {
+        network.cancel(previous.boundServer)
+      }
+      break
+    }
+  }
+
+  override fun isBound() = state.bound
+
+  override fun isClosed() = state is State.Closed
+
+  override fun setReuseAddress(reuseAddress: Boolean) {
+    if (state is State.Closed) throw SocketException("closed")
+    this.reuseAddress = reuseAddress
+  }
+
+  override fun getReuseAddress() = reuseAddress
+
+  override fun toString() = "FakeServerSocket"
+
+  override fun bind(endpoint: SocketAddress) = error("unsupported")
+
+  override fun getChannel() = error("unsupported")
+
+  override fun setSoTimeout(timeout: Int) = error("unsupported")
+
+  override fun getSoTimeout() = error("unsupported")
+
+  override fun setReceiveBufferSize(size: Int) = error("unsupported")
+
+  override fun getReceiveBufferSize() = error("unsupported")
+
+  override fun setPerformancePreferences(
+    connectionTime: Int,
+    latency: Int,
+    bandwidth: Int
+  ) = error("unsupported")
+
+  override fun <T> setOption(
+    name: SocketOption<T?>,
+    value: T?
+  ) = error("unsupported")
+
+  override fun <T> getOption(name: SocketOption<T?>) = error("unsupported")
+
+  override fun supportedOptions() = error("unsupported")
+
+  private sealed interface State {
+    val bound: Boolean
+      get() = false
+    val endpoint: SocketAddress?
+      get() = null
+
+    object New : State
+
+    /** Like [New], but while we're attempting to bind an address. */
+    object Binding : State
+
+    class Bound(
+      val boundServer: BoundServer,
+    ) : State {
+      override val endpoint: SocketAddress
+        get() = boundServer.serverAddress
+      override val bound: Boolean
+        get() = true
+    }
+
+    class Closed(
+      override val endpoint: SocketAddress?,
+      override val bound: Boolean,
+    ) : State {
+      constructor(previous: State) : this(
+        endpoint = previous.endpoint,
+        bound = previous.bound
+      )
+    }
+  }
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
@@ -34,7 +34,10 @@ internal class FakeServerSocket(
 
   private var reuseAddress = false
 
-  override fun bind(endpoint: SocketAddress, backlog: Int) {
+  override fun bind(
+    endpoint: SocketAddress,
+    backlog: Int,
+  ) {
     check(endpoint is InetSocketAddress)
 
     while (true) {
@@ -50,9 +53,10 @@ internal class FakeServerSocket(
         throw SocketException("bind collision")
       }
 
-      val next = State.Bound(
-        boundServer = boundServer,
-      )
+      val next =
+        State.Bound(
+          boundServer = boundServer,
+        )
       check(atomicState.compareAndSet(State.Binding, next))
       break
     }
@@ -65,18 +69,21 @@ internal class FakeServerSocket(
   override fun getLocalSocketAddress() = state.endpoint
 
   override fun accept(): Socket {
-    val boundAddress = (state as? State.Bound)?.boundServer
-      ?: throw SocketException("not bound")
+    val boundAddress =
+      (state as? State.Bound)?.boundServer
+        ?: throw SocketException("not bound")
 
     val connection = boundAddress.accept()
-    val socket = FakeSocket(
-      network = network,
-      initialState = FakeSocket.State.Connected(
-        localAddress = connection.serverAddress,
-        remoteAddress = connection.clientAddress,
-        bufferedSocket = connection.serverSocket,
+    val socket =
+      FakeSocket(
+        network = network,
+        initialState =
+          FakeSocket.State.Connected(
+            localAddress = connection.serverAddress,
+            remoteAddress = connection.clientAddress,
+            bufferedSocket = connection.serverSocket,
+          ),
       )
-    )
 
     return socket
   }
@@ -122,12 +129,12 @@ internal class FakeServerSocket(
   override fun setPerformancePreferences(
     connectionTime: Int,
     latency: Int,
-    bandwidth: Int
+    bandwidth: Int,
   ) = error("unsupported")
 
   override fun <T> setOption(
     name: SocketOption<T?>,
-    value: T?
+    value: T?,
   ) = error("unsupported")
 
   override fun <T> getOption(name: SocketOption<T?>) = error("unsupported")
@@ -160,7 +167,7 @@ internal class FakeServerSocket(
     ) : State {
       constructor(previous: State) : this(
         endpoint = previous.endpoint,
-        bound = previous.bound
+        bound = previous.bound,
       )
     }
   }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
@@ -41,8 +41,7 @@ internal class FakeSocket(
 
   private var socketReadTimeoutMillis: Long = 0
 
-  private fun connectedSocket() =
-    (state as? State.Connected)?.bufferedSocket ?: throw IOException("not connected")
+  private fun connectedSocket() = (state as? State.Connected)?.bufferedSocket ?: throw IOException("not connected")
 
   override fun getInputStream() = connectedSocket().source.inputStream()
 
@@ -74,14 +73,18 @@ internal class FakeSocket(
 
   override fun getSoTimeout() = socketReadTimeoutMillis.toInt()
 
-  override fun connect(endpoint: SocketAddress, timeout: Int) {
+  override fun connect(
+    endpoint: SocketAddress,
+    timeout: Int,
+  ) {
     require(timeout >= 0)
     require(endpoint is InetSocketAddress)
 
-    val attempt = ConnectAttempt(
-      clientAddress = network.nextClientAddress(),
-      serverAddress = endpoint,
-    )
+    val attempt =
+      ConnectAttempt(
+        clientAddress = network.nextClientAddress(),
+        serverAddress = endpoint,
+      )
 
     while (true) {
       val previous = state
@@ -91,22 +94,24 @@ internal class FakeSocket(
       val connectingState = State.Connecting(attempt)
       if (!atomicState.compareAndSet(previous, connectingState)) continue // Lost a race, retry.
 
-      val connection = try {
-        network.connect(
-          attempt = attempt,
-          connectTimeoutMillis = timeout.toLong(),
-        )
-      } catch (e: Throwable) {
-        // If the state changed while we were connecting, the other state wins.
-        atomicState.compareAndSet(connectingState, previous)
-        throw e
-      }
+      val connection =
+        try {
+          network.connect(
+            attempt = attempt,
+            connectTimeoutMillis = timeout.toLong(),
+          )
+        } catch (e: Throwable) {
+          // If the state changed while we were connecting, the other state wins.
+          atomicState.compareAndSet(connectingState, previous)
+          throw e
+        }
 
-      val next = State.Connected(
-        localAddress = attempt.clientAddress,
-        remoteAddress = attempt.serverAddress,
-        bufferedSocket = connection.clientSocket,
-      )
+      val next =
+        State.Connected(
+          localAddress = attempt.clientAddress,
+          remoteAddress = attempt.serverAddress,
+          bufferedSocket = connection.clientSocket,
+        )
 
       // If the state changed while we were connecting, the other state wins.
       if (!atomicState.compareAndSet(connectingState, next)) {
@@ -126,10 +131,11 @@ internal class FakeSocket(
         throw SocketException("cannot shutdown input")
       }
 
-      val next = when {
-        previous.outputShutdown -> State.Closed(previous)
-        else -> previous.copy(inputShutdown = true)
-      }
+      val next =
+        when {
+          previous.outputShutdown -> State.Closed(previous)
+          else -> previous.copy(inputShutdown = true)
+        }
 
       if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
 
@@ -147,10 +153,11 @@ internal class FakeSocket(
         throw SocketException("cannot shutdown output")
       }
 
-      val next = when {
-        previous.inputShutdown -> State.Closed(previous)
-        else -> previous.copy(outputShutdown = true)
-      }
+      val next =
+        when {
+          previous.inputShutdown -> State.Closed(previous)
+          else -> previous.copy(outputShutdown = true)
+        }
 
       if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
 
@@ -182,7 +189,10 @@ internal class FakeSocket(
 
   override fun getTcpNoDelay() = error("unsupported")
 
-  override fun setSoLinger(on: Boolean, linger: Int) = error("unsupported")
+  override fun setSoLinger(
+    on: Boolean,
+    linger: Int,
+  ) = error("unsupported")
 
   override fun getSoLinger() = error("unsupported")
 
@@ -215,12 +225,12 @@ internal class FakeSocket(
   override fun setPerformancePreferences(
     connectionTime: Int,
     latency: Int,
-    bandwidth: Int
+    bandwidth: Int,
   ) = error("unsupported")
 
   override fun <T> setOption(
     name: SocketOption<T>,
-    value: T?
+    value: T?,
   ): Socket = error("unsupported")
 
   override fun <T> getOption(name: SocketOption<T>) = error("unsupported")

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("Since15")
+
+package okhttp3.sockets
+
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.SocketAddress
+import java.net.SocketException
+import java.net.SocketOption
+import java.util.concurrent.atomic.AtomicReference
+import okhttp3.internal.connection.BufferedSocket
+
+/**
+ * A client or server socket.
+ *
+ * Server sockets are typically created already connected.
+ */
+internal class FakeSocket(
+  val network: FakeNetwork,
+  initialState: State = State.New,
+) : Socket() {
+  private val atomicState = AtomicReference<State>(initialState)
+  private val state: State
+    get() = atomicState.get()
+
+  private var socketReadTimeoutMillis: Long = 0
+
+  private fun connectedSocket() =
+    (state as? State.Connected)?.bufferedSocket ?: throw IOException("not connected")
+
+  override fun getInputStream() = connectedSocket().source.inputStream()
+
+  override fun getOutputStream() = connectedSocket().sink.outputStream()
+
+  override fun getRemoteSocketAddress() = state.remoteAddress
+
+  override fun getInetAddress() = state.remoteAddress?.address
+
+  override fun getPort() = state.remoteAddress?.port ?: 0
+
+  override fun getLocalSocketAddress() = state.localAddress
+
+  override fun getLocalAddress() = state.localAddress?.address ?: network.anyAddress
+
+  override fun getLocalPort() = state.localAddress?.port ?: -1
+
+  override fun isBound() = state.bound
+
+  override fun isConnected() = state.connected
+
+  override fun isClosed() = state is State.Closed
+
+  override fun setSoTimeout(soTimeout: Int) {
+    if (state is State.Closed) throw SocketException("closed")
+    check(soTimeout >= 0)
+    this.socketReadTimeoutMillis = soTimeout.toLong()
+  }
+
+  override fun getSoTimeout() = socketReadTimeoutMillis.toInt()
+
+  override fun connect(endpoint: SocketAddress, timeout: Int) {
+    require(timeout >= 0)
+    require(endpoint is InetSocketAddress)
+
+    val attempt = ConnectAttempt(
+      clientAddress = network.nextClientAddress(),
+      serverAddress = endpoint,
+    )
+
+    while (true) {
+      val previous = state
+
+      if (previous !is State.New) throw SocketException("cannot connect")
+
+      val connectingState = State.Connecting(attempt)
+      if (!atomicState.compareAndSet(previous, connectingState)) continue // Lost a race, retry.
+
+      val connection = try {
+        network.connect(
+          attempt = attempt,
+          connectTimeoutMillis = timeout.toLong(),
+        )
+      } catch (e: Throwable) {
+        // If the state changed while we were connecting, the other state wins.
+        atomicState.compareAndSet(connectingState, previous)
+        throw e
+      }
+
+      val next = State.Connected(
+        localAddress = attempt.clientAddress,
+        remoteAddress = attempt.serverAddress,
+        bufferedSocket = connection.clientSocket,
+      )
+
+      // If the state changed while we were connecting, the other state wins.
+      if (!atomicState.compareAndSet(connectingState, next)) {
+        connection.clientSocket.cancel()
+      }
+
+      break
+    }
+  }
+
+  override fun isInputShutdown() = state.inputShutdown
+
+  override fun shutdownInput() {
+    while (true) {
+      val previous = state
+      if (previous !is State.Connected || previous.inputShutdown) {
+        throw SocketException("cannot shutdown input")
+      }
+
+      val next = when {
+        previous.outputShutdown -> State.Closed(previous)
+        else -> previous.copy(inputShutdown = true)
+      }
+
+      if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
+
+      previous.bufferedSocket.source.close()
+      break
+    }
+  }
+
+  override fun isOutputShutdown() = state.outputShutdown
+
+  override fun shutdownOutput() {
+    while (true) {
+      val previous = state
+      if (previous !is State.Connected || previous.outputShutdown) {
+        throw SocketException("cannot shutdown output")
+      }
+
+      val next = when {
+        previous.inputShutdown -> State.Closed(previous)
+        else -> previous.copy(outputShutdown = true)
+      }
+
+      if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
+
+      previous.bufferedSocket.sink.close()
+      break
+    }
+  }
+
+  override fun close() {
+    while (true) {
+      val previous = state
+      val next = State.Closed(previous)
+
+      if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
+
+      (previous as? State.Connecting)?.attempt?.cancel(SocketException("client closed"))
+      (previous as? State.Connected)?.bufferedSocket?.cancel()
+      break
+    }
+  }
+
+  override fun connect(endpoint: SocketAddress) = error("unsupported")
+
+  override fun bind(bindpoint: SocketAddress) = error("unsupported")
+
+  override fun getChannel() = error("unsupported")
+
+  override fun setTcpNoDelay(on: Boolean) = error("unsupported")
+
+  override fun getTcpNoDelay() = error("unsupported")
+
+  override fun setSoLinger(on: Boolean, linger: Int) = error("unsupported")
+
+  override fun getSoLinger() = error("unsupported")
+
+  override fun sendUrgentData(data: Int) = error("unsupported")
+
+  override fun setOOBInline(on: Boolean) = error("unsupported")
+
+  override fun getOOBInline() = error("unsupported")
+
+  override fun setSendBufferSize(size: Int) = error("unsupported")
+
+  override fun getSendBufferSize() = error("unsupported")
+
+  override fun setReceiveBufferSize(size: Int) = error("unsupported")
+
+  override fun getReceiveBufferSize() = error("unsupported")
+
+  override fun setReuseAddress(reuseAddress: Boolean) = error("unsupported")
+
+  override fun getReuseAddress() = error("unsupported")
+
+  override fun setKeepAlive(on: Boolean) = error("unsupported")
+
+  override fun getKeepAlive() = error("unsupported")
+
+  override fun setTrafficClass(tc: Int) = error("unsupported")
+
+  override fun getTrafficClass() = error("unsupported")
+
+  override fun setPerformancePreferences(
+    connectionTime: Int,
+    latency: Int,
+    bandwidth: Int
+  ) = error("unsupported")
+
+  override fun <T> setOption(
+    name: SocketOption<T>,
+    value: T?
+  ): Socket = error("unsupported")
+
+  override fun <T> getOption(name: SocketOption<T>) = error("unsupported")
+
+  override fun supportedOptions() = error("unsupported")
+
+  override fun toString() = "FakeSocket"
+
+  sealed interface State {
+    val localAddress: InetSocketAddress?
+      get() = null
+    val remoteAddress: InetSocketAddress?
+      get() = null
+    val bound: Boolean
+      get() = false
+    val connected: Boolean
+      get() = false
+    val inputShutdown: Boolean
+      get() = false
+    val outputShutdown: Boolean
+      get() = false
+
+    object New : State
+
+    class Connecting(
+      val attempt: ConnectAttempt,
+    ) : State
+
+    data class Connected(
+      override val localAddress: InetSocketAddress,
+      override val remoteAddress: InetSocketAddress,
+      val bufferedSocket: BufferedSocket,
+      override val inputShutdown: Boolean = false,
+      override val outputShutdown: Boolean = false,
+    ) : State {
+      override val bound: Boolean
+        get() = true
+      override val connected: Boolean
+        get() = true
+    }
+
+    /** A closed socket remembers what happened before it was closed. */
+    class Closed(
+      override val localAddress: InetSocketAddress?,
+      override val remoteAddress: InetSocketAddress?,
+      override val bound: Boolean,
+      override val connected: Boolean,
+    ) : State {
+      constructor(previous: State) : this(
+        localAddress = previous.localAddress,
+        remoteAddress = previous.remoteAddress,
+        bound = previous.bound,
+        connected = previous.connected,
+      )
+
+      override val inputShutdown: Boolean
+        get() = true
+      override val outputShutdown: Boolean
+        get() = true
+    }
+  }
+}

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/Lockable.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/concurrent/Lockable.kt
@@ -20,6 +20,7 @@ package okhttp3.internal.concurrent
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+import okhttp3.internal.OkHttpInternalApi
 import okhttp3.internal.assertionsEnabled
 
 /**
@@ -31,13 +32,17 @@ import okhttp3.internal.assertionsEnabled
  */
 interface Lockable
 
-internal inline fun Lockable.wait() = (this as Object).wait()
+@OkHttpInternalApi
+inline fun Lockable.wait() = (this as Object).wait()
 
-internal inline fun Lockable.notify() = (this as Object).notify()
+@OkHttpInternalApi
+inline fun Lockable.notify() = (this as Object).notify()
 
-internal inline fun Lockable.notifyAll() = (this as Object).notifyAll()
+@OkHttpInternalApi
+inline fun Lockable.notifyAll() = (this as Object).notifyAll()
 
-internal inline fun Lockable.awaitNanos(nanos: Long) {
+@OkHttpInternalApi
+inline fun Lockable.awaitNanos(nanos: Long) {
   val ms = nanos / 1_000_000L
   val ns = nanos - (ms * 1_000_000L)
   if (ms > 0L || nanos > 0) {

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt
@@ -116,6 +116,7 @@ import okhttp3.internal.http.HTTP_PROCESSING
 import okhttp3.internal.http.RecordingProxySelector
 import okhttp3.java.net.cookiejar.JavaNetCookieJar
 import okhttp3.okio.LoggingFilesystem
+import okhttp3.sockets.DelegatingSSLSocketFactory
 import okhttp3.testing.Flaky
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.HandshakeCertificates

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CipherSuiteTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CipherSuiteTest.kt
@@ -118,11 +118,12 @@ class CipherSuiteTest {
 
   @Test
   fun applyIntersectionRetainsTlsPrefixes() {
-    val socket = FakeSslSocket(
-      enabledProtocols = listOf("TLSv1"),
-      supportedCipherSuites = listOf("SSL_A", "SSL_B", "SSL_C", "SSL_D", "SSL_E"),
-      enabledCipherSuites = listOf("SSL_A", "SSL_B", "SSL_C"),
-    )
+    val socket =
+      FakeSslSocket(
+        enabledProtocols = listOf("TLSv1"),
+        supportedCipherSuites = listOf("SSL_A", "SSL_B", "SSL_C", "SSL_D", "SSL_E"),
+        enabledCipherSuites = listOf("SSL_A", "SSL_B", "SSL_C"),
+      )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -135,11 +136,12 @@ class CipherSuiteTest {
 
   @Test
   fun applyIntersectionRetainsSslPrefixes() {
-    val socket = FakeSslSocket(
-      enabledProtocols = listOf("TLSv1"),
-      supportedCipherSuites = listOf("TLS_A", "TLS_B", "TLS_C", "TLS_D", "TLS_E"),
-      enabledCipherSuites = listOf("TLS_A", "TLS_B", "TLS_C"),
-    )
+    val socket =
+      FakeSslSocket(
+        enabledProtocols = listOf("TLSv1"),
+        supportedCipherSuites = listOf("TLS_A", "TLS_B", "TLS_C", "TLS_D", "TLS_E"),
+        enabledCipherSuites = listOf("TLS_A", "TLS_B", "TLS_C"),
+      )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -152,11 +154,12 @@ class CipherSuiteTest {
 
   @Test
   fun applyIntersectionAddsSslScsvForFallback() {
-    val socket = FakeSslSocket(
-      enabledProtocols = listOf("TLSv1"),
-      supportedCipherSuites = listOf("SSL_A", "SSL_FALLBACK_SCSV"),
-      enabledCipherSuites = listOf("SSL_A"),
-    )
+    val socket =
+      FakeSslSocket(
+        enabledProtocols = listOf("TLSv1"),
+        supportedCipherSuites = listOf("SSL_A", "SSL_FALLBACK_SCSV"),
+        enabledCipherSuites = listOf("SSL_A"),
+      )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -169,11 +172,12 @@ class CipherSuiteTest {
 
   @Test
   fun applyIntersectionAddsTlsScsvForFallback() {
-    val socket = FakeSslSocket(
-      enabledProtocols = listOf("TLSv1"),
-      supportedCipherSuites = listOf("TLS_A", "TLS_FALLBACK_SCSV"),
-      enabledCipherSuites = listOf("TLS_A"),
-    )
+    val socket =
+      FakeSslSocket(
+        enabledProtocols = listOf("TLSv1"),
+        supportedCipherSuites = listOf("TLS_A", "TLS_FALLBACK_SCSV"),
+        enabledCipherSuites = listOf("TLS_A"),
+      )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -186,11 +190,12 @@ class CipherSuiteTest {
 
   @Test
   fun applyIntersectionToProtocolVersion() {
-    val socket = FakeSslSocket(
-      enabledProtocols = listOf("TLSv1", "TLSv1.1", "TLSv1.2"),
-      supportedCipherSuites = listOf("TLS_A"),
-      enabledCipherSuites = listOf("TLS_A"),
-    )
+    val socket =
+      FakeSslSocket(
+        enabledProtocols = listOf("TLSv1", "TLSv1.1", "TLSv1.2"),
+        supportedCipherSuites = listOf("TLS_A"),
+        enabledCipherSuites = listOf("TLS_A"),
+      )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -203,11 +208,12 @@ class CipherSuiteTest {
 
   class FakeSslSocket(
     var enabledProtocols: List<String> = listOf(TlsVersion.TLS_1_3.javaName),
-    var supportedCipherSuites: List<String> = listOf(
-      CipherSuite.TLS_AES_128_GCM_SHA256.javaName,
-      CipherSuite.TLS_AES_256_GCM_SHA384.javaName,
-      CipherSuite.TLS_CHACHA20_POLY1305_SHA256.javaName,
-    ),
+    var supportedCipherSuites: List<String> =
+      listOf(
+        CipherSuite.TLS_AES_128_GCM_SHA256.javaName,
+        CipherSuite.TLS_AES_256_GCM_SHA384.javaName,
+        CipherSuite.TLS_CHACHA20_POLY1305_SHA256.javaName,
+      ),
     var enabledCipherSuites: List<String> = supportedCipherSuites,
   ) : DelegatingSSLSocket(null) {
     override fun getEnabledProtocols() = enabledProtocols.toTypedArray()

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CipherSuiteTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CipherSuiteTest.kt
@@ -16,12 +16,13 @@
 package okhttp3
 
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isSameInstanceAs
 import okhttp3.CipherSuite.Companion.forJavaName
 import okhttp3.internal.applyConnectionSpec
-import org.junit.jupiter.api.Assertions.assertArrayEquals
+import okhttp3.sockets.DelegatingSSLSocket
 import org.junit.jupiter.api.Test
 
 class CipherSuiteTest {
@@ -117,10 +118,11 @@ class CipherSuiteTest {
 
   @Test
   fun applyIntersectionRetainsTlsPrefixes() {
-    val socket = FakeSslSocket()
-    socket.enabledProtocols = arrayOf("TLSv1")
-    socket.supportedCipherSuites = arrayOf("SSL_A", "SSL_B", "SSL_C", "SSL_D", "SSL_E")
-    socket.enabledCipherSuites = arrayOf("SSL_A", "SSL_B", "SSL_C")
+    val socket = FakeSslSocket(
+      enabledProtocols = listOf("TLSv1"),
+      supportedCipherSuites = listOf("SSL_A", "SSL_B", "SSL_C", "SSL_D", "SSL_E"),
+      enabledCipherSuites = listOf("SSL_A", "SSL_B", "SSL_C"),
+    )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -128,16 +130,16 @@ class CipherSuiteTest {
         .cipherSuites("TLS_A", "TLS_C", "TLS_E")
         .build()
     applyConnectionSpec(connectionSpec, socket, false)
-    assertArrayEquals(arrayOf("TLS_A", "TLS_C"), socket.enabledCipherSuites)
+    assertThat(socket.enabledCipherSuites).containsExactly("TLS_A", "TLS_C")
   }
 
   @Test
   fun applyIntersectionRetainsSslPrefixes() {
-    val socket = FakeSslSocket()
-    socket.enabledProtocols = arrayOf("TLSv1")
-    socket.supportedCipherSuites =
-      arrayOf("TLS_A", "TLS_B", "TLS_C", "TLS_D", "TLS_E")
-    socket.enabledCipherSuites = arrayOf("TLS_A", "TLS_B", "TLS_C")
+    val socket = FakeSslSocket(
+      enabledProtocols = listOf("TLSv1"),
+      supportedCipherSuites = listOf("TLS_A", "TLS_B", "TLS_C", "TLS_D", "TLS_E"),
+      enabledCipherSuites = listOf("TLS_A", "TLS_B", "TLS_C"),
+    )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -145,15 +147,16 @@ class CipherSuiteTest {
         .cipherSuites("SSL_A", "SSL_C", "SSL_E")
         .build()
     applyConnectionSpec(connectionSpec, socket, false)
-    assertArrayEquals(arrayOf("SSL_A", "SSL_C"), socket.enabledCipherSuites)
+    assertThat(socket.enabledCipherSuites).containsExactly("SSL_A", "SSL_C")
   }
 
   @Test
   fun applyIntersectionAddsSslScsvForFallback() {
-    val socket = FakeSslSocket()
-    socket.enabledProtocols = arrayOf("TLSv1")
-    socket.supportedCipherSuites = arrayOf("SSL_A", "SSL_FALLBACK_SCSV")
-    socket.enabledCipherSuites = arrayOf("SSL_A")
+    val socket = FakeSslSocket(
+      enabledProtocols = listOf("TLSv1"),
+      supportedCipherSuites = listOf("SSL_A", "SSL_FALLBACK_SCSV"),
+      enabledCipherSuites = listOf("SSL_A"),
+    )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -161,18 +164,16 @@ class CipherSuiteTest {
         .cipherSuites("SSL_A")
         .build()
     applyConnectionSpec(connectionSpec, socket, true)
-    assertArrayEquals(
-      arrayOf("SSL_A", "SSL_FALLBACK_SCSV"),
-      socket.enabledCipherSuites,
-    )
+    assertThat(socket.enabledCipherSuites).containsExactly("SSL_A", "SSL_FALLBACK_SCSV")
   }
 
   @Test
   fun applyIntersectionAddsTlsScsvForFallback() {
-    val socket = FakeSslSocket()
-    socket.enabledProtocols = arrayOf("TLSv1")
-    socket.supportedCipherSuites = arrayOf("TLS_A", "TLS_FALLBACK_SCSV")
-    socket.enabledCipherSuites = arrayOf("TLS_A")
+    val socket = FakeSslSocket(
+      enabledProtocols = listOf("TLSv1"),
+      supportedCipherSuites = listOf("TLS_A", "TLS_FALLBACK_SCSV"),
+      enabledCipherSuites = listOf("TLS_A"),
+    )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -180,18 +181,16 @@ class CipherSuiteTest {
         .cipherSuites("TLS_A")
         .build()
     applyConnectionSpec(connectionSpec, socket, true)
-    assertArrayEquals(
-      arrayOf("TLS_A", "TLS_FALLBACK_SCSV"),
-      socket.enabledCipherSuites,
-    )
+    assertThat(socket.enabledCipherSuites).containsExactly("TLS_A", "TLS_FALLBACK_SCSV")
   }
 
   @Test
   fun applyIntersectionToProtocolVersion() {
-    val socket = FakeSslSocket()
-    socket.enabledProtocols = arrayOf("TLSv1", "TLSv1.1", "TLSv1.2")
-    socket.supportedCipherSuites = arrayOf("TLS_A")
-    socket.enabledCipherSuites = arrayOf("TLS_A")
+    val socket = FakeSslSocket(
+      enabledProtocols = listOf("TLSv1", "TLSv1.1", "TLSv1.2"),
+      supportedCipherSuites = listOf("TLS_A"),
+      enabledCipherSuites = listOf("TLS_A"),
+    )
     val connectionSpec =
       ConnectionSpec
         .Builder(true)
@@ -199,30 +198,30 @@ class CipherSuiteTest {
         .cipherSuites("TLS_A")
         .build()
     applyConnectionSpec(connectionSpec, socket, false)
-    assertArrayEquals(arrayOf("TLSv1.1", "TLSv1.2"), socket.enabledProtocols)
+    assertThat(socket.enabledProtocols).containsExactly("TLSv1.1", "TLSv1.2")
   }
 
-  internal class FakeSslSocket : DelegatingSSLSocket(null) {
-    private lateinit var enabledProtocols: Array<String>
-    private lateinit var supportedCipherSuites: Array<String>
-    private lateinit var enabledCipherSuites: Array<String>
-
-    override fun getEnabledProtocols(): Array<String> = enabledProtocols
+  class FakeSslSocket(
+    var enabledProtocols: List<String> = listOf(TlsVersion.TLS_1_3.javaName),
+    var supportedCipherSuites: List<String> = listOf(
+      CipherSuite.TLS_AES_128_GCM_SHA256.javaName,
+      CipherSuite.TLS_AES_256_GCM_SHA384.javaName,
+      CipherSuite.TLS_CHACHA20_POLY1305_SHA256.javaName,
+    ),
+    var enabledCipherSuites: List<String> = supportedCipherSuites,
+  ) : DelegatingSSLSocket(null) {
+    override fun getEnabledProtocols() = enabledProtocols.toTypedArray()
 
     override fun setEnabledProtocols(protocols: Array<String>) {
-      this.enabledProtocols = protocols
+      this.enabledProtocols = protocols.toList()
     }
 
-    override fun getSupportedCipherSuites(): Array<String> = supportedCipherSuites
+    override fun getSupportedCipherSuites() = supportedCipherSuites.toTypedArray()
 
-    fun setSupportedCipherSuites(supportedCipherSuites: Array<String>) {
-      this.supportedCipherSuites = supportedCipherSuites
-    }
-
-    override fun getEnabledCipherSuites(): Array<String> = enabledCipherSuites
+    override fun getEnabledCipherSuites() = enabledCipherSuites.toTypedArray()
 
     override fun setEnabledCipherSuites(suites: Array<String>) {
-      this.enabledCipherSuites = suites
+      this.enabledCipherSuites = suites.toList()
     }
   }
 }

--- a/okhttp/src/jvmTest/kotlin/okhttp3/FakeNetworkOkHttpTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/FakeNetworkOkHttpTest.kt
@@ -32,10 +32,11 @@ open class FakeNetworkOkHttpTest {
   val clientTestRule = OkHttpClientTestRule()
 
   @StartStop
-  private val server = MockWebServer()
-    .apply {
-      serverSocketFactory = network.serverSocketFactory
-    }
+  private val server =
+    MockWebServer()
+      .apply {
+        serverSocketFactory = network.serverSocketFactory
+      }
 
   private var client =
     clientTestRule
@@ -52,9 +53,10 @@ open class FakeNetworkOkHttpTest {
         .build(),
     )
 
-    val request = Request(
-      url = server.url("/"),
-    )
+    val request =
+      Request(
+        url = server.url("/"),
+      )
 
     val call = client.newCall(request)
 

--- a/okhttp/src/jvmTest/kotlin/okhttp3/FakeNetworkOkHttpTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/FakeNetworkOkHttpTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.junit5.StartStop
+import okhttp3.sockets.FakeNetwork
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+open class FakeNetworkOkHttpTest {
+  private val network = FakeNetwork()
+
+  @RegisterExtension
+  val clientTestRule = OkHttpClientTestRule()
+
+  @StartStop
+  private val server = MockWebServer()
+    .apply {
+      serverSocketFactory = network.serverSocketFactory
+    }
+
+  private var client =
+    clientTestRule
+      .newClientBuilder()
+      .socketFactory(network.socketFactory)
+      .build()
+
+  @Test
+  fun `happy path`() {
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .body("abc")
+        .build(),
+    )
+
+    val request = Request(
+      url = server.url("/"),
+    )
+
+    val call = client.newCall(request)
+
+    val response = call.execute()
+    assertThat(response.code).isEqualTo(200)
+    assertThat(response.body.string()).isEqualTo("abc")
+
+    val recordedRequest = server.takeRequest()
+    assertThat(recordedRequest.method).isEqualTo("GET")
+    assertThat(recordedRequest.body).isNull()
+  }
+}

--- a/okhttp/src/jvmTest/kotlin/okhttp3/FallbackTestClientSocketFactory.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/FallbackTestClientSocketFactory.kt
@@ -18,6 +18,8 @@ package okhttp3
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import okhttp3.FallbackTestClientSocketFactory.Companion.TLS_FALLBACK_SCSV
+import okhttp3.sockets.DelegatingSSLSocket
+import okhttp3.sockets.DelegatingSSLSocketFactory
 
 /**
  * An SSLSocketFactory that delegates calls. Sockets created by the delegate are wrapped with ones

--- a/okhttp/src/jvmTest/kotlin/okhttp3/FastFallbackTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/FastFallbackTest.kt
@@ -35,6 +35,7 @@ import okhttp3.CallEvent.ConnectEnd
 import okhttp3.CallEvent.ConnectFailed
 import okhttp3.CallEvent.ConnectStart
 import okhttp3.internal.http2.ErrorCode
+import okhttp3.sockets.DelegatingSocketFactory
 import okhttp3.testing.Flaky
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach

--- a/okhttp/src/jvmTest/kotlin/okhttp3/HandshakeTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/HandshakeTest.kt
@@ -25,6 +25,7 @@ import java.io.IOException
 import java.security.cert.Certificate
 import kotlin.test.assertFailsWith
 import okhttp3.Handshake.Companion.handshake
+import okhttp3.sockets.DelegatingSSLSession
 import okhttp3.tls.HeldCertificate
 import org.junit.jupiter.api.Test
 

--- a/okhttp/src/jvmTest/kotlin/okhttp3/InterceptorOverridesTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/InterceptorOverridesTest.kt
@@ -52,6 +52,8 @@ import okhttp3.CertificatePinner.Companion.pin
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.internal.connection.ConnectionListener
 import okhttp3.internal.platform.Platform
+import okhttp3.sockets.DelegatingSSLSocketFactory
+import okhttp3.sockets.DelegatingSocketFactory
 import okhttp3.testing.PlatformRule
 import okio.BufferedSink
 import okio.ForwardingFileSystem

--- a/okhttp/src/jvmTest/kotlin/okhttp3/SessionReuseTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/SessionReuseTest.kt
@@ -25,6 +25,7 @@ import javax.net.ssl.SSLSocket
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.junit5.StartStop
+import okhttp3.sockets.DelegatingSSLSocketFactory
 import okhttp3.testing.PlatformRule
 import okhttp3.testing.PlatformVersion
 import okio.ByteString.Companion.toByteString

--- a/okhttp/src/jvmTest/kotlin/okhttp3/SocketChannelTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/SocketChannelTest.kt
@@ -39,6 +39,7 @@ import okhttp3.Provider.CONSCRYPT
 import okhttp3.TlsExtensionMode.STANDARD
 import okhttp3.TlsVersion.TLS_1_2
 import okhttp3.TlsVersion.TLS_1_3
+import okhttp3.sockets.DelegatingSSLSocketFactory
 import okhttp3.testing.PlatformRule
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate

--- a/okhttp/src/jvmTest/kotlin/okhttp3/URLConnectionTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/URLConnectionTest.kt
@@ -87,6 +87,8 @@ import okhttp3.internal.http.HTTP_PERM_REDIRECT
 import okhttp3.internal.http.HTTP_TEMP_REDIRECT
 import okhttp3.internal.platform.Platform.Companion.get
 import okhttp3.java.net.cookiejar.JavaNetCookieJar
+import okhttp3.sockets.DelegatingServerSocketFactory
+import okhttp3.sockets.DelegatingSocketFactory
 import okhttp3.testing.Flaky
 import okhttp3.testing.PlatformRule
 import okio.Buffer

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http/CancelTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http/CancelTest.kt
@@ -43,8 +43,6 @@ import okhttp3.CallEvent.ConnectionAcquired
 import okhttp3.CallEvent.ConnectionReleased
 import okhttp3.CallEvent.RequestFailed
 import okhttp3.CallEvent.ResponseFailed
-import okhttp3.DelegatingServerSocketFactory
-import okhttp3.DelegatingSocketFactory
 import okhttp3.EventRecorder
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
@@ -58,6 +56,8 @@ import okhttp3.internal.http.CancelTest.CancelMode.INTERRUPT
 import okhttp3.internal.http.CancelTest.ConnectionType.H2
 import okhttp3.internal.http.CancelTest.ConnectionType.HTTP
 import okhttp3.internal.http.CancelTest.ConnectionType.HTTPS
+import okhttp3.sockets.DelegatingServerSocketFactory
+import okhttp3.sockets.DelegatingSocketFactory
 import okhttp3.testing.PlatformRule
 import okio.Buffer
 import okio.BufferedSink

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http/ThreadInterruptTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http/ThreadInterruptTest.kt
@@ -16,8 +16,6 @@
 package okhttp3.internal.http
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isIn
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.matchesPredicate
@@ -33,8 +31,6 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.assertFailsWith
 import okhttp3.Call
 import okhttp3.Callback
-import okhttp3.DelegatingServerSocketFactory
-import okhttp3.DelegatingSocketFactory
 import okhttp3.OkHttpClient
 import okhttp3.OkHttpClientTestRule
 import okhttp3.Request
@@ -43,6 +39,8 @@ import okhttp3.Response
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
+import okhttp3.sockets.DelegatingServerSocketFactory
+import okhttp3.sockets.DelegatingSocketFactory
 import okhttp3.testing.PlatformRule
 import okio.Buffer
 import okio.BufferedSink

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/platform/Jdk9PlatformTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/platform/Jdk9PlatformTest.kt
@@ -20,8 +20,8 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import javax.net.ssl.SSLSocket
-import okhttp3.DelegatingSSLSocket
 import okhttp3.internal.platform.Jdk9Platform.Companion.buildIfSupported
+import okhttp3.sockets.DelegatingSSLSocket
 import okhttp3.testing.PlatformRule
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension


### PR DESCRIPTION
This covers the happy path of OkHttp + MockWebServer with no TLS.

There's nothing too exciting here, other than using Okio's inMemorySocketPair instead of a proper TCP socket for data.

In a follow-up PR I intend to layer on TLS including all the exotic options like ECH and handshake failures. I won't do any actual cryptography, just like how this doesn't do any actual TCP packets.