### PR TITLE
New 'No Generative Tools' section in contributing doc

### DIFF
--- a/docs/contribute/contributing.md
+++ b/docs/contribute/contributing.md
@@ -1,10 +1,12 @@
 Contributing
 ============
 
+Our goal with this project is to build a simple, fast, and secure component that you can trust. We
+have scoped the project deliberately to address common use cases easily, and made it extensible so
+it'll handle exotic use cases too.
+
 Keeping the project small and stable limits our ability to accept new contributors. We are not
 seeking new committers at this time, but some small contributions are welcome.
-
-If you've found a security problem, please follow our [bug bounty][security] program.
 
 If you've found a bug, please contribute a failing test case so we can study and fix it.
 
@@ -12,8 +14,25 @@ If you have a new feature idea, please build it in an external library. There ar
 [many libraries][works_with_okhttp] that sit on top or hook in via existing APIs. If you build
 something that integrates with OkHttp, tell us so that we can link it!
 
-Before code can be accepted all contributors must complete our
-[Individual Contributor License Agreement (CLA)][cla].
+
+No Generative Tools
+-------------------
+
+We don't use LLMs or generative tools in our source code or documentation. We don't use them for
+human-to-human communication in commits, issues, and pull requests. We believe writing is thinking,
+and want our work to be thoughtful.
+
+We require all contributors to do likewise. Building is more fun when everyone is making an effort.
+
+We’ll immediately reject LLM-generated contributions to protect the culture of our project. We ban
+repeat offenders.
+
+Some narrow exceptions to this policy:
+
+ * Non-English speakers may use machine translation tools if they are disclosed.
+ * Local autocomplete. (Avoid tools that are metered in tokens.)
+
+Coding is fun.
 
 
 Code Contributions
@@ -53,10 +72,8 @@ Committer's Guides
  * [Debug Logging][debug_logging]
  * [Releasing][releasing]
 
- [cla]: https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1
  [concurrency]: https://lysine.dev/okhttp/concurrency/
  [debug_logging]: https://lysine.dev/okhttp/debug_logging/
  [releasing]: https://lysine.dev/okhttp/releasing/
- [security]: https://lysine.dev/okhttp/security/
  [works_with_okhttp]: https://lysine.dev/okhttp/works_with_okhttp/
  [okhttp_build]: https://github.com/lysine-dev/okhttp/blob/master/okhttp/build.gradle.kts


### PR DESCRIPTION
Also drop the link to Square's CLA and bug bounty, which are no longer part of this project.