### PR TITLE
Get rid of property delegate syntax

### DIFF
--- a/okhttp/build.gradle.kts
+++ b/okhttp/build.gradle.kts
@@ -34,7 +34,7 @@ val copyKotlinTemplates =
   }
 
 // Build & use okhttp3/internal/idn/IdnaMappingTableInstance.kt
-val generateIdnaMappingTableConfiguration: Configuration by configurations.creating
+val generateIdnaMappingTableConfiguration = configurations.create("generateIdnaMappingTableConfiguration")
 dependencies {
   generateIdnaMappingTableConfiguration(projects.okhttpIdnaMappingTable)
 }
@@ -142,7 +142,7 @@ kotlin {
       }
     }
 
-    val jvmTest by getting {
+    jvmTest {
       dependencies {
         implementation(libs.assertk)
         implementation(libs.conscrypt.openjdk)
@@ -185,7 +185,7 @@ kotlin {
     }
 
     if (testJavaVersion >= 17) {
-      val androidHostTest by getting {
+      named("androidHostTest") {
         dependencies {
           implementation(libs.androidx.junit)
           implementation(libs.assertk)
@@ -236,9 +236,9 @@ project.applyOsgiMultiplatform(
   "Bundle-SymbolicName: com.squareup.okhttp3",
 )
 
-val androidSignature by configurations.getting
-val jvmSignature by configurations.getting
-val checkstyleConfig by configurations.getting
+val androidSignature = configurations.getByName("androidSignature")
+val jvmSignature = configurations.getByName("jvmSignature")
+val checkstyleConfig = configurations.getByName("checkstyleConfig")
 
 // Animal Sniffer confirms we generally don't use APIs not on Java 8.
 configure<AnimalSnifferExtension> {


### PR DESCRIPTION
It is (thankfully) being removed in future Gradle versions.