### PR TITLE
Completely fake out TLS for testing

### DIFF
--- a/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskRunnerTesting.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/internal/concurrent/TaskRunnerTesting.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.concurrent
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+fun TaskRunner.schedule(
+  name: String,
+  delay: Duration = 0.milliseconds,
+  block: () -> Unit,
+) {
+  newQueue().schedule(name, delay.inWholeNanoseconds) {
+    block()
+    -1L
+  }
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeConnection.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeConnection.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.sockets
+
+import java.net.InetSocketAddress
+import java.net.SocketException
+import okhttp3.internal.concurrent.Lockable
+import okhttp3.internal.concurrent.notifyAll
+import okhttp3.internal.concurrent.withLock
+import okio.Socket
+import okio.Timeout
+
+/**
+ * This class implements a rendezvous point for [Handshaker.ClientInputs] and [Handshaker.ServerInputs]. When they're
+ * both provided, the client caller does a handshake and shares the handshake result.
+ */
+internal class FakeConnection(
+  val clientAddress: InetSocketAddress,
+  val serverAddress: InetSocketAddress,
+  val clientSocket: Socket,
+  val serverSocket: Socket,
+) : Lockable {
+  private var closed = false
+  private var serverInputs: Handshaker.ServerInputs? = null
+  private var handshakeResult: Result<Handshaker.Result>? = null
+
+  fun handshake(
+    handshaker: Handshaker,
+    clientInputs: Handshaker.ClientInputs,
+    timeout: Timeout,
+  ): Handshaker.Result {
+    val serverInputs =
+      withLock {
+        awaitServerInputs(timeout)
+      }
+
+    // Destroy the unencrypted socket pair; we'll build a new encrypted one to replace it.
+    clientSocket.cancel()
+    serverSocket.cancel()
+
+    val result =
+      runCatching {
+        handshaker.handshake(clientInputs, serverInputs)
+      }
+
+    withLock {
+      this.handshakeResult = result
+      notifyAll()
+    }
+
+    return result.getOrThrow()
+  }
+
+  private tailrec fun awaitServerInputs(timeout: Timeout): Handshaker.ServerInputs {
+    if (closed) throw SocketException("closed")
+    serverInputs?.let { return it }
+    timeout.waitUntilNotified(this)
+    return awaitServerInputs(timeout)
+  }
+
+  fun handshake(
+    serverInputs: Handshaker.ServerInputs,
+    timeout: Timeout,
+  ): Handshaker.Result {
+    withLock {
+      this.serverInputs = serverInputs
+      notifyAll()
+      return awaitResult(timeout).getOrThrow()
+    }
+  }
+
+  private tailrec fun awaitResult(timeout: Timeout): Result<Handshaker.Result> {
+    if (closed) throw SocketException("closed")
+    handshakeResult?.let { return it }
+    timeout.waitUntilNotified(this)
+    return awaitResult(timeout)
+  }
+
+  fun close() {
+    withLock {
+      closed = true
+      notifyAll()
+    }
+  }
+
+  override fun toString() = "$clientAddress<->$serverAddress"
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetwork.kt
@@ -31,7 +31,6 @@ import okhttp3.internal.concurrent.wait
 import okhttp3.internal.concurrent.withLock
 import okhttp3.internal.connection.asBufferedSocket
 import okio.Buffer
-import okio.Socket
 import okio.Timeout
 import okio.inMemorySocketPair
 
@@ -57,7 +56,7 @@ class FakeNetwork {
     get() = InetAddress.getByAddress(byteArrayOf(0, 0, 0, 0))
 
   /** Generate a new unique address. */
-  internal fun nextSocketAddress(): InetSocketAddress {
+  fun nextSocketAddress(): InetSocketAddress {
     val ipv4AddressInt = nextIpv4Address.getAndIncrement()
     val ipv4AddressBytes =
       Buffer()
@@ -268,13 +267,4 @@ internal class BoundServer(
   }
 
   override fun toString() = "Server@$serverAddress"
-}
-
-internal class FakeConnection(
-  val clientAddress: InetSocketAddress,
-  val serverAddress: InetSocketAddress,
-  val clientSocket: Socket,
-  val serverSocket: Socket,
-) {
-  override fun toString() = "$clientAddress<->$serverAddress"
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetworkTesting.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetworkTesting.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.sockets
+
+import okio.inMemorySocketPair
+
+/** Returns a two-element array containing mutually-connected sockets. */
+internal fun FakeNetwork.socketPair(): Array<FakeSocket> {
+  val (clientOkioSocket, serverOkioSocket) = inMemorySocketPair(maxBufferSize = 1024 * 1024)
+  val connection =
+    FakeConnection(
+      clientAddress = nextSocketAddress(),
+      serverAddress = nextSocketAddress(),
+      clientSocket = clientOkioSocket,
+      serverSocket = serverOkioSocket,
+    )
+
+  val clientJavaNetSocket =
+    FakeSocket(
+      network = this,
+      initialState =
+        FakeSocket.State.Connected(
+          connection = connection,
+          localAddress = connection.clientAddress,
+          remoteAddress = connection.serverAddress,
+          source = SocketSource(connection.clientSocket.source),
+          sink = SocketSink(connection.clientSocket.sink),
+        ),
+    )
+
+  val serverJavaNetSocket =
+    FakeSocket(
+      network = this,
+      initialState =
+        FakeSocket.State.Connected(
+          connection = connection,
+          localAddress = connection.serverAddress,
+          remoteAddress = connection.clientAddress,
+          source = SocketSource(connection.serverSocket.source),
+          sink = SocketSink(connection.serverSocket.sink),
+        ),
+    )
+
+  return arrayOf(clientJavaNetSocket, serverJavaNetSocket)
+}
+
+internal fun FakeTls.clientSocket(
+  socket: FakeSocket,
+  serverHostname: String = "testing.lysine.dev",
+  serverPort: Int = 443,
+): FakeSslSocket = sslSocketFactory.createSocket(socket, serverHostname, serverPort, true) as FakeSslSocket
+
+internal fun FakeTls.serverSocket(
+  socket: FakeSocket,
+  clientPort: Int = 1024,
+): FakeSslSocket {
+  val result = sslSocketFactory.createSocket(socket, null, clientPort, true) as FakeSslSocket
+  result.useClientMode = false
+  return result
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetworkTesting.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeNetworkTesting.kt
@@ -36,8 +36,7 @@ internal fun FakeNetwork.socketPair(): Array<FakeSocket> {
           connection = connection,
           localAddress = connection.clientAddress,
           remoteAddress = connection.serverAddress,
-          source = SocketSource(connection.clientSocket.source),
-          sink = SocketSink(connection.clientSocket.sink),
+          socket = connection.clientSocket,
         ),
     )
 
@@ -49,8 +48,7 @@ internal fun FakeNetwork.socketPair(): Array<FakeSocket> {
           connection = connection,
           localAddress = connection.serverAddress,
           remoteAddress = connection.clientAddress,
-          source = SocketSource(connection.serverSocket.source),
-          sink = SocketSink(connection.serverSocket.sink),
+          socket = connection.serverSocket,
         ),
     )
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
@@ -79,6 +79,7 @@ internal class FakeServerSocket(
         network = network,
         initialState =
           FakeSocket.State.Connected(
+            connection = connection,
             localAddress = connection.serverAddress,
             remoteAddress = connection.clientAddress,
             source = SocketSource(connection.serverSocket.source),

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeServerSocket.kt
@@ -82,8 +82,7 @@ internal class FakeServerSocket(
             connection = connection,
             localAddress = connection.serverAddress,
             remoteAddress = connection.clientAddress,
-            source = SocketSource(connection.serverSocket.source),
-            sink = SocketSink(connection.serverSocket.sink),
+            socket = connection.serverSocket,
           ),
       )
 

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
@@ -28,7 +28,9 @@ import java.net.SocketOption
 import java.util.concurrent.atomic.AtomicReference
 import okhttp3.sockets.FakeSslSocket.HandshakeState
 import okio.Buffer
+import okio.Closeable
 import okio.Sink
+import okio.Socket as OkioSocket
 import okio.Source
 import okio.buffer
 
@@ -122,8 +124,7 @@ internal class FakeSocket(
           connection = connection,
           localAddress = attempt.clientAddress,
           remoteAddress = attempt.serverAddress,
-          source = SocketSource(connection.clientSocket.source),
-          sink = SocketSink(connection.clientSocket.sink),
+          socket = connection.clientSocket,
         )
 
       // If the state changed while we were connecting, the other state wins.
@@ -187,8 +188,8 @@ internal class FakeSocket(
         }
 
         is State.Connected -> {
-          previous.inputStream.close()
-          previous.outputStream.close()
+          previous.source.cancel()
+          previous.sink.cancel()
           previous.connection.close()
         }
 
@@ -291,8 +292,9 @@ internal class FakeSocket(
       override val localAddress: InetSocketAddress,
       override val remoteAddress: InetSocketAddress,
       override val handshakeState: HandshakeState = HandshakeState.New,
-      val source: SocketSource,
-      val sink: SocketSink,
+      val socket: OkioSocket,
+      val source: SocketSource = SocketSource(socket),
+      val sink: SocketSink = SocketSink(socket),
       val inputStream: InputStream = source.buffer().inputStream(),
       val outputStream: OutputStream = sink.buffer().outputStream(),
     ) : State {
@@ -301,22 +303,20 @@ internal class FakeSocket(
       override val connected: Boolean
         get() = true
       override val inputShutdown: Boolean
-        get() = source.delegate == null
+        get() = source.closed
       override val outputShutdown: Boolean
-        get() = sink.delegate == null
+        get() = sink.closed
 
       /** Note that this yields a new [inputStream] and [outputStream]. */
       fun withHandshakeSuccess(
         handshakeState: HandshakeState.Success,
-        source: SocketSource,
-        sink: SocketSink,
+        socket: OkioSocket,
       ) = Connected(
         connection = connection,
         localAddress = localAddress,
         remoteAddress = remoteAddress,
         handshakeState = handshakeState,
-        source = source,
-        sink = sink,
+        socket = socket,
       )
 
       /** Note that this retains the previous [inputStream] and [outputStream]. */
@@ -326,6 +326,7 @@ internal class FakeSocket(
           localAddress = localAddress,
           remoteAddress = remoteAddress,
           handshakeState = handshakeState,
+          socket = socket,
           source = source,
           sink = sink,
           inputStream = inputStream,
@@ -357,57 +358,100 @@ internal class FakeSocket(
   }
 }
 
+/**
+ * This wraps an `okio.Socket` and exposes it as either the source or sink of a `java.net.Socket`.
+ *
+ * It's made complicated by how [okio.inMemorySocketPair] handles asynchronous cancellation.
+ * Canceling an in-memory socket cancels both streams for both peers. In-flight operations
+ * immediately fail and all following operations throw an [IOException].
+ *
+ * To contrast, closing a [java.net.Socket] immediately fails local operations only. The peer can
+ * read the remainder of the stream until it is exhausted.
+ *
+ * Our mitigation is straightforward enough: if the [FakeSocket] is closed while a local operation
+ * is in-flight, we trigger a maximally invasive cancel. Otherwise, we do a graceful close.
+ */
+internal open class SocketStream<T : Closeable>(
+  val socket: OkioSocket,
+  val stream: T,
+) : Closeable {
+  val closed: Boolean
+    get() = state.get() == StreamState.Closed
+
+  private val state = AtomicReference(StreamState.Ready)
+
+  override fun close() {
+    val previous = state.getAndSet(StreamState.Closed)
+    if (previous != StreamState.Closed) {
+      stream.close()
+    }
+  }
+
+  /**
+   * Equivalent to [close] unless there's a local operation in-flight, in which case the entire
+   * socket is interrupted.
+   */
+  fun cancel() {
+    val previous = state.getAndSet(StreamState.Closed)
+    if (previous != StreamState.Closed) {
+      stream.close()
+    }
+    if (previous == StreamState.Blocked) {
+      socket.cancel()
+    }
+  }
+
+  protected inline fun <T> blockingOp(block: () -> T): T {
+    if (!state.compareAndSet(StreamState.Ready, StreamState.Blocked)) {
+      throw IOException("closed")
+    }
+    try {
+      return block()
+    } finally {
+      // If the state is since closed, that's okay.
+      state.compareAndSet(StreamState.Blocked, StreamState.Ready)
+    }
+  }
+
+  internal enum class StreamState {
+    Ready,
+    Blocked,
+    Closed
+  }
+}
+
 internal class SocketSource(
-  delegate: Source,
-) : Source {
-  private val timeout = delegate.timeout()
-
-  @Volatile
-  var delegate: Source? = delegate
-    private set
-
+  socket: OkioSocket,
+) : SocketStream<Source>(socket, socket.source), Source {
   override fun read(
     sink: Buffer,
     byteCount: Long,
   ): Long {
-    val delegate = this.delegate ?: throw IOException("closed")
-    return delegate.read(sink, byteCount)
+    blockingOp {
+      return stream.read(sink, byteCount)
+    }
   }
 
-  override fun timeout() = timeout
-
-  override fun close() {
-    delegate?.close()
-    delegate = null
-  }
+  override fun timeout() = stream.timeout()
 }
 
 internal class SocketSink(
-  delegate: Sink,
-) : Sink {
-  private val timeout = delegate.timeout()
-
-  @Volatile
-  var delegate: Sink? = delegate
-    private set
-
+  socket: OkioSocket,
+) : SocketStream<Sink>(socket, socket.sink), Sink {
   override fun write(
     source: Buffer,
     byteCount: Long,
   ) {
-    val delegate = this.delegate ?: throw IOException("closed")
-    delegate.write(source, byteCount)
+    blockingOp {
+      stream.write(source, byteCount)
+    }
   }
 
   override fun flush() {
-    val delegate = this.delegate ?: throw IOException("closed")
-    delegate.flush()
+    blockingOp {
+      stream.flush()
+    }
   }
 
-  override fun timeout() = timeout
-
-  override fun close() {
-    delegate?.close()
-    delegate = null
-  }
+  override fun timeout() = stream.timeout()
 }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
@@ -18,12 +18,15 @@
 package okhttp3.sockets
 
 import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.SocketAddress
 import java.net.SocketException
 import java.net.SocketOption
 import java.util.concurrent.atomic.AtomicReference
+import okhttp3.sockets.FakeSslSocket.HandshakeState
 import okio.Buffer
 import okio.Sink
 import okio.Source
@@ -38,8 +41,8 @@ internal class FakeSocket(
   val network: FakeNetwork,
   initialState: State = State.New,
 ) : Socket() {
-  private val atomicState = AtomicReference<State>(initialState)
-  private val state: State
+  internal val atomicState = AtomicReference<State>(initialState)
+  internal val state: State
     get() = atomicState.get()
 
   private var socketReadTimeoutMillis: Long = 0
@@ -186,6 +189,7 @@ internal class FakeSocket(
         is State.Connected -> {
           previous.inputStream.close()
           previous.outputStream.close()
+          previous.connection.close()
         }
 
         is State.Closed -> {
@@ -255,6 +259,11 @@ internal class FakeSocket(
 
   override fun toString() = "FakeSocket"
 
+  /**
+   * This represents the lifecycle state of the TCP socket, which includes a nested lifecycle for
+   * the TLS handshake. Tracking the TLS lifecycle here is a layering violation, but it lets us
+   * easily keep a single atomic state for both layers.
+   */
   sealed interface State {
     val localAddress: InetSocketAddress?
       get() = null
@@ -268,6 +277,8 @@ internal class FakeSocket(
       get() = false
     val outputShutdown: Boolean
       get() = false
+    val handshakeState: HandshakeState
+      get() = HandshakeState.New
 
     object New : State
 
@@ -279,12 +290,12 @@ internal class FakeSocket(
       val connection: FakeConnection,
       override val localAddress: InetSocketAddress,
       override val remoteAddress: InetSocketAddress,
+      override val handshakeState: HandshakeState = HandshakeState.New,
       val source: SocketSource,
       val sink: SocketSink,
+      val inputStream: InputStream = source.buffer().inputStream(),
+      val outputStream: OutputStream = sink.buffer().outputStream(),
     ) : State {
-      val inputStream = source.buffer().inputStream()
-      val outputStream = sink.buffer().outputStream()
-
       override val bound: Boolean
         get() = true
       override val connected: Boolean
@@ -293,18 +304,47 @@ internal class FakeSocket(
         get() = source.delegate == null
       override val outputShutdown: Boolean
         get() = sink.delegate == null
+
+      /** Note that this yields a new [inputStream] and [outputStream]. */
+      fun withHandshakeSuccess(
+        handshakeState: HandshakeState.Success,
+        source: SocketSource,
+        sink: SocketSink,
+      ) = Connected(
+        connection = connection,
+        localAddress = localAddress,
+        remoteAddress = remoteAddress,
+        handshakeState = handshakeState,
+        source = source,
+        sink = sink,
+      )
+
+      /** Note that this retains the previous [inputStream] and [outputStream]. */
+      fun withHandshakeState(handshakeState: HandshakeState) =
+        Connected(
+          connection = connection,
+          localAddress = localAddress,
+          remoteAddress = remoteAddress,
+          handshakeState = handshakeState,
+          source = source,
+          sink = sink,
+          inputStream = inputStream,
+          outputStream = outputStream,
+        )
     }
 
     /** A closed socket remembers what happened before it was closed. */
     class Closed(
       override val localAddress: InetSocketAddress?,
       override val remoteAddress: InetSocketAddress?,
+      override val handshakeState: HandshakeState,
       override val bound: Boolean,
       override val connected: Boolean,
     ) : State {
       constructor(previous: State) : this(
         localAddress = previous.localAddress,
         remoteAddress = previous.remoteAddress,
+        handshakeState = previous.handshakeState,
         bound = previous.bound,
         connected = previous.connected,
       )

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
@@ -44,6 +44,9 @@ internal class FakeSocket(
 
   private var socketReadTimeoutMillis: Long = 0
 
+  val connection: FakeConnection?
+    get() = (state as? State.Connected)?.connection
+
   override fun getInputStream() =
     (state as? State.Connected)?.inputStream
       ?: throw IOException("not connected")
@@ -113,6 +116,7 @@ internal class FakeSocket(
 
       val next =
         State.Connected(
+          connection = connection,
           localAddress = attempt.clientAddress,
           remoteAddress = attempt.serverAddress,
           source = SocketSource(connection.clientSocket.source),
@@ -141,6 +145,7 @@ internal class FakeSocket(
       }
 
       previous.inputStream.close()
+      if (previous.outputShutdown) previous.connection.close()
       break
     }
   }
@@ -158,6 +163,7 @@ internal class FakeSocket(
       }
 
       previous.outputStream.close()
+      if (previous.inputShutdown) previous.connection.close()
       break
     }
   }
@@ -173,13 +179,13 @@ internal class FakeSocket(
         State.New -> {
         }
 
+        is State.Connecting -> {
+          previous.attempt.cancel(SocketException("client closed"))
+        }
+
         is State.Connected -> {
           previous.inputStream.close()
           previous.outputStream.close()
-        }
-
-        is State.Connecting -> {
-          previous.attempt.cancel(SocketException("client closed"))
         }
 
         is State.Closed -> {
@@ -270,6 +276,7 @@ internal class FakeSocket(
     ) : State
 
     class Connected(
+      val connection: FakeConnection,
       override val localAddress: InetSocketAddress,
       override val remoteAddress: InetSocketAddress,
       val source: SocketSource,
@@ -315,7 +322,8 @@ internal class SocketSource(
 ) : Source {
   private val timeout = delegate.timeout()
 
-  @Volatile var delegate: Source? = delegate
+  @Volatile
+  var delegate: Source? = delegate
     private set
 
   override fun read(
@@ -339,7 +347,8 @@ internal class SocketSink(
 ) : Sink {
   private val timeout = delegate.timeout()
 
-  @Volatile var delegate: Sink? = delegate
+  @Volatile
+  var delegate: Sink? = delegate
     private set
 
   override fun write(

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSocket.kt
@@ -416,13 +416,14 @@ internal open class SocketStream<T : Closeable>(
   internal enum class StreamState {
     Ready,
     Blocked,
-    Closed
+    Closed,
   }
 }
 
 internal class SocketSource(
   socket: OkioSocket,
-) : SocketStream<Source>(socket, socket.source), Source {
+) : SocketStream<Source>(socket, socket.source),
+  Source {
   override fun read(
     sink: Buffer,
     byteCount: Long,
@@ -437,7 +438,8 @@ internal class SocketSource(
 
 internal class SocketSink(
   socket: OkioSocket,
-) : SocketStream<Sink>(socket, socket.sink), Sink {
+) : SocketStream<Sink>(socket, socket.sink),
+  Sink {
   override fun write(
     source: Buffer,
     byteCount: Long,

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSslSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSslSocket.kt
@@ -1,0 +1,516 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("Since15")
+
+package okhttp3.sockets
+
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.SocketAddress
+import java.net.SocketException
+import java.net.SocketOption
+import java.nio.channels.SocketChannel
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.BiFunction
+import javax.net.ssl.HandshakeCompletedListener
+import javax.net.ssl.SSLParameters
+import javax.net.ssl.SSLPeerUnverifiedException
+import javax.net.ssl.SSLSession
+import javax.net.ssl.SSLSocket
+import okhttp3.CipherSuite
+import okhttp3.Handshake
+import okhttp3.Protocol
+import okhttp3.TlsVersion
+import okio.ByteString
+import okio.Timeout
+import okio.buffer
+
+/**
+ * The TLS layer on top of socket.
+ *
+ * The [java.net.Socket] API uses inheritance rather than composition for TLS, but this uses
+ * composition, and delegates socket methods to its underlying [FakeSocket].
+ */
+internal class FakeSslSocket(
+  val tls: FakeTls,
+  val socket: FakeSocket,
+  val hostname: String?,
+  tlsVersions: List<TlsVersion>,
+  cipherSuites: List<CipherSuite>,
+) : SSLSocket() {
+  private val atomicState = AtomicReference<State>(State.New)
+  private val state: State
+    get() = atomicState.get()
+
+  private var sslParameters =
+    SSLParameters().apply {
+      this.protocols = tlsVersions.map { it.javaName }.toTypedArray()
+      this.cipherSuites = cipherSuites.map { it.javaName }.toTypedArray()
+    }
+  private var enableSessionCreation = true
+  private var useClientMode = true
+  private var echConfigList: ByteString? = null
+
+  override fun getEnabledProtocols(): Array<String> = sslParameters.protocols
+
+  override fun setEnabledProtocols(protocols: Array<String>) {
+    sslParameters.protocols = protocols
+  }
+
+  override fun getSupportedProtocols() = tls.supportedTlsVersions.map { it.javaName }.toTypedArray()
+
+  override fun getSupportedCipherSuites() = tls.supportedCipherSuites.map { it.javaName }.toTypedArray()
+
+  override fun getEnabledCipherSuites(): Array<out String?> = sslParameters.cipherSuites
+
+  override fun setEnabledCipherSuites(cipherSuites: Array<String>) {
+    sslParameters.cipherSuites = cipherSuites
+  }
+
+  override fun setNeedClientAuth(needClientAuth: Boolean) {
+    sslParameters.needClientAuth = needClientAuth
+  }
+
+  override fun setWantClientAuth(wantClientAuth: Boolean) {
+    this.sslParameters.wantClientAuth = wantClientAuth
+  }
+
+  override fun getNeedClientAuth() = sslParameters.needClientAuth
+
+  override fun getWantClientAuth() = sslParameters.wantClientAuth
+
+  override fun setEnableSessionCreation(flag: Boolean) {
+    this.enableSessionCreation = flag
+  }
+
+  override fun getEnableSessionCreation() = enableSessionCreation
+
+  override fun getSSLParameters() = sslParameters
+
+  override fun setSSLParameters(sslParameters: SSLParameters) {
+    this.sslParameters = sslParameters
+  }
+
+  override fun setUseClientMode(useClientMode: Boolean) {
+    this.useClientMode = useClientMode
+  }
+
+  override fun getUseClientMode() = useClientMode
+
+  override fun getSession(): SSLSession = requireSession()
+
+  override fun startHandshake() {
+    requireSession()
+  }
+
+  private fun requireSession(): SSLSession {
+    val tlsVersions = sslParameters.protocols.map { TlsVersion.forJavaName(it) }
+    val cipherSuites = sslParameters.cipherSuites.map { CipherSuite.forJavaName(it) }
+    val protocols = sslParameters.applicationProtocols.map { Protocol.get(it) }
+
+    val inputs =
+      when {
+        useClientMode -> {
+          Handshaker.ClientInputs(
+            tlsVersions = tlsVersions,
+            cipherSuites = cipherSuites,
+            protocols = protocols,
+            handshakeCertificates = tls.handshakeCertificates,
+            hostname = hostname,
+            echConfigList = echConfigList,
+          )
+        }
+
+        else -> {
+          Handshaker.ServerInputs(
+            tlsVersions = tlsVersions,
+            cipherSuites = cipherSuites,
+            protocols = protocols,
+            handshakeCertificates = tls.handshakeCertificates,
+            clientAuth =
+              when {
+                sslParameters.needClientAuth -> Handshaker.ClientAuth.Required
+                sslParameters.wantClientAuth -> Handshaker.ClientAuth.Requested
+                else -> Handshaker.ClientAuth.None
+              },
+          )
+        }
+      }
+
+    if (state == State.New) {
+      val connection =
+        socket.connection
+          ?: throw SocketException("not connected")
+
+      if (!atomicState.compareAndSet(State.New, State.Handshaking)) {
+        throw SocketException("not ready")
+      }
+
+      val handshakeTimeout = Timeout()
+      val soTimeout = soTimeout
+      if (soTimeout != 0) {
+        handshakeTimeout.deadline(soTimeout.toLong(), TimeUnit.MILLISECONDS)
+      }
+
+      val next =
+        try {
+          when (inputs) {
+            is Handshaker.ClientInputs -> {
+              val result = connection.handshake(tls.handshaker, inputs, handshakeTimeout)
+              State.SecurelyConnected(
+                source = SocketSource(result.clientSocket.source),
+                sink = SocketSink(result.clientSocket.sink),
+                session =
+                  FakeSslSession(
+                    peerAddress = remoteSocketAddress,
+                    handshake = result.clientHandshake,
+                    selectedProtocol = result.selectedProtocol,
+                  ),
+              )
+            }
+
+            is Handshaker.ServerInputs -> {
+              val result = connection.handshake(inputs, handshakeTimeout)
+              State.SecurelyConnected(
+                source = SocketSource(result.serverSocket.source),
+                sink = SocketSink(result.serverSocket.sink),
+                session =
+                  FakeSslSession(
+                    peerAddress = remoteSocketAddress,
+                    handshake = result.serverHandshake,
+                    selectedProtocol = result.selectedProtocol,
+                  ),
+              )
+            }
+          }
+        } catch (e: IOException) {
+          State.HandshakeFailed(
+            exception = e,
+            session = FakeSslSession(),
+          )
+        }
+
+      // If the state changed while we were connecting, the other state wins.
+      atomicState.compareAndSet(State.Handshaking, next)
+    }
+
+    return when (val state = state) {
+      is State.HandshakeFailed -> throw state.exception
+      else -> state.session ?: error("unexpected state")
+    }
+  }
+
+  override fun getApplicationProtocol(): String? {
+    val session = state.session ?: return null
+    return session.selectedProtocol?.toString() ?: ""
+  }
+
+  override fun getInputStream() =
+    (state as? State.SecurelyConnected)?.inputStream
+      ?: throw IOException("not connected")
+
+  override fun getOutputStream() =
+    (state as? State.SecurelyConnected)?.outputStream
+      ?: throw IOException("not connected")
+
+  override fun isInputShutdown() = state.inputShutdown
+
+  override fun shutdownInput() {
+    while (true) {
+      val previous = state
+      if (previous !is State.SecurelyConnected) throw SocketException("cannot shutdown input")
+
+      if (previous.outputShutdown) {
+        val next = State.Closed(previous)
+        if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
+      }
+
+      previous.inputStream.close()
+      if (previous.outputShutdown) socket.close()
+      break
+    }
+  }
+
+  override fun isOutputShutdown() = state.outputShutdown
+
+  override fun shutdownOutput() {
+    while (true) {
+      val previous = state
+      if (previous !is State.SecurelyConnected) throw SocketException("cannot shutdown output")
+
+      if (previous.inputShutdown) {
+        val next = State.Closed(previous)
+        if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
+      }
+
+      previous.outputStream.close()
+      if (previous.inputShutdown) socket.close()
+      break
+    }
+  }
+
+  override fun close() {
+    while (true) {
+      val previous = state
+      val next = State.Closed(previous)
+
+      if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
+
+      if (previous is State.SecurelyConnected) {
+        previous.inputStream.close()
+        previous.outputStream.close()
+      }
+      socket.close()
+      break
+    }
+  }
+
+  override fun isClosed() = state is State.Closed
+
+  override fun getLocalSocketAddress() = socket.localSocketAddress
+
+  override fun getLocalAddress() = socket.localAddress
+
+  override fun getLocalPort() = socket.localPort
+
+  override fun getRemoteSocketAddress() = socket.remoteSocketAddress
+
+  override fun getInetAddress() = socket.inetAddress
+
+  override fun getPort() = socket.port
+
+  override fun getKeepAlive() = socket.keepAlive
+
+  override fun getSoLinger() = socket.soLinger
+
+  override fun getReceiveBufferSize() = socket.receiveBufferSize
+
+  override fun getSendBufferSize() = socket.sendBufferSize
+
+  override fun getSoTimeout() = socket.soTimeout
+
+  override fun getTcpNoDelay() = socket.tcpNoDelay
+
+  override fun setKeepAlive(keepAlive: Boolean) {
+    socket.setKeepAlive(keepAlive)
+  }
+
+  override fun setSendBufferSize(sendBufferSize: Int) {
+    socket.setSendBufferSize(sendBufferSize)
+  }
+
+  override fun setReceiveBufferSize(receiveBufferSize: Int) {
+    socket.setReceiveBufferSize(receiveBufferSize)
+  }
+
+  override fun setSoLinger(
+    on: Boolean,
+    timeout: Int,
+  ) {
+    socket.setSoLinger(on, timeout)
+  }
+
+  override fun setSoTimeout(soTimeout: Int) {
+    socket.soTimeout = soTimeout
+  }
+
+  override fun setTcpNoDelay(tcpNoDelay: Boolean) {
+    socket.setTcpNoDelay(tcpNoDelay)
+  }
+
+  override fun isBound() = socket.isBound
+
+  override fun isConnected() = socket.isConnected
+
+  override fun bind(localAddr: SocketAddress) {
+    socket.bind(localAddr)
+  }
+
+  override fun connect(remoteAddr: SocketAddress) {
+    socket.connect(remoteAddr)
+  }
+
+  override fun connect(
+    remoteAddr: SocketAddress,
+    timeout: Int,
+  ) {
+    socket.connect(remoteAddr, timeout)
+  }
+
+  override fun setReuseAddress(reuseAddress: Boolean) {
+    socket.setReuseAddress(reuseAddress)
+  }
+
+  override fun getReuseAddress() = socket.reuseAddress
+
+  override fun setOOBInline(oobInline: Boolean) {
+    socket.setOOBInline(oobInline)
+  }
+
+  override fun getOOBInline() = socket.oobInline
+
+  override fun setTrafficClass(trafficClass: Int) {
+    socket.setTrafficClass(trafficClass)
+  }
+
+  override fun getTrafficClass() = socket.trafficClass
+
+  override fun getChannel(): SocketChannel = socket.channel
+
+  override fun sendUrgentData(data: Int) = socket.sendUrgentData(data)
+
+  override fun setPerformancePreferences(
+    connectionTime: Int,
+    latency: Int,
+    bandwidth: Int,
+  ) = socket.setPerformancePreferences(connectionTime, latency, bandwidth)
+
+  override fun <T> setOption(
+    name: SocketOption<T?>,
+    value: T?,
+  ) = socket.setOption(name, value)
+
+  override fun <T> getOption(name: SocketOption<T?>) = socket.getOption(name)
+
+  override fun supportedOptions(): Set<SocketOption<*>> = socket.supportedOptions()
+
+  override fun addHandshakeCompletedListener(listener: HandshakeCompletedListener) = error("unsupported")
+
+  override fun removeHandshakeCompletedListener(listener: HandshakeCompletedListener) = error("unsupported")
+
+  override fun getHandshakeSession() = error("unsupported")
+
+  override fun getHandshakeApplicationProtocol() = error("unsupported")
+
+  override fun setHandshakeApplicationProtocolSelector(selector: BiFunction<SSLSocket, MutableList<String>, String>) = error("unsupported")
+
+  override fun getHandshakeApplicationProtocolSelector() = error("unsupported")
+
+  override fun toString() = "FakeSslSocket"
+
+  private sealed interface State {
+    val handshakerResult: Handshaker.Result?
+      get() = null
+    val inputShutdown: Boolean
+      get() = false
+    val outputShutdown: Boolean
+      get() = false
+    val session: FakeSslSession?
+      get() = null
+
+    object New : State
+
+    object Handshaking : State
+
+    data class SecurelyConnected(
+      override val session: FakeSslSession,
+      val source: SocketSource,
+      val sink: SocketSink,
+    ) : State {
+      val inputStream = source.buffer().inputStream()
+      val outputStream = sink.buffer().outputStream()
+
+      override val inputShutdown: Boolean
+        get() = source.delegate == null
+      override val outputShutdown: Boolean
+        get() = sink.delegate == null
+    }
+
+    class HandshakeFailed(
+      val exception: IOException,
+      override val session: FakeSslSession,
+    ) : State
+
+    class Closed(
+      override val handshakerResult: Handshaker.Result?,
+      override val session: FakeSslSession,
+    ) : State {
+      constructor(previous: State) : this(
+        handshakerResult = previous.handshakerResult,
+        session = previous.session ?: FakeSslSession(),
+      )
+
+      override val inputShutdown: Boolean
+        get() = true
+      override val outputShutdown: Boolean
+        get() = true
+    }
+  }
+
+  /**
+   * For OkHttp this is useful as a holder for the handshake.
+   *
+   * It's particularly awkward to use because it returns dummy values when used without an actual
+   * TLS handshake.
+   */
+  private class FakeSslSession(
+    val peerAddress: InetSocketAddress? = null,
+    val handshake: Handshake? = null,
+    val selectedProtocol: Protocol? = null,
+  ) : SSLSession {
+    override fun getPeerCertificates() =
+      handshake?.peerCertificates?.toTypedArray()
+        ?: throw SSLPeerUnverifiedException("no handshake")
+
+    override fun getLocalCertificates() =
+      handshake?.localCertificates?.toTypedArray()
+        ?: throw SSLPeerUnverifiedException("no handshake")
+
+    override fun getPeerPrincipal() =
+      handshake?.peerPrincipal
+        ?: throw SSLPeerUnverifiedException("no handshake")
+
+    override fun getLocalPrincipal() =
+      handshake?.localPrincipal
+        ?: throw SSLPeerUnverifiedException("no handshake")
+
+    override fun getCipherSuite() = handshake?.cipherSuite?.javaName ?: "TLS_NULL_WITH_NULL_NULL"
+
+    override fun getProtocol() = handshake?.tlsVersion?.javaName ?: "NONE"
+
+    override fun getPeerHost() = peerAddress?.hostName
+
+    override fun getPeerPort() = peerAddress?.port ?: -1
+
+    override fun getId() = error("unsupported")
+
+    override fun getSessionContext() = error("unsupported")
+
+    override fun getCreationTime() = error("unsupported")
+
+    override fun getLastAccessedTime() = error("unsupported")
+
+    override fun invalidate() = error("unsupported")
+
+    override fun isValid() = error("unsupported")
+
+    override fun putValue(
+      name: String,
+      value: Any,
+    ) = error("unsupported")
+
+    override fun getValue(name: String) = error("unsupported")
+
+    override fun removeValue(name: String) = error("unsupported")
+
+    override fun getValueNames() = error("unsupported")
+
+    override fun getPacketBufferSize() = error("unsupported")
+
+    override fun getApplicationBufferSize() = error("unsupported")
+  }
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSslSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSslSocket.kt
@@ -18,13 +18,14 @@
 package okhttp3.sockets
 
 import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.InetSocketAddress
 import java.net.SocketAddress
 import java.net.SocketException
 import java.net.SocketOption
 import java.nio.channels.SocketChannel
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 import java.util.function.BiFunction
 import javax.net.ssl.HandshakeCompletedListener
 import javax.net.ssl.SSLParameters
@@ -37,13 +38,13 @@ import okhttp3.Protocol
 import okhttp3.TlsVersion
 import okio.ByteString
 import okio.Timeout
-import okio.buffer
 
 /**
  * The TLS layer on top of socket.
  *
  * The [java.net.Socket] API uses inheritance rather than composition for TLS, but this uses
- * composition, and delegates socket methods to its underlying [FakeSocket].
+ * composition, and delegates socket methods to its underlying [FakeSocket]. It also relies on that
+ * class to hold the state of the TLS handshake.
  */
 internal class FakeSslSocket(
   val tls: FakeTls,
@@ -52,10 +53,6 @@ internal class FakeSslSocket(
   tlsVersions: List<TlsVersion>,
   cipherSuites: List<CipherSuite>,
 ) : SSLSocket() {
-  private val atomicState = AtomicReference<State>(State.New)
-  private val state: State
-    get() = atomicState.get()
-
   private var sslParameters =
     SSLParameters().apply {
       this.protocols = tlsVersions.map { it.javaName }.toTypedArray()
@@ -151,12 +148,18 @@ internal class FakeSslSocket(
         }
       }
 
-    if (state == State.New) {
+    val previous = socket.state
+    if (previous.handshakeState == HandshakeState.New) {
       val connection =
-        socket.connection
+        (previous as? FakeSocket.State.Connected)?.connection
           ?: throw SocketException("not connected")
 
-      if (!atomicState.compareAndSet(State.New, State.Handshaking)) {
+      val handshaking =
+        previous.withHandshakeState(
+          handshakeState = HandshakeState.Handshaking,
+        )
+
+      if (!socket.atomicState.compareAndSet(previous, handshaking)) {
         throw SocketException("not ready")
       }
 
@@ -171,115 +174,97 @@ internal class FakeSslSocket(
           when (inputs) {
             is Handshaker.ClientInputs -> {
               val result = connection.handshake(tls.handshaker, inputs, handshakeTimeout)
-              State.SecurelyConnected(
+              previous.withHandshakeSuccess(
                 source = SocketSource(result.clientSocket.source),
                 sink = SocketSink(result.clientSocket.sink),
-                session =
-                  FakeSslSession(
-                    peerAddress = remoteSocketAddress,
-                    handshake = result.clientHandshake,
-                    selectedProtocol = result.selectedProtocol,
+                handshakeState =
+                  HandshakeState.Success(
+                    session =
+                      FakeSslSession(
+                        peerAddress = remoteSocketAddress,
+                        handshake = result.clientHandshake,
+                        selectedProtocol = result.selectedProtocol,
+                      ),
                   ),
               )
             }
 
             is Handshaker.ServerInputs -> {
               val result = connection.handshake(inputs, handshakeTimeout)
-              State.SecurelyConnected(
+              previous.withHandshakeSuccess(
                 source = SocketSource(result.serverSocket.source),
                 sink = SocketSink(result.serverSocket.sink),
-                session =
-                  FakeSslSession(
-                    peerAddress = remoteSocketAddress,
-                    handshake = result.serverHandshake,
-                    selectedProtocol = result.selectedProtocol,
+                handshakeState =
+                  HandshakeState.Success(
+                    session =
+                      FakeSslSession(
+                        peerAddress = remoteSocketAddress,
+                        handshake = result.serverHandshake,
+                        selectedProtocol = result.selectedProtocol,
+                      ),
                   ),
               )
             }
           }
         } catch (e: IOException) {
-          State.HandshakeFailed(
-            exception = e,
-            session = FakeSslSession(),
+          previous.withHandshakeState(
+            handshakeState =
+              HandshakeState.Failed(
+                exception = e,
+                session = FakeSslSession(),
+              ),
           )
         }
 
       // If the state changed while we were connecting, the other state wins.
-      atomicState.compareAndSet(State.Handshaking, next)
+      socket.atomicState.compareAndSet(handshaking, next)
     }
 
-    return when (val state = state) {
-      is State.HandshakeFailed -> throw state.exception
-      else -> state.session ?: error("unexpected state")
+    val state = socket.state
+    if (state is FakeSocket.State.Closed) throw SocketException("closed")
+
+    return when (val handshakeState = state.handshakeState) {
+      is HandshakeState.Failed -> throw handshakeState.exception
+      else -> handshakeState.session ?: error("unexpected state")
     }
   }
 
   override fun getApplicationProtocol(): String? {
-    val session = state.session ?: return null
+    val session = socket.state.handshakeState.session ?: return null
     return session.selectedProtocol?.toString() ?: ""
   }
 
-  override fun getInputStream() =
-    (state as? State.SecurelyConnected)?.inputStream
-      ?: throw IOException("not connected")
-
-  override fun getOutputStream() =
-    (state as? State.SecurelyConnected)?.outputStream
-      ?: throw IOException("not connected")
-
-  override fun isInputShutdown() = state.inputShutdown
-
-  override fun shutdownInput() {
-    while (true) {
-      val previous = state
-      if (previous !is State.SecurelyConnected) throw SocketException("cannot shutdown input")
-
-      if (previous.outputShutdown) {
-        val next = State.Closed(previous)
-        if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
-      }
-
-      previous.inputStream.close()
-      if (previous.outputShutdown) socket.close()
-      break
-    }
+  override fun getInputStream(): InputStream {
+    val state = socket.state
+    if (state !is FakeSocket.State.Connected) throw IOException("not connected")
+    if (state.handshakeState.session == null) throw IOException("no handshake")
+    return state.inputStream
   }
 
-  override fun isOutputShutdown() = state.outputShutdown
+  override fun getOutputStream(): OutputStream {
+    val state = socket.state
+    if (state !is FakeSocket.State.Connected) throw IOException("not connected")
+    if (state.handshakeState.session == null) throw IOException("no handshake")
+    return state.outputStream
+  }
+
+  override fun isInputShutdown() = socket.isInputShutdown()
+
+  override fun shutdownInput() {
+    socket.shutdownInput()
+  }
+
+  override fun isOutputShutdown() = socket.isOutputShutdown
 
   override fun shutdownOutput() {
-    while (true) {
-      val previous = state
-      if (previous !is State.SecurelyConnected) throw SocketException("cannot shutdown output")
-
-      if (previous.inputShutdown) {
-        val next = State.Closed(previous)
-        if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
-      }
-
-      previous.outputStream.close()
-      if (previous.inputShutdown) socket.close()
-      break
-    }
+    socket.shutdownOutput()
   }
 
   override fun close() {
-    while (true) {
-      val previous = state
-      val next = State.Closed(previous)
-
-      if (!atomicState.compareAndSet(previous, next)) continue // Lost a race, retry.
-
-      if (previous is State.SecurelyConnected) {
-        previous.inputStream.close()
-        previous.outputStream.close()
-      }
-      socket.close()
-      break
-    }
+    socket.close()
   }
 
-  override fun isClosed() = state is State.Closed
+  override fun isClosed() = socket.isClosed
 
   override fun getLocalSocketAddress() = socket.localSocketAddress
 
@@ -402,53 +387,22 @@ internal class FakeSslSocket(
 
   override fun toString() = "FakeSslSocket"
 
-  private sealed interface State {
-    val handshakerResult: Handshaker.Result?
-      get() = null
-    val inputShutdown: Boolean
-      get() = false
-    val outputShutdown: Boolean
-      get() = false
+  internal sealed interface HandshakeState {
     val session: FakeSslSession?
       get() = null
 
-    object New : State
+    object New : HandshakeState
 
-    object Handshaking : State
+    object Handshaking : HandshakeState
 
-    data class SecurelyConnected(
+    data class Success(
       override val session: FakeSslSession,
-      val source: SocketSource,
-      val sink: SocketSink,
-    ) : State {
-      val inputStream = source.buffer().inputStream()
-      val outputStream = sink.buffer().outputStream()
+    ) : HandshakeState
 
-      override val inputShutdown: Boolean
-        get() = source.delegate == null
-      override val outputShutdown: Boolean
-        get() = sink.delegate == null
-    }
-
-    class HandshakeFailed(
+    class Failed(
       val exception: IOException,
       override val session: FakeSslSession,
-    ) : State
-
-    class Closed(
-      override val handshakerResult: Handshaker.Result?,
-      override val session: FakeSslSession,
-    ) : State {
-      constructor(previous: State) : this(
-        handshakerResult = previous.handshakerResult,
-        session = previous.session ?: FakeSslSession(),
-      )
-
-      override val inputShutdown: Boolean
-        get() = true
-      override val outputShutdown: Boolean
-        get() = true
-    }
+    ) : HandshakeState
   }
 
   /**
@@ -457,7 +411,7 @@ internal class FakeSslSocket(
    * It's particularly awkward to use because it returns dummy values when used without an actual
    * TLS handshake.
    */
-  private class FakeSslSession(
+  internal class FakeSslSession(
     val peerAddress: InetSocketAddress? = null,
     val handshake: Handshake? = null,
     val selectedProtocol: Protocol? = null,

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSslSocket.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeSslSocket.kt
@@ -175,8 +175,7 @@ internal class FakeSslSocket(
             is Handshaker.ClientInputs -> {
               val result = connection.handshake(tls.handshaker, inputs, handshakeTimeout)
               previous.withHandshakeSuccess(
-                source = SocketSource(result.clientSocket.source),
-                sink = SocketSink(result.clientSocket.sink),
+                socket = result.clientSocket,
                 handshakeState =
                   HandshakeState.Success(
                     session =
@@ -192,8 +191,7 @@ internal class FakeSslSocket(
             is Handshaker.ServerInputs -> {
               val result = connection.handshake(inputs, handshakeTimeout)
               previous.withHandshakeSuccess(
-                source = SocketSource(result.serverSocket.source),
-                sink = SocketSink(result.serverSocket.sink),
+                socket = result.serverSocket,
                 handshakeState =
                   HandshakeState.Success(
                     session =

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeTls.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeTls.kt
@@ -69,7 +69,7 @@ class FakeTls(
 
       override fun createSocket(
         socket: Socket,
-        host: String,
+        host: String?,
         port: Int,
         autoClose: Boolean,
       ): FakeSslSocket {
@@ -84,12 +84,12 @@ class FakeTls(
       }
 
       override fun createSocket(
-        host: String,
+        host: String?,
         port: Int,
       ) = error("unsupported")
 
       override fun createSocket(
-        host: String,
+        host: String?,
         port: Int,
         localHost: InetAddress,
         localPort: Int,
@@ -103,7 +103,7 @@ class FakeTls(
       override fun createSocket(
         address: InetAddress,
         port: Int,
-        localAddress: InetAddress,
+        localAddress: InetAddress?,
         localPort: Int,
       ) = error("unsupported")
     }

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeTls.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeTls.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.sockets
+
+import java.io.InputStream
+import java.net.InetAddress
+import java.net.Socket
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.X509TrustManager
+import okhttp3.CipherSuite
+import okhttp3.TlsVersion
+import okhttp3.tls.HandshakeCertificates
+
+/**
+ * A fake TLS stack to accompany our fake network.
+ *
+ * Unlike [FakeNetwork] which is a natural singleton, we expect each peer to have their own
+ * independent instances of [FakeTls]. This allows us to simulate different configurations for
+ * each peer.
+ */
+class FakeTls(
+  val handshaker: Handshaker,
+  val handshakeCertificates: HandshakeCertificates,
+  val supportedTlsVersions: List<TlsVersion> =
+    listOf(
+      TlsVersion.TLS_1_3,
+      TlsVersion.TLS_1_2,
+    ),
+  val enabledTlsVersions: List<TlsVersion> = supportedTlsVersions,
+  val supportedCipherSuites: List<CipherSuite> =
+    listOf(
+      CipherSuite.TLS_AES_128_GCM_SHA256, // TLSv1.3.
+      CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // TLSv1.2
+    ),
+  val defaultCipherSuites: List<CipherSuite> = supportedCipherSuites,
+) {
+  val trustManager: X509TrustManager
+    get() = handshakeCertificates.trustManager
+
+  val sslSocketFactory =
+    object : SSLSocketFactory() {
+      override fun getDefaultCipherSuites() = this@FakeTls.defaultCipherSuites.map { it.javaName }.toTypedArray()
+
+      override fun getSupportedCipherSuites() = this@FakeTls.supportedCipherSuites.map { it.javaName }.toTypedArray()
+
+      override fun createSocket(
+        socket: Socket,
+        consumed: InputStream,
+        autoClose: Boolean,
+      ) = error("unsupported")
+
+      override fun createSocket() = error("unsupported")
+
+      override fun createSocket(
+        socket: Socket,
+        host: String,
+        port: Int,
+        autoClose: Boolean,
+      ): FakeSslSocket {
+        require(autoClose)
+        return FakeSslSocket(
+          tls = this@FakeTls,
+          socket = socket as FakeSocket,
+          hostname = host,
+          tlsVersions = this@FakeTls.enabledTlsVersions,
+          cipherSuites = this@FakeTls.defaultCipherSuites,
+        )
+      }
+
+      override fun createSocket(
+        host: String,
+        port: Int,
+      ) = error("unsupported")
+
+      override fun createSocket(
+        host: String,
+        port: Int,
+        localHost: InetAddress,
+        localPort: Int,
+      ) = error("unsupported")
+
+      override fun createSocket(
+        host: InetAddress?,
+        port: Int,
+      ) = error("unsupported")
+
+      override fun createSocket(
+        address: InetAddress,
+        port: Int,
+        localAddress: InetAddress,
+        localPort: Int,
+      ) = error("unsupported")
+    }
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeTls.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/FakeTls.kt
@@ -30,6 +30,9 @@ import okhttp3.tls.HandshakeCertificates
  * Unlike [FakeNetwork] which is a natural singleton, we expect each peer to have their own
  * independent instances of [FakeTls]. This allows us to simulate different configurations for
  * each peer.
+ *
+ * Note that only the client's [handshaker] is used, and its result is used by both client and
+ * server.
  */
 class FakeTls(
   val handshaker: Handshaker,

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/Handshaker.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/Handshaker.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.sockets
+
+import java.io.IOException
+import okhttp3.CipherSuite
+import okhttp3.Handshake
+import okhttp3.Protocol
+import okhttp3.TlsVersion
+import okhttp3.tls.HandshakeCertificates
+import okio.ByteString
+import okio.Socket
+
+/**
+ * This implements the policy of a TLS handshake, deciding which [TlsVersion], [CipherSuite], and
+ * [Protocol] to negotiate.
+ *
+ * In a real TLS handshake the client and server are mutually-distrusting parties, and they each
+ * implement their own handshaking logic. For this fake, we use a single handshaker that makes
+ * decisions on behalf of both parties.
+ */
+interface Handshaker {
+  /**
+   * Returns a two-element array containing the client result and the server result.
+   *
+   * @throws [EchRejectedException] if that is why this handshake was rejected.
+   */
+  @Throws(IOException::class)
+  fun handshake(
+    client: ClientInputs,
+    server: ServerInputs,
+  ): Result
+
+  sealed interface Inputs {
+    val tlsVersions: List<TlsVersion>
+    val cipherSuites: List<CipherSuite>
+    val protocols: List<Protocol>?
+    val handshakeCertificates: HandshakeCertificates
+  }
+
+  class ClientInputs(
+    override val tlsVersions: List<TlsVersion>,
+    override val cipherSuites: List<CipherSuite>,
+    override val protocols: List<Protocol>?,
+    override val handshakeCertificates: HandshakeCertificates,
+    val hostname: String?,
+    val echConfigList: ByteString?,
+  ) : Inputs
+
+  class ServerInputs(
+    override val tlsVersions: List<TlsVersion>,
+    override val cipherSuites: List<CipherSuite>,
+    override val protocols: List<Protocol>?,
+    override val handshakeCertificates: HandshakeCertificates,
+    val clientAuth: ClientAuth,
+  ) : Inputs
+
+  enum class ClientAuth {
+    None,
+    Requested,
+    Required,
+  }
+
+  class Result(
+    val clientSocket: Socket,
+    val serverSocket: Socket,
+    val clientHandshake: Handshake,
+    val serverHandshake: Handshake,
+    val selectedProtocol: Protocol?,
+  )
+}

--- a/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/InsecureHandshaker.kt
+++ b/okhttp-testing-support/src/main/kotlin/okhttp3/sockets/InsecureHandshaker.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.sockets
+
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLHandshakeException
+import javax.net.ssl.X509KeyManager
+import okhttp3.Handshake
+import okhttp3.internal.connection.asBufferedSocket
+import okio.inMemorySocketPair
+
+/**
+ * A basic handshaker that makes policy decisions without doing any useful cryptography.
+ */
+class InsecureHandshaker : Handshaker {
+  override fun handshake(
+    client: Handshaker.ClientInputs,
+    server: Handshaker.ServerInputs,
+  ): Handshaker.Result {
+    val tlsVersion =
+      server.tlsVersions.firstOrNull { it in client.tlsVersions }
+        ?: throw SSLHandshakeException("no matching TLS version")
+    val cipherSuite =
+      server.cipherSuites.firstOrNull { it in client.cipherSuites }
+        ?: throw SSLHandshakeException("no matching cipher suite")
+    val protocol =
+      server.protocols
+        .orEmpty()
+        .firstOrNull { it in client.protocols.orEmpty() }
+
+    // For more accuracy, we should pick the key type based on the cipher suite.
+    val keyType = "EC"
+
+    val clientCertificates =
+      when (server.clientAuth) {
+        Handshaker.ClientAuth.Required -> {
+          client.handshakeCertificates.keyManager.clientCertificatesOrNull(keyType)
+            ?: throw SSLHandshakeException("required client certificates not sent")
+        }
+
+        Handshaker.ClientAuth.Requested -> {
+          client.handshakeCertificates.keyManager.clientCertificatesOrNull(keyType)
+            ?: listOf()
+        }
+
+        Handshaker.ClientAuth.None -> {
+          listOf()
+        }
+      }
+
+    val serverCertificates = server.handshakeCertificates.keyManager.serverCertificates(keyType)
+
+    val (clientSocket, serverSocket) = inMemorySocketPair(maxBufferSize = 1024 * 1024)
+
+    return Handshaker.Result(
+      clientSocket = clientSocket.asBufferedSocket(),
+      serverSocket = serverSocket.asBufferedSocket(),
+      clientHandshake =
+        Handshake.get(
+          tlsVersion = tlsVersion,
+          cipherSuite = cipherSuite,
+          peerCertificates = serverCertificates,
+          localCertificates = clientCertificates,
+        ),
+      serverHandshake =
+        Handshake.get(
+          tlsVersion = tlsVersion,
+          cipherSuite = cipherSuite,
+          peerCertificates = clientCertificates,
+          localCertificates = serverCertificates,
+        ),
+      selectedProtocol = protocol,
+    )
+  }
+
+  private fun X509KeyManager.serverCertificates(keyType: String): List<X509Certificate> {
+    val alias =
+      getServerAliases(keyType, null)
+        .firstOrNull()
+        ?: throw SSLHandshakeException("no server aliases for $keyType")
+
+    return getCertificateChain(alias).toList()
+  }
+
+  private fun X509KeyManager.clientCertificatesOrNull(keyType: String): List<X509Certificate>? {
+    val alias =
+      getClientAliases(keyType, null)
+        .firstOrNull()
+        ?: return null
+
+    return getCertificateChain(alias).toList()
+  }
+}

--- a/okhttp-testing-support/src/test/kotlin/okhttp3/sockets/FakeNetworkTest.kt
+++ b/okhttp-testing-support/src/test/kotlin/okhttp3/sockets/FakeNetworkTest.kt
@@ -22,11 +22,11 @@ import assertk.assertions.isEqualTo
 import java.io.InterruptedIOException
 import java.net.SocketException
 import kotlin.test.assertFailsWith
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
 import okhttp3.OkHttpClientTestRule
 import okhttp3.internal.concurrent.TaskRunner
+import okhttp3.internal.concurrent.schedule
 import okio.buffer
 import okio.sink
 import okio.source
@@ -261,17 +261,6 @@ class FakeNetworkTest {
           client.connect(serverAddress, 5_000)
         }
       assertThat(e).hasMessage("server closed")
-    }
-  }
-
-  private fun TaskRunner.schedule(
-    name: String,
-    delay: Duration = 0.milliseconds,
-    block: () -> Unit,
-  ) {
-    newQueue().schedule(name, delay.inWholeNanoseconds) {
-      block()
-      -1L
     }
   }
 }

--- a/okhttp-testing-support/src/test/kotlin/okhttp3/sockets/FakeTlsTest.kt
+++ b/okhttp-testing-support/src/test/kotlin/okhttp3/sockets/FakeTlsTest.kt
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.sockets
+
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isBetween
+import assertk.assertions.isEqualTo
+import java.io.InterruptedIOException
+import java.net.SocketException
+import javax.net.ssl.SSLHandshakeException
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTime
+import okhttp3.OkHttpClientTestRule
+import okhttp3.internal.concurrent.TaskRunner
+import okhttp3.internal.concurrent.schedule
+import okhttp3.sockets.Handshaker.ClientInputs
+import okhttp3.sockets.Handshaker.ServerInputs
+import okhttp3.tls.internal.TlsUtil
+import okio.buffer
+import okio.sink
+import okio.source
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@Tag("Slowish")
+class FakeTlsTest {
+  @RegisterExtension
+  @JvmField
+  val clientTestRule = OkHttpClientTestRule()
+
+  val taskRunner = TaskRunner.INSTANCE
+  val network = FakeNetwork()
+
+  val clientTls =
+    FakeTls(
+      handshaker = InsecureHandshaker(),
+      handshakeCertificates = TlsUtil.localhost(),
+    )
+  val serverTls =
+    FakeTls(
+      handshaker = InsecureHandshaker(),
+      handshakeCertificates = TlsUtil.localhost(),
+    )
+
+  @Test
+  fun `happy path`() {
+    val (clientSocket, serverSocket) = network.socketPair()
+    val clientSslSocket = clientTls.clientSocket(clientSocket)
+    val serverSslSocket = serverTls.serverSocket(serverSocket)
+
+    taskRunner.schedule("client") {
+      clientSslSocket.startHandshake()
+      clientSslSocket.use { socket ->
+        val sink = socket.getOutputStream().sink().buffer()
+        sink.writeUtf8("hello from client\n")
+        sink.flush()
+
+        val source = socket.getInputStream().source().buffer()
+        assertThat(source.readUtf8Line()).isEqualTo("hello from server")
+      }
+    }
+
+    serverSslSocket.startHandshake()
+    serverSslSocket.use { socket ->
+      val source = socket.getInputStream().source().buffer()
+      assertThat(source.readUtf8Line()).isEqualTo("hello from client")
+
+      val sink = socket.getOutputStream().sink().buffer()
+      sink.writeUtf8("hello from server\n")
+      sink.flush()
+    }
+  }
+
+  @Test
+  fun `handshake fails`() {
+    val (clientSocket, serverSocket) = network.socketPair()
+
+    val clientTls =
+      FakeTls(
+        handshaker =
+          object : Handshaker {
+            private var handshakeCount = 0
+
+            override fun handshake(
+              client: ClientInputs,
+              server: ServerInputs,
+            ): Handshaker.Result {
+              assertThat(handshakeCount++).isEqualTo(0)
+              throw SSLHandshakeException("boom!")
+            }
+          },
+        handshakeCertificates = TlsUtil.localhost(),
+      )
+
+    val clientSslSocket = clientTls.clientSocket(clientSocket)
+    val serverSslSocket = serverTls.serverSocket(serverSocket)
+
+    taskRunner.schedule("client") {
+      val e =
+        assertFailsWith<SSLHandshakeException> {
+          clientSslSocket.startHandshake()
+        }
+      assertThat(e).hasMessage("boom!")
+    }
+
+    val e =
+      assertFailsWith<SSLHandshakeException> {
+        serverSslSocket.startHandshake()
+      }
+    assertThat(e).hasMessage("boom!")
+
+    // Exception is memoized.
+    assertFailsWith<SSLHandshakeException> {
+      serverSslSocket.getSession()
+    }
+
+    clientSslSocket.close()
+    serverSslSocket.close()
+  }
+
+  @Test
+  fun `connection closed during successful handshake`() {
+    val (clientSocket, serverSocket) = network.socketPair()
+
+    val clientTls =
+      FakeTls(
+        handshaker =
+          object : Handshaker {
+            override fun handshake(
+              client: ClientInputs,
+              server: ServerInputs,
+            ): Handshaker.Result {
+              clientSocket.close()
+              return InsecureHandshaker().handshake(client, server)
+            }
+          },
+        handshakeCertificates = TlsUtil.localhost(),
+      )
+
+    val clientSslSocket = clientTls.clientSocket(clientSocket)
+    val serverSslSocket = serverTls.serverSocket(serverSocket)
+
+    taskRunner.schedule("server") {
+      val e =
+        assertFailsWith<SocketException> {
+          serverSslSocket.startHandshake()
+        }
+      assertThat(e).hasMessage("closed")
+    }
+
+    val e =
+      assertFailsWith<SocketException> {
+        clientSslSocket.startHandshake()
+      }
+    assertThat(e).hasMessage("closed")
+  }
+
+  @Test
+  fun `client handshake timeout`() {
+    val (clientSocket, _) = network.socketPair()
+    clientSocket.soTimeout = 250
+
+    val clientSslSocket = clientTls.clientSocket(clientSocket)
+
+    val elapsed =
+      measureTime {
+        assertFailsWith<InterruptedIOException> {
+          clientSslSocket.startHandshake()
+        }
+      }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  @Test
+  fun `client handshake fails because server is closed`() {
+    val (clientSocket, serverSocket) = network.socketPair()
+    clientSocket.soTimeout = 5_000
+
+    val clientSslSocket = clientTls.clientSocket(clientSocket)
+
+    taskRunner.schedule("close server later", 250.milliseconds) {
+      serverSocket.close()
+    }
+
+    val elapsed =
+      measureTime {
+        assertFailsWith<SocketException> {
+          clientSslSocket.startHandshake()
+        }
+      }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  @Test
+  fun `client handshake fails because client is closed`() {
+    val (clientSocket, _) = network.socketPair()
+    clientSocket.soTimeout = 5_000
+
+    val clientSslSocket = clientTls.clientSocket(clientSocket)
+
+    taskRunner.schedule("close client later", 250.milliseconds) {
+      clientSocket.close()
+    }
+
+    val elapsed =
+      measureTime {
+        assertFailsWith<SocketException> {
+          clientSslSocket.startHandshake()
+        }
+      }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  @Test
+  fun `server handshake timeout`() {
+    val (_, serverSocket) = network.socketPair()
+    serverSocket.soTimeout = 250
+
+    val serverSslSocket = serverTls.clientSocket(serverSocket)
+
+    val elapsed =
+      measureTime {
+        assertFailsWith<InterruptedIOException> {
+          serverSslSocket.startHandshake()
+        }
+      }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  @Test
+  fun `server handshake fails because server is closed`() {
+    val (_, serverSocket) = network.socketPair()
+    serverSocket.soTimeout = 5_000
+
+    val serverSslSocket = serverTls.clientSocket(serverSocket)
+
+    taskRunner.schedule("close server later", 250.milliseconds) {
+      serverSocket.close()
+    }
+
+    val elapsed =
+      measureTime {
+        assertFailsWith<SocketException> {
+          serverSslSocket.startHandshake()
+        }
+      }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+
+  @Test
+  fun `server handshake fails because client is closed`() {
+    val (clientSocket, serverSocket) = network.socketPair()
+    serverSocket.soTimeout = 5_000
+
+    val serverSslSocket = serverTls.clientSocket(serverSocket)
+
+    taskRunner.schedule("close server later", 250.milliseconds) {
+      clientSocket.close()
+    }
+
+    val elapsed =
+      measureTime {
+        assertFailsWith<SocketException> {
+          serverSslSocket.startHandshake()
+        }
+      }
+    assertThat(elapsed).isBetween(200.milliseconds, 350.milliseconds)
+  }
+}

--- a/okhttp/src/jvmTest/kotlin/okhttp3/FakeNetworkOkHttpTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/FakeNetworkOkHttpTest.kt
@@ -22,11 +22,28 @@ import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.junit5.StartStop
 import okhttp3.sockets.FakeNetwork
+import okhttp3.sockets.FakeTls
+import okhttp3.sockets.InsecureHandshaker
+import okhttp3.tls.internal.TlsUtil
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
 open class FakeNetworkOkHttpTest {
   private val network = FakeNetwork()
+
+  private val handshaker = InsecureHandshaker()
+
+  private val clientTls =
+    FakeTls(
+      handshaker = handshaker,
+      handshakeCertificates = TlsUtil.localhost(),
+    )
+
+  private val serverTls =
+    FakeTls(
+      handshaker = handshaker,
+      handshakeCertificates = TlsUtil.localhost(),
+    )
 
   @RegisterExtension
   val clientTestRule = OkHttpClientTestRule()
@@ -46,6 +63,16 @@ open class FakeNetworkOkHttpTest {
 
   @Test
   fun `happy path`() {
+    makeRequest()
+  }
+
+  @Test
+  fun `happy path with TLS`() {
+    enableTls()
+    makeRequest()
+  }
+
+  fun makeRequest() {
     server.enqueue(
       MockResponse
         .Builder()
@@ -67,5 +94,14 @@ open class FakeNetworkOkHttpTest {
     val recordedRequest = server.takeRequest()
     assertThat(recordedRequest.method).isEqualTo("GET")
     assertThat(recordedRequest.body).isNull()
+  }
+
+  private fun enableTls() {
+    client =
+      client
+        .newBuilder()
+        .sslSocketFactory(clientTls.sslSocketFactory, clientTls.trustManager)
+        .build()
+    server.useHttps(serverTls.sslSocketFactory)
   }
 }


### PR DESCRIPTION
This covers the happy path of OkHttp + MockWebServer with HTTPS.

This doesn't actually perform anything cryptographic; certificates and protocols and things are transmitted in-memory rather than over the wire.

This replaces the Okio.inMemorySocketPair() after the fake TLS handshake; that way there's no risk of data leaking from the pre-encrypted session to the post-encrypted session.

The useful capability this unlocks is testing TLS scenarios like ECH retries, before we have a server-side TLS stack that can support them.