### PR TITLE
Order ServiceMetadata records per the spec

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-StateMachineDnsCall.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-StateMachineDnsCall.kt
@@ -182,45 +182,43 @@ class StateMachineDnsCall(
     val dnsRecords: List<Dns.Record> =
       when (question.type) {
         TYPE_HTTPS -> {
-          resourceRecords.mapNotNull { resourceRecord ->
-            // Discard resource records that don't fit the query.
-            if (resourceRecord !is ResourceRecord.Https) return@mapNotNull null
+          resourceRecords.filterIsInstance<ResourceRecord.Https>()
+            .shuffled()
+            .sortedBy { it.priority }
+            .map { resourceRecord ->
+              // OkHttp doesn't yet implement AliasMode resource records. If any AliasMode record is
+              // returned, we must ignore ALL returned resource records.
+              if (resourceRecord.priority == 0) {
+                return updateStateAndCallCallbacks(
+                  completedQuery = completedQuery,
+                )
+              }
 
-            // OkHttp doesn't yet implement AliasMode resource records. If any AliasMode record is
-            // returned, we must ignore ALL returned resource records.
-            if (resourceRecord.priority == 0) {
-              return updateStateAndCallCallbacks(
-                completedQuery = completedQuery,
+              Dns.Record.ServiceMetadata(
+                hostname = resourceRecord.targetName.takeIf { it != "" } ?: request.hostname,
+                alpnIds =
+                  resourceRecord.alpnIds?.mapNotNull { alpnId ->
+                    try {
+                      Protocol.get(alpnId)
+                    } catch (_: IOException) {
+                      null // Skip unrecognized ALPN ID.
+                    }
+                  },
+                port = resourceRecord.port,
+                ipAddressHints = resourceRecord.ipAddressHints,
+                echConfigList = resourceRecord.echConfigList,
               )
             }
-
-            Dns.Record.ServiceMetadata(
-              hostname = resourceRecord.targetName.takeIf { it != "" } ?: request.hostname,
-              alpnIds =
-                resourceRecord.alpnIds?.mapNotNull { alpnId ->
-                  try {
-                    Protocol.get(alpnId)
-                  } catch (_: IOException) {
-                    null // Skip unrecognized ALPN ID.
-                  }
-                },
-              port = resourceRecord.port,
-              ipAddressHints = resourceRecord.ipAddressHints,
-              echConfigList = resourceRecord.echConfigList,
-            )
-          }
         }
 
         TYPE_A, TYPE_AAAA -> {
-          resourceRecords.mapNotNull { resourceRecord ->
-            // Discard resource records that don't fit the query.
-            if (resourceRecord !is ResourceRecord.IpAddress) return@mapNotNull null
-
-            Dns.Record.IpAddress(
-              hostname = request.hostname,
-              address = resourceRecord.address,
-            )
-          }
+          resourceRecords.filterIsInstance<ResourceRecord.IpAddress>()
+            .map { resourceRecord ->
+              Dns.Record.IpAddress(
+                hostname = request.hostname,
+                address = resourceRecord.address,
+              )
+            }
         }
 
         else -> {

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-StateMachineDnsCall.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/dns/-StateMachineDnsCall.kt
@@ -182,7 +182,8 @@ class StateMachineDnsCall(
     val dnsRecords: List<Dns.Record> =
       when (question.type) {
         TYPE_HTTPS -> {
-          resourceRecords.filterIsInstance<ResourceRecord.Https>()
+          resourceRecords
+            .filterIsInstance<ResourceRecord.Https>()
             .shuffled()
             .sortedBy { it.priority }
             .map { resourceRecord ->
@@ -212,7 +213,8 @@ class StateMachineDnsCall(
         }
 
         TYPE_A, TYPE_AAAA -> {
-          resourceRecords.filterIsInstance<ResourceRecord.IpAddress>()
+          resourceRecords
+            .filterIsInstance<ResourceRecord.IpAddress>()
             .map { resourceRecord ->
               Dns.Record.IpAddress(
                 hostname = request.hostname,

--- a/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
+++ b/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
@@ -19,13 +19,17 @@ package okhttp3.internal.dns
 
 import app.cash.burst.Burst
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.size
 import java.net.InetAddress
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 import okhttp3.Dns
 import okhttp3.Protocol
 import okhttp3.internal.OkHttpInternalApi
+import okio.ByteString.Companion.encodeUtf8
 
 @Burst
 class StateMachineDnsCallTest {
@@ -1126,4 +1130,109 @@ class StateMachineDnsCallTest {
         addresses = blueIpv4s,
       )
     }
+
+  @Test
+  fun `service mode records are sorted by priority`(caching: Boolean = true) =
+    testStateMachineDnsCall {
+      val processedRecords = serveAndProcessResourceRecords(
+        caching = caching,
+        attempt = 0,
+        ResourceRecord.Https(
+          name = "lysine.dev",
+          timeToLive = 300.seconds.inWholeSeconds.toInt(),
+          priority = 3,
+          echConfigList = "priority three ECH config list".encodeUtf8(),
+        ),
+        ResourceRecord.Https(
+          name = "lysine.dev",
+          timeToLive = 300.seconds.inWholeSeconds.toInt(),
+          priority = 1,
+          echConfigList = "priority one ECH config list".encodeUtf8(),
+        ),
+        ResourceRecord.Https(
+          name = "lysine.dev",
+          timeToLive = 300.seconds.inWholeSeconds.toInt(),
+          priority = 2,
+          echConfigList = "priority two ECH config list".encodeUtf8(),
+        ),
+      )
+
+      val sortedEchConfigLists = processedRecords
+        .map { it.echConfigList }
+      assertThat(sortedEchConfigLists).containsExactly(
+        "priority one ECH config list".encodeUtf8(),
+        "priority two ECH config list".encodeUtf8(),
+        "priority three ECH config list".encodeUtf8(),
+      )
+    }
+
+  /**
+   * We've got 8 lists, each containing 3 elements. If we shuffle each list we should expect all the
+   * lists to be the same once in every ~280,000 runs. (So this test is flaky, but acceptably so.)
+   */
+  @Test
+  fun `service mode records are shuffled within each priority`(caching: Boolean = true) =
+    testStateMachineDnsCall {
+      val attemptCount = 8
+      val distinctOrderings = mutableSetOf<List<Dns.Record.ServiceMetadata>>()
+      for (i in 0 until attemptCount) {
+        val processedRecords = serveAndProcessResourceRecords(
+          caching,
+          attempt = i,
+          ResourceRecord.Https(
+            name = "lysine.dev",
+            timeToLive = 300.seconds.inWholeSeconds.toInt(),
+            echConfigList = "element A ECH config list".encodeUtf8(),
+          ),
+          ResourceRecord.Https(
+            name = "lysine.dev",
+            timeToLive = 300.seconds.inWholeSeconds.toInt(),
+            echConfigList = "element B ECH config list".encodeUtf8(),
+          ),
+          ResourceRecord.Https(
+            name = "lysine.dev",
+            timeToLive = 300.seconds.inWholeSeconds.toInt(),
+            echConfigList = "element C ECH config list".encodeUtf8(),
+          ),
+        )
+
+        distinctOrderings += processedRecords
+      }
+
+      assertThat(distinctOrderings).size().isGreaterThan(1)
+    }
+
+  /**
+   * Use the state machine to transform server-provided [resourceRecords] to the user-facing
+   * [Dns.Record] instances.
+   */
+  private fun StateMachineDnsCallTester.serveAndProcessResourceRecords(
+    caching: Boolean,
+    attempt: Int,
+    vararg resourceRecords: ResourceRecord.Https,
+  ): List<Dns.Record.ServiceMetadata> {
+    val call =
+      newCall(
+        request = Dns.Request(hostname = "lysine.dev"),
+        caching = caching,
+        includeIPv6 = false,
+      )
+    call.enqueue()
+
+    if (attempt == 0 || !caching) {
+      queryFactory.respondToQuery(
+        hostname = "lysine.dev",
+        type = TYPE_HTTPS,
+        *resourceRecords,
+      )
+      queryFactory.respondToQuery(
+        hostname = "lysine.dev",
+        type = TYPE_A,
+        addresses = blueIpv4s,
+      )
+    }
+
+    return call.takeAllRecords()
+      .filterIsInstance<Dns.Record.ServiceMetadata>()
+  }
 }

--- a/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
+++ b/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTest.kt
@@ -1134,31 +1134,33 @@ class StateMachineDnsCallTest {
   @Test
   fun `service mode records are sorted by priority`(caching: Boolean = true) =
     testStateMachineDnsCall {
-      val processedRecords = serveAndProcessResourceRecords(
-        caching = caching,
-        attempt = 0,
-        ResourceRecord.Https(
-          name = "lysine.dev",
-          timeToLive = 300.seconds.inWholeSeconds.toInt(),
-          priority = 3,
-          echConfigList = "priority three ECH config list".encodeUtf8(),
-        ),
-        ResourceRecord.Https(
-          name = "lysine.dev",
-          timeToLive = 300.seconds.inWholeSeconds.toInt(),
-          priority = 1,
-          echConfigList = "priority one ECH config list".encodeUtf8(),
-        ),
-        ResourceRecord.Https(
-          name = "lysine.dev",
-          timeToLive = 300.seconds.inWholeSeconds.toInt(),
-          priority = 2,
-          echConfigList = "priority two ECH config list".encodeUtf8(),
-        ),
-      )
+      val processedRecords =
+        serveAndProcessResourceRecords(
+          caching = caching,
+          attempt = 0,
+          ResourceRecord.Https(
+            name = "lysine.dev",
+            timeToLive = 300.seconds.inWholeSeconds.toInt(),
+            priority = 3,
+            echConfigList = "priority three ECH config list".encodeUtf8(),
+          ),
+          ResourceRecord.Https(
+            name = "lysine.dev",
+            timeToLive = 300.seconds.inWholeSeconds.toInt(),
+            priority = 1,
+            echConfigList = "priority one ECH config list".encodeUtf8(),
+          ),
+          ResourceRecord.Https(
+            name = "lysine.dev",
+            timeToLive = 300.seconds.inWholeSeconds.toInt(),
+            priority = 2,
+            echConfigList = "priority two ECH config list".encodeUtf8(),
+          ),
+        )
 
-      val sortedEchConfigLists = processedRecords
-        .map { it.echConfigList }
+      val sortedEchConfigLists =
+        processedRecords
+          .map { it.echConfigList }
       assertThat(sortedEchConfigLists).containsExactly(
         "priority one ECH config list".encodeUtf8(),
         "priority two ECH config list".encodeUtf8(),
@@ -1176,25 +1178,26 @@ class StateMachineDnsCallTest {
       val attemptCount = 8
       val distinctOrderings = mutableSetOf<List<Dns.Record.ServiceMetadata>>()
       for (i in 0 until attemptCount) {
-        val processedRecords = serveAndProcessResourceRecords(
-          caching,
-          attempt = i,
-          ResourceRecord.Https(
-            name = "lysine.dev",
-            timeToLive = 300.seconds.inWholeSeconds.toInt(),
-            echConfigList = "element A ECH config list".encodeUtf8(),
-          ),
-          ResourceRecord.Https(
-            name = "lysine.dev",
-            timeToLive = 300.seconds.inWholeSeconds.toInt(),
-            echConfigList = "element B ECH config list".encodeUtf8(),
-          ),
-          ResourceRecord.Https(
-            name = "lysine.dev",
-            timeToLive = 300.seconds.inWholeSeconds.toInt(),
-            echConfigList = "element C ECH config list".encodeUtf8(),
-          ),
-        )
+        val processedRecords =
+          serveAndProcessResourceRecords(
+            caching,
+            attempt = i,
+            ResourceRecord.Https(
+              name = "lysine.dev",
+              timeToLive = 300.seconds.inWholeSeconds.toInt(),
+              echConfigList = "element A ECH config list".encodeUtf8(),
+            ),
+            ResourceRecord.Https(
+              name = "lysine.dev",
+              timeToLive = 300.seconds.inWholeSeconds.toInt(),
+              echConfigList = "element B ECH config list".encodeUtf8(),
+            ),
+            ResourceRecord.Https(
+              name = "lysine.dev",
+              timeToLive = 300.seconds.inWholeSeconds.toInt(),
+              echConfigList = "element C ECH config list".encodeUtf8(),
+            ),
+          )
 
         distinctOrderings += processedRecords
       }
@@ -1232,7 +1235,8 @@ class StateMachineDnsCallTest {
       )
     }
 
-    return call.takeAllRecords()
+    return call
+      .takeAllRecords()
       .filterIsInstance<Dns.Record.ServiceMetadata>()
   }
 }

--- a/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTester.kt
+++ b/okhttp/src/commonTest/kotlin/okhttp3/internal/dns/StateMachineDnsCallTester.kt
@@ -123,6 +123,17 @@ class StateMachineDnsCallTester internal constructor() {
       return event
     }
 
+    /** Combines [takeQuery] and [QueryEnqueued.respond]. */
+    fun respondToQuery(
+      hostname: String,
+      type: Int,
+      vararg resourceRecords: ResourceRecord,
+    ): QueryEnqueued {
+      val event = takeQuery(hostname, type)
+      event.respond(*resourceRecords)
+      return event
+    }
+
     /** Asserts that the next-posted event is a query cancel. */
     fun takeCancel(
       hostname: String,


### PR DESCRIPTION
Sort by priority, shuffle within each priority.

For source code simplicity this is implemented as a shuffle of everything, followed by a sort on priority. This is less efficient than independent sort + shuffle, but N is very small.