### PR TITLE
Add overdue tests for FakeNetwork

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
@@ -42,7 +42,7 @@ import okio.inMemorySocketPair
 class FakeNetwork {
   private val boundServers = ConcurrentHashMap<SocketAddress, BoundServer>()
 
-  private val nextClientIpv4Address =
+  private val nextIpv4Address =
     Buffer().run {
       writeByte(192)
       writeByte(168)
@@ -51,27 +51,26 @@ class FakeNetwork {
       AtomicInteger(readInt())
     }
 
-  private var nextClientPort = AtomicInteger(5_000)
-  private var nextServerPort = AtomicInteger(6_000)
+  private var nextPort = AtomicInteger(5_000)
 
   internal val anyAddress: InetAddress
     get() = InetAddress.getByAddress(byteArrayOf(0, 0, 0, 0))
 
-  /** Generate a new unique client address. */
-  internal fun nextClientAddress(): InetSocketAddress {
-    val ipv4AddressInt = nextClientIpv4Address.getAndIncrement()
+  /** Generate a new unique address. */
+  internal fun nextSocketAddress(): InetSocketAddress {
+    val ipv4AddressInt = nextIpv4Address.getAndIncrement()
     val ipv4AddressBytes =
       Buffer()
         .writeInt(ipv4AddressInt)
         .readByteArray()
     return InetSocketAddress(
       InetAddress.getByAddress(ipv4AddressBytes),
-      nextClientPort.getAndIncrement(),
+      nextPort(),
     )
   }
 
-  /** Generate a new unique server port. */
-  fun nextServerPort() = nextServerPort.getAndIncrement()
+  /** Generate a new unique port. */
+  fun nextPort() = nextPort.getAndIncrement()
 
   val serverSocketFactory =
     object : ServerSocketFactory() {
@@ -142,7 +141,7 @@ class FakeNetwork {
   ): BoundServer? {
     val serverAddress =
       when (endpoint.port) {
-        0 -> InetSocketAddress(endpoint.address, nextServerPort())
+        0 -> InetSocketAddress(endpoint.address, nextPort())
         else -> endpoint
       }
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
@@ -29,9 +29,9 @@ import okhttp3.internal.concurrent.Lockable
 import okhttp3.internal.concurrent.notifyAll
 import okhttp3.internal.concurrent.wait
 import okhttp3.internal.concurrent.withLock
-import okhttp3.internal.connection.BufferedSocket
 import okhttp3.internal.connection.asBufferedSocket
 import okio.Buffer
+import okio.Socket
 import okio.Timeout
 import okio.inMemorySocketPair
 
@@ -273,8 +273,8 @@ internal class BoundServer(
 internal class FakeConnection(
   val clientAddress: InetSocketAddress,
   val serverAddress: InetSocketAddress,
-  val clientSocket: BufferedSocket,
-  val serverSocket: BufferedSocket,
+  val clientSocket: Socket,
+  val serverSocket: Socket,
 ) {
   override fun toString() = "$clientAddress<->$serverAddress"
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
@@ -81,7 +81,8 @@ internal class FakeServerSocket(
           FakeSocket.State.Connected(
             localAddress = connection.serverAddress,
             remoteAddress = connection.clientAddress,
-            bufferedSocket = connection.serverSocket,
+            source = SocketSource(connection.serverSocket.source),
+            sink = SocketSink(connection.serverSocket.sink),
           ),
       )
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
@@ -24,7 +24,10 @@ import java.net.SocketAddress
 import java.net.SocketException
 import java.net.SocketOption
 import java.util.concurrent.atomic.AtomicReference
-import okhttp3.internal.connection.BufferedSocket
+import okio.Buffer
+import okio.Sink
+import okio.Source
+import okio.buffer
 
 /**
  * A client or server socket.
@@ -41,11 +44,13 @@ internal class FakeSocket(
 
   private var socketReadTimeoutMillis: Long = 0
 
-  private fun connectedSocket() = (state as? State.Connected)?.bufferedSocket ?: throw IOException("not connected")
+  override fun getInputStream() =
+    (state as? State.Connected)?.inputStream
+      ?: throw IOException("not connected")
 
-  override fun getInputStream() = connectedSocket().source.inputStream()
-
-  override fun getOutputStream() = connectedSocket().sink.outputStream()
+  override fun getOutputStream() =
+    (state as? State.Connected)?.outputStream
+      ?: throw IOException("not connected")
 
   override fun getRemoteSocketAddress() = state.remoteAddress
 
@@ -110,7 +115,8 @@ internal class FakeSocket(
         State.Connected(
           localAddress = attempt.clientAddress,
           remoteAddress = attempt.serverAddress,
-          bufferedSocket = connection.clientSocket,
+          source = SocketSource(connection.clientSocket.source),
+          sink = SocketSink(connection.clientSocket.sink),
         )
 
       // If the state changed while we were connecting, the other state wins.
@@ -127,19 +133,14 @@ internal class FakeSocket(
   override fun shutdownInput() {
     while (true) {
       val previous = state
-      if (previous !is State.Connected || previous.inputShutdown) {
-        throw SocketException("cannot shutdown input")
+      if (previous !is State.Connected) throw SocketException("cannot shutdown input")
+
+      if (previous.outputShutdown) {
+        val next = State.Closed(previous)
+        if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
       }
 
-      val next =
-        when {
-          previous.outputShutdown -> State.Closed(previous)
-          else -> previous.copy(inputShutdown = true)
-        }
-
-      if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
-
-      previous.bufferedSocket.source.close()
+      previous.inputStream.close()
       break
     }
   }
@@ -149,19 +150,14 @@ internal class FakeSocket(
   override fun shutdownOutput() {
     while (true) {
       val previous = state
-      if (previous !is State.Connected || previous.outputShutdown) {
-        throw SocketException("cannot shutdown output")
+      if (previous !is State.Connected) throw SocketException("cannot shutdown output")
+
+      if (previous.inputShutdown) {
+        val next = State.Closed(previous)
+        if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
       }
 
-      val next =
-        when {
-          previous.inputShutdown -> State.Closed(previous)
-          else -> previous.copy(outputShutdown = true)
-        }
-
-      if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
-
-      previous.bufferedSocket.sink.close()
+      previous.outputStream.close()
       break
     }
   }
@@ -173,8 +169,22 @@ internal class FakeSocket(
 
       if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
 
-      (previous as? State.Connecting)?.attempt?.cancel(SocketException("client closed"))
-      (previous as? State.Connected)?.bufferedSocket?.cancel()
+      when (previous) {
+        State.New -> {
+        }
+
+        is State.Connected -> {
+          previous.inputStream.close()
+          previous.outputStream.close()
+        }
+
+        is State.Connecting -> {
+          previous.attempt.cancel(SocketException("client closed"))
+        }
+
+        is State.Closed -> {
+        }
+      }
       break
     }
   }
@@ -259,17 +269,23 @@ internal class FakeSocket(
       val attempt: ConnectAttempt,
     ) : State
 
-    data class Connected(
+    class Connected(
       override val localAddress: InetSocketAddress,
       override val remoteAddress: InetSocketAddress,
-      val bufferedSocket: BufferedSocket,
-      override val inputShutdown: Boolean = false,
-      override val outputShutdown: Boolean = false,
+      val source: SocketSource,
+      val sink: SocketSink,
     ) : State {
+      val inputStream = source.buffer().inputStream()
+      val outputStream = sink.buffer().outputStream()
+
       override val bound: Boolean
         get() = true
       override val connected: Boolean
         get() = true
+      override val inputShutdown: Boolean
+        get() = source.delegate == null
+      override val outputShutdown: Boolean
+        get() = sink.delegate == null
     }
 
     /** A closed socket remembers what happened before it was closed. */
@@ -291,5 +307,58 @@ internal class FakeSocket(
       override val outputShutdown: Boolean
         get() = true
     }
+  }
+}
+
+internal class SocketSource(
+  delegate: Source,
+) : Source {
+  private val timeout = delegate.timeout()
+
+  @Volatile var delegate: Source? = delegate
+    private set
+
+  override fun read(
+    sink: Buffer,
+    byteCount: Long,
+  ): Long {
+    val delegate = this.delegate ?: throw IOException("closed")
+    return delegate.read(sink, byteCount)
+  }
+
+  override fun timeout() = timeout
+
+  override fun close() {
+    delegate?.close()
+    delegate = null
+  }
+}
+
+internal class SocketSink(
+  delegate: Sink,
+) : Sink {
+  private val timeout = delegate.timeout()
+
+  @Volatile var delegate: Sink? = delegate
+    private set
+
+  override fun write(
+    source: Buffer,
+    byteCount: Long,
+  ) {
+    val delegate = this.delegate ?: throw IOException("closed")
+    delegate.write(source, byteCount)
+  }
+
+  override fun flush() {
+    val delegate = this.delegate ?: throw IOException("closed")
+    delegate.flush()
+  }
+
+  override fun timeout() = timeout
+
+  override fun close() {
+    delegate?.close()
+    delegate = null
   }
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
@@ -82,7 +82,7 @@ internal class FakeSocket(
 
     val attempt =
       ConnectAttempt(
-        clientAddress = network.nextClientAddress(),
+        clientAddress = network.nextSocketAddress(),
         serverAddress = endpoint,
       )
 

--- a/okhttp-testing-support/src/test/kotlin/okhttp3/sockets/FakeNetworkTest.kt
+++ b/okhttp-testing-support/src/test/kotlin/okhttp3/sockets/FakeNetworkTest.kt
@@ -83,9 +83,10 @@ class FakeNetworkTest {
     server.bind(serverAddress, 3)
 
     val server2 = network.serverSocketFactory.createServerSocket()
-    val e = assertFailsWith<SocketException> {
-      server2.bind(serverAddress, 3)
-    }
+    val e =
+      assertFailsWith<SocketException> {
+        server2.bind(serverAddress, 3)
+      }
     assertThat(e).hasMessage("bind collision")
 
     server2.close()
@@ -95,17 +96,19 @@ class FakeNetworkTest {
   fun `cannot bind after close`() {
     server.close()
 
-    val e = assertFailsWith<SocketException> {
-      server.bind(serverAddress, 3)
-    }
+    val e =
+      assertFailsWith<SocketException> {
+        server.bind(serverAddress, 3)
+      }
     assertThat(e).hasMessage("cannot bind")
   }
 
   @Test
   fun `cannot accept without bind`() {
-    val e = assertFailsWith<SocketException> {
-      server.accept()
-    }
+    val e =
+      assertFailsWith<SocketException> {
+        server.accept()
+      }
     assertThat(e).hasMessage("not bound")
   }
 
@@ -144,9 +147,10 @@ class FakeNetworkTest {
     val client = network.socketFactory.createSocket()
     client.close()
 
-    val e = assertFailsWith<SocketException> {
-      client.connect(serverAddress, 5_000)
-    }
+    val e =
+      assertFailsWith<SocketException> {
+        client.connect(serverAddress, 5_000)
+      }
     assertThat(e).hasMessage("cannot connect")
   }
 
@@ -159,12 +163,14 @@ class FakeNetworkTest {
     }
 
     val client = network.socketFactory.createSocket()
-    val elapsed = measureTime {
-      val e = assertFailsWith<SocketException> {
-        client.connect(serverAddress, 5_000)
+    val elapsed =
+      measureTime {
+        val e =
+          assertFailsWith<SocketException> {
+            client.connect(serverAddress, 5_000)
+          }
+        assertThat(e).hasMessage("server closed")
       }
-      assertThat(e).hasMessage("server closed")
-    }
     assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
   }
 
@@ -177,12 +183,14 @@ class FakeNetworkTest {
       client.close()
     }
 
-    val elapsed = measureTime {
-      val e = assertFailsWith<SocketException> {
-        client.connect(serverAddress, 5_000)
+    val elapsed =
+      measureTime {
+        val e =
+          assertFailsWith<SocketException> {
+            client.connect(serverAddress, 5_000)
+          }
+        assertThat(e).hasMessage("client closed")
       }
-      assertThat(e).hasMessage("client closed")
-    }
     assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
   }
 
@@ -194,12 +202,14 @@ class FakeNetworkTest {
       server.close()
     }
 
-    val elapsed = measureTime {
-      val e = assertFailsWith<SocketException> {
-        server.accept()
+    val elapsed =
+      measureTime {
+        val e =
+          assertFailsWith<SocketException> {
+            server.accept()
+          }
+        assertThat(e).hasMessage("closed")
       }
-      assertThat(e).hasMessage("closed")
-    }
     assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
   }
 
@@ -208,11 +218,12 @@ class FakeNetworkTest {
     server.bind(serverAddress, 3)
 
     val client = network.socketFactory.createSocket()
-    val elapsed = measureTime {
-      assertFailsWith<InterruptedIOException> {
-        client.connect(serverAddress, 250)
+    val elapsed =
+      measureTime {
+        assertFailsWith<InterruptedIOException> {
+          client.connect(serverAddress, 250)
+        }
       }
-    }
     assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
   }
 
@@ -233,20 +244,22 @@ class FakeNetworkTest {
     // previously-started clients can fill up the backlog.
     Thread.sleep(100)
     val clientD = network.socketFactory.createSocket()
-    val elapsed = measureTime {
-      assertFailsWith<InterruptedIOException> {
-        clientD.connect(serverAddress, 250)
+    val elapsed =
+      measureTime {
+        assertFailsWith<InterruptedIOException> {
+          clientD.connect(serverAddress, 250)
+        }
       }
-    }
     assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
   }
 
   private fun connectExpectingServerClose(name: String) {
     val client = network.socketFactory.createSocket()
     taskRunner.schedule(name) {
-      val e = assertFailsWith<SocketException> {
-        client.connect(serverAddress, 5_000)
-      }
+      val e =
+        assertFailsWith<SocketException> {
+          client.connect(serverAddress, 5_000)
+        }
       assertThat(e).hasMessage("server closed")
     }
   }

--- a/okhttp-testing-support/src/test/kotlin/okhttp3/sockets/FakeNetworkTest.kt
+++ b/okhttp-testing-support/src/test/kotlin/okhttp3/sockets/FakeNetworkTest.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.sockets
+
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isBetween
+import assertk.assertions.isEqualTo
+import java.io.InterruptedIOException
+import java.net.SocketException
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTime
+import okhttp3.OkHttpClientTestRule
+import okhttp3.internal.concurrent.TaskRunner
+import okio.buffer
+import okio.sink
+import okio.source
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@Tag("Slowish")
+class FakeNetworkTest {
+  @RegisterExtension
+  @JvmField
+  val clientTestRule = OkHttpClientTestRule()
+
+  val taskRunner = TaskRunner.INSTANCE
+  val network = FakeNetwork()
+  val server = network.serverSocketFactory.createServerSocket()
+  val serverAddress = network.nextSocketAddress()
+
+  @AfterEach
+  fun tearDown() {
+    server.close()
+  }
+
+  @Test
+  fun `happy path`() {
+    server.bind(serverAddress, 3)
+
+    taskRunner.schedule("client") {
+      network.socketFactory.createSocket().use { socket ->
+        socket.connect(serverAddress, 5_000)
+
+        val sink = socket.getOutputStream().sink().buffer()
+        sink.writeUtf8("hello from client\n")
+        sink.flush()
+
+        val source = socket.getInputStream().source().buffer()
+        assertThat(source.readUtf8Line()).isEqualTo("hello from server")
+      }
+    }
+
+    server.accept().use { socket ->
+      val source = socket.getInputStream().source().buffer()
+      assertThat(source.readUtf8Line()).isEqualTo("hello from client")
+
+      val sink = socket.getOutputStream().sink().buffer()
+      sink.writeUtf8("hello from server\n")
+      sink.flush()
+    }
+  }
+
+  @Test
+  fun `cannot bind when already bound by another server`() {
+    server.bind(serverAddress, 3)
+
+    val server2 = network.serverSocketFactory.createServerSocket()
+    val e = assertFailsWith<SocketException> {
+      server2.bind(serverAddress, 3)
+    }
+    assertThat(e).hasMessage("bind collision")
+
+    server2.close()
+  }
+
+  @Test
+  fun `cannot bind after close`() {
+    server.close()
+
+    val e = assertFailsWith<SocketException> {
+      server.bind(serverAddress, 3)
+    }
+    assertThat(e).hasMessage("cannot bind")
+  }
+
+  @Test
+  fun `cannot accept without bind`() {
+    val e = assertFailsWith<SocketException> {
+      server.accept()
+    }
+    assertThat(e).hasMessage("not bound")
+  }
+
+  @Test
+  fun `reuse server address`() {
+    server.bind(serverAddress, 3)
+
+    taskRunner.schedule("clientA") {
+      val client = network.socketFactory.createSocket()
+      client.connect(serverAddress, 5_000)
+      client.close()
+    }
+
+    val acceptedClientA = server.accept()
+    acceptedClientA.close()
+
+    server.close()
+
+    val server2 = network.serverSocketFactory.createServerSocket()
+    server2.bind(serverAddress, 3)
+
+    taskRunner.schedule("clientB") {
+      val client = network.socketFactory.createSocket()
+      client.connect(serverAddress, 5_000)
+      client.close()
+    }
+
+    val acceptedClientB = server2.accept()
+    acceptedClientB.close()
+
+    server2.close()
+  }
+
+  @Test
+  fun `cannot connect after close`() {
+    val client = network.socketFactory.createSocket()
+    client.close()
+
+    val e = assertFailsWith<SocketException> {
+      client.connect(serverAddress, 5_000)
+    }
+    assertThat(e).hasMessage("cannot connect")
+  }
+
+  @Test
+  fun `connect fails because server is closed`() {
+    server.bind(serverAddress, 3)
+
+    taskRunner.schedule("close server later", 250.milliseconds) {
+      server.close()
+    }
+
+    val client = network.socketFactory.createSocket()
+    val elapsed = measureTime {
+      val e = assertFailsWith<SocketException> {
+        client.connect(serverAddress, 5_000)
+      }
+      assertThat(e).hasMessage("server closed")
+    }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  @Test
+  fun `connect fails because client is closed`() {
+    server.bind(serverAddress, 3)
+
+    val client = network.socketFactory.createSocket()
+    taskRunner.schedule("close client later", 250.milliseconds) {
+      client.close()
+    }
+
+    val elapsed = measureTime {
+      val e = assertFailsWith<SocketException> {
+        client.connect(serverAddress, 5_000)
+      }
+      assertThat(e).hasMessage("client closed")
+    }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  @Test
+  fun `accept fails because server is closed`() {
+    server.bind(serverAddress, 3)
+
+    taskRunner.schedule("close server later", 250.milliseconds) {
+      server.close()
+    }
+
+    val elapsed = measureTime {
+      val e = assertFailsWith<SocketException> {
+        server.accept()
+      }
+      assertThat(e).hasMessage("closed")
+    }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  @Test
+  fun `connect timeout waiting for accept`() {
+    server.bind(serverAddress, 3)
+
+    val client = network.socketFactory.createSocket()
+    val elapsed = measureTime {
+      assertFailsWith<InterruptedIOException> {
+        client.connect(serverAddress, 250)
+      }
+    }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  /**
+   * This is effectively the same as [`connect timeout waiting for accept`], but in this test we're
+   * waiting for a slot in the server's backlog.
+   */
+  @Test
+  fun `connect timeout waiting in backlog`() {
+    server.bind(serverAddress, 3)
+
+    // Put 3 clients in the server's backlog, all blocked waiting for accept().
+    connectExpectingServerClose("clientA")
+    connectExpectingServerClose("clientB")
+    connectExpectingServerClose("clientC")
+
+    // A 4th client will time out waiting in the backlog. We don't start it for 100 ms so the
+    // previously-started clients can fill up the backlog.
+    Thread.sleep(100)
+    val clientD = network.socketFactory.createSocket()
+    val elapsed = measureTime {
+      assertFailsWith<InterruptedIOException> {
+        clientD.connect(serverAddress, 250)
+      }
+    }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  private fun connectExpectingServerClose(name: String) {
+    val client = network.socketFactory.createSocket()
+    taskRunner.schedule(name) {
+      val e = assertFailsWith<SocketException> {
+        client.connect(serverAddress, 5_000)
+      }
+      assertThat(e).hasMessage("server closed")
+    }
+  }
+
+  private fun TaskRunner.schedule(
+    name: String,
+    delay: Duration = 0.milliseconds,
+    block: () -> Unit,
+  ) {
+    newQueue().schedule(name, delay.inWholeNanoseconds) {
+      block()
+      -1L
+    }
+  }
+}


### PR DESCRIPTION
The test that uses real OkHttp is good to confirm it works, but it isn't useful for debugging problems with FakeNetwork.