### PR TITLE
Flush HTTP/1 request bodies before detachTimeout

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http1/Http1ExchangeCodec.kt
@@ -335,6 +335,8 @@ class Http1ExchangeCodec(
     override fun close() {
       if (closed) return
       closed = true
+      // Flush before detachTimeout().
+      socket.sink.flush()
       detachTimeout(timeout)
       state = STATE_READ_RESPONSE_HEADERS
     }
@@ -376,6 +378,8 @@ class Http1ExchangeCodec(
       if (closed) return
       closed = true
       socket.sink.writeUtf8("0\r\n\r\n")
+      // Flush before detachTimeout().
+      socket.sink.flush()
       detachTimeout(timeout)
       state = STATE_READ_RESPONSE_HEADERS
     }

--- a/okhttp/src/jvmTest/kotlin/okhttp3/InterceptorOverridesTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/InterceptorOverridesTest.kt
@@ -44,18 +44,17 @@ import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.nanoseconds
 import mockwebserver3.MockResponse
 import mockwebserver3.MockWebServer
 import mockwebserver3.junit5.StartStop
 import okhttp3.CertificatePinner.Companion.pin
 import okhttp3.Headers.Companion.headersOf
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.internal.connection.ConnectionListener
 import okhttp3.internal.platform.Platform
 import okhttp3.sockets.DelegatingSSLSocketFactory
 import okhttp3.sockets.DelegatingSocketFactory
 import okhttp3.testing.PlatformRule
-import okio.BufferedSink
 import okio.ForwardingFileSystem
 import okio.IOException
 import okio.Path
@@ -295,21 +294,21 @@ class InterceptorOverridesTest {
       }
 
       OverrideParam.WriteTimeout -> {
-        val body =
-          object : RequestBody() {
-            override fun contentType(): MediaType? = null
+        client =
+          client
+            .newBuilder()
+            .socketFactory(
+              DelayingSocketFactory(onWrite = {
+                Thread.sleep(100L)
+              }),
+            ).build()
 
-            override fun writeTo(sink: BufferedSink) {
-              if (sink
-                  .timeout()
-                  .timeoutNanos()
-                  .nanoseconds.inWholeMilliseconds == 10L
-              ) {
-                throw IOException()
-              }
-            }
-          }
-        overrideBadImplementation(override = override.override, testItFails = testItFails, body = body)
+        // Need a body so KnownLengthSink.close() runs (issue 9228).
+        overrideBadImplementation(
+          override = override.override,
+          testItFails = testItFails,
+          body = "test".toRequestBody(),
+        )
       }
 
       OverrideParam.ReadTimeout -> {

--- a/okhttp/src/jvmTest/kotlin/okhttp3/WriteTimeoutDuringWriteToTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/WriteTimeoutDuringWriteToTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 OkHttp Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3
+
+import java.io.FilterOutputStream
+import java.io.OutputStream
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.util.concurrent.TimeUnit
+import javax.net.SocketFactory
+import kotlin.test.assertFailsWith
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.junit5.StartStop
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.sockets.DelegatingSocketFactory
+import okhttp3.testing.PlatformRule
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class WriteTimeoutDuringWriteToTest {
+  @RegisterExtension
+  val platform = PlatformRule()
+
+  @RegisterExtension
+  val clientTestRule = OkHttpClientTestRule()
+
+  @StartStop
+  private val server = MockWebServer()
+
+  @Tag("Slowish")
+  @Test
+  fun delayedSocketWritesHonorWriteTimeout() {
+    server.enqueue(MockResponse())
+
+    val writeTimeoutMillis = 200L
+    val client =
+      clientTestRule
+        .newClientBuilder()
+        .writeTimeout(writeTimeoutMillis, TimeUnit.MILLISECONDS)
+        .socketFactory(
+          object : DelegatingSocketFactory(SocketFactory.getDefault()) {
+            override fun createSocket(): Socket =
+              object : Socket() {
+                override fun getOutputStream(): OutputStream =
+                  object : FilterOutputStream(super.getOutputStream()) {
+                    override fun write(
+                      b: ByteArray,
+                      off: Int,
+                      len: Int,
+                    ) {
+                      Thread.sleep(writeTimeoutMillis + 150)
+                      super.write(b, off, len)
+                    }
+                  }
+              }
+          },
+        ).build()
+
+    val request =
+      Request(
+        url = server.url("/"),
+        body = "test".toRequestBody(),
+      )
+
+    assertFailsWith<SocketTimeoutException> {
+      client.newCall(request).execute()
+    }
+  }
+}


### PR DESCRIPTION
HTTP/1 keeps the connection sink buffered. Closing a request body called detachTimeout() and cleared the write timeout; then finishRequest() flushed the remaining bytes with the timeout already gone.

Flush in KnownLengthSink/ChunkedSink.close() before detachTimeout() so that write still has write timeout. Also switched InterceptorOverridesTest's WriteTimeout case to a delayed socket write (with a request body), same idea as ReadTimeout.

Fixes #9228.