### PR TITLE
fix: handle null from ExtendedSSLSession.getRequestedServerNames (#9523)

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/platform/Platform.kt
@@ -149,7 +149,7 @@ open class Platform {
   open fun getHandshakeServerNames(sslSocket: SSLSocket): List<String> {
     val session = sslSocket.session as? ExtendedSSLSession ?: return listOf()
     return try {
-      session.requestedServerNames.mapNotNull { (it as? SNIHostName)?.asciiName }
+      (session.requestedServerNames ?: emptyList()).mapNotNull { (it as? SNIHostName)?.asciiName }
     } catch (_: UnsupportedOperationException) {
       // UnsupportedOperationException – if the underlying provider does not implement the operation
       // https://github.com/bcgit/bc-java/issues/1773


### PR DESCRIPTION
## Fix: handle null from `ExtendedSSLSession.getRequestedServerNames()`

On some Android versions (SDK 27, 28), `ExtendedSSLSession.getRequestedServerNames()` can return `null` instead of an empty list. This causes a `NullPointerException` when MockWebServer records the `handshakeServerNames` in `RecordedRequest`.

### Changes

In `Platform.kt`, use `(session.requestedServerNames ?: emptyList())` instead of `session.requestedServerNames` directly to handle the null case gracefully.

### Related

Closes https://github.com/square/okhttp/issues/9523
