### PR TITLE
Complete fixed-length duplex request before reporting length mismatch

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Exchange.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/Exchange.kt
@@ -295,7 +295,7 @@ class Exchange(
       if (closed) return
       closed = true
       if (contentLength != -1L && bytesReceived != contentLength) {
-        throw ProtocolException("unexpected end of stream")
+        throw complete(ProtocolException("unexpected end of stream"))!!
       }
       try {
         super.close()

--- a/okhttp/src/jvmTest/kotlin/okhttp3/DuplexTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/DuplexTest.kt
@@ -736,6 +736,59 @@ class DuplexTest {
       .contains("StreamResetException: stream was reset: CANCEL")
   }
 
+  @Test
+  fun fixedLengthDuplexRequestCompletedWhenClosedEarly() {
+    enableProtocol(Protocol.HTTP_2)
+    val body =
+      MockSocketHandler()
+        .receiveRequest("partial")
+        .sendResponse("response A\n")
+        .sleep(2, TimeUnit.SECONDS)
+    server.enqueue(
+      MockResponse
+        .Builder()
+        .clearHeaders()
+        .socketHandler(body)
+        .build(),
+    )
+    val requestSinks = LinkedBlockingQueue<BufferedSink>()
+    val requestBody =
+      object : RequestBody() {
+        override fun contentType(): MediaType? = null
+
+        override fun contentLength(): Long = 10L
+
+        override fun isDuplex(): Boolean = true
+
+        override fun writeTo(sink: BufferedSink) {
+          requestSinks.add(sink)
+        }
+      }
+    val call =
+      client.newCall(
+        Request
+          .Builder()
+          .url(server.url("/"))
+          .post(requestBody)
+          .build(),
+      )
+    call.execute().use { response ->
+      val responseBody = response.body.source()
+      val requestBody = requestSinks.poll(5, TimeUnit.SECONDS)!!
+      requestBody.writeUtf8("partial")
+      requestBody.flush()
+      assertThat(responseBody.readUtf8Line()).isEqualTo("response A")
+      val e =
+        assertFailsWith<ProtocolException> {
+          requestBody.close()
+        }
+      assertThat(e.message).isEqualTo("unexpected end of stream")
+    }
+    body.awaitSuccess()
+    assertThat(client.connectionPool.connectionCount()).isEqualTo(1)
+    assertThat(client.connectionPool.idleConnectionCount()).isEqualTo(1)
+  }
+
   /**
    * We delay sending the last byte of the request body 1500 ms. The 1000 ms read timeout should
    * only elapse 1000 ms after the request body is sent.


### PR DESCRIPTION
## Problem

When a fixed-length duplex request body is closed before all declared bytes are written, `Exchange.RequestBodySink.close()` throws a `ProtocolException` ("unexpected end of stream") **before** calling `complete(...)`. As a result the request side is never marked complete, so the HTTP/2 connection allocation is never released:

```
connectionCount() == 1
idleConnectionCount() == 0
```

See issue #9648 for the original report.

## Fix

Complete the request side with failure before reporting the length mismatch, so the cancelled call can release its connection allocation:

```kotlin
if (contentLength != -1L && bytesReceived != contentLength) {
  throw complete(ProtocolException("unexpected end of stream"))!!
}
```

## Test

Added `DuplexTest.fixedLengthDuplexRequestCompletedWhenClosedEarly`, which writes a partial fixed-length duplex body, receives the server's final response, then closes the sink. Before the fix the test fails (connection stays allocated, `idleConnectionCount() == 0`); after the fix it asserts `idleConnectionCount() == 1`.

Fixes #9648.