### PR TITLE
Synthethise IpAddress records from ServiceMetadata hints

### DIFF
--- a/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
+++ b/okhttp-dnsoverhttps/src/test/java/okhttp3/dnsoverhttps/DnsOverHttpsTest.kt
@@ -486,6 +486,14 @@ class DnsOverHttpsTest(
                 ),
               echConfigList = "this is an encrypted client hello".encodeUtf8(),
             ),
+            Dns.Record.IpAddress(
+              hostname = "cdn.lysine.dev",
+              address = InetAddress.getByName("55.66.77.88"),
+            ),
+            Dns.Record.IpAddress(
+              hostname = "cdn.lysine.dev",
+              address = InetAddress.getByName("aa:bb::cc:dd"),
+            ),
           ),
       ),
     )

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-StateMachineDnsCall.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-StateMachineDnsCall.kt
@@ -242,8 +242,11 @@ class StateMachineDnsCall(
         val mutableReturnedIpAddresses = previous.returnedIpAddresses!!.toMutableSet()
         deduplicatedNewRecords =
           newRecords.filter { record ->
-            // Include the hostname: an address for an alternate service is a distinct result.
-            record !is Dns.Record.IpAddress || mutableReturnedIpAddresses.add(record)
+            when (record) {
+              // ServiceMetadata hints and IpAddress (A/AAAA) may overlap
+              is Dns.Record.IpAddress -> mutableReturnedIpAddresses.add(record)
+              is Dns.Record.ServiceMetadata -> true
+            }
           }
         returnedIpAddresses = mutableReturnedIpAddresses
       } else {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-StateMachineDnsCall.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-StateMachineDnsCall.kt
@@ -104,6 +104,7 @@ class StateMachineDnsCall(
           canceled = false,
           callback = callback,
           runningQueries = queries,
+          returnedIpAddresses = if (includeServiceMetadata) setOf() else null,
         )
 
       if (!state.compareAndSet(previous, next)) continue // Lost a race, retry.
@@ -167,29 +168,40 @@ class StateMachineDnsCall(
       }
 
     val dnsRecords =
-      resourceRecords.map { resourceRecord ->
+      resourceRecords.flatMap { resourceRecord ->
         when (resourceRecord) {
           is ResourceRecord.Https -> {
-            Dns.Record.ServiceMetadata(
-              hostname = resourceRecord.targetName.takeIf { it != "" } ?: request.hostname,
-              alpnIds =
-                resourceRecord.alpnIds?.mapNotNull { alpnId ->
-                  try {
-                    Protocol.get(alpnId)
-                  } catch (_: IOException) {
-                    null // Skip unrecognized ALPN ID.
-                  }
-                },
-              port = resourceRecord.port,
-              ipAddressHints = resourceRecord.ipAddressHints,
-              echConfigList = resourceRecord.echConfigList,
-            )
+            val hostname = resourceRecord.targetName.takeIf { it != "" } ?: request.hostname
+            listOf(
+              Dns.Record.ServiceMetadata(
+                hostname = hostname,
+                alpnIds =
+                  resourceRecord.alpnIds?.mapNotNull { alpnId ->
+                    try {
+                      Protocol.get(alpnId)
+                    } catch (_: IOException) {
+                      null // Skip unrecognized ALPN ID.
+                    }
+                  },
+                port = resourceRecord.port,
+                ipAddressHints = resourceRecord.ipAddressHints,
+                echConfigList = resourceRecord.echConfigList,
+              ),
+            ) +
+              resourceRecord.ipAddressHints.map { address ->
+                Dns.Record.IpAddress(
+                  hostname = hostname,
+                  address = address,
+                )
+              }
           }
 
           is ResourceRecord.IpAddress -> {
-            Dns.Record.IpAddress(
-              hostname = request.hostname,
-              address = resourceRecord.address,
+            listOf(
+              Dns.Record.IpAddress(
+                hostname = request.hostname,
+                address = resourceRecord.address,
+              ),
             )
           }
         }
@@ -224,9 +236,24 @@ class StateMachineDnsCall(
           else -> previous.pendingExceptions
         }
 
+      val returnedIpAddresses: Set<Dns.Record.IpAddress>?
+      val deduplicatedNewRecords: List<Dns.Record>
+      if (includeServiceMetadata) {
+        val mutableReturnedIpAddresses = previous.returnedIpAddresses!!.toMutableSet()
+        deduplicatedNewRecords =
+          newRecords.filter { record ->
+            // Include the hostname: an address for an alternate service is a distinct result.
+            record !is Dns.Record.IpAddress || mutableReturnedIpAddresses.add(record)
+          }
+        returnedIpAddresses = mutableReturnedIpAddresses
+      } else {
+        returnedIpAddresses = null
+        deduplicatedNewRecords = newRecords
+      }
+
       val allRecords =
         when {
-          newRecords.isNotEmpty() -> previous.pendingRecords + newRecords
+          deduplicatedNewRecords.isNotEmpty() -> previous.pendingRecords + deduplicatedNewRecords
           else -> previous.pendingRecords
         }
 
@@ -246,6 +273,7 @@ class StateMachineDnsCall(
             lockHeld = lockHeldByAnotherThread,
             pendingRecords = allRecords,
             pendingExceptions = allExceptions,
+            returnedIpAddresses = returnedIpAddresses,
           )
         if (!state.compareAndSet(previous, next)) continue // Lost a race, retry.
         return
@@ -266,6 +294,7 @@ class StateMachineDnsCall(
               lockHeld = true,
               pendingRecords = listOf(),
               pendingExceptions = allExceptions,
+              returnedIpAddresses = returnedIpAddresses,
             )
           }
         }
@@ -311,6 +340,7 @@ class StateMachineDnsCall(
       val runningQueries: List<DnsQuery>,
       val pendingRecords: List<Dns.Record> = listOf(),
       val pendingExceptions: List<IOException> = listOf(),
+      val returnedIpAddresses: Set<Dns.Record.IpAddress>?,
     ) : State {
       init {
         check(pendingRecords.isEmpty() || lockHeld)
@@ -324,6 +354,7 @@ class StateMachineDnsCall(
           runningQueries = runningQueries,
           pendingRecords = pendingRecords,
           pendingExceptions = pendingExceptions,
+          returnedIpAddresses = returnedIpAddresses,
         )
     }
 

--- a/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
+++ b/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
@@ -107,14 +107,17 @@ class StateMachineDnsCallTest {
               hostname = "lysine.dev",
               ipAddressHints = blueIpv6s + greenIpv4s,
             ),
+            // This comes from a HTTPS record hint
             Dns.Record.IpAddress(
               hostname = "lysine.dev",
               address = blueIpv6s.single(),
             ),
+            // This comes from a HTTPS record hint
             Dns.Record.IpAddress(
               hostname = "lysine.dev",
               address = greenIpv4s.single(),
             ),
+            // This comes from a late A record
             Dns.Record.IpAddress(
               hostname = "lysine.dev",
               address = blueIpv4s.single(),
@@ -147,10 +150,12 @@ class StateMachineDnsCallTest {
       assertThat(call.takeAllRecords())
         .isEqualTo(
           listOf(
+            // This comes from an A record
             Dns.Record.IpAddress(
               hostname = "lysine.dev",
               address = blueIpv6s.single(),
             ),
+            // This comes from an AAAA record
             Dns.Record.IpAddress(
               hostname = "lysine.dev",
               address = blueIpv4s.single(),
@@ -159,6 +164,7 @@ class StateMachineDnsCallTest {
               hostname = "lysine.dev",
               ipAddressHints = blueIpv6s + greenIpv4s,
             ),
+            // This comes from a HTTPS record hint
             Dns.Record.IpAddress(
               hostname = "lysine.dev",
               address = greenIpv4s.single(),

--- a/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
+++ b/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
@@ -81,6 +81,94 @@ class StateMachineDnsCallTest {
   }
 
   @Test
+  fun `partially overlapping ip address hints return first`(caching: Boolean = true) {
+    testStateMachineDnsCall {
+      val call =
+        newCall(
+          request = Dns.Request(hostname = "lysine.dev"),
+          caching = caching,
+        )
+      call.enqueue()
+
+      val httpsQuery = queryFactory.takeQuery("lysine.dev", TYPE_HTTPS)
+      val ipv6Query = queryFactory.takeQuery("lysine.dev", TYPE_AAAA)
+      val ipv4Query = queryFactory.takeQuery("lysine.dev", TYPE_A)
+
+      httpsQuery.respondServiceMetadata(
+        ipAddressHints = blueIpv6s + greenIpv4s,
+      )
+      ipv6Query.respondIpAddresses(addresses = blueIpv6s)
+      ipv4Query.respondIpAddresses(addresses = blueIpv4s)
+
+      assertThat(call.takeAllRecords())
+        .isEqualTo(
+          listOf(
+            Dns.Record.ServiceMetadata(
+              hostname = "lysine.dev",
+              ipAddressHints = blueIpv6s + greenIpv4s,
+            ),
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = blueIpv6s.single(),
+            ),
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = greenIpv4s.single(),
+            ),
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = blueIpv4s.single(),
+            ),
+          ),
+        )
+    }
+  }
+
+  @Test
+  fun `partially overlapping ip address hints return last`(caching: Boolean = true) {
+    testStateMachineDnsCall {
+      val call =
+        newCall(
+          request = Dns.Request(hostname = "lysine.dev"),
+          caching = caching,
+        )
+      call.enqueue()
+
+      val httpsQuery = queryFactory.takeQuery("lysine.dev", TYPE_HTTPS)
+      val ipv6Query = queryFactory.takeQuery("lysine.dev", TYPE_AAAA)
+      val ipv4Query = queryFactory.takeQuery("lysine.dev", TYPE_A)
+
+      ipv6Query.respondIpAddresses(addresses = blueIpv6s)
+      ipv4Query.respondIpAddresses(addresses = blueIpv4s)
+      httpsQuery.respondServiceMetadata(
+        ipAddressHints = blueIpv6s + greenIpv4s,
+      )
+
+      assertThat(call.takeAllRecords())
+        .isEqualTo(
+          listOf(
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = blueIpv6s.single(),
+            ),
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = blueIpv4s.single(),
+            ),
+            Dns.Record.ServiceMetadata(
+              hostname = "lysine.dev",
+              ipAddressHints = blueIpv6s + greenIpv4s,
+            ),
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = greenIpv4s.single(),
+            ),
+          ),
+        )
+    }
+  }
+
+  @Test
   fun `caches are independent per hostname`() {
     testStateMachineDnsCall {
       val lysineCall0 =

--- a/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
+++ b/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
@@ -81,100 +81,6 @@ class StateMachineDnsCallTest {
   }
 
   @Test
-  fun `partially overlapping ip address hints return first`(caching: Boolean = true) {
-    testStateMachineDnsCall {
-      val call =
-        newCall(
-          request = Dns.Request(hostname = "lysine.dev"),
-          caching = caching,
-        )
-      call.enqueue()
-
-      val httpsQuery = queryFactory.takeQuery("lysine.dev", TYPE_HTTPS)
-      val ipv6Query = queryFactory.takeQuery("lysine.dev", TYPE_AAAA)
-      val ipv4Query = queryFactory.takeQuery("lysine.dev", TYPE_A)
-
-      httpsQuery.respondServiceMetadata(
-        ipAddressHints = blueIpv6s + greenIpv4s,
-      )
-      ipv6Query.respondIpAddresses(addresses = blueIpv6s)
-      ipv4Query.respondIpAddresses(addresses = blueIpv4s)
-
-      assertThat(call.takeAllRecords())
-        .isEqualTo(
-          listOf(
-            Dns.Record.ServiceMetadata(
-              hostname = "lysine.dev",
-              ipAddressHints = blueIpv6s + greenIpv4s,
-            ),
-            // This comes from a HTTPS record hint
-            Dns.Record.IpAddress(
-              hostname = "lysine.dev",
-              address = blueIpv6s.single(),
-            ),
-            // This comes from a HTTPS record hint
-            Dns.Record.IpAddress(
-              hostname = "lysine.dev",
-              address = greenIpv4s.single(),
-            ),
-            // This comes from a late A record
-            Dns.Record.IpAddress(
-              hostname = "lysine.dev",
-              address = blueIpv4s.single(),
-            ),
-          ),
-        )
-    }
-  }
-
-  @Test
-  fun `partially overlapping ip address hints return last`(caching: Boolean = true) {
-    testStateMachineDnsCall {
-      val call =
-        newCall(
-          request = Dns.Request(hostname = "lysine.dev"),
-          caching = caching,
-        )
-      call.enqueue()
-
-      val httpsQuery = queryFactory.takeQuery("lysine.dev", TYPE_HTTPS)
-      val ipv6Query = queryFactory.takeQuery("lysine.dev", TYPE_AAAA)
-      val ipv4Query = queryFactory.takeQuery("lysine.dev", TYPE_A)
-
-      ipv6Query.respondIpAddresses(addresses = blueIpv6s)
-      ipv4Query.respondIpAddresses(addresses = blueIpv4s)
-      httpsQuery.respondServiceMetadata(
-        ipAddressHints = blueIpv6s + greenIpv4s,
-      )
-
-      assertThat(call.takeAllRecords())
-        .isEqualTo(
-          listOf(
-            // This comes from an A record
-            Dns.Record.IpAddress(
-              hostname = "lysine.dev",
-              address = blueIpv6s.single(),
-            ),
-            // This comes from an AAAA record
-            Dns.Record.IpAddress(
-              hostname = "lysine.dev",
-              address = blueIpv4s.single(),
-            ),
-            Dns.Record.ServiceMetadata(
-              hostname = "lysine.dev",
-              ipAddressHints = blueIpv6s + greenIpv4s,
-            ),
-            // This comes from a HTTPS record hint
-            Dns.Record.IpAddress(
-              hostname = "lysine.dev",
-              address = greenIpv4s.single(),
-            ),
-          ),
-        )
-    }
-  }
-
-  @Test
   fun `caches are independent per hostname`() {
     testStateMachineDnsCall {
       val lysineCall0 =
@@ -1096,4 +1002,98 @@ class StateMachineDnsCallTest {
       assertThat(cache.networkCount).isEqualTo(3)
       assertThat(cache.hitCount).isEqualTo(0)
     }
+
+  @Test
+  fun `ip address hints partially overlapping HTTPS first`(caching: Boolean = true) {
+    testStateMachineDnsCall {
+      val call =
+        newCall(
+          request = Dns.Request(hostname = "lysine.dev"),
+          caching = caching,
+        )
+      call.enqueue()
+
+      val httpsQuery = queryFactory.takeQuery("lysine.dev", TYPE_HTTPS)
+      val ipv6Query = queryFactory.takeQuery("lysine.dev", TYPE_AAAA)
+      val ipv4Query = queryFactory.takeQuery("lysine.dev", TYPE_A)
+
+      httpsQuery.respondServiceMetadata(
+        ipAddressHints = blueIpv6s + greenIpv4s,
+      )
+      ipv6Query.respondIpAddresses(addresses = blueIpv6s)
+      ipv4Query.respondIpAddresses(addresses = blueIpv4s)
+
+      assertThat(call.takeAllRecords())
+        .isEqualTo(
+          listOf(
+            Dns.Record.ServiceMetadata(
+              hostname = "lysine.dev",
+              ipAddressHints = blueIpv6s + greenIpv4s,
+            ),
+            // This comes from a HTTPS record hint
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = blueIpv6s.single(),
+            ),
+            // This comes from a HTTPS record hint
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = greenIpv4s.single(),
+            ),
+            // This comes from a late A record
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = blueIpv4s.single(),
+            ),
+          ),
+        )
+    }
+  }
+
+  @Test
+  fun `ip address hints partially overlapping HTTPS last`(caching: Boolean = true) {
+    testStateMachineDnsCall {
+      val call =
+        newCall(
+          request = Dns.Request(hostname = "lysine.dev"),
+          caching = caching,
+        )
+      call.enqueue()
+
+      val httpsQuery = queryFactory.takeQuery("lysine.dev", TYPE_HTTPS)
+      val ipv6Query = queryFactory.takeQuery("lysine.dev", TYPE_AAAA)
+      val ipv4Query = queryFactory.takeQuery("lysine.dev", TYPE_A)
+
+      ipv6Query.respondIpAddresses(addresses = blueIpv6s)
+      ipv4Query.respondIpAddresses(addresses = blueIpv4s)
+      httpsQuery.respondServiceMetadata(
+        ipAddressHints = blueIpv6s + greenIpv4s,
+      )
+
+      assertThat(call.takeAllRecords())
+        .isEqualTo(
+          listOf(
+            // This comes from an A record
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = blueIpv6s.single(),
+            ),
+            // This comes from an AAAA record
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = blueIpv4s.single(),
+            ),
+            Dns.Record.ServiceMetadata(
+              hostname = "lysine.dev",
+              ipAddressHints = blueIpv6s + greenIpv4s,
+            ),
+            // This comes from a HTTPS record hint
+            Dns.Record.IpAddress(
+              hostname = "lysine.dev",
+              address = greenIpv4s.single(),
+            ),
+          ),
+        )
+    }
+  }
 }

--- a/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTester.kt
+++ b/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTester.kt
@@ -279,7 +279,9 @@ class StateMachineDnsCallTester internal constructor() {
       /** Respond to a [TYPE_HTTPS] query with service metadata. */
       fun respondServiceMetadata(
         timeToLive: Duration = 300.seconds,
+        targetName: String = "",
         alpnIds: List<String>? = null,
+        ipAddressHints: List<InetAddress> = listOf(),
         echConfigList: ByteString? = null,
       ) {
         callback.onResponse(
@@ -290,7 +292,9 @@ class StateMachineDnsCallTester internal constructor() {
                 ResourceRecord.Https(
                   name = question.name,
                   timeToLive = timeToLive.inWholeSeconds.toInt(),
+                  targetName = targetName,
                   alpnIds = alpnIds,
+                  ipAddressHints = ipAddressHints,
                   echConfigList = echConfigList,
                 ),
               ),


### PR DESCRIPTION
We should consider the ip address hints as valid for dns routing, arguably we should even prefer them as they are less likely to have a mismatch.