### PR TITLE
retryOnConnectionFailure doesn't impact ECH retries

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/ConnectPlan.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/connection/ConnectPlan.kt
@@ -503,8 +503,6 @@ class ConnectPlan internal constructor(
     sslSocket: SSLSocket,
     sslException: SSLException,
   ): ConnectPlan? {
-    if (!retryOnConnectionFailure) return null
-
     // If this was an ECH retry, don't retry again.
     if (echRetryPlan != null) return null
 
@@ -532,6 +530,9 @@ class ConnectPlan internal constructor(
         echRetryPlan = nextEchRetryPlan,
       )
     }
+
+    // If recovery is configured off, don't retry.
+    if (!retryOnConnectionFailure) return null
 
     // If the exception is not recoverable, don't retry.
     if (!attemptAnotherConnectionSpec(sslException)) return null

--- a/okhttp/src/jvmTest/kotlin/okhttp3/EchOnFakeNetworkTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/EchOnFakeNetworkTest.kt
@@ -303,14 +303,24 @@ class EchOnFakeNetworkTest {
       .isEqualTo("handshake hostname=private.ech.example.com echConfigList=null")
   }
 
+  /**
+   * This runs with [OkHttpClient.retryOnConnectionFailure] enabled and disabled. (We always want
+   * ECH retries, regardless of what this setting is.)
+   */
   @Test
-  fun `server updates ech config for retry`() {
+  fun `server updates ech config for retry`(retryOnConnectionFailure: Boolean) {
     val updatedEchConfigList = "new key to encrypt 'private.ech.example.com'".encodeUtf8()
     platform.handshaker =
       handshakerWithUpdatedEchConfigList(
         updatedEchConfigList = updatedEchConfigList,
         attemptLimit = 2,
       )
+
+    client =
+      client
+        .newBuilder()
+        .retryOnConnectionFailure(retryOnConnectionFailure)
+        .build()
 
     executeHttpExchange()
 


### PR DESCRIPTION
This setting is related to client-triggered retries.

ECH retries are related to server teams rolling back ECH settings non-atomically.