### PR TITLE
Flip wiring of Dns.SYSTEM

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dns.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Dns.kt
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(OkHttpInternalApi::class)
+
 package okhttp3
 
 import java.io.IOException
 import java.net.InetAddress
 import java.net.UnknownHostException
+import okhttp3.internal.OkHttpInternalApi
 import okhttp3.internal.concurrent.TaskRunner
 import okhttp3.internal.dns.LookupDnsCall
+import okhttp3.internal.platform.Platform
 import okhttp3.internal.toCanonicalHost
 import okio.ByteString
 
@@ -279,22 +283,18 @@ fun interface Dns {
 
   companion object {
     /**
-     * A DNS that uses [InetAddress.getAllByName] to ask the underlying operating system to
-     * lookup IP addresses. Most custom [Dns] implementations should delegate to this instance.
+     * The current process's host DNS service.
+     *
+     * Most custom [Dns] implementations should delegate to this instance.
      */
     @JvmField
-    val SYSTEM: Dns = DnsSystem()
+    val SYSTEM: Dns =
+      object : Dns {
+        override fun lookup(hostname: String) = Platform.get().systemDns.lookup(hostname)
 
-    private class DnsSystem : Dns {
-      override fun lookup(hostname: String): List<InetAddress> {
-        try {
-          return InetAddress.getAllByName(hostname).toList()
-        } catch (e: NullPointerException) {
-          throw UnknownHostException("Broken system behaviour for dns lookup of $hostname").apply {
-            initCause(e)
-          }
-        }
+        override fun newCall(request: Request) = Platform.get().systemDns.newCall(request)
+
+        override fun toString() = "Dns.SYSTEM"
       }
-    }
   }
 }

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt
@@ -600,7 +600,7 @@ open class OkHttpClient internal constructor(
     internal var followSslRedirects = true
     internal var cookieJar: CookieJar = CookieJar.NO_COOKIES
     internal var cache: Cache? = null
-    internal var dns: Dns = Platform.get().platformDns()
+    internal var dns: Dns = Dns.SYSTEM
     internal var proxy: Proxy? = null
     internal var proxySelector: ProxySelector? = null
     internal var proxyAuthenticator: Authenticator = Authenticator.NONE

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/InetAddressDns.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/InetAddressDns.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package okhttp3.internal.dns
+
+import java.net.InetAddress
+import java.net.UnknownHostException
+import okhttp3.Dns
+import okhttp3.internal.OkHttpInternalApi
+
+/**
+ * A DNS that uses [InetAddress.getAllByName] to ask the underlying operating system to
+ * lookup IP addresses.
+ */
+@OkHttpInternalApi
+internal object InetAddressDns : Dns {
+  override fun lookup(hostname: String): List<InetAddress> {
+    try {
+      return InetAddress.getAllByName(hostname).toList()
+    } catch (e: NullPointerException) {
+      throw UnknownHostException("Broken system behaviour for dns lookup of $hostname").apply {
+        initCause(e)
+      }
+    }
+  }
+}

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/platform/Platform.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/platform/Platform.kt
@@ -38,6 +38,7 @@ import okhttp3.Dns
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.internal.OkHttpInternalApi
+import okhttp3.internal.dns.InetAddressDns
 import okhttp3.internal.ech.EchRetryPlan
 import okhttp3.internal.publicsuffix.PublicSuffixDatabase
 import okhttp3.internal.readFieldOrNull
@@ -83,6 +84,10 @@ open class Platform {
 
   open val serverSocketFactory: ServerSocketFactory
     get() = ServerSocketFactory.getDefault()
+
+  /** The default [Dns] for the system, by default [InetAddressDns]. */
+  open val systemDns: Dns
+    get() = InetAddressDns
 
   /** Prefix used on custom headers. */
   val prefix: String
@@ -158,11 +163,6 @@ open class Platform {
       listOf()
     }
   }
-
-  /**
-   * Provides the default [Dns] for the system, by default [Dns.SYSTEM].
-   */
-  open fun platformDns(): Dns = Dns.SYSTEM
 
   @Throws(IOException::class)
   open fun connectSocket(


### PR DESCRIPTION
Previously Dns.SYSTEM was a constant, and Platform.platformDns() was a hook to return something different.

With this change, Dns.SYSTEM forwards to whatever Platform.systemDns currently returns.